### PR TITLE
feat(rules): rule graduation lifecycle — nursery → warn → error

### DIFF
--- a/data/rule-scorecard.json
+++ b/data/rule-scorecard.json
@@ -1,0 +1,138 @@
+{
+  "_comment": "VibeGuard rule lifecycle scorecard. Managed by scripts/precision-tracker.py",
+  "_schema": {
+    "stage": "experimental | warn | error | demoted | disabled",
+    "precision": "TP / (TP + FP), null if no samples",
+    "samples": "total triage verdicts (tp + fp + acceptable)",
+    "tp": "true positive count",
+    "fp": "false positive count",
+    "acceptable": "acceptable (borderline) count",
+    "last_fp_ts": "ISO-8601 timestamp of most recent FP verdict, null if none",
+    "stage_entered_ts": "ISO-8601 timestamp when current stage was entered",
+    "notes": "human-readable notes"
+  },
+  "rules": {
+    "RS-03": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "unwrap()/expect() in production Rust code"
+    },
+    "RS-10": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "let _ = silent Result discard"
+    },
+    "RS-14": {
+      "stage": "experimental",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-03-11T00:00:00Z",
+      "notes": "declaration-execution gap; disabled pending precision data"
+    },
+    "TS-01": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "any type abuse in TypeScript"
+    },
+    "DEBUG": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "console.log/print() debug residue"
+    },
+    "U-11": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "hardcoded database paths"
+    },
+    "GO-01": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "error discard in Go"
+    },
+    "GO-08": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "defer in loop"
+    },
+    "STUB": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "stub/todo placeholder in production code"
+    },
+    "LARGE-EDIT": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "single edit exceeds 200 lines"
+    },
+    "CHURN": {
+      "stage": "warn",
+      "precision": null,
+      "samples": 0,
+      "tp": 0,
+      "fp": 0,
+      "acceptable": 0,
+      "last_fp_ts": null,
+      "stage_entered_ts": "2026-01-01T00:00:00Z",
+      "notes": "same file edited 5+ times in one session"
+    }
+  },
+  "_updated_ts": "2026-03-24T00:00:00Z"
+}

--- a/data/triage.jsonl
+++ b/data/triage.jsonl
@@ -1,0 +1,14 @@
+# VibeGuard Triage Log — user feedback per guard warning
+# Each line is a JSON object with the following fields:
+#   ts        ISO-8601 timestamp
+#   rule      Rule ID, e.g. "RS-03"
+#   verdict   "tp" | "fp" | "acceptable"
+#   file      Source file path (optional)
+#   context   Short snippet or note (optional)
+#   session   Session ID from VIBEGUARD_SESSION_ID (optional)
+#
+# Record feedback with:
+#   echo '{"ts":"2026-03-24T11:00:00Z","rule":"RS-03","verdict":"fp","context":"signal handler"}' >> data/triage.jsonl
+#
+# Then regenerate scorecard:
+#   python3 scripts/precision-tracker.py --update-scorecard

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -43,9 +43,15 @@ rule = sys.argv[1]
 suppress_pat = re.compile(r'^\s*(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
 
 def _in_multiline_string(lines, idx):
-    # Count triple-quote delimiters before this line; odd count means we are inside one.
+    # Count multi-line string delimiters before this line; odd count means inside one.
     text_before = '\n'.join(lines[:idx])
-    return (text_before.count('\"\"\"') % 2 == 1) or (text_before.count(\"'''\") % 2 == 1)
+    # Python triple-quoted strings
+    if (text_before.count('\"\"\"') % 2 == 1) or (text_before.count(\"'''\") % 2 == 1):
+        return True
+    # Go/JS/TS backtick raw/template strings (backtick cannot be escaped inside)
+    if text_before.count('\`') % 2 == 1:
+        return True
+    return False
 
 lines = sys.stdin.read().splitlines()
 for i, line in enumerate(lines):

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -40,7 +40,7 @@ vg_filter_suppressed() {
   python3 -c "
 import sys, re
 rule = sys.argv[1]
-suppress_pat = re.compile(r'vibeguard-disable-next-line\s+' + re.escape(rule))
+suppress_pat = re.compile(r'(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
 lines = sys.stdin.read().splitlines()
 for i, line in enumerate(lines):
     prev = lines[i - 1] if i > 0 else ''

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -7,6 +7,10 @@
 #   - 通用: 新增硬编码路径 (.db/.sqlite)
 #
 # 输出警告上下文，不阻止操作（事后提醒）
+#
+# 抑制单行警告：在被检测行的上一行添加：
+#   // vibeguard-disable-next-line RS-03 -- reason   (Rust/TS/JS/Go)
+#   # vibeguard-disable-next-line RS-03 -- reason    (Python/Shell)
 
 set -euo pipefail
 
@@ -25,6 +29,27 @@ fi
 
 WARNINGS=""
 
+# ---------------------------------------------------------------------------
+# vg_filter_suppressed RULE_ID
+# Reads NEW_STRING from stdin; outputs lines NOT suppressed by the rule.
+# Suppression: a line is suppressed when the immediately preceding line
+# contains "vibeguard-disable-next-line RULE_ID" (any comment prefix).
+# ---------------------------------------------------------------------------
+vg_filter_suppressed() {
+  local rule="$1"
+  python3 -c "
+import sys, re
+rule = sys.argv[1]
+suppress_pat = re.compile(r'vibeguard-disable-next-line\s+' + re.escape(rule))
+lines = sys.stdin.read().splitlines()
+for i, line in enumerate(lines):
+    prev = lines[i - 1] if i > 0 else ''
+    if suppress_pat.search(prev):
+        continue
+    print(line)
+" "$rule"
+}
+
 # --- Rust 检查 ---
 if [[ "$FILE_PATH" == *.rs ]]; then
   # 排除测试文件
@@ -32,17 +57,18 @@ if [[ "$FILE_PATH" == *.rs ]]; then
     */tests/*|*_test.rs|*/test_*) ;;
     *)
       # [RS-03] 检测新增的 unwrap()/expect()
-      if echo "$NEW_STRING" | grep -qE '\.(unwrap|expect)\(' 2>/dev/null; then
+      _RS03_FILTERED=$(echo "$NEW_STRING" | vg_filter_suppressed "RS-03")
+      if echo "$_RS03_FILTERED" | grep -qE '\.(unwrap|expect)\(' 2>/dev/null; then
         # 排除安全变体
-        UNSAFE_COUNT=$(echo "$NEW_STRING" | grep -cE '\.(unwrap|expect)\(' 2>/dev/null || true)
-        SAFE_COUNT=$(echo "$NEW_STRING" | grep -cE '\.(unwrap_or|unwrap_or_else|unwrap_or_default)\(' 2>/dev/null || true)
+        UNSAFE_COUNT=$(echo "$_RS03_FILTERED" | grep -cE '\.(unwrap|expect)\(' 2>/dev/null || true)
+        SAFE_COUNT=$(echo "$_RS03_FILTERED" | grep -cE '\.(unwrap_or|unwrap_or_else|unwrap_or_default)\(' 2>/dev/null || true)
         REAL_COUNT=$((UNSAFE_COUNT - SAFE_COUNT))
         if [[ $REAL_COUNT -gt 0 ]]; then
           WARNINGS="${WARNINGS}[RS-03] 新增了 ${REAL_COUNT} 个 unwrap()/expect()。修复：将 .unwrap() 替换为 .map_err(|e| YourError::from(e))? 或 .unwrap_or_default()；在 main() 入口可用 anyhow::Result<()>。立即修复，不要留到后面。参考 vibeguard/rules/rust.md RS-03。"
         fi
       fi
       # [RS-10] 检测静默丢弃 Result（let _ = expr）
-      SILENT_COUNT=$(echo "$NEW_STRING" | grep -cE '^\s*let\s+_\s*=' 2>/dev/null; true)
+      SILENT_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "RS-10" | grep -cE '^\s*let\s+_\s*=' 2>/dev/null; true)
       if [[ $SILENT_COUNT -gt 0 ]]; then
         WARNINGS="${WARNINGS:+${WARNINGS} }[RS-10] 新增了 ${SILENT_COUNT} 个 let _ = 静默丢弃。修复：用 if let Err(e) = expr { log::warn(...) } 记录错误，或用 .map_err() 传播。参考 vibeguard/rules/rust.md RS-10。"
       fi
@@ -75,7 +101,7 @@ case "$FILE_PATH" in
         elif [[ -f "$FILE_PATH" ]] && grep -qE '(StdioServerTransport|new Server\(|McpServer)' "$FILE_PATH" 2>/dev/null; then
           : # MCP 入口文件，跳过 console 检测
         else
-          CONSOLE_COUNT=$(echo "$NEW_STRING" | grep -cE '\bconsole\.(log|warn|error)\(' 2>/dev/null; true)
+          CONSOLE_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "DEBUG" | grep -cE '\bconsole\.(log|warn|error)\(' 2>/dev/null; true)
           if [[ $CONSOLE_COUNT -gt 0 ]]; then
             # 检查文件中已有的 console 残留总数
             FILE_CONSOLE_TOTAL=0
@@ -103,7 +129,7 @@ case "$FILE_PATH" in
     case "$FILE_PATH" in
       */tests/*|*test_*|*_test.py) ;;
       *)
-        PRINT_COUNT=$(echo "$NEW_STRING" | grep -cE '^\s*print\(' 2>/dev/null; true)
+        PRINT_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "DEBUG" | grep -cE '^\s*print\(' 2>/dev/null; true)
         if [[ $PRINT_COUNT -gt 0 ]]; then
           WARNINGS="${WARNINGS:+${WARNINGS} }[DEBUG] 新增了 ${PRINT_COUNT} 个 print() 语句。修复：使用 logging 模块替代 print；如果是临时调试，完成后删除。"
         fi
@@ -113,7 +139,7 @@ case "$FILE_PATH" in
 esac
 
 # --- 通用检查：硬编码数据库路径 ---
-if echo "$NEW_STRING" | grep -qE '"[^"]*\.(db|sqlite)"' 2>/dev/null; then
+if echo "$NEW_STRING" | vg_filter_suppressed "U-11" | grep -qE '"[^"]*\.(db|sqlite)"' 2>/dev/null; then
   case "$FILE_PATH" in
     */tests/*|*_test.*|*.test.*|*.spec.*) ;;
     *)
@@ -129,13 +155,13 @@ case "$FILE_PATH" in
       *_test.go|*/vendor/*) ;;
       *)
         # [GO-01] 检测 error 丢弃（排除 for range 和 map 查找）
-        ERR_DISCARD=$(echo "$NEW_STRING" | grep -E '^\s*_\s*(,\s*_)?\s*[:=]+' 2>/dev/null \
+        ERR_DISCARD=$(echo "$NEW_STRING" | vg_filter_suppressed "GO-01" | grep -E '^\s*_\s*(,\s*_)?\s*[:=]+' 2>/dev/null \
           | grep -cvE '(for\s+.*range|,\s*(ok|found|exists)\s*:?=)' 2>/dev/null; true)
         if [[ $ERR_DISCARD -gt 0 ]]; then
           WARNINGS="${WARNINGS:+${WARNINGS} }[GO-01] 新增了 ${ERR_DISCARD} 处 error 丢弃（_ = ...）。修复：用 if err != nil 处理错误。"
         fi
         # [GO-08] 检测 defer 在循环内
-        DEFER_LOOP=$(echo "$NEW_STRING" | awk '/^\s*for\s/ {in_loop=1} /^\s*defer\s/ && in_loop {count++} /^\s*\}/ {in_loop=0} END {print count+0}' 2>/dev/null; true)
+        DEFER_LOOP=$(echo "$NEW_STRING" | vg_filter_suppressed "GO-08" | awk '/^\s*for\s/ {in_loop=1} /^\s*defer\s/ && in_loop {count++} /^\s*\}/ {in_loop=0} END {print count+0}' 2>/dev/null; true)
         DEFER_LOOP="${DEFER_LOOP:-0}"
         if [[ $DEFER_LOOP -gt 0 ]]; then
           WARNINGS="${WARNINGS:+${WARNINGS} }[GO-08] 检测到 defer 在循环内，可能导致资源泄漏。修复：将 defer 所在逻辑提取为独立函数。"
@@ -149,25 +175,25 @@ esac
 STUB_WARNINGS=""
 case "$FILE_PATH" in
   *.rs)
-    STUB_COUNT=$(echo "$NEW_STRING" | grep -cE '^\s*(todo!\(|unimplemented!\(|panic!\("not implemented)' 2>/dev/null; true)
+    STUB_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "STUB" | grep -cE '^\s*(todo!\(|unimplemented!\(|panic!\("not implemented)' 2>/dev/null; true)
     if [[ "${STUB_COUNT:-0}" -gt 0 ]]; then
       STUB_WARNINGS="[STUB] 新增了 ${STUB_COUNT} 个 stub 占位符（todo!/unimplemented!）。必须在当前任务内替换为真实实现，或标记 DEFER 并说明原因。"
     fi
     ;;
   *.ts|*.tsx|*.js|*.jsx)
-    STUB_COUNT=$(echo "$NEW_STRING" | grep -cE '^\s*(throw new Error\(.*(not implemented|TODO|FIXME)|// TODO|// FIXME|return null.*// stub)' 2>/dev/null; true)
+    STUB_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "STUB" | grep -cE '^\s*(throw new Error\(.*(not implemented|TODO|FIXME)|// TODO|// FIXME|return null.*// stub)' 2>/dev/null; true)
     if [[ "${STUB_COUNT:-0}" -gt 0 ]]; then
       STUB_WARNINGS="[STUB] 新增了 ${STUB_COUNT} 个 stub 占位符（throw not implemented / TODO）。必须替换为真实实现或标记 DEFER。"
     fi
     ;;
   *.py)
