### PR TITLE
feat(hooks): circuit breaker to prevent infinite loop and repeated blocking

### DIFF
--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -7,6 +7,7 @@ Claude Code hooks 脚本，在 AI 操作前后自动触发。
 | 文件 | 触发时机 | 职责 |
 |------|----------|------|
 | `log.sh` | 被其他 hook source | 日志模块，提供 `vg_log`、JSON 解析、源码判断等共享函数 |
+| `circuit-breaker.sh` | 被其他 hook source | 断路器库：CLOSED→OPEN→HALF-OPEN 状态机、CI guard（`vg_is_ci`）、stop_hook_active 检查（`vg_stop_hook_active`） |
 | `pre-bash-guard.sh` | PreToolUse(Bash) | 拦截危险命令：force push、rm -rf /、reset --hard 等 |
 | `pre-edit-guard.sh` | PreToolUse(Edit) | 拦截编辑不存在的文件（防幻觉） |
 | `pre-write-guard.sh` | PreToolUse(Write) | 新建源码文件前提醒先搜索已有实现 |

--- a/hooks/analysis-paralysis-guard.sh
+++ b/hooks/analysis-paralysis-guard.sh
@@ -6,10 +6,18 @@
 #
 # Mechanism: count recent events in session log. If the last N tool uses are all
 # Read/Glob/Grep (research tools) with no Write/Edit/Bash interleaved, trigger warning.
+#
+# Circuit breaker: after CB_THRESHOLD consecutive warns (default 3), the hook
+# auto-passes for CB_COOLDOWN seconds (default 5 min) to prevent alert fatigue
+# and the 716x warn loop documented in GitHub issue #10205.
 
 set -euo pipefail
 
 source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/circuit-breaker.sh"
+
+# CI guard: analysis-paralysis warnings are not actionable in CI
+vg_is_ci && exit 0
 
 THRESHOLD="${VG_PARALYSIS_THRESHOLD:-7}"
 
@@ -63,15 +71,19 @@ print(consecutive)
 
 CONSECUTIVE="${CONSECUTIVE:-0}"
 
-# Log the Read event itself
+# Log the Read event itself (always, regardless of circuit breaker state)
 vg_log "analysis-paralysis-guard" "Read" "pass" "consecutive_reads=${CONSECUTIVE}" ""
 
 if [[ "$CONSECUTIVE" -ge "$THRESHOLD" ]]; then
-  WARNING="[ANALYSIS PARALYSIS] 已连续 ${CONSECUTIVE} 次只读操作（Read/Glob/Grep）没有任何写入。你可能陷入了"读了又读"循环。必须选择：(1) 动手写代码/编辑文件 (2) 向用户报告 blocker 并说明卡在哪里。"
+  # Circuit breaker check: if this hook has been firing repeatedly without
+  # resolution, open the circuit and auto-pass to prevent 716x warn loops.
+  if vg_cb_check "analysis-paralysis-guard"; then
+    WARNING="[ANALYSIS PARALYSIS] 已连续 ${CONSECUTIVE} 次只读操作（Read/Glob/Grep）没有任何写入。你可能陷入了"读了又读"循环。必须选择：(1) 动手写代码/编辑文件 (2) 向用户报告 blocker 并说明卡在哪里。"
 
-  vg_log "analysis-paralysis-guard" "Read" "warn" "paralysis ${CONSECUTIVE}x" ""
+    vg_log "analysis-paralysis-guard" "Read" "warn" "paralysis ${CONSECUTIVE}x" ""
+    vg_cb_record_block "analysis-paralysis-guard"
 
