### PR TITLE
feat: add npm publishing setup for @vibeguard/core

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,21 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Pack and smoke-test binary
+        run: |
+          TARBALL=$(npm pack | tail -1)
+          TARBALL_PATH="$(pwd)/$TARBALL"
+          mkdir /tmp/smoke
+          cd /tmp/smoke
+          npm install "$TARBALL_PATH"
+          output=$(./node_modules/.bin/vibeguard --check 2>&1 || true)
+          if echo "$output" | grep -q "missing setup script"; then
+            echo "SMOKE TEST FAILED: binary cannot resolve setup scripts after tarball install"
+            echo "$output"
+            exit 1
+          fi
+          echo "Smoke test passed"
+
       - name: Dry-run publish
         run: npm publish --dry-run --access public
 
@@ -48,6 +63,21 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Pack and smoke-test binary
+        run: |
+          TARBALL=$(npm pack | tail -1)
+          TARBALL_PATH="$(pwd)/$TARBALL"
+          mkdir /tmp/smoke
+          cd /tmp/smoke
+          npm install "$TARBALL_PATH"
+          output=$(./node_modules/.bin/vibeguard --check 2>&1 || true)
+          if echo "$output" | grep -q "missing setup script"; then
+            echo "SMOKE TEST FAILED: binary cannot resolve setup scripts after tarball install"
+            echo "$output"
+            exit 1
+          fi
+          echo "Smoke test passed"
 
       - name: Publish
         run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run:
+    name: Publish dry-run (PR only)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Dry-run publish
+        run: npm publish --dry-run --access public
+
+  publish:
+    name: Publish to npm
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,28 @@
+# Tests
+tests/
+
+# Documentation source
+docs/
+
+# GitHub-specific files
+.github/
+
+# Claude configuration
+.claude/
+claude-md/
+
+# CI scripts
+scripts/ci/
+scripts/constraint-recommender.py
+
+# Spec and project-specific docs
+spec.md
+CONTRIBUTING.md
+SECURITY.md
+
+# MCP server (separate package)
+mcp-server/
+
+# Development dotfiles
+.gitignore
+.gitattributes

--- a/.npmignore
+++ b/.npmignore
@@ -7,9 +7,9 @@ docs/
 # GitHub-specific files
 .github/
 
-# Claude configuration
-.claude/
-claude-md/
+# Claude configuration (keep commands/vibeguard, exclude the rest)
+.claude/settings.json
+.claude/settings.local.json
 
 # CI scripts
 scripts/ci/
@@ -19,9 +19,6 @@ scripts/constraint-recommender.py
 spec.md
 CONTRIBUTING.md
 SECURITY.md
-
-# MCP server (separate package)
-mcp-server/
 
 # Development dotfiles
 .gitignore

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vibeguard/core",
+      "devDependencies": {
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+// VibeGuard — AI anti-hallucination guard system for Claude Code
+// Shell-script package; use `npx @vibeguard/core` or `bash setup.sh` to install.
+module.exports = {};

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,3 @@
+// VibeGuard — AI anti-hallucination guard system for Claude Code
+// Shell-script package; this file provides TypeScript type declarations only.
+export {};

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   },
   "license": "MIT",
   "author": "majiayu000",
-  "main": "setup.sh",
+  "main": "index.js",
   "bin": {
     "vibeguard": "./setup.sh"
   },
   "files": [
+    "index.js",
     "setup.sh",
     "install-hook.sh",
     "guards/",
@@ -53,6 +54,9 @@
     "scripts/quality-grader.sh",
     "scripts/stats.sh",
     "scripts/worktree-guard.sh",
+    "mcp-server/",
+    ".claude/commands/vibeguard",
+    "claude-md/",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@vibeguard/core",
+  "version": "1.0.0",
+  "description": "AI anti-hallucination guard system for Claude Code — rule injection, real-time interception, and static scanning to prevent hallucinated APIs, over-engineering, and hardcoded values",
+  "keywords": [
+    "claude-code",
+    "ai-guard",
+    "anti-hallucination",
+    "vibeguard",
+    "llm",
+    "code-quality",
+    "hooks",
+    "pre-commit"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/majiayu000/vibeguard.git"
+  },
+  "homepage": "https://github.com/majiayu000/vibeguard#readme",
+  "bugs": {
+    "url": "https://github.com/majiayu000/vibeguard/issues"
+  },
+  "license": "MIT",
+  "author": "majiayu000",
+  "main": "setup.sh",
+  "bin": {
+    "vibeguard": "./setup.sh"
+  },
+  "files": [
+    "setup.sh",
+    "install-hook.sh",
+    "guards/",
+    "hooks/",
+    "rules/",
+    "skills/",
+    "agents/",
+    "blueprints/",
+    "context-profiles/",
+    "resources/",
+    "templates/",
+    "workflows/",
+    "scripts/setup/",
+    "scripts/lib/",
+    "scripts/compliance_check.sh",
+    "scripts/doc-freshness-check.sh",
+    "scripts/gc-logs.sh",
+    "scripts/gc-scheduled.sh",
+    "scripts/gc-worktrees.sh",
+    "scripts/log-capability-change.sh",
+    "scripts/metrics-exporter.sh",
+    "scripts/metrics_collector.sh",
+    "scripts/project-init.sh",
+    "scripts/quality-grader.sh",
+    "scripts/stats.sh",
+    "scripts/worktree-guard.sh",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "test": "bash tests/test_hooks.sh && bash tests/test_rust_guards.sh && bash tests/test_setup.sh",
+    "prepublishOnly": "npm test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks so this script works when invoked via npm's .bin/ shim
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [ -L "$SCRIPT_PATH" ]; do
+  SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ $SCRIPT_PATH != /* ]] && SCRIPT_PATH="$SCRIPT_DIR/$SCRIPT_PATH"
+done
+REPO_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 SETUP_DIR="${REPO_DIR}/scripts/setup"
 
 run_setup() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary

- Add root `package.json` with `name: @vibeguard/core`, `version: 1.0.0` (matching CHANGELOG.md), full metadata (description, keywords, repository, license, author, main/bin/files)
- Add `.npmignore` to exclude `tests/`, `docs/`, `.github/`, `.claude/`, `scripts/ci/`, and dev-only files from the published package
- Add `prepublishOnly` script that runs the test suite before `npm publish`
- Add `.github/workflows/publish.yml` that publishes to npm on `v*` tag pushes using `NODE_AUTH_TOKEN` secret, and runs a dry-run on PRs

## Test plan

- [ ] Verify `npm publish --dry-run` succeeds locally
- [ ] Confirm CI dry-run step passes on this PR
- [ ] After merging, push a `v1.0.0` tag to trigger the publish job
- [ ] Check https://www.npmjs.com/package/@vibeguard/core for the published package