-    STUB_COUNT=$(echo "$NEW_STRING" | grep -cE '^\s*(pass\s*$|pass\s*#|raise NotImplementedError|# TODO|# FIXME)' 2>/dev/null; true)
+    STUB_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "STUB" | grep -cE '^\s*(pass\s*$|pass\s*#|raise NotImplementedError|# TODO|# FIXME)' 2>/dev/null; true)
     if [[ "${STUB_COUNT:-0}" -gt 0 ]]; then
       STUB_WARNINGS="[STUB] 新增了 ${STUB_COUNT} 个 stub 占位符（pass/NotImplementedError/TODO）。必须替换为真实实现或标记 DEFER。"
     fi
     ;;
   *.go)
-    STUB_COUNT=$(echo "$NEW_STRING" | grep -cE '^\s*(panic\("not implemented|// TODO|// FIXME)' 2>/dev/null; true)
+    STUB_COUNT=$(echo "$NEW_STRING" | vg_filter_suppressed "STUB" | grep -cE '^\s*(panic\("not implemented|// TODO|// FIXME)' 2>/dev/null; true)
     if [[ "${STUB_COUNT:-0}" -gt 0 ]]; then
       STUB_WARNINGS="[STUB] 新增了 ${STUB_COUNT} 个 stub 占位符（panic not implemented / TODO）。必须替换为真实实现或标记 DEFER。"
     fi

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -40,7 +40,7 @@ vg_filter_suppressed() {
   python3 -c "
 import sys, re
 rule = sys.argv[1]
-suppress_pat = re.compile(r'(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
+suppress_pat = re.compile(r'^\s*(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
 lines = sys.stdin.read().splitlines()
 for i, line in enumerate(lines):
     prev = lines[i - 1] if i > 0 else ''

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -41,10 +41,16 @@ vg_filter_suppressed() {
 import sys, re
 rule = sys.argv[1]
 suppress_pat = re.compile(r'^\s*(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
+
+def _in_multiline_string(lines, idx):
+    # Count triple-quote delimiters before this line; odd count means we are inside one.
+    text_before = '\n'.join(lines[:idx])
+    return (text_before.count('\"\"\"') % 2 == 1) or (text_before.count(\"'''\") % 2 == 1)
+
 lines = sys.stdin.read().splitlines()
 for i, line in enumerate(lines):
     prev = lines[i - 1] if i > 0 else ''
-    if suppress_pat.search(prev):
+    if suppress_pat.search(prev) and not _in_multiline_string(lines, i - 1):
         continue
     print(line)
 " "$rule"

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -70,13 +70,31 @@ FILE_COUNT=$(echo "$STAGED_FILES" | wc -l | tr -d ' ')
 
 # --- 导出 staged 文件列表供守卫脚本使用（只扫 staged 文件，不扫全量） ---
 _STAGED_TMPFILE=$(mktemp)
-_cleanup_staged() { rm -f "$_STAGED_TMPFILE" 2>/dev/null; }
+_DIFF_ADDED_TMPFILE=$(mktemp)
+_cleanup_staged() {
+  rm -f "$_STAGED_TMPFILE" "$_DIFF_ADDED_TMPFILE" 2>/dev/null
+}
 trap '_cleanup_staged' EXIT
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 while IFS= read -r f; do
   [[ -n "$f" ]] && echo "${REPO_ROOT}/${f}"
 done <<< "$STAGED_FILES" > "$_STAGED_TMPFILE"
 export VIBEGUARD_STAGED_FILES="$_STAGED_TMPFILE"
+
+# --- 导出 diff 新增行内容（Baseline Scanning）---
+# VIBEGUARD_DIFF_ONLY=1  — 告知守卫当前处于 pre-commit 差量扫描模式
+# VIBEGUARD_DIFF_ADDED_LINES — 指向包含所有 staged 新增行（+ 前缀已去除）的临时文件
+# 守卫脚本可选择读取此文件而非扫描整个文件，从而只检查本次新增的代码行。
+export VIBEGUARD_DIFF_ONLY=1
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  git diff --cached -U0 -- "${REPO_ROOT}/${f}" 2>/dev/null \
+    | grep '^+' \
+    | grep -v '^+++' \
+    | sed 's/^+//' \
+    >> "$_DIFF_ADDED_TMPFILE" || true
+done <<< "$STAGED_FILES"
+export VIBEGUARD_DIFF_ADDED_LINES="$_DIFF_ADDED_TMPFILE"
 
 # --- 语言自动检测（Verifier 模式核心） ---
 # 使用 REPO_ROOT 绝对路径，避免子目录 commit 时检测失败

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "scripts/setup/",
     "scripts/codex/",
     "scripts/lib/",
+    "data/rule-scorecard.json",
+    "scripts/precision-tracker.py",
     "scripts/compliance_check.sh",
     "scripts/doc-freshness-check.sh",
     "scripts/gc-logs.sh",
@@ -66,7 +68,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "bash tests/test_hooks.sh && bash tests/test_rust_guards.sh && bash tests/test_setup.sh",
+    "test": "bash tests/test_hooks.sh && bash tests/test_rust_guards.sh && bash tests/test_setup.sh && bash tests/test_precision_tracker.sh",
     "prepublishOnly": "npm test"
   },
   "engines": {

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -389,13 +389,28 @@ def update_scorecard(
 # Report rendering
 # ---------------------------------------------------------------------------
 
-STAGE_SYMBOL = {
+def _stdout_supports_unicode() -> bool:
+    enc = getattr(sys.stdout, "encoding", None) or ""
+    return enc.lower().replace("-", "") in {"utf8", "utf16", "utf32"}
+
+
+_STAGE_SYMBOL_UNICODE: dict[str, str] = {
     "experimental": "🧪",
     "warn": "⚠️ ",
     "error": "🔴",
     "demoted": "⬇️ ",
     "disabled": "⏸️ ",
 }
+
+_STAGE_SYMBOL_ASCII: dict[str, str] = {
+    "experimental": "[EXP]",
+    "warn": "[WRN]",
+    "error": "[ERR]",
+    "demoted": "[DEM]",
+    "disabled": "[DIS]",
+}
+
+STAGE_SYMBOL = _STAGE_SYMBOL_UNICODE if _stdout_supports_unicode() else _STAGE_SYMBOL_ASCII
 
 
 def render_report(scorecard: dict[str, Any], rule_filter: str | None = None) -> str:

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -28,9 +28,11 @@ import argparse
 import json
 import os
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Generator
 
 # ---------------------------------------------------------------------------
 # Paths (relative to repo root, resolved from script location)
@@ -53,6 +55,8 @@ WARN_TO_ERROR_NO_FP_DAYS = 30
 DEMOTION_PRECISION = 0.80
 DEMOTION_MIN_SAMPLES = 20
 
+VALID_VERDICTS = {"tp", "fp", "acceptable"}
+
 # Severity × Confidence → stage mapping
 # Used only as documentation; actual graduation is data-driven.
 SEVERITY_CONFIDENCE_MATRIX = {
@@ -69,11 +73,72 @@ SEVERITY_CONFIDENCE_MATRIX = {
 
 
 # ---------------------------------------------------------------------------
+# File locking (Unix: fcntl; Windows: no-op — atomic os.replace still guards
+# against truncated files, but concurrent lost-update is not prevented)
+# ---------------------------------------------------------------------------
+
+try:
+    import fcntl as _fcntl
+
+    @contextmanager
+    def _scorecard_write_lock(scorecard_path: Path) -> Generator[None, None, None]:
+        lock_path = scorecard_path.with_suffix(".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a") as lock_fh:
+            _fcntl.flock(lock_fh, _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                _fcntl.flock(lock_fh, _fcntl.LOCK_UN)
+
+except ImportError:
+    @contextmanager
+    def _scorecard_write_lock(scorecard_path: Path) -> Generator[None, None, None]:  # type: ignore[misc]
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Triage record validation
+# ---------------------------------------------------------------------------
+
+def _validate_triage_record(rec: Any, lineno: int) -> bool:
+    """Return True if rec is a valid triage record; print [ERROR] and return False otherwise."""
+    if not isinstance(rec, dict):
+        print(
+            f"[ERROR] triage.jsonl line {lineno}: expected object, got {type(rec).__name__}",
+            file=sys.stderr,
+        )
+        return False
+    rule = rec.get("rule")
+    if not isinstance(rule, str) or not rule:
+        print(
+            f"[ERROR] triage.jsonl line {lineno}: 'rule' must be a non-empty string, got {rule!r}",
+            file=sys.stderr,
+        )
+        return False
+    verdict = rec.get("verdict")
+    if verdict not in VALID_VERDICTS:
+        print(
+            f"[ERROR] triage.jsonl line {lineno}: 'verdict' must be one of {sorted(VALID_VERDICTS)}, got {verdict!r}",
+            file=sys.stderr,
+        )
+        return False
+    ts = rec.get("ts")
+    if ts is not None and not isinstance(ts, str):
+        print(
+            f"[ERROR] triage.jsonl line {lineno}: 'ts' must be a string if present, got {type(ts).__name__}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Triage loading
 # ---------------------------------------------------------------------------
 
 def load_triage(path: Path) -> list[dict[str, Any]]:
-    """Load triage.jsonl; skip comment lines and blank lines."""
+    """Load triage.jsonl; skip comment/blank lines and reject malformed records."""
     records: list[dict[str, Any]] = []
     if not path.exists():
         return records
@@ -87,7 +152,8 @@ def load_triage(path: Path) -> list[dict[str, Any]]:
             except json.JSONDecodeError as exc:
                 print(f"[WARN] triage.jsonl line {lineno}: {exc}", file=sys.stderr)
                 continue
-            records.append(rec)
+            if _validate_triage_record(rec, lineno):
+                records.append(rec)
     return records
 
 
@@ -103,10 +169,23 @@ def load_scorecard(path: Path) -> dict[str, Any]:
 
 
 def save_scorecard(scorecard: dict[str, Any], path: Path) -> None:
+    """Write scorecard atomically: temp file in same dir + os.replace()."""
     scorecard["_updated_ts"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump(scorecard, fh, indent=2, ensure_ascii=False)
-        fh.write("\n")
+    content = json.dumps(scorecard, indent=2, ensure_ascii=False) + "\n"
+    dir_path = path.parent
+    dir_path.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path_str = tempfile.mkstemp(dir=dir_path, prefix=".scorecard-", suffix=".tmp")
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +285,11 @@ def update_scorecard(
 ) -> tuple[dict[str, Any], list[str]]:
     """
     Recompute stats from triage records, apply lifecycle transitions.
+
+    Rules present in scorecard but absent from triage have their counters
+    reset to zero so that the scorecard stays consistent with triage truth
+    (e.g. after a triage window rotation or manual cleanup).
+
     Returns (updated_scorecard, list of transition messages).
     """
     stats = compute_rule_stats(triage_records)
@@ -235,6 +319,18 @@ def update_scorecard(
         entry["last_fp_ts"] = s["last_fp_ts"]
         prec = precision_of(s["tp"], s["fp"])
         entry["precision"] = round(prec, 4) if prec is not None else None
+
+    # Reset stats for rules no longer present in triage (window rotation /
+    # manual cleanup).  Stage and notes are preserved so the history is
+    # visible, but counters reflect the current triage truth.
+    for rule, entry in rules.items():
+        if rule not in stats:
+            entry["tp"] = 0
+            entry["fp"] = 0
+            entry["acceptable"] = 0
+            entry["samples"] = 0
+            entry["last_fp_ts"] = None
+            entry["precision"] = None
 
     # Apply lifecycle transitions for all rules
     for rule, entry in rules.items():
@@ -328,7 +424,7 @@ def record_verdict(
     context: str | None,
     triage_path: Path,
 ) -> None:
-    if verdict not in ("tp", "fp", "acceptable"):
+    if verdict not in VALID_VERDICTS:
         print(f"[ERROR] verdict must be tp, fp, or acceptable; got: {verdict}", file=sys.stderr)
         sys.exit(1)
 
@@ -394,12 +490,12 @@ def main(argv: list[str] | None = None) -> int:
     # --record verdict rule
     if args.record:
         verdict, rule = args.record
-        record_verdict(rule, verdict, args.context, triage_path)
-        # Auto-update scorecard after recording
-        triage = load_triage(triage_path)
-        scorecard = load_scorecard(scorecard_path)
-        scorecard, transitions = update_scorecard(scorecard, triage)
-        save_scorecard(scorecard, scorecard_path)
+        with _scorecard_write_lock(scorecard_path):
+            record_verdict(rule, verdict, args.context, triage_path)
+            triage = load_triage(triage_path)
+            scorecard = load_scorecard(scorecard_path)
+            scorecard, transitions = update_scorecard(scorecard, triage)
+            save_scorecard(scorecard, scorecard_path)
         if transitions:
             print("Lifecycle transitions:")
             for t in transitions:
@@ -408,10 +504,11 @@ def main(argv: list[str] | None = None) -> int:
 
     # --update-scorecard
     if args.update_scorecard:
-        triage = load_triage(triage_path)
-        scorecard = load_scorecard(scorecard_path)
-        scorecard, transitions = update_scorecard(scorecard, triage)
-        save_scorecard(scorecard, scorecard_path)
+        with _scorecard_write_lock(scorecard_path):
+            triage = load_triage(triage_path)
+            scorecard = load_scorecard(scorecard_path)
+            scorecard, transitions = update_scorecard(scorecard, triage)
+            save_scorecard(scorecard, scorecard_path)
         if transitions:
             print("Lifecycle transitions:")
             for t in transitions:

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -133,7 +133,13 @@ def _validate_triage_record(rec: Any, lineno: int) -> bool:
     # Validate ts is parseable ISO-8601 when present
     if isinstance(ts, str) and ts:
         try:
-            datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                print(
+                    f"[ERROR] triage.jsonl line {lineno}: 'ts' must include timezone offset (e.g. 2026-03-01T10:00:00Z): {ts!r}",
+                    file=sys.stderr,
+                )
+                return False
         except ValueError:
             print(
                 f"[ERROR] triage.jsonl line {lineno}: 'ts' is not a valid ISO-8601 timestamp: {ts!r}",
@@ -230,11 +236,15 @@ def compute_rule_stats(
             if ts:
                 try:
                     ts_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    if ts_dt.tzinfo is None:
+                        ts_dt = ts_dt.replace(tzinfo=timezone.utc)
                     last_fp_ts = stats[rule]["last_fp_ts"]
                     if last_fp_ts is None:
                         stats[rule]["last_fp_ts"] = ts
                     else:
                         last_dt = datetime.fromisoformat(last_fp_ts.replace("Z", "+00:00"))
+                        if last_dt.tzinfo is None:
+                            last_dt = last_dt.replace(tzinfo=timezone.utc)
                         if ts_dt > last_dt:
                             stats[rule]["last_fp_ts"] = ts
                 except ValueError:
@@ -261,6 +271,8 @@ def days_since(ts_str: str | None) -> float | None:
         return None
     try:
         dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
         return (datetime.now(timezone.utc) - dt).total_seconds() / 86400
     except ValueError:
         return None

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -251,9 +251,11 @@ def next_stage(rule_entry: dict[str, Any]) -> str | None:
     samples = tp + fp + acceptable
     prec = precision_of(tp, fp)
 
-    # Demotion takes priority: if we have enough data and precision is poor
+    # Demotion applies only to rules that have graduated past experimental.
+    # experimental rules must go through the normal promotion path first
+    # (experimental → warn) before they can be demoted.
     if samples >= DEMOTION_MIN_SAMPLES and prec is not None and prec < DEMOTION_PRECISION:
-        if stage not in ("demoted", "disabled"):
+        if stage not in ("demoted", "disabled", "experimental"):
             return "demoted"
 
     if stage == "experimental":

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -130,6 +130,23 @@ def _validate_triage_record(rec: Any, lineno: int) -> bool:
             file=sys.stderr,
         )
         return False
+    # Validate ts is parseable ISO-8601 when present
+    if isinstance(ts, str) and ts:
+        try:
+            datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            print(
+                f"[ERROR] triage.jsonl line {lineno}: 'ts' is not a valid ISO-8601 timestamp: {ts!r}",
+                file=sys.stderr,
+            )
+            return False
+    # fp records must have a parseable ts so last_fp_ts is always tracked
+    if verdict == "fp" and not (isinstance(ts, str) and ts):
+        print(
+            f"[ERROR] triage.jsonl line {lineno}: 'ts' is required for fp records",
+            file=sys.stderr,
+        )
+        return False
     return True
 
 
@@ -210,8 +227,18 @@ def compute_rule_stats(
             stats[rule]["tp"] += 1
         elif verdict == "fp":
             stats[rule]["fp"] += 1
-            if ts and (stats[rule]["last_fp_ts"] is None or ts > stats[rule]["last_fp_ts"]):
-                stats[rule]["last_fp_ts"] = ts
+            if ts:
+                try:
+                    ts_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    last_fp_ts = stats[rule]["last_fp_ts"]
+                    if last_fp_ts is None:
+                        stats[rule]["last_fp_ts"] = ts
+                    else:
+                        last_dt = datetime.fromisoformat(last_fp_ts.replace("Z", "+00:00"))
+                        if ts_dt > last_dt:
+                            stats[rule]["last_fp_ts"] = ts
+                except ValueError:
+                    pass  # ts already validated; should not reach here
         elif verdict == "acceptable":
             stats[rule]["acceptable"] += 1
 

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""
+VibeGuard Precision Tracker
+============================
+Reads data/triage.jsonl and data/rule-scorecard.json to:
+  - Compute per-rule precision stats
+  - Apply lifecycle transitions (experimental → warn → error, or → demoted)
+  - Generate monthly/on-demand reports
+
+Usage:
+  python3 scripts/precision-tracker.py                  # print report
+  python3 scripts/precision-tracker.py --update-scorecard  # recalculate + save scorecard
+  python3 scripts/precision-tracker.py --rule RS-03     # report for one rule
+  python3 scripts/precision-tracker.py --record tp RS-03 [--context "note"]
+  python3 scripts/precision-tracker.py --record fp RS-03 [--context "note"]
+  python3 scripts/precision-tracker.py --record acceptable RS-03 [--context "note"]
+
+Lifecycle thresholds (borrowing from Semgrep Pro / Clippy categories):
+  EXPERIMENTAL → WARN   : precision ≥ 70%  AND samples ≥ 20
+  WARN         → ERROR  : precision ≥ 90%  AND samples ≥ 50  AND 30 days no FP
+  WARN/ERROR   → DEMOTED: precision < 80%  (after ≥ 20 samples)
+  DEMOTED      → DISABLED: manual only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Paths (relative to repo root, resolved from script location)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_DIR = SCRIPT_DIR.parent
+TRIAGE_FILE = REPO_DIR / "data" / "triage.jsonl"
+SCORECARD_FILE = REPO_DIR / "data" / "rule-scorecard.json"
+
+# ---------------------------------------------------------------------------
+# Lifecycle thresholds
+# ---------------------------------------------------------------------------
+EXPERIMENTAL_TO_WARN_PRECISION = 0.70
+EXPERIMENTAL_TO_WARN_SAMPLES = 20
+
+WARN_TO_ERROR_PRECISION = 0.90
+WARN_TO_ERROR_SAMPLES = 50
+WARN_TO_ERROR_NO_FP_DAYS = 30
+
+DEMOTION_PRECISION = 0.80
+DEMOTION_MIN_SAMPLES = 20
+
+# Severity × Confidence → stage mapping
+# Used only as documentation; actual graduation is data-driven.
+SEVERITY_CONFIDENCE_MATRIX = {
+    ("high", "high"): "error",
+    ("high", "medium"): "warn",
+    ("high", "low"): "warn",
+    ("medium", "high"): "warn",
+    ("medium", "medium"): "warn",
+    ("medium", "low"): "off",
+    ("low", "high"): "warn",
+    ("low", "medium"): "off",
+    ("low", "low"): "off",
+}
+
+
+# ---------------------------------------------------------------------------
+# Triage loading
+# ---------------------------------------------------------------------------
+
+def load_triage(path: Path) -> list[dict[str, Any]]:
+    """Load triage.jsonl; skip comment lines and blank lines."""
+    records: list[dict[str, Any]] = []
+    if not path.exists():
+        return records
+    with path.open(encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                print(f"[WARN] triage.jsonl line {lineno}: {exc}", file=sys.stderr)
+                continue
+            records.append(rec)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Scorecard loading / saving
+# ---------------------------------------------------------------------------
+
+def load_scorecard(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"rules": {}}
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_scorecard(scorecard: dict[str, Any], path: Path) -> None:
+    scorecard["_updated_ts"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(scorecard, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Stats computation
+# ---------------------------------------------------------------------------
+
+def compute_rule_stats(
+    triage_records: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Aggregate triage records into per-rule stats."""
+    stats: dict[str, dict[str, Any]] = {}
+
+    for rec in triage_records:
+        rule = rec.get("rule", "UNKNOWN")
+        verdict = rec.get("verdict", "")
+        ts = rec.get("ts", "")
+
+        if rule not in stats:
+            stats[rule] = {"tp": 0, "fp": 0, "acceptable": 0, "last_fp_ts": None}
+
+        if verdict == "tp":
+            stats[rule]["tp"] += 1
+        elif verdict == "fp":
+            stats[rule]["fp"] += 1
+            if ts and (stats[rule]["last_fp_ts"] is None or ts > stats[rule]["last_fp_ts"]):
+                stats[rule]["last_fp_ts"] = ts
+        elif verdict == "acceptable":
+            stats[rule]["acceptable"] += 1
+
+    return stats
+
+
+def precision_of(tp: int, fp: int) -> float | None:
+    """TP / (TP + FP).  Returns None when no positive predictions exist."""
+    denom = tp + fp
+    return tp / denom if denom > 0 else None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle transition
+# ---------------------------------------------------------------------------
+
+def days_since(ts_str: str | None) -> float | None:
+    """Return days elapsed since ISO-8601 timestamp, or None if ts is None."""
+    if not ts_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - dt).total_seconds() / 86400
+    except ValueError:
+        return None
+
+
+def next_stage(rule_entry: dict[str, Any]) -> str | None:
+    """
+    Compute target stage based on current stats.
+    Returns new stage string if a transition should occur, else None.
+    """
+    stage = rule_entry.get("stage", "experimental")
+    tp = rule_entry.get("tp", 0)
+    fp = rule_entry.get("fp", 0)
+    acceptable = rule_entry.get("acceptable", 0)
+    samples = tp + fp + acceptable
+    prec = precision_of(tp, fp)
+
+    # Demotion takes priority: if we have enough data and precision is poor
+    if samples >= DEMOTION_MIN_SAMPLES and prec is not None and prec < DEMOTION_PRECISION:
+        if stage not in ("demoted", "disabled"):
+            return "demoted"
+
+    if stage == "experimental":
+        if (
+            prec is not None
+            and prec >= EXPERIMENTAL_TO_WARN_PRECISION
+            and samples >= EXPERIMENTAL_TO_WARN_SAMPLES
+        ):
+            return "warn"
+
+    elif stage == "warn":
+        if prec is not None and prec >= WARN_TO_ERROR_PRECISION and samples >= WARN_TO_ERROR_SAMPLES:
+            last_fp_ts = rule_entry.get("last_fp_ts")
+            days = days_since(last_fp_ts)
+            # No FP ever, or last FP was > 30 days ago
+            if last_fp_ts is None or (days is not None and days >= WARN_TO_ERROR_NO_FP_DAYS):
+                return "error"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scorecard update
+# ---------------------------------------------------------------------------
+
+def update_scorecard(
+    scorecard: dict[str, Any],
+    triage_records: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[str]]:
+    """
+    Recompute stats from triage records, apply lifecycle transitions.
+    Returns (updated_scorecard, list of transition messages).
+    """
+    stats = compute_rule_stats(triage_records)
+    transitions: list[str] = []
+
+    rules = scorecard.setdefault("rules", {})
+
+    # Update stats for rules present in triage
+    for rule, s in stats.items():
+        if rule not in rules:
+            rules[rule] = {
+                "stage": "experimental",
+                "precision": None,
+                "samples": 0,
+                "tp": 0,
+                "fp": 0,
+                "acceptable": 0,
+                "last_fp_ts": None,
+                "stage_entered_ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "notes": "",
+            }
+        entry = rules[rule]
+        entry["tp"] = s["tp"]
+        entry["fp"] = s["fp"]
+        entry["acceptable"] = s["acceptable"]
+        entry["samples"] = s["tp"] + s["fp"] + s["acceptable"]
+        entry["last_fp_ts"] = s["last_fp_ts"]
+        prec = precision_of(s["tp"], s["fp"])
+        entry["precision"] = round(prec, 4) if prec is not None else None
+
+    # Apply lifecycle transitions for all rules
+    for rule, entry in rules.items():
+        new_stage = next_stage(entry)
+        if new_stage is not None:
+            old_stage = entry["stage"]
+            entry["stage"] = new_stage
+            entry["stage_entered_ts"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            transitions.append(f"{rule}: {old_stage} → {new_stage}")
+
+    return scorecard, transitions
+
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+
+STAGE_SYMBOL = {
+    "experimental": "🧪",
+    "warn": "⚠️ ",
+    "error": "🔴",
+    "demoted": "⬇️ ",
+    "disabled": "⏸️ ",
+}
+
+
+def render_report(scorecard: dict[str, Any], rule_filter: str | None = None) -> str:
+    lines: list[str] = []
+    lines.append("VibeGuard Rule Precision Scorecard")
+    lines.append("=" * 60)
+    updated = scorecard.get("_updated_ts", "unknown")
+    lines.append(f"Updated: {updated}")
+    lines.append("")
+
+    rules = scorecard.get("rules", {})
+    if rule_filter:
+        rules = {k: v for k, v in rules.items() if k == rule_filter}
+
+    if not rules:
+        lines.append("(no rules)")
+        return "\n".join(lines)
+
+    # Header
+    lines.append(
+        f"{'Rule':<14} {'Stage':<14} {'Prec':>6} {'TP':>4} {'FP':>4} {'Acc':>4} {'Samples':>7}  Notes"
+    )
+    lines.append("-" * 80)
+
+    for rule in sorted(rules.keys()):
+        entry = rules[rule]
+        stage = entry.get("stage", "?")
+        prec = entry.get("precision")
+        tp = entry.get("tp", 0)
+        fp = entry.get("fp", 0)
+        acceptable = entry.get("acceptable", 0)
+        samples = entry.get("samples", 0)
+        notes = entry.get("notes", "")[:40]
+        symbol = STAGE_SYMBOL.get(stage, "  ")
+        prec_str = f"{prec * 100:.1f}%" if prec is not None else "  N/A"
+        lines.append(
+            f"{rule:<14} {symbol}{stage:<12} {prec_str:>6} {tp:>4} {fp:>4} {acceptable:>4} {samples:>7}  {notes}"
+        )
+
+    lines.append("")
+    lines.append("Lifecycle thresholds:")
+    lines.append(
+        f"  experimental → warn : precision ≥ {EXPERIMENTAL_TO_WARN_PRECISION*100:.0f}%  AND samples ≥ {EXPERIMENTAL_TO_WARN_SAMPLES}"
+    )
+    lines.append(
+        f"  warn         → error: precision ≥ {WARN_TO_ERROR_PRECISION*100:.0f}%  AND samples ≥ {WARN_TO_ERROR_SAMPLES}  AND {WARN_TO_ERROR_NO_FP_DAYS}d no FP"
+    )
+    lines.append(
+        f"  any          → demoted: precision < {DEMOTION_PRECISION*100:.0f}%  after ≥ {DEMOTION_MIN_SAMPLES} samples"
+    )
+    lines.append("")
+    lines.append("Record feedback:")
+    lines.append(
+        "  python3 scripts/precision-tracker.py --record tp|fp|acceptable RULE-ID [--context NOTE]"
+    )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Record a verdict
+# ---------------------------------------------------------------------------
+
+def record_verdict(
+    rule: str,
+    verdict: str,
+    context: str | None,
+    triage_path: Path,
+) -> None:
+    if verdict not in ("tp", "fp", "acceptable"):
+        print(f"[ERROR] verdict must be tp, fp, or acceptable; got: {verdict}", file=sys.stderr)
+        sys.exit(1)
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    session = os.environ.get("VIBEGUARD_SESSION_ID", "")
+    rec: dict[str, Any] = {"ts": ts, "rule": rule, "verdict": verdict}
+    if context:
+        rec["context"] = context
+    if session:
+        rec["session"] = session
+
+    with triage_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+    print(f"Recorded {verdict} for {rule} at {ts}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="VibeGuard precision tracker — manage rule lifecycle from triage feedback",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument("--rule", metavar="RULE", help="filter report to a single rule")
+    p.add_argument(
+        "--update-scorecard",
+        action="store_true",
+        help="recompute stats from triage.jsonl and save rule-scorecard.json",
+    )
+    p.add_argument(
+        "--record",
+        nargs=2,
+        metavar=("VERDICT", "RULE"),
+        help="append a triage verdict (tp|fp|acceptable) for RULE",
+    )
+    p.add_argument("--context", metavar="NOTE", help="optional note for --record")
+    p.add_argument(
+        "--triage-file",
+        metavar="PATH",
+        default=str(TRIAGE_FILE),
+        help=f"path to triage.jsonl (default: {TRIAGE_FILE})",
+    )
+    p.add_argument(
+        "--scorecard-file",
+        metavar="PATH",
+        default=str(SCORECARD_FILE),
+        help=f"path to rule-scorecard.json (default: {SCORECARD_FILE})",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    triage_path = Path(args.triage_file)
+    scorecard_path = Path(args.scorecard_file)
+
+    # --record verdict rule
+    if args.record:
+        verdict, rule = args.record
+        record_verdict(rule, verdict, args.context, triage_path)
+        # Auto-update scorecard after recording
+        triage = load_triage(triage_path)
+        scorecard = load_scorecard(scorecard_path)
+        scorecard, transitions = update_scorecard(scorecard, triage)
+        save_scorecard(scorecard, scorecard_path)
+        if transitions:
+            print("Lifecycle transitions:")
+            for t in transitions:
+                print(f"  {t}")
+        return 0
+
+    # --update-scorecard
+    if args.update_scorecard:
+        triage = load_triage(triage_path)
+        scorecard = load_scorecard(scorecard_path)
+        scorecard, transitions = update_scorecard(scorecard, triage)
+        save_scorecard(scorecard, scorecard_path)
+        if transitions:
+            print("Lifecycle transitions:")
+            for t in transitions:
+                print(f"  {t}")
+        else:
+            print("No lifecycle transitions.")
+        print(f"Scorecard saved to {scorecard_path}")
+
+    # Always print report
+    scorecard = load_scorecard(scorecard_path)
+    print(render_report(scorecard, rule_filter=args.rule))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -173,10 +173,13 @@ def load_triage(path: Path) -> list[dict[str, Any]]:
             try:
                 rec = json.loads(line)
             except json.JSONDecodeError as exc:
-                print(f"[WARN] triage.jsonl line {lineno}: {exc}", file=sys.stderr)
-                continue
-            if _validate_triage_record(rec, lineno):
-                records.append(rec)
+                print(f"[ERROR] triage.jsonl line {lineno}: {exc}", file=sys.stderr)
+                print("[ERROR] Aborting: corrupted triage line could cause incorrect lifecycle transitions.", file=sys.stderr)
+                sys.exit(1)
+            if not _validate_triage_record(rec, lineno):
+                print("[ERROR] Aborting: invalid triage record could cause incorrect lifecycle transitions.", file=sys.stderr)
+                sys.exit(1)
+            records.append(rec)
     return records
 
 
@@ -471,34 +474,6 @@ def render_report(scorecard: dict[str, Any], rule_filter: str | None = None) -> 
 
 
 # ---------------------------------------------------------------------------
-# Record a verdict
-# ---------------------------------------------------------------------------
-
-def record_verdict(
-    rule: str,
-    verdict: str,
-    context: str | None,
-    triage_path: Path,
-) -> None:
-    if verdict not in VALID_VERDICTS:
-        print(f"[ERROR] verdict must be tp, fp, or acceptable; got: {verdict}", file=sys.stderr)
-        sys.exit(1)
-
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    session = os.environ.get("VIBEGUARD_SESSION_ID", "")
-    rec: dict[str, Any] = {"ts": ts, "rule": rule, "verdict": verdict}
-    if context:
-        rec["context"] = context
-    if session:
-        rec["session"] = session
-
-    with triage_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
-
-    print(f"Recorded {verdict} for {rule} at {ts}")
-
-
-# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -546,12 +521,29 @@ def main(argv: list[str] | None = None) -> int:
     # --record verdict rule
     if args.record:
         verdict, rule = args.record
+        if verdict not in VALID_VERDICTS:
+            print(f"[ERROR] verdict must be tp, fp, or acceptable; got: {verdict}", file=sys.stderr)
+            return 1
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        session = os.environ.get("VIBEGUARD_SESSION_ID", "")
+        new_rec: dict[str, Any] = {"ts": ts, "rule": rule, "verdict": verdict}
+        if args.context:
+            new_rec["context"] = args.context
+        if session:
+            new_rec["session"] = session
         with _scorecard_write_lock(scorecard_path):
-            record_verdict(rule, verdict, args.context, triage_path)
             triage = load_triage(triage_path)
             scorecard = load_scorecard(scorecard_path)
-            scorecard, transitions = update_scorecard(scorecard, triage)
+            # Include new_rec in memory so scorecard and triage stay consistent.
+            # Scorecard is written first (atomic); triage append follows.
+            # If scorecard write fails nothing is persisted — safe to retry.
+            # If triage append fails after scorecard write, --update-scorecard
+            # will recompute the correct scorecard from triage on next run.
+            scorecard, transitions = update_scorecard(scorecard, triage + [new_rec])
             save_scorecard(scorecard, scorecard_path)
+            with triage_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(new_rec, ensure_ascii=False) + "\n")
+        print(f"Recorded {verdict} for {rule} at {ts}")
         if transitions:
             print("Lifecycle transitions:")
             for t in transitions:

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -616,6 +616,56 @@ else
 fi
 
 rm -rf "$_test_log_dir"
+header "post-edit-guard — vibeguard-disable-next-line 抑制"
+# =========================================================
+
+# RS-03 不带抑制注释 → 应产生警告
+result=$(python3 -c "
+import json
+content = 'let x = foo.unwrap();'
+print(json.dumps({'tool_input': {'file_path': 'src/main.rs', 'new_string': content}}))
+" | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" bash hooks/post-edit-guard.sh 2>/dev/null || true)
+assert_contains "$result" "RS-03" "RS-03: unwrap() 无抑制注释时产生警告"
+
+# RS-03 带抑制注释 → 应抑制该行警告
+result=$(python3 -c "
+import json
+content = '// vibeguard-disable-next-line RS-03 -- signal handler\nlet x = foo.unwrap();'
+print(json.dumps({'tool_input': {'file_path': 'src/main.rs', 'new_string': content}}))
+" | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" bash hooks/post-edit-guard.sh 2>/dev/null || true)
+assert_not_contains "$result" "RS-03" "RS-03: vibeguard-disable-next-line 抑制 unwrap() 警告"
+
+# RS-10 带抑制注释 → 应抑制
+result=$(python3 -c "
+import json
+content = '// vibeguard-disable-next-line RS-10 -- intentional drop\nlet _ = sender.send(msg);'
+print(json.dumps({'tool_input': {'file_path': 'src/main.rs', 'new_string': content}}))
+" | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" bash hooks/post-edit-guard.sh 2>/dev/null || true)
+assert_not_contains "$result" "RS-10" "RS-10: vibeguard-disable-next-line 抑制 let _ = 警告"
+
+# DEBUG 带抑制注释 → 应抑制 console 警告
+result=$(python3 -c "
+import json
+content = '// vibeguard-disable-next-line DEBUG -- intentional stderr\nconsole.log(\"debug info\");'
+print(json.dumps({'tool_input': {'file_path': 'src/service.ts', 'new_string': content}}))
+" | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" bash hooks/post-edit-guard.sh 2>/dev/null || true)
+assert_not_contains "$result" "DEBUG" "DEBUG: vibeguard-disable-next-line 抑制 console.log 警告"
+
+# U-11 带抑制注释 → 应抑制硬编码路径警告
+result=$(python3 -c "
+import json
+content = '// vibeguard-disable-next-line U-11 -- test fixture\nconst DB = \"test.db\";'
+print(json.dumps({'tool_input': {'file_path': 'src/config.ts', 'new_string': content}}))
+" | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" bash hooks/post-edit-guard.sh 2>/dev/null || true)
+assert_not_contains "$result" "U-11" "U-11: vibeguard-disable-next-line 抑制硬编码路径警告"
+
+# 抑制注释只作用于紧接下一行（第三行的 unwrap 仍应报警）
+result=$(python3 -c "
+import json
+content = '// vibeguard-disable-next-line RS-03 -- ok\nlet a = safe.unwrap();\nlet b = other.unwrap();'
+print(json.dumps({'tool_input': {'file_path': 'src/main.rs', 'new_string': content}}))
+" | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" bash hooks/post-edit-guard.sh 2>/dev/null || true)
+assert_contains "$result" "RS-03" "RS-03: 抑制注释仅作用于紧接的下一行，第三行 unwrap 仍报警"
 
 # =========================================================
 # 总结

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -523,7 +523,7 @@ header "Issue-3: 抑制规则边界 — RS-03X 不误匹配 RS-03"
 suppress_out=$(python3 -c "
 import sys, re
 rule = 'RS-03'
-suppress_pat = re.compile(r'(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
+suppress_pat = re.compile(r'^\s*(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
 lines = [
     '// vibeguard-disable-next-line RS-03X -- wrong rule',
     'should_appear_1',
@@ -542,13 +542,13 @@ assert_contains "$suppress_out" "should_appear_1" "RS-03X 注释不抑制 RS-03 
 assert_not_contains "$suppress_out" "should_not_appear" "RS-03 注释正确抑制下一行"
 assert_not_contains "$suppress_out" "also_not_appear" "无 reason 的 RS-03 注释也正确抑制"
 
-# Code strings must not suppress
+# Code strings containing // must not suppress (reviewer bypass scenario)
 suppress_out2=$(python3 -c "
 import sys, re
 rule = 'RS-03'
-suppress_pat = re.compile(r'(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
+suppress_pat = re.compile(r'^\s*(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
 lines = [
-    'let s = \"vibeguard-disable-next-line RS-03 in string\";',
+    'let s = \"// vibeguard-disable-next-line RS-03 in string\";',
     'should_appear_2',
 ]
 for i, line in enumerate(lines):
@@ -557,7 +557,49 @@ for i, line in enumerate(lines):
         continue
     print(line)
 ")
-assert_contains "$suppress_out2" "should_appear_2" "代码字符串中的标记不抑制（无注释前缀）"
+assert_contains "$suppress_out2" "should_appear_2" "字符串中的 // 标记不抑制（非行首注释）"
+
+header "Issue-4: 无时区时间戳被校验拒绝（防 naive vs aware TypeError）"
+TRIAGE_NAIVE="${TMPDIR_TEST}/triage_naive.jsonl"
+SCORECARD_NAIVE="${TMPDIR_TEST}/scorecard_naive.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'NZ-01': {
+      'stage': 'warn', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': ''
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_NAIVE"
+# naive timestamp (no Z / offset) must be rejected; tz-aware tp must be accepted
+printf '%s\n' \
+  '{"ts":"2026-03-01T10:00:00","rule":"NZ-01","verdict":"fp"}' \
+  '{"ts":"2026-03-01T11:00:00Z","rule":"NZ-01","verdict":"tp"}' \
+  > "$TRIAGE_NAIVE"
+
+naive_stderr=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE_NAIVE" \
+  --scorecard-file "$SCORECARD_NAIVE" \
+  --update-scorecard 2>&1 >/dev/null)
+assert_contains "$naive_stderr" "[ERROR]" "无时区 fp ts 产生 ERROR 输出"
+
+naive_samples=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD_NAIVE'))
+print(sc['rules']['NZ-01']['samples'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$naive_samples" == "1" ]]; then
+  green "无时区 fp 被拒绝，仅 tp 计入 samples=1"
+  PASS=$((PASS + 1))
+else
+  red "samples 错误（期望 1，实际 $naive_samples）"
+  FAIL=$((FAIL + 1))
+fi
 
 # =========================================================
 echo

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -431,6 +431,134 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "Issue-1: fp 缺失 ts 被拒绝，不计入 fp 统计"
+TRIAGE_NO_TS="${TMPDIR_TEST}/triage_no_ts.jsonl"
+SCORECARD_NO_TS="${TMPDIR_TEST}/scorecard_no_ts.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'TS-01': {
+      'stage': 'warn', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': ''
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_NO_TS"
+# fp without ts must be rejected; tp with ts is valid; total samples should be 1
+printf '%s\n' \
+  '{"ts":"2026-03-01T00:00:00Z","rule":"TS-01","verdict":"tp"}' \
+  '{"rule":"TS-01","verdict":"fp"}' \
+  > "$TRIAGE_NO_TS"
+
+no_ts_stderr=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE_NO_TS" \
+  --scorecard-file "$SCORECARD_NO_TS" \
+  --update-scorecard 2>&1 >/dev/null)
+assert_contains "$no_ts_stderr" "[ERROR]" "fp 缺失 ts 时产生 ERROR 输出"
+
+# last_fp_ts must remain None (fp was rejected), so warn→error must not fire
+no_ts_last_fp=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD_NO_TS'))
+print(sc['rules']['TS-01']['last_fp_ts'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$no_ts_last_fp" == "None" ]]; then
+  green "fp 缺失 ts 时 last_fp_ts 保持 None（不误晋级）"
+  PASS=$((PASS + 1))
+else
+  red "last_fp_ts 不应被更新（期望 None，实际 $no_ts_last_fp）"
+  FAIL=$((FAIL + 1))
+fi
+
+header "Issue-2: 跨时区 fp ts 比较使用 datetime 而非字符串"
+TRIAGE_TZ="${TMPDIR_TEST}/triage_tz.jsonl"
+SCORECARD_TZ="${TMPDIR_TEST}/scorecard_tz.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'TZ-01': {
+      'stage': 'warn', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': ''
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_TZ"
+# +09:00 record is 2026-03-01T12:00:00+09:00 = 2026-03-01T03:00:00Z
+# Z record is 2026-03-01T10:00:00Z  (later in UTC)
+# String sort: "+09:00" < "Z" is wrong; datetime comparison must pick the Z record
+printf '%s\n' \
+  '{"ts":"2026-03-01T12:00:00+09:00","rule":"TZ-01","verdict":"fp"}' \
+  '{"ts":"2026-03-01T10:00:00Z","rule":"TZ-01","verdict":"fp"}' \
+  > "$TRIAGE_TZ"
+
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE_TZ" \
+  --scorecard-file "$SCORECARD_TZ" \
+  --update-scorecard >/dev/null 2>&1
+
+tz_last_fp=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD_TZ'))
+print(sc['rules']['TZ-01']['last_fp_ts'])
+")
+TOTAL=$((TOTAL + 1))
+# 10:00Z is 10:00 UTC; 12:00+09:00 is 03:00 UTC — so 10:00Z is the later one
+if [[ "$tz_last_fp" == "2026-03-01T10:00:00Z" ]]; then
+  green "跨时区 fp 比较正确选出最新 ts（UTC 10:00Z 晚于 +09:00 的 03:00Z）"
+  PASS=$((PASS + 1))
+else
+  red "跨时区比较错误（期望 2026-03-01T10:00:00Z，实际 $tz_last_fp）"
+  FAIL=$((FAIL + 1))
+fi
+
+header "Issue-3: 抑制规则边界 — RS-03X 不误匹配 RS-03"
+# Verify vg_filter_suppressed only suppresses the exact rule ID
+suppress_out=$(python3 -c "
+import sys, re
+rule = 'RS-03'
+suppress_pat = re.compile(r'(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
+lines = [
+    '// vibeguard-disable-next-line RS-03X -- wrong rule',
+    'should_appear_1',
+    '// vibeguard-disable-next-line RS-03 -- correct',
+    'should_not_appear',
+    '// vibeguard-disable-next-line RS-03',
+    'also_not_appear',
+]
+for i, line in enumerate(lines):
+    prev = lines[i - 1] if i > 0 else ''
+    if suppress_pat.search(prev):
+        continue
+    print(line)
+")
+assert_contains "$suppress_out" "should_appear_1" "RS-03X 注释不抑制 RS-03 规则"
+assert_not_contains "$suppress_out" "should_not_appear" "RS-03 注释正确抑制下一行"
+assert_not_contains "$suppress_out" "also_not_appear" "无 reason 的 RS-03 注释也正确抑制"
+
+# Code strings must not suppress
+suppress_out2=$(python3 -c "
+import sys, re
+rule = 'RS-03'
+suppress_pat = re.compile(r'(?://|#)\s*vibeguard-disable-next-line\s+' + re.escape(rule) + r'(?:\s|--|$)')
+lines = [
+    'let s = \"vibeguard-disable-next-line RS-03 in string\";',
+    'should_appear_2',
+]
+for i, line in enumerate(lines):
+    prev = lines[i - 1] if i > 0 else ''
+    if suppress_pat.search(prev):
+        continue
+    print(line)
+")
+assert_contains "$suppress_out2" "should_appear_2" "代码字符串中的标记不抑制（无注释前缀）"
+
 # =========================================================
 echo
 echo "=============================="

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -233,6 +233,53 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "实验阶段规则精度不足时不直接降级 — experimental 不走 demoted 快捷路径"
+TRIAGE_EXP="${TMPDIR_TEST}/triage_exp.jsonl"
+SCORECARD_EXP="${TMPDIR_TEST}/scorecard_exp.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'EXP-01': {
+      'stage': 'experimental', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'test'
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_EXP"
+# 5 tp, 20 fp → precision = 5/25 = 20% < 80%; samples = 25 ≥ 20
+# experimental rule with poor precision must NOT be demoted directly
+python3 -c "
+import json
+lines = []
+for _ in range(5):
+    lines.append(json.dumps({'ts': '2026-03-01T00:00:00Z', 'rule': 'EXP-01', 'verdict': 'tp'}))
+for _ in range(20):
+    lines.append(json.dumps({'ts': '2026-03-02T00:00:00Z', 'rule': 'EXP-01', 'verdict': 'fp'}))
+print('\n'.join(lines))
+" > "$TRIAGE_EXP"
+
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE_EXP" \
+  --scorecard-file "$SCORECARD_EXP" \
+  --update-scorecard >/dev/null 2>&1
+
+exp_stage=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD_EXP'))
+print(sc['rules']['EXP-01']['stage'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$exp_stage" == "experimental" ]]; then
+  green "精度不足的 experimental 规则保持 experimental（不直接降级）"
+  PASS=$((PASS + 1))
+else
+  red "experimental 规则不应直接降级，应保持 experimental，实际: $exp_stage"
+  FAIL=$((FAIL + 1))
+fi
+
 header "无效 triage 行被隔离（issue-1：schema 校验）"
 TRIAGE_BAD="${TMPDIR_TEST}/triage_bad.jsonl"
 SCORECARD_BAD="${TMPDIR_TEST}/scorecard_bad.json"

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# VibeGuard Precision Tracker 测试套件
+#
+# 用法：bash tests/test_precision_tracker.sh
+# 从仓库根目录运行
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRACKER="${REPO_DIR}/scripts/precision-tracker.py"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    echo "  output: $(echo "$output" | head -5)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if ! echo "$output" | grep -qF "$unexpected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (unexpectedly contains: $unexpected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd_ok() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code non-zero)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── 独立临时目录，不污染真实数据 ────────────────────────────────────────────
+TMPDIR_TEST=$(mktemp -d)
+TRIAGE_FILE="${TMPDIR_TEST}/triage.jsonl"
+SCORECARD_FILE="${TMPDIR_TEST}/rule-scorecard.json"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+# Seed scorecard with a known initial state
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'RS-03': {'stage': 'experimental', 'precision': None, 'samples': 0,
+              'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+              'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'unwrap'},
+    'RS-99': {'stage': 'warn', 'precision': None, 'samples': 0,
+              'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+              'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'test rule'}
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_FILE"
+
+# Empty triage file
+touch "$TRIAGE_FILE"
+
+header "precision-tracker.py — 语法检查"
+assert_cmd_ok "Python 语法正确" python3 -m py_compile "$TRACKER"
+
+header "精度报告输出"
+report=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE_FILE" \
+  --scorecard-file "$SCORECARD_FILE")
+assert_contains "$report" "VibeGuard Rule Precision Scorecard" "报告标题存在"
+assert_contains "$report" "RS-03" "报告包含 RS-03"
+assert_contains "$report" "RS-99" "报告包含 RS-99"
+assert_contains "$report" "experimental" "报告显示 experimental 阶段"
+assert_contains "$report" "warn" "报告显示 warn 阶段"
+assert_contains "$report" "N/A" "无样本时精度显示 N/A"
+
+header "--rule 过滤"
+report_single=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE_FILE" \
+  --scorecard-file "$SCORECARD_FILE" \
+  --rule RS-03)
+assert_contains "$report_single" "RS-03" "--rule RS-03 包含 RS-03"
+assert_not_contains "$report_single" "RS-99" "--rule RS-03 排除 RS-99"
+
+header "--record 记录 triage 反馈"
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE_FILE" \
+  --scorecard-file "$SCORECARD_FILE" \
+  --record tp RS-03 >/dev/null
+assert_contains "$(cat "$TRIAGE_FILE")" '"verdict": "tp"' "--record tp 写入 triage.jsonl"
+assert_contains "$(cat "$TRIAGE_FILE")" '"rule": "RS-03"' "--record tp 写入正确 rule"
+
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE_FILE" \
+  --scorecard-file "$SCORECARD_FILE" \
+  --record fp RS-03 --context "false alarm in tests" >/dev/null
+assert_contains "$(cat "$TRIAGE_FILE")" '"verdict": "fp"' "--record fp 写入 triage.jsonl"
+assert_contains "$(cat "$TRIAGE_FILE")" "false alarm in tests" "--context 写入 triage.jsonl"
+
+header "精度计算正确性"
+# 1 tp + 1 fp → precision = 50%
+updated_scorecard=$(cat "$SCORECARD_FILE")
+echo "$updated_scorecard" | python3 -c "
+import json, sys
+sc = json.load(sys.stdin)
+rs03 = sc['rules']['RS-03']
+assert rs03['tp'] == 1, f'tp should be 1, got {rs03[\"tp\"]}'
+assert rs03['fp'] == 1, f'fp should be 1, got {rs03[\"fp\"]}'
+assert rs03['samples'] == 2, f'samples should be 2, got {rs03[\"samples\"]}'
+assert abs(rs03['precision'] - 0.5) < 0.001, f'precision should be ~0.5, got {rs03[\"precision\"]}'
+print('OK')
+" > /dev/null && {
+  PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1))
+  green "1 TP + 1 FP 时精度为 50%"
+} || {
+  FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1))
+  red "精度计算错误（期望 50%）"
+}
+
+header "生命周期晋升 — experimental → warn"
+# 添加 20 个 tp（precision ≥ 70% AND samples ≥ 20）到一个新的测试规则
+TRIAGE2="${TMPDIR_TEST}/triage2.jsonl"
+SCORECARD2="${TMPDIR_TEST}/scorecard2.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'TEST-01': {
+      'stage': 'experimental', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'test'
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD2"
+# 21 tp, 1 fp → precision = 21/22 ≈ 95% ≥ 70%; samples = 22 ≥ 20
+python3 -c "
+import json
+lines = []
+for _ in range(21):
+    lines.append(json.dumps({'ts': '2026-03-01T00:00:00Z', 'rule': 'TEST-01', 'verdict': 'tp'}))
+lines.append(json.dumps({'ts': '2026-03-02T00:00:00Z', 'rule': 'TEST-01', 'verdict': 'fp'}))
+print('\n'.join(lines))
+" > "$TRIAGE2"
+
+transition_out=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE2" \
+  --scorecard-file "$SCORECARD2" \
+  --update-scorecard 2>&1)
+assert_contains "$transition_out" "TEST-01" "晋升输出包含规则名"
+assert_contains "$transition_out" "experimental → warn" "experimental 晋升到 warn"
+
+new_stage=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD2'))
+print(sc['rules']['TEST-01']['stage'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$new_stage" == "warn" ]]; then
+  green "晋升后 stage 为 warn"
+  PASS=$((PASS + 1))
+else
+  red "晋升后 stage 应为 warn，实际: $new_stage"
+  FAIL=$((FAIL + 1))
+fi
+
+header "生命周期降级 — warn → demoted（精度 < 80%）"
+TRIAGE3="${TMPDIR_TEST}/triage3.jsonl"
+SCORECARD3="${TMPDIR_TEST}/scorecard3.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'TEST-02': {
+      'stage': 'warn', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'test'
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD3"
+# 10 tp, 15 fp → precision = 10/25 = 40% < 80%; samples = 25 ≥ 20
+python3 -c "
+import json
+lines = []
+for _ in range(10):
+    lines.append(json.dumps({'ts': '2026-03-01T00:00:00Z', 'rule': 'TEST-02', 'verdict': 'tp'}))
+for _ in range(15):
+    lines.append(json.dumps({'ts': '2026-03-02T00:00:00Z', 'rule': 'TEST-02', 'verdict': 'fp'}))
+print('\n'.join(lines))
+" > "$TRIAGE3"
+
+transition_out3=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE3" \
+  --scorecard-file "$SCORECARD3" \
+  --update-scorecard 2>&1)
+assert_contains "$transition_out3" "warn → demoted" "精度不足时降级到 demoted"
+
+demoted_stage=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD3'))
+print(sc['rules']['TEST-02']['stage'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$demoted_stage" == "demoted" ]]; then
+  green "降级后 stage 为 demoted"
+  PASS=$((PASS + 1))
+else
+  red "降级后 stage 应为 demoted，实际: $demoted_stage"
+  FAIL=$((FAIL + 1))
+fi
+
+# =========================================================
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -233,6 +233,157 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "无效 triage 行被隔离（issue-1：schema 校验）"
+TRIAGE_BAD="${TMPDIR_TEST}/triage_bad.jsonl"
+SCORECARD_BAD="${TMPDIR_TEST}/scorecard_bad.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'RS-04': {
+      'stage': 'experimental', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': ''
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_BAD"
+printf '%s\n' \
+  '{"ts":"2026-03-01T00:00:00Z","rule":"RS-04","verdict":"tp"}' \
+  '[]' \
+  '42' \
+  '{"rule":{"bad":1},"verdict":"tp"}' \
+  '{"ts":"2026-03-01T00:00:00Z","rule":"RS-04","verdict":"unknown_verdict"}' \
+  '{"ts":"2026-03-01T00:00:00Z","rule":"RS-04","verdict":"fp"}' \
+  > "$TRIAGE_BAD"
+
+bad_stderr=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE_BAD" \
+  --scorecard-file "$SCORECARD_BAD" \
+  --update-scorecard 2>&1 >/dev/null)
+assert_contains "$bad_stderr" "[ERROR]" "无效行产生 ERROR 输出"
+
+valid_samples=$(python3 -c "
+import json, sys
+sc = json.load(open('$SCORECARD_BAD'))
+print(sc['rules']['RS-04']['samples'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$valid_samples" == "2" ]]; then
+  green "有效记录正确计入（2 条，跳过无效行）"
+  PASS=$((PASS + 1))
+else
+  red "有效记录数量错误（期望 2，实际 $valid_samples）"
+  FAIL=$((FAIL + 1))
+fi
+
+header "原子写保证 scorecard 格式完整（issue-2：atomic write）"
+SCORECARD_ATOMIC="${TMPDIR_TEST}/scorecard_atomic.json"
+TRIAGE_ATOMIC="${TMPDIR_TEST}/triage_atomic.jsonl"
+python3 -c "
+import json
+scorecard = {'rules': {'AT-01': {'stage': 'experimental', 'precision': None, 'samples': 0,
+  'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+  'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': ''}}}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_ATOMIC"
+printf '{"ts":"2026-03-01T00:00:00Z","rule":"AT-01","verdict":"tp"}\n' > "$TRIAGE_ATOMIC"
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE_ATOMIC" \
+  --scorecard-file "$SCORECARD_ATOMIC" \
+  --update-scorecard >/dev/null 2>&1
+# Verify the output is valid JSON (atomic write should never leave a partial file)
+python3 -c "import json; json.load(open('$SCORECARD_ATOMIC'))" 2>/dev/null && {
+  TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1))
+  green "update-scorecard 后 scorecard 是合法 JSON"
+} || {
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  red "update-scorecard 后 scorecard 不是合法 JSON"
+}
+# Verify no stray .tmp files remain
+tmp_count=$(find "${TMPDIR_TEST}" -maxdepth 1 -name '.scorecard-*.tmp' 2>/dev/null | wc -l | tr -d ' ')
+TOTAL=$((TOTAL + 1))
+if [[ "$tmp_count" == "0" ]]; then
+  green "无残留临时文件"
+  PASS=$((PASS + 1))
+else
+  red "发现残留临时文件（$tmp_count 个）"
+  FAIL=$((FAIL + 1))
+fi
+
+header "triage 清理后旧规则统计被重置（issue-3：stale rule reset）"
+TRIAGE4="${TMPDIR_TEST}/triage4.jsonl"
+SCORECARD4="${TMPDIR_TEST}/scorecard4.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'STALE-01': {
+      'stage': 'warn', 'precision': 0.95, 'samples': 50,
+      'tp': 45, 'fp': 5, 'acceptable': 0, 'last_fp_ts': '2026-01-01T00:00:00Z',
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'stale rule'
+    },
+    'ACTIVE-01': {
+      'stage': 'experimental', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': 'active rule'
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD4"
+# Only ACTIVE-01 has triage records; STALE-01 has been archived
+printf '{"ts":"2026-03-01T00:00:00Z","rule":"ACTIVE-01","verdict":"tp"}\n' > "$TRIAGE4"
+
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE4" \
+  --scorecard-file "$SCORECARD4" \
+  --update-scorecard >/dev/null 2>&1
+
+stale_samples=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD4'))
+print(sc['rules']['STALE-01']['samples'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$stale_samples" == "0" ]]; then
+  green "triage 清理后旧规则 samples 被重置为 0"
+  PASS=$((PASS + 1))
+else
+  red "旧规则 samples 未被重置（期望 0，实际 $stale_samples）"
+  FAIL=$((FAIL + 1))
+fi
+
+stale_precision=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD4'))
+print(sc['rules']['STALE-01']['precision'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$stale_precision" == "None" ]]; then
+  green "triage 清理后旧规则 precision 被重置为 None"
+  PASS=$((PASS + 1))
+else
+  red "旧规则 precision 未被重置（期望 None，实际 $stale_precision）"
+  FAIL=$((FAIL + 1))
+fi
+
+# Active rule should still have correct stats
+active_samples=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD4'))
+print(sc['rules']['ACTIVE-01']['samples'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$active_samples" == "1" ]]; then
+  green "活跃规则统计不受影响（samples=1）"
+  PASS=$((PASS + 1))
+else
+  red "活跃规则统计异常（期望 1，实际 $active_samples）"
+  FAIL=$((FAIL + 1))
+fi
+
 # =========================================================
 echo
 echo "=============================="


### PR DESCRIPTION
## Summary

- **Lifecycle engine** (`scripts/precision-tracker.py`): reads `data/triage.jsonl` feedback and auto-graduates rules through `experimental → warn → error` (or demotes on low precision), backed by thresholds borrowed from Semgrep Pro and Clippy
- **Triage data** (`data/triage.jsonl`, `data/rule-scorecard.json`): per-warning user feedback store and per-rule precision scorecard with lifecycle stage
- **Suppression comments** (`hooks/post-edit-guard.sh`): `// vibeguard-disable-next-line RS-03 -- reason` silences a specific rule on the next line only
- **Baseline scanning infra** (`hooks/pre-commit-guard.sh`): exports `VIBEGUARD_DIFF_ONLY=1` and `VIBEGUARD_DIFF_ADDED_LINES` (added-lines-only temp file) so guards can opt into diff-only scanning

## Test plan

- [ ] `npm test` — all 4 suites pass (118 tests)
- [ ] `bash tests/test_precision_tracker.sh` — 19 tests: record feedback, precision calc, experimental→warn promotion, warn→demoted demotion
- [ ] Suppression: 6 new tests in `test_hooks.sh` covering RS-03/RS-10/DEBUG/U-11 and scope (only next line)