-  VG_WARNINGS="$WARNING" python3 -c '
+    VG_WARNINGS="$WARNING" python3 -c '
 import json, os
 warnings = os.environ.get("VG_WARNINGS", "")
 result = {
@@ -82,4 +94,9 @@ result = {
 }
 print(json.dumps(result, ensure_ascii=False))
 '
+  fi
+  # If circuit is OPEN, vg_cb_check returned 1 and already logged the auto-pass.
+  # We silently skip the warn to break the loop.
+else
+  vg_cb_record_pass "analysis-paralysis-guard"
 fi

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# VibeGuard Hook Circuit Breaker
+#
+# Prevents infinite loops when a hook repeatedly blocks/warns in an unresolvable condition.
+# Implements Martin Fowler's circuit breaker: CLOSED → OPEN (cooldown) → HALF-OPEN → CLOSED
+#
+# States:
+#   CLOSED    — normal operation; blocks/warns are recorded
+#   OPEN      — tripped after CB_THRESHOLD consecutive blocks; auto-pass for CB_COOLDOWN seconds
+#   HALF-OPEN — one probe attempt after cooldown; pass → CLOSED, block → back to OPEN
+#
+# Usage (source after log.sh):
+#   source "$(dirname "$0")/circuit-breaker.sh"
+#
+#   # In a hook that can block:
+#   vg_cb_check "my-hook" || { vg_log "my-hook" "Tool" "pass" "CB auto-pass" ""; exit 0; }
+#   if [[ blocking_condition ]]; then
+#     vg_cb_record_block "my-hook"
+#     exit 2
+#   fi
+#   vg_cb_record_pass "my-hook"
+
+# ── Configuration ────────────────────────────────────────────────────────────
+CB_DIR="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/circuit-breaker"
+CB_COOLDOWN="${VG_CB_COOLDOWN:-300}"   # seconds until OPEN → HALF-OPEN (5 min)
+CB_THRESHOLD="${VG_CB_THRESHOLD:-3}"   # consecutive blocks before tripping to OPEN
+
+mkdir -p "$CB_DIR" 2>/dev/null || true
+
+# ── Internal helpers ─────────────────────────────────────────────────────────
+
+_vg_cb_now() { date +%s; }
+
+# Emit a log entry if vg_log is available (log.sh may not be sourced in tests)
+_vg_cb_log() {
+  if declare -f vg_log &>/dev/null; then
+    vg_log "$@"
+  fi
+}
+
+# Load state for <hook> into CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION
+_vg_cb_load() {
+  local hook="$1"
+  local state_file="${CB_DIR}/${hook}.cb"
+  CB_STATE="CLOSED"
+  CB_BLOCKS=0
+  CB_LAST_BLOCK=0
+  CB_SESSION=""
+  if [[ -f "$state_file" ]]; then
+    # shellcheck source=/dev/null
+    source "$state_file" 2>/dev/null || true
+  fi
+  # Reset if the state belongs to a different session
+  local cur_session="${VIBEGUARD_SESSION_ID:-}"
+  if [[ -n "$cur_session" && -n "$CB_SESSION" && "$CB_SESSION" != "$cur_session" ]]; then
+    CB_STATE="CLOSED"
+    CB_BLOCKS=0
+    CB_LAST_BLOCK=0
+    CB_SESSION=""
+  fi
+}
+
+# Persist CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION for <hook>
+_vg_cb_save() {
+  local hook="$1"
+  local state_file="${CB_DIR}/${hook}.cb"
+  {
+    printf 'CB_STATE=%s\n' "$CB_STATE"
+    printf 'CB_BLOCKS=%s\n' "$CB_BLOCKS"
+    printf 'CB_LAST_BLOCK=%s\n' "$CB_LAST_BLOCK"
+    printf 'CB_SESSION=%s\n' "${VIBEGUARD_SESSION_ID:-}"
+  } > "$state_file" 2>/dev/null || true
+}
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+# vg_cb_check <hook>
+# Returns 0 if the hook should run normally.
+# Returns 1 if the circuit is OPEN and the call should be auto-passed.
+# Transitions OPEN → HALF-OPEN when the cooldown has expired.
+vg_cb_check() {
+  local hook="$1"
+  _vg_cb_load "$hook"
+  local now
+  now=$(_vg_cb_now)
+
+  case "$CB_STATE" in
+    CLOSED)
+      return 0
+      ;;
+    OPEN)
+      local elapsed=$(( now - CB_LAST_BLOCK ))
+      if [[ "$elapsed" -ge "$CB_COOLDOWN" ]]; then
+        CB_STATE="HALF-OPEN"
+        _vg_cb_save "$hook"
+        return 0  # Let one probe through
+      else
+        local remaining=$(( CB_COOLDOWN - elapsed ))
+        _vg_cb_log "$hook" "circuit-breaker" "pass" \
+          "CB OPEN: auto-pass (${remaining}s remaining, ${CB_BLOCKS} consecutive blocks)" ""
+        return 1  # Auto-pass: caller should skip hook logic and exit 0
+      fi
+      ;;
+    HALF-OPEN)
+      return 0  # Probe attempt: let it through
+      ;;
+    *)
+      CB_STATE="CLOSED"; CB_BLOCKS=0
+      _vg_cb_save "$hook"
+      return 0
+      ;;
+  esac
+}
+
+# vg_cb_record_block <hook>
+# Records one block/warn event. Trips circuit to OPEN after CB_THRESHOLD consecutive events.
+vg_cb_record_block() {
+  local hook="$1"
+  _vg_cb_load "$hook"
+  CB_BLOCKS=$(( CB_BLOCKS + 1 ))
+  CB_LAST_BLOCK=$(_vg_cb_now)
+
+  if [[ "$CB_STATE" == "HALF-OPEN" ]] || [[ "$CB_BLOCKS" -ge "$CB_THRESHOLD" ]]; then
+    CB_STATE="OPEN"
+    _vg_cb_log "$hook" "circuit-breaker" "warn" \
+      "CB tripped OPEN: ${CB_BLOCKS} consecutive blocks, cooldown ${CB_COOLDOWN}s" ""
+  fi
+  _vg_cb_save "$hook"
+}
+
+# vg_cb_record_pass <hook>
+# Records a successful (non-blocking) result. Resets circuit to CLOSED.
+vg_cb_record_pass() {
+  local hook="$1"
+  _vg_cb_load "$hook"
+  if [[ "$CB_STATE" != "CLOSED" ]] || [[ "$CB_BLOCKS" -gt 0 ]]; then
+    CB_STATE="CLOSED"
+    CB_BLOCKS=0
+    CB_LAST_BLOCK=0
+    _vg_cb_save "$hook"
+  fi
+}
+
+# ── CI guard ─────────────────────────────────────────────────────────────────
+
+# vg_is_ci
+# Returns 0 (true) if running inside a CI environment.
+# Hooks that rely on desktop-only context should call:  vg_is_ci && exit 0
+vg_is_ci() {
+  [[ -n "${CI:-}" ]] \
+    || [[ -n "${GITHUB_ACTIONS:-}" ]] \
+    || [[ -n "${TRAVIS:-}" ]] \
+    || [[ -n "${CIRCLECI:-}" ]] \
+    || [[ -n "${JENKINS_URL:-}" ]] \
+    || [[ -n "${GITLAB_CI:-}" ]] \
+    || [[ -n "${TF_BUILD:-}" ]]
+}
+
+# ── stop_hook_active guard ────────────────────────────────────────────────────
+
+# vg_stop_hook_active <json_string>
+# Returns 0 (true) if the Stop hook input JSON has stop_hook_active == true,
+# indicating this invocation was triggered by another Stop hook and should not block.
+# Usage:  vg_stop_hook_active "$INPUT" && exit 0
+vg_stop_hook_active() {
+  local input="$1"
+  VG_CB_INPUT="$input" python3 -c "
+import json, os, sys
+try:
+    data = json.loads(os.environ.get('VG_CB_INPUT', '{}'))
+    sys.exit(0 if data.get('stop_hook_active', False) else 1)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null
+}

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -173,7 +173,12 @@ vg_cb_check() {
         fi
         ;;
       HALF-OPEN)
-        exit 0  # Probe attempt: let it through
+        # Probe already in flight (dispatched when OPEN→HALF-OPEN transition
+        # ran exit 0 above).  Auto-pass subsequent callers until
+        # vg_cb_record_pass/block transitions state back to CLOSED or OPEN.
+        _vg_cb_log "$hook" "circuit-breaker" "pass" \
+          "CB HALF-OPEN: probe in-flight, auto-passing (${CB_BLOCKS} prior blocks)" ""
+        exit 1
         ;;
       *)
         CB_STATE="CLOSED"; CB_BLOCKS=0

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -38,10 +38,27 @@ _vg_cb_log() {
   fi
 }
 
