### PR TITLE
fix(hooks): isolate runtime hooks from dev repo via installed snapshot

### DIFF
--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -12,14 +12,19 @@ set -euo pipefail
 HOOK_NAME="${1:?Usage: run-hook.sh <hook-name>}"
 shift
 
-REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
-if [[ ! -f "$REPO_PATH_FILE" ]]; then
-  echo "ERROR: ${REPO_PATH_FILE} not found. Re-run: bash <vibeguard-repo>/scripts/setup/install.sh" >&2
-  exit 1
-fi
+INSTALLED_DIR="${HOME}/.vibeguard/installed/hooks"
+HOOK_PATH="${INSTALLED_DIR}/${HOOK_NAME}"
 
-REPO_DIR=$(<"$REPO_PATH_FILE")
-HOOK_PATH="${REPO_DIR}/hooks/${HOOK_NAME}"
+if [[ ! -d "$INSTALLED_DIR" ]]; then
+  # Fallback: legacy direct-repo mode
+  REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
+  if [[ ! -f "$REPO_PATH_FILE" ]]; then
+    echo "ERROR: ${REPO_PATH_FILE} not found. Re-run: bash <vibeguard-repo>/scripts/setup/install.sh" >&2
+    exit 1
+  fi
+  REPO_DIR=$(<"$REPO_PATH_FILE")
+  HOOK_PATH="${REPO_DIR}/hooks/${HOOK_NAME}"
+fi
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   echo "ERROR: hook not found: ${HOOK_PATH}" >&2

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -105,6 +105,15 @@ green "  ~/.vibeguard/repo-path + run-hook.sh ready"
 mkdir -p "${VIBEGUARD_HOME}/user-rules"
 green "  ~/.vibeguard/user-rules/ ready (add custom .md rules here)"
 
+# Install hooks and guards snapshot (isolated from dev repo — prevents dirty state from breaking hooks)
+INSTALLED_DIR="${VIBEGUARD_HOME}/installed"
+mkdir -p "${INSTALLED_DIR}/hooks" "${INSTALLED_DIR}/guards"
+rm -rf "${INSTALLED_DIR}/hooks" "${INSTALLED_DIR}/guards"
+cp -r "${REPO_DIR}/hooks" "${INSTALLED_DIR}/"
+cp -r "${REPO_DIR}/guards" "${INSTALLED_DIR}/"
+printf '%s' "$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')" > "${INSTALLED_DIR}/version"
+green "  ~/.vibeguard/installed/ hooks+guards snapshot ($(cat "${INSTALLED_DIR}/version"))"
+
 # Initialize install state tracking
 state_init "$PROFILE" "$LANGUAGES"
 state_record_file "${VIBEGUARD_HOME}/repo-path" "generated/repo-path" "copy"


### PR DESCRIPTION
## Summary
- Copy `hooks/` and `guards/` to `~/.vibeguard/installed/` on install
- `run-hook.sh` loads from `installed/hooks/` instead of directly from repo
- Dirty working tree or merge conflicts in dev repo no longer affect hooks in other projects

## Test plan
- [ ] Run `bash scripts/setup/install.sh` → verify `~/.vibeguard/installed/` created with version hash
- [ ] Introduce a syntax error in `hooks/log.sh` in dev repo → confirm hooks still work normally
- [ ] Re-run install → confirm snapshot updated