### PR TITLE
feat: add Docker image build and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.claude
+tests
+docs
+node_modules
+mcp-server/node_modules
+mcp-server/dist
+*.md
+!README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd mcp-server && npm run build
 FROM node:22-alpine
 
 # Install runtime dependencies required by guard scripts and MCP tools
-RUN apk add --no-cache bash python3 go git
+RUN apk add --no-cache bash python3 py3-pytest go git ripgrep grep
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN cd mcp-server && npm run build
 # Stage 2: Lightweight runtime image
 FROM node:22-alpine
 
+# Install runtime dependencies required by guard scripts and MCP tools
+RUN apk add --no-cache bash python3 go git
+
 WORKDIR /app
 
 # Copy compiled MCP server and production dependencies
@@ -19,10 +22,11 @@ COPY --from=builder /app/mcp-server/dist/ ./mcp-server/dist/
 COPY --from=builder /app/mcp-server/node_modules/ ./mcp-server/node_modules/
 COPY mcp-server/package.json ./mcp-server/package.json
 
-# Copy guard scripts, hooks, and utility scripts
+# Copy guard scripts, hooks, utility scripts, and rule references
 COPY guards/ ./guards/
 COPY hooks/ ./hooks/
 COPY scripts/ ./scripts/
+COPY rules/ ./rules/
 
 ENV NODE_ENV=production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Build the MCP server TypeScript sources
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY mcp-server/package.json mcp-server/package-lock.json ./mcp-server/
+RUN cd mcp-server && npm ci
+
+COPY mcp-server/ ./mcp-server/
+RUN cd mcp-server && npm run build
+
+# Stage 2: Lightweight runtime image
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Copy compiled MCP server and production dependencies
+COPY --from=builder /app/mcp-server/dist/ ./mcp-server/dist/
+COPY --from=builder /app/mcp-server/node_modules/ ./mcp-server/node_modules/
+COPY mcp-server/package.json ./mcp-server/package.json
+
+# Copy guard scripts, hooks, and utility scripts
+COPY guards/ ./guards/
+COPY hooks/ ./hooks/
+COPY scripts/ ./scripts/
+
+ENV NODE_ENV=production
+
+# Default: run the MCP server; override CMD to run a different command
+ENTRYPOINT ["node", "mcp-server/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -438,6 +438,42 @@ mkdir -p .claude/rules
 cp ~/vibeguard/templates/project-rules/*.md .claude/rules/
 ```
 
+## Docker
+
+The VibeGuard MCP server is published to GitHub Container Registry on every version tag.
+
+### Pull
+
+```bash
+docker pull ghcr.io/majiayu000/vibeguard:latest
+# or a specific version
+docker pull ghcr.io/majiayu000/vibeguard:1.0.0
+```
+
+### Run the MCP server
+
+```bash
+docker run --rm -i ghcr.io/majiayu000/vibeguard:latest
+```
+
+### Run a guard script against your project
+
+```bash
+# Mount your project directory and run a guard check
+docker run --rm \
+  -v /path/to/your/project:/workspace \
+  --entrypoint bash \
+  ghcr.io/majiayu000/vibeguard:latest \
+  guards/universal/check_code_slop.sh /workspace
+```
+
+### Build locally
+
+```bash
+docker build -t vibeguard .
+docker run --rm -i vibeguard
+```
+
 ## 设计理念
 
 | 原则 | 来源 | 实现 |


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` using `node:22-alpine` — builder stage compiles the TypeScript MCP server, runtime stage copies only compiled output + `guards/`, `hooks/`, `scripts/`
- Add `.dockerignore` to exclude `.git`, `.github`, `tests`, `docs`, `node_modules`, `.claude`
- Add `.github/workflows/docker.yml` to build and push to `ghcr.io` on version tag pushes (`v*`), producing `latest` + semver tags via `docker/metadata-action`
- Add Docker usage section to `README.md` with `docker pull` and `docker run` examples

## Test plan

- [ ] `docker build -t vibeguard .` succeeds locally
- [ ] Pushing a `v*` tag triggers the workflow and the image appears under `ghcr.io/majiayu000/vibeguard`
- [ ] `docker run --rm -i vibeguard` starts the MCP server process