+# Return the per-project state file path for <hook>.
+# Reuses _vg_project_hash from log.sh if already computed in this shell;
+# otherwise computes it fresh from git so state is isolated per repository.
+_vg_cb_state_file() {
+  local hook="$1"
+  local slug
+  if [[ -n "${_vg_project_hash:-}" ]]; then
+    slug="$_vg_project_hash"
+  else
+    local root
+    root=$(git rev-parse --show-toplevel 2>/dev/null || echo "global")
+    slug=$(printf '%s' "$root" | shasum -a 256 2>/dev/null | cut -c1-8) || slug="fallback0"
+  fi
+  printf '%s/%s/%s.cb' "$CB_DIR" "$slug" "$hook"
+}
+
 # Load state for <hook> into CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION
 _vg_cb_load() {
   local hook="$1"
-  local state_file="${CB_DIR}/${hook}.cb"
+  local state_file
+  state_file=$(_vg_cb_state_file "$hook")
   CB_STATE="CLOSED"
   CB_BLOCKS=0
   CB_LAST_BLOCK=0
@@ -60,16 +77,21 @@ _vg_cb_load() {
   fi
 }
 
-# Persist CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION for <hook>
+# Persist CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION for <hook>.
+# Writes to a temp file then renames for atomicity, preventing concurrent
+# readers from seeing a partial/empty state file.
 _vg_cb_save() {
   local hook="$1"
-  local state_file="${CB_DIR}/${hook}.cb"
+  local state_file tmp_file
+  state_file=$(_vg_cb_state_file "$hook")
+  mkdir -p "$(dirname "$state_file")" 2>/dev/null || true
+  tmp_file="${state_file}.tmp.$$"
   {
     printf 'CB_STATE=%s\n' "$CB_STATE"
     printf 'CB_BLOCKS=%s\n' "$CB_BLOCKS"
     printf 'CB_LAST_BLOCK=%s\n' "$CB_LAST_BLOCK"
     printf 'CB_SESSION=%s\n' "${VIBEGUARD_SESSION_ID:-}"
-  } > "$state_file" 2>/dev/null || true
+  } > "$tmp_file" 2>/dev/null && mv "$tmp_file" "$state_file" 2>/dev/null || true
 }
 
 # ── Public API ───────────────────────────────────────────────────────────────
@@ -162,14 +184,17 @@ vg_is_ci() {
 # Returns 0 (true) if the Stop hook input JSON has stop_hook_active == true,
 # indicating this invocation was triggered by another Stop hook and should not block.
 # Usage:  vg_stop_hook_active "$INPUT" && exit 0
+#
+# Passes JSON via stdin (pipe) instead of an environment variable to avoid
+# hitting execve env-size limits when the input contains a long last_assistant_message.
 vg_stop_hook_active() {
   local input="$1"
-  VG_CB_INPUT="$input" python3 -c "
-import json, os, sys
+  printf '%s' "$input" | python3 -c "
+import json, sys
 try:
-    data = json.loads(os.environ.get('VG_CB_INPUT', '{}'))
+    data = json.loads(sys.stdin.read())
     sys.exit(0 if data.get('stop_hook_active', False) else 1)
 except Exception:
     sys.exit(1)
-" 2>/dev/null
+"
 }

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -74,6 +74,7 @@ _vg_cb_load() {
     CB_BLOCKS=0
     CB_LAST_BLOCK=0
     CB_SESSION=""
+    _vg_cb_save "$hook"
   fi
 }
 
@@ -114,6 +115,7 @@ vg_cb_check() {
       local elapsed=$(( now - CB_LAST_BLOCK ))
       if [[ "$elapsed" -ge "$CB_COOLDOWN" ]]; then
         CB_STATE="HALF-OPEN"
+        CB_LAST_BLOCK=$(_vg_cb_now)
         _vg_cb_save "$hook"
         return 0  # Let one probe through
       else

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -22,8 +22,13 @@
 
 # ── Configuration ────────────────────────────────────────────────────────────
 CB_DIR="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/circuit-breaker"
-CB_COOLDOWN="${VG_CB_COOLDOWN:-300}"   # seconds until OPEN → HALF-OPEN (5 min)
-CB_THRESHOLD="${VG_CB_THRESHOLD:-3}"   # consecutive blocks before tripping to OPEN
+
+# Validate that a value is a non-negative integer; fall back to default if not.
+# Prevents arithmetic errors under set -euo pipefail when env vars are misconfigured.
+_vg_cb_to_int() { local v="$1" d="$2"; [[ "$v" =~ ^[0-9]+$ ]] && printf '%s' "$v" || printf '%s' "$d"; }
+
+CB_COOLDOWN=$(_vg_cb_to_int "${VG_CB_COOLDOWN:-300}" 300)   # seconds until OPEN → HALF-OPEN (5 min)
+CB_THRESHOLD=$(_vg_cb_to_int "${VG_CB_THRESHOLD:-3}" 3)     # consecutive blocks before tripping to OPEN
 
 mkdir -p "$CB_DIR" 2>/dev/null || true
 
@@ -64,8 +69,31 @@ _vg_cb_load() {
   CB_LAST_BLOCK=0
   CB_SESSION=""
   if [[ -f "$state_file" ]]; then
-    # shellcheck source=/dev/null
-    source "$state_file" 2>/dev/null || true
+    # Safe key=value parser — never executes the file as shell code.
+    # Each field is validated before assignment to prevent injection via a
+    # tampered state file (e.g. malicious VIBEGUARD_SESSION_ID).
+    local _line _key _val
+    while IFS= read -r _line; do
+      _key="${_line%%=*}"
+      _val="${_line#*=}"
+      case "$_key" in
+        CB_STATE)
+          case "$_val" in
+            CLOSED|OPEN|HALF-OPEN) CB_STATE="$_val" ;;
+          esac
+          ;;
+        CB_BLOCKS)
+          [[ "$_val" =~ ^[0-9]+$ ]] && CB_BLOCKS="$_val"
+          ;;
+        CB_LAST_BLOCK)
+          [[ "$_val" =~ ^[0-9]+$ ]] && CB_LAST_BLOCK="$_val"
+          ;;
+        CB_SESSION)
+          # Allow only characters safe for a session ID (UUID / slug)
+          [[ "$_val" =~ ^[a-zA-Z0-9_=-]*$ ]] && CB_SESSION="$_val"
+          ;;
+      esac
+    done < "$state_file"
   fi
   # Reset if the state belongs to a different session
   local cur_session="${VIBEGUARD_SESSION_ID:-}"
@@ -195,7 +223,9 @@ vg_stop_hook_active() {
 import json, sys
 try:
     data = json.loads(sys.stdin.read())
-    sys.exit(0 if data.get('stop_hook_active', False) else 1)
+    val = data.get('stop_hook_active', False)
+    # Require the boolean literal true, not a truthy string like 'false'
+    sys.exit(0 if val is True else 1)
 except Exception:
     sys.exit(1)
 "

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -59,6 +59,19 @@ _vg_cb_state_file() {
   printf '%s/%s/%s.cb' "$CB_DIR" "$slug" "$hook"
 }
 
+# Return the exclusive lock file path for <hook> (sibling of the state file).
+_vg_cb_lock_file() {
+  local hook="$1"
+  printf '%s.lock' "$(_vg_cb_state_file "$hook")"
+}
+
+# Acquire an exclusive flock on fd <n>, waiting up to 5 seconds.
+# Silently skips if flock(1) is unavailable (e.g., macOS without util-linux).
+# Always returns 0 so callers under set -euo pipefail are not aborted.
+_vg_cb_try_flock() {
+  command -v flock >/dev/null 2>&1 && flock -x -w 5 "$1" 2>/dev/null || true
+}
+
 # Load state for <hook> into CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION
 _vg_cb_load() {
   local hook="$1"
@@ -129,83 +142,115 @@ _vg_cb_save() {
 # Returns 0 if the hook should run normally.
 # Returns 1 if the circuit is OPEN and the call should be auto-passed.
 # Transitions OPEN → HALF-OPEN when the cooldown has expired.
+# The entire read-decide-write cycle runs inside an exclusive flock to prevent
+# concurrent hook invocations from racing on the state file.
 vg_cb_check() {
   local hook="$1"
-  _vg_cb_load "$hook"
-  local now
-  now=$(_vg_cb_now)
+  local lock_file
+  lock_file=$(_vg_cb_lock_file "$hook")
+  mkdir -p "$(dirname "$lock_file")" 2>/dev/null || true
+  (
+    _vg_cb_try_flock 9
+    _vg_cb_load "$hook"
+    now=$(_vg_cb_now)
 
-  case "$CB_STATE" in
-    CLOSED)
-      return 0
-      ;;
-    OPEN)
-      local elapsed=$(( now - CB_LAST_BLOCK ))
-      if [[ "$elapsed" -ge "$CB_COOLDOWN" ]]; then
-        CB_STATE="HALF-OPEN"
-        CB_LAST_BLOCK=$(_vg_cb_now)
+    case "$CB_STATE" in
+      CLOSED)
+        exit 0
+        ;;
+      OPEN)
+        elapsed=$(( now - CB_LAST_BLOCK ))
+        if [[ "$elapsed" -ge "$CB_COOLDOWN" ]]; then
+          CB_STATE="HALF-OPEN"
+          CB_LAST_BLOCK=$(_vg_cb_now)
+          _vg_cb_save "$hook"
+          exit 0  # Let one probe through
+        else
+          remaining=$(( CB_COOLDOWN - elapsed ))
+          _vg_cb_log "$hook" "circuit-breaker" "pass" \
+            "CB OPEN: auto-pass (${remaining}s remaining, ${CB_BLOCKS} consecutive blocks)" ""
+          exit 1  # Auto-pass: caller should skip hook logic and exit 0
+        fi
+        ;;
+      HALF-OPEN)
+        exit 0  # Probe attempt: let it through
+        ;;
+      *)
+        CB_STATE="CLOSED"; CB_BLOCKS=0
         _vg_cb_save "$hook"
-        return 0  # Let one probe through
-      else
-        local remaining=$(( CB_COOLDOWN - elapsed ))
-        _vg_cb_log "$hook" "circuit-breaker" "pass" \
-          "CB OPEN: auto-pass (${remaining}s remaining, ${CB_BLOCKS} consecutive blocks)" ""
-        return 1  # Auto-pass: caller should skip hook logic and exit 0
-      fi
-      ;;
-    HALF-OPEN)
-      return 0  # Probe attempt: let it through
-      ;;
-    *)
-      CB_STATE="CLOSED"; CB_BLOCKS=0
-      _vg_cb_save "$hook"
-      return 0
-      ;;
-  esac
+        exit 0
+        ;;
+    esac
+  ) 9>"$lock_file"
 }
 
 # vg_cb_record_block <hook>
 # Records one block/warn event. Trips circuit to OPEN after CB_THRESHOLD consecutive events.
+# Protected by an exclusive flock to prevent lost-update races under concurrent access.
 vg_cb_record_block() {
   local hook="$1"
-  _vg_cb_load "$hook"
-  CB_BLOCKS=$(( CB_BLOCKS + 1 ))
-  CB_LAST_BLOCK=$(_vg_cb_now)
+  local lock_file
+  lock_file=$(_vg_cb_lock_file "$hook")
+  mkdir -p "$(dirname "$lock_file")" 2>/dev/null || true
+  (
+    _vg_cb_try_flock 9
+    _vg_cb_load "$hook"
+    CB_BLOCKS=$(( CB_BLOCKS + 1 ))
+    CB_LAST_BLOCK=$(_vg_cb_now)
 
-  if [[ "$CB_STATE" == "HALF-OPEN" ]] || [[ "$CB_BLOCKS" -ge "$CB_THRESHOLD" ]]; then
-    CB_STATE="OPEN"
-    _vg_cb_log "$hook" "circuit-breaker" "warn" \
-      "CB tripped OPEN: ${CB_BLOCKS} consecutive blocks, cooldown ${CB_COOLDOWN}s" ""
-  fi
-  _vg_cb_save "$hook"
+    if [[ "$CB_STATE" == "HALF-OPEN" ]] || [[ "$CB_BLOCKS" -ge "$CB_THRESHOLD" ]]; then
+      CB_STATE="OPEN"
+      _vg_cb_log "$hook" "circuit-breaker" "warn" \
+        "CB tripped OPEN: ${CB_BLOCKS} consecutive blocks, cooldown ${CB_COOLDOWN}s" ""
+    fi
+    _vg_cb_save "$hook"
+  ) 9>"$lock_file"
 }
 
 # vg_cb_record_pass <hook>
 # Records a successful (non-blocking) result. Resets circuit to CLOSED.
+# Protected by an exclusive flock to prevent lost-update races under concurrent access.
 vg_cb_record_pass() {
   local hook="$1"
-  _vg_cb_load "$hook"
-  if [[ "$CB_STATE" != "CLOSED" ]] || [[ "$CB_BLOCKS" -gt 0 ]]; then
-    CB_STATE="CLOSED"
-    CB_BLOCKS=0
-    CB_LAST_BLOCK=0
-    _vg_cb_save "$hook"
-  fi
+  local lock_file
+  lock_file=$(_vg_cb_lock_file "$hook")
+  mkdir -p "$(dirname "$lock_file")" 2>/dev/null || true
+  (
+    _vg_cb_try_flock 9
+    _vg_cb_load "$hook"
+    if [[ "$CB_STATE" != "CLOSED" ]] || [[ "$CB_BLOCKS" -gt 0 ]]; then
+      CB_STATE="CLOSED"
+      CB_BLOCKS=0
+      CB_LAST_BLOCK=0
+      _vg_cb_save "$hook"
+    fi
+  ) 9>"$lock_file"
 }
 
 # ── CI guard ─────────────────────────────────────────────────────────────────
 
+# _vg_is_truthy <value>
+# Returns 0 if the value is a recognized truthy CI flag: true, True, TRUE, 1, yes, Yes, YES.
+# This prevents CI=false or CI=0 from being misread as "running in CI".
+_vg_is_truthy() {
+  case "${1:-}" in
+    true|True|TRUE|1|yes|Yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # vg_is_ci
 # Returns 0 (true) if running inside a CI environment.
+# Only truthy values (true/1/yes) are accepted; CI=false or CI=0 are treated as "not CI".
 # Hooks that rely on desktop-only context should call:  vg_is_ci && exit 0
 vg_is_ci() {
-  [[ -n "${CI:-}" ]] \
-    || [[ -n "${GITHUB_ACTIONS:-}" ]] \
-    || [[ -n "${TRAVIS:-}" ]] \
-    || [[ -n "${CIRCLECI:-}" ]] \
+  _vg_is_truthy "${CI:-}" \
+    || _vg_is_truthy "${GITHUB_ACTIONS:-}" \
+    || _vg_is_truthy "${TRAVIS:-}" \
+    || _vg_is_truthy "${CIRCLECI:-}" \
     || [[ -n "${JENKINS_URL:-}" ]] \
-    || [[ -n "${GITLAB_CI:-}" ]] \
-    || [[ -n "${TF_BUILD:-}" ]]
+    || _vg_is_truthy "${GITLAB_CI:-}" \
+    || _vg_is_truthy "${TF_BUILD:-}"
 }
 
 # ── stop_hook_active guard ────────────────────────────────────────────────────

--- a/hooks/learn-evaluator.sh
+++ b/hooks/learn-evaluator.sh
@@ -11,6 +11,14 @@
 # 检测到显著信号时输出建议（不阻塞）
 set -euo pipefail
 source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/circuit-breaker.sh"
+
+# CI guard: skip in automated environments
+vg_is_ci && exit 0
+
+# Read stdin; check stop_hook_active to break Stop-hook chain loops
+INPUT=$(cat 2>/dev/null || true)
+vg_stop_hook_active "$INPUT" && exit 0
 
 # 不在 git 仓库 → 跳过
 if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then

--- a/hooks/stop-guard.sh
+++ b/hooks/stop-guard.sh
@@ -2,12 +2,23 @@
 # VibeGuard Stop Hook — 完成前验证门禁
 #
 # AI 会话结束时检查是否有未提交的源码变更。
-# 有未提交变更 → exit 2（阻塞，stderr 反馈给 Claude）
+# 有未提交变更 → exit 0（log only; exit 2 在 Stop 上下文会触发无限循环）
 # 无变更或非 git 仓库 → exit 0（静默通过）
 
 set -euo pipefail
 
 source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/circuit-breaker.sh"
+
+# CI guard: skip interactive hooks in CI environments
+vg_is_ci && exit 0
+
+# Read stdin once (Stop hook receives JSON input)
+INPUT=$(cat 2>/dev/null || true)
+
+# stop_hook_active: platform sets this when a Stop hook triggered another Stop hook.
+# Checking it breaks the feedback → Stop hook → feedback → Stop hook infinite loop.
+vg_stop_hook_active "$INPUT" && exit 0
 
 # 不在 git 仓库 → 跳过
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then
@@ -30,7 +41,8 @@ if [[ -n "$changed_source_files" ]]; then
   vg_log "stop-guard" "Stop" "gate" "uncommitted source changes: ${count} files" "$(echo "$changed_source_files" | head -5 | tr '\n' ' ')"
 
   # exit 0: log only, do not block — Claude cannot commit in Stop context,
-  # so exit 2 here causes an infinite loop (feedback → response → stop hooks → repeat)
+  # so exit 2 here causes an infinite loop (feedback → response → stop hooks → repeat).
+  # See GitHub issues #3573, #10205.
   exit 0
 fi
 

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Unit tests for hooks/circuit-breaker.sh
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CB_SCRIPT="${REPO_DIR}/hooks/circuit-breaker.sh"
+
+PASS=0; FAIL=0; TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+
+assert_ok() {
+  local desc="$1"; shift; TOTAL=$((TOTAL+1))
+  if "$@" >/dev/null 2>&1; then green "$desc"; PASS=$((PASS+1))
+  else red "$desc (expected exit 0)"; FAIL=$((FAIL+1)); fi
+}
+
+assert_fail() {
+  local desc="$1"; shift; TOTAL=$((TOTAL+1))
+  if "$@" >/dev/null 2>&1; then red "$desc (expected non-zero)"; FAIL=$((FAIL+1))
+  else green "$desc"; PASS=$((PASS+1)); fi
+}
+
+assert_output_contains() {
+  local desc="$1" expected="$2"; shift 2; TOTAL=$((TOTAL+1))
+  local out; out=$("$@" 2>&1 || true)
+  if echo "$out" | grep -qF "$expected"; then green "$desc"; PASS=$((PASS+1))
+  else red "$desc (missing: '$expected' in: '$out')"; FAIL=$((FAIL+1)); fi
+}
+
+assert_output_not_contains() {
+  local desc="$1" unexpected="$2"; shift 2; TOTAL=$((TOTAL+1))
+  local out; out=$("$@" 2>&1 || true)
+  if echo "$out" | grep -qF "$unexpected"; then
+    red "$desc (unexpected: '$unexpected')"; FAIL=$((FAIL+1))
+  else green "$desc"; PASS=$((PASS+1)); fi
+}
+
+# ── Test helpers ──────────────────────────────────────────────────────────────
+
+CB_TMPDIR=""
+
+setup() {
+  CB_TMPDIR="$(mktemp -d)"
+  export VIBEGUARD_LOG_DIR="$CB_TMPDIR"
+  export VIBEGUARD_SESSION_ID="testsession01"
+  unset VG_CB_COOLDOWN VG_CB_THRESHOLD CI GITHUB_ACTIONS TRAVIS CIRCLECI JENKINS_URL GITLAB_CI TF_BUILD
+}
+
+teardown() {
+  [[ -n "$CB_TMPDIR" ]] && rm -rf "$CB_TMPDIR"
+}
+
+# Run a snippet that sources circuit-breaker.sh in a subshell with isolated CB_DIR
+run_cb() {
+  bash -c "
+    export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+    export VIBEGUARD_SESSION_ID='${VIBEGUARD_SESSION_ID:-testsession01}'
+    ${VG_CB_EXTRA_ENV:-}
+    source '${CB_SCRIPT}'
+    $*
+  " 2>&1
+}
+
+run_cb_exit() {
+  bash -c "
+    export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+    export VIBEGUARD_SESSION_ID='${VIBEGUARD_SESSION_ID:-testsession01}'
+    ${VG_CB_EXTRA_ENV:-}
+    source '${CB_SCRIPT}'
+    $*
+  " >/dev/null 2>&1
+  echo $?
+}
+
+printf '\n=== circuit-breaker.sh ===\n'
+
+# ── 1. CLOSED state: vg_cb_check returns 0 ───────────────────────────────────
+printf '\n--- State machine ---\n'
+
+setup
+assert_ok "CLOSED: vg_cb_check passes on fresh state" \
+  bash -c "
+    export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+    export VIBEGUARD_SESSION_ID='testsession01'
+    source '${CB_SCRIPT}'
+    vg_cb_check 'test-hook'
+  "
+teardown
+
+# ── 2. Trip circuit after CB_THRESHOLD blocks ────────────────────────────────
+setup
+TRIP_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=3
+  source '${CB_SCRIPT}'
+  vg_cb_record_block 'test-hook'
+  vg_cb_record_block 'test-hook'
+  vg_cb_record_block 'test-hook'
+  # Now circuit should be OPEN; vg_cb_check should return 1
+  vg_cb_check 'test-hook' && echo 'PASSED_THROUGH' || echo 'AUTO_PASSED'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$TRIP_TEST" | grep -q "AUTO_PASSED"; then
+  green "OPEN after 3 blocks: vg_cb_check returns 1 (auto-pass)"; PASS=$((PASS+1))
+else
+  red "OPEN after 3 blocks: expected AUTO_PASSED, got: $TRIP_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 3. Below threshold: stays CLOSED ────────────────────────────────────────
+setup
+BELOW_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=3
+  source '${CB_SCRIPT}'
+  vg_cb_record_block 'test-hook'
+  vg_cb_record_block 'test-hook'
+  # Only 2 blocks, threshold is 3 — still CLOSED
+  vg_cb_check 'test-hook' && echo 'PASSED_THROUGH' || echo 'AUTO_PASSED'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$BELOW_TEST" | grep -q "PASSED_THROUGH"; then
+  green "Below threshold: circuit stays CLOSED"; PASS=$((PASS+1))
+else
+  red "Below threshold: expected PASSED_THROUGH, got: $BELOW_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 4. vg_cb_record_pass resets to CLOSED ───────────────────────────────────
+setup
+RESET_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=2
+  source '${CB_SCRIPT}'
+  vg_cb_record_block 'test-hook'
+  vg_cb_record_pass 'test-hook'   # reset
+  vg_cb_record_block 'test-hook'  # should not trip (counter was reset)
+  vg_cb_check 'test-hook' && echo 'PASSED_THROUGH' || echo 'AUTO_PASSED'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$RESET_TEST" | grep -q "PASSED_THROUGH"; then
+  green "record_pass resets counter to CLOSED"; PASS=$((PASS+1))
+else
+  red "record_pass reset: expected PASSED_THROUGH, got: $RESET_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 5. HALF-OPEN after cooldown ──────────────────────────────────────────────
+setup
+HALFOPEN_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=2
+  export VG_CB_COOLDOWN=0   # instant cooldown for testing
+  source '${CB_SCRIPT}'
+  vg_cb_record_block 'test-hook'
+  vg_cb_record_block 'test-hook'  # trips to OPEN
+  sleep 1                          # wait past cooldown (0s)
+  vg_cb_check 'test-hook' && echo 'HALF_OPEN_PROBE' || echo 'STILL_OPEN'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$HALFOPEN_TEST" | grep -q "HALF_OPEN_PROBE"; then
+  green "HALF-OPEN after cooldown expires: probe allowed"; PASS=$((PASS+1))
+else
+  red "HALF-OPEN probe: expected HALF_OPEN_PROBE, got: $HALFOPEN_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 6. HALF-OPEN block → back to OPEN ───────────────────────────────────────
+# Inject HALF-OPEN state directly to avoid cooldown=0 re-expiry race
+setup
+REOPEN_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=2
+  export VG_CB_COOLDOWN=9999
+  source '${CB_SCRIPT}'
+  # Directly write HALF-OPEN state (old timestamp, same session)
+  mkdir -p '${CB_TMPDIR}/circuit-breaker'
+  printf 'CB_STATE=HALF-OPEN\nCB_BLOCKS=2\nCB_LAST_BLOCK=1\nCB_SESSION=testsession01\n' \
+    > '${CB_TMPDIR}/circuit-breaker/test-hook.cb'
+  # Block during probe → circuit returns to OPEN
+  vg_cb_record_block 'test-hook'
+  # vg_cb_check: OPEN with long cooldown → auto-pass (return 1)
+  vg_cb_check 'test-hook' && echo 'PASSED_THROUGH' || echo 'BACK_TO_OPEN'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$REOPEN_TEST" | grep -q "BACK_TO_OPEN"; then
+  green "HALF-OPEN block: circuit returns to OPEN"; PASS=$((PASS+1))
+else
+  red "HALF-OPEN reopen: expected BACK_TO_OPEN, got: $REOPEN_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 7. Session isolation: new session resets circuit ─────────────────────────
+setup
+SESSION_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VG_CB_THRESHOLD=2
+  export VG_CB_COOLDOWN=9999
+  source '${CB_SCRIPT}'
+  # Trip in session A
+  export VIBEGUARD_SESSION_ID='sessionA'
+  vg_cb_record_block 'test-hook'
+  vg_cb_record_block 'test-hook'  # OPEN in session A
+  # Switch to session B — should start CLOSED
+  export VIBEGUARD_SESSION_ID='sessionB'
+  vg_cb_check 'test-hook' && echo 'NEW_SESSION_FRESH' || echo 'STILL_OPEN'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$SESSION_TEST" | grep -q "NEW_SESSION_FRESH"; then
+  green "Session isolation: new session starts with CLOSED circuit"; PASS=$((PASS+1))
+else
+  red "Session isolation: expected NEW_SESSION_FRESH, got: $SESSION_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 8. CI guard: vg_is_ci detects common CI vars ────────────────────────────
+printf '\n--- CI guard ---\n'
+
+setup
+assert_ok "vg_is_ci: detects CI=true" \
+  bash -c "source '${CB_SCRIPT}'; CI=true vg_is_ci"
+assert_ok "vg_is_ci: detects GITHUB_ACTIONS=true" \
+  bash -c "source '${CB_SCRIPT}'; GITHUB_ACTIONS=true vg_is_ci"
+assert_fail "vg_is_ci: returns 1 when no CI vars set" \
+  bash -c "
+    unset CI GITHUB_ACTIONS TRAVIS CIRCLECI JENKINS_URL GITLAB_CI TF_BUILD
+    source '${CB_SCRIPT}'
+    vg_is_ci
+  "
+teardown
+
+# ── 9. stop_hook_active: parses JSON correctly ───────────────────────────────
+printf '\n--- stop_hook_active ---\n'
+
+setup
+assert_ok "stop_hook_active: returns 0 when true" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"stop_hook_active\": true}'
+  "
+assert_fail "stop_hook_active: returns 1 when false" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"stop_hook_active\": false}'
+  "
+assert_fail "stop_hook_active: returns 1 when field absent" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"session_id\": \"abc\"}'
+  "
+assert_fail "stop_hook_active: returns 1 on empty string" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active ''
+  "
+assert_fail "stop_hook_active: returns 1 on invalid JSON" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active 'not-json'
+  "
+teardown
+
+# ── 10. State directory is created automatically ─────────────────────────────
+printf '\n--- State persistence ---\n'
+
+setup
+STATEDIR_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  source '${CB_SCRIPT}'
+  vg_cb_record_block 'statedir-hook'
+  ls '${CB_TMPDIR}/circuit-breaker/statedir-hook.cb' 2>/dev/null && echo 'FILE_EXISTS' || echo 'MISSING'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$STATEDIR_TEST" | grep -q "FILE_EXISTS"; then
+  green "State file created after record_block"; PASS=$((PASS+1))
+else
+  red "State file: expected FILE_EXISTS, got: $STATEDIR_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo
+printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
+[[ $FAIL -gt 0 ]] && exit 1 || exit 0

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -267,6 +267,18 @@ assert_fail "stop_hook_active: returns 1 on invalid JSON" \
     source '${CB_SCRIPT}'
     vg_stop_hook_active 'not-json'
   "
+# String "false" is truthy in Python — must be treated as false (not active)
+assert_fail "stop_hook_active: returns 1 when value is string \"false\"" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"stop_hook_active\": \"false\"}'
+  "
+# String "true" is not the boolean true literal — must also be treated as false
+assert_fail "stop_hook_active: returns 1 when value is string \"true\"" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"stop_hook_active\": \"true\"}'
+  "
 teardown
 
 # ── 10. State directory is created automatically ─────────────────────────────

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -171,6 +171,30 @@ else
 fi
 teardown
 
+# ── 5b. HALF-OPEN subsequent callers are auto-passed (single-probe semantics) ─
+# Inject HALF-OPEN state directly; vg_cb_check should return 1 (auto-pass)
+# since the probe slot was already consumed by the OPEN→HALF-OPEN transition.
+setup
+HALFOPEN_INFLIGHT_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=2
+  export VG_CB_COOLDOWN=9999
+  source '${CB_SCRIPT}'
+  STATE_FILE=\$(_vg_cb_state_file 'test-hook')
+  mkdir -p \"\$(dirname \"\$STATE_FILE\")\"
+  printf 'CB_STATE=HALF-OPEN\nCB_BLOCKS=2\nCB_LAST_BLOCK=1\nCB_SESSION=testsession01\n' \
+    > \"\$STATE_FILE\"
+  vg_cb_check 'test-hook' && echo 'PASSED_THROUGH' || echo 'AUTO_PASSED'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$HALFOPEN_INFLIGHT_TEST" | grep -q "AUTO_PASSED"; then
+  green "HALF-OPEN probe in-flight: subsequent callers are auto-passed"; PASS=$((PASS+1))
+else
+  red "HALF-OPEN in-flight: expected AUTO_PASSED, got: $HALFOPEN_INFLIGHT_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
 # ── 6. HALF-OPEN block → back to OPEN ───────────────────────────────────────
 # Inject HALF-OPEN state directly to avoid cooldown=0 re-expiry race.
 # Use _vg_cb_state_file to resolve the per-project path rather than hardcoding it.

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -172,7 +172,8 @@ fi
 teardown
 
 # ── 6. HALF-OPEN block → back to OPEN ───────────────────────────────────────
-# Inject HALF-OPEN state directly to avoid cooldown=0 re-expiry race
+# Inject HALF-OPEN state directly to avoid cooldown=0 re-expiry race.
+# Use _vg_cb_state_file to resolve the per-project path rather than hardcoding it.
 setup
 REOPEN_TEST=$(bash -c "
   export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
@@ -180,10 +181,11 @@ REOPEN_TEST=$(bash -c "
   export VG_CB_THRESHOLD=2
   export VG_CB_COOLDOWN=9999
   source '${CB_SCRIPT}'
-  # Directly write HALF-OPEN state (old timestamp, same session)
-  mkdir -p '${CB_TMPDIR}/circuit-breaker'
+  # Resolve the per-project state file path and inject HALF-OPEN state
+  STATE_FILE=\$(_vg_cb_state_file 'test-hook')
+  mkdir -p \"\$(dirname \"\$STATE_FILE\")\"
   printf 'CB_STATE=HALF-OPEN\nCB_BLOCKS=2\nCB_LAST_BLOCK=1\nCB_SESSION=testsession01\n' \
-    > '${CB_TMPDIR}/circuit-breaker/test-hook.cb'
+    > \"\$STATE_FILE\"
   # Block during probe → circuit returns to OPEN
   vg_cb_record_block 'test-hook'
   # vg_cb_check: OPEN with long cooldown → auto-pass (return 1)
@@ -276,13 +278,41 @@ STATEDIR_TEST=$(bash -c "
   export VIBEGUARD_SESSION_ID='testsession01'
   source '${CB_SCRIPT}'
   vg_cb_record_block 'statedir-hook'
-  ls '${CB_TMPDIR}/circuit-breaker/statedir-hook.cb' 2>/dev/null && echo 'FILE_EXISTS' || echo 'MISSING'
+  # State file is now under a per-project subdirectory; find it anywhere under circuit-breaker/
+  find '${CB_TMPDIR}/circuit-breaker' -name 'statedir-hook.cb' 2>/dev/null | grep -q . && echo 'FILE_EXISTS' || echo 'MISSING'
 " 2>&1 || true)
 TOTAL=$((TOTAL+1))
 if echo "$STATEDIR_TEST" | grep -q "FILE_EXISTS"; then
   green "State file created after record_block"; PASS=$((PASS+1))
 else
   red "State file: expected FILE_EXISTS, got: $STATEDIR_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+# ── 11. Cross-project isolation: OPEN in one project does not affect another ──
+printf '\n--- Cross-project isolation ---\n'
+
+setup
+# Write OPEN state for project-A slug directly, then verify project-B (different slug) starts CLOSED.
+NOW_TS=$(date +%s)
+mkdir -p "${CB_TMPDIR}/circuit-breaker/aaaaaaaa"
+printf 'CB_STATE=OPEN\nCB_BLOCKS=3\nCB_LAST_BLOCK=%s\nCB_SESSION=shared-session\n' "$NOW_TS" \
+  > "${CB_TMPDIR}/circuit-breaker/aaaaaaaa/test-hook.cb"
+
+XPROJECT_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='shared-session'
+  export VG_CB_COOLDOWN=9999
+  # Simulate project-B by setting a different hash (bbbbbbbb has no state file)
+  export _vg_project_hash='bbbbbbbb'
+  source '${CB_SCRIPT}'
+  vg_cb_check 'test-hook' && echo 'PROJECT_B_FRESH' || echo 'PROJECT_B_BLOCKED'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$XPROJECT_TEST" | grep -q "PROJECT_B_FRESH"; then
+  green "Cross-project isolation: OPEN in project-A does not affect project-B"; PASS=$((PASS+1))
+else
+  red "Cross-project isolation: expected PROJECT_B_FRESH, got: $XPROJECT_TEST"; FAIL=$((FAIL+1))
 fi
 teardown
 

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -228,6 +228,8 @@ printf '\n--- CI guard ---\n'
 setup
 assert_ok "vg_is_ci: detects CI=true" \
   bash -c "source '${CB_SCRIPT}'; CI=true vg_is_ci"
+assert_ok "vg_is_ci: detects CI=1" \
+  bash -c "source '${CB_SCRIPT}'; CI=1 vg_is_ci"
 assert_ok "vg_is_ci: detects GITHUB_ACTIONS=true" \
   bash -c "source '${CB_SCRIPT}'; GITHUB_ACTIONS=true vg_is_ci"
 assert_fail "vg_is_ci: returns 1 when no CI vars set" \
@@ -235,6 +237,18 @@ assert_fail "vg_is_ci: returns 1 when no CI vars set" \
     unset CI GITHUB_ACTIONS TRAVIS CIRCLECI JENKINS_URL GITLAB_CI TF_BUILD
     source '${CB_SCRIPT}'
     vg_is_ci
+  "
+assert_fail "vg_is_ci: returns 1 when CI=false" \
+  bash -c "
+    unset GITHUB_ACTIONS TRAVIS CIRCLECI JENKINS_URL GITLAB_CI TF_BUILD
+    source '${CB_SCRIPT}'
+    CI=false vg_is_ci
+  "
+assert_fail "vg_is_ci: returns 1 when CI=0" \
+  bash -c "
+    unset GITHUB_ACTIONS TRAVIS CIRCLECI JENKINS_URL GITLAB_CI TF_BUILD
+    source '${CB_SCRIPT}'
+    CI=0 vg_is_ci
   "
 teardown
 


### PR DESCRIPTION
## Summary

- Adds `hooks/circuit-breaker.sh`: Martin Fowler's circuit breaker adapted for hooks — `CLOSED → OPEN (5 min cooldown) → HALF-OPEN` state machine, trips after 3 consecutive blocks/warns, resets per session
- `vg_is_ci()`: CI guard skips desktop-only hooks in CI environments (addresses #3573)
- `vg_stop_hook_active()`: Stop hooks check the `stop_hook_active` input field and exit 0 immediately when set, breaking the Stop-hook feedback chain (addresses #10205, #34600)
- Integrates circuit breaker into `analysis-paralysis-guard.sh` — prevents the 716x warn loop where the guard fires without resolution
- Adds `stop_hook_active` + CI guard to `stop-guard.sh` and `learn-evaluator.sh`

## Test plan

- [x] `tests/unit/test_circuit_breaker.sh`: 16 unit tests — all state transitions (CLOSED/OPEN/HALF-OPEN), session isolation, CI detection, `stop_hook_active` parsing
- [x] `npm test`: all 34 existing tests pass
- [x] `tsc --noEmit`: TypeScript clean