### PR TITLE
feat(guards): protect test infrastructure files from AI modification (W-12)

### DIFF
--- a/guards/universal/check_test_integrity.sh
+++ b/guards/universal/check_test_integrity.sh
@@ -128,16 +128,8 @@ for fpath in find_test_files(target):
             continue
         if not node.name.startswith("test_") and node.name != "test":
             continue
-        # Skip functions with only pass/... body (explicit stubs)
-        body = node.body
-        if all(
-            isinstance(s, (ast.Pass, ast.Expr)) and (
-                isinstance(s, ast.Pass) or
-                (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant) and s.value.value in (None, ...))
-            )
-            for s in body
-        ):
-            continue
+        # Flag functions with only pass/... body — emptied test body is a direct
+        # forgery pattern (W-12); treat the same as no-assertion functions.
         if not has_assertion(node):
             rel = os.path.relpath(fpath, target)
             violations.append(f"{rel}:{node.lineno}: {node.name}() has no assertions")
@@ -180,7 +172,9 @@ if [[ -n "$JS_EMPTY_STUBS" ]]; then
   COUNT=$(echo "$JS_EMPTY_STUBS" | wc -l | tr -d ' ')
   yellow "无断言测试块 (JS/TS): ${COUNT} 处 (需人工确认)"
   echo "$JS_EMPTY_STUBS" | head -10
-  # Don't increment ISSUES for JS — heuristic is less reliable
+  ISSUES=$((ISSUES + COUNT))
+else
+  echo "  未发现无断言测试块 (JS/TS)"
 fi
 
 # =========================================================

--- a/guards/universal/check_test_integrity.sh
+++ b/guards/universal/check_test_integrity.sh
@@ -188,14 +188,17 @@ if [[ "$_GREP_EXIT" -gt 1 ]]; then
   JS_EMPTY_STUBS=""
 else
   rm -f "$_GREP_ERR"
-  JS_EMPTY_STUBS=$(echo "$_GREP_OUT" | while IFS= read -r line; do
-    file=$(echo "$line" | cut -d: -f1)
-    lineno=$(echo "$line" | cut -d: -f2)
-    # Check the next 15 lines for expect(
-    if ! sed -n "${lineno},$((lineno + 15))p" "$file" 2>/dev/null | grep -qE 'expect\s*\(|assert\s*\(|should\.|\.toBe|\.toEqual|\.toContain|\.toThrow'; then
-      echo "${file#${TARGET_DIR}/}:${lineno}"
-    fi
-  done | head -20)
+  JS_EMPTY_STUBS=""
+  if [[ -n "$_GREP_OUT" ]]; then
+    JS_EMPTY_STUBS=$(echo "$_GREP_OUT" | while IFS= read -r line; do
+      file=$(echo "$line" | cut -d: -f1)
+      lineno=$(echo "$line" | cut -d: -f2)
+      # Check the next 15 lines for expect(
+      if ! sed -n "${lineno},$((lineno + 15))p" "$file" 2>/dev/null | grep -qE 'expect\s*\(|assert\s*\(|should\.|\.toBe|\.toEqual|\.toContain|\.toThrow'; then
+        echo "${file#${TARGET_DIR}/}:${lineno}"
+      fi
+    done | head -20)
+  fi
 fi
 
 if [[ -n "$JS_EMPTY_STUBS" ]]; then

--- a/guards/universal/check_test_integrity.sh
+++ b/guards/universal/check_test_integrity.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# VibeGuard Guard — 测试完整性检测 (W-12)
+#
+# 检测 AI 代理可能用于伪造测试通过的攻击向量：
+#   1. 库影子文件 (Library Shadowing) — 本地文件覆盖标准库模块
+#   2. 空断言测试函数 (Empty Stub Detection) — 无断言的测试函数
+#
+# 用法：
+#   bash check_test_integrity.sh [target_dir]    # 扫描指定目录
+#   bash check_test_integrity.sh                 # 扫描当前目录
+#
+# 退出码：
+#   0 — 无问题
+#   1 — 发现问题
+
+set -euo pipefail
+
+TARGET_DIR="${1:-.}"
+ISSUES=0
+
+yellow() { printf '\033[33m[W-12] %s\033[0m\n' "$1"; }
+red()    { printf '\033[31m[W-12] %s\033[0m\n' "$1"; }
+green()  { printf '\033[32m%s\033[0m\n' "$1"; }
+
+echo "测试完整性检测 (W-12): ${TARGET_DIR}"
+echo "---"
+
+# =========================================================
+# 1. 库影子文件检测
+# =========================================================
+echo "检查库影子文件..."
+
+# Python 标准库模块名（最常见的 shadow 目标）
+PYTHON_STDLIB_MODULES=(
+  os sys re io json math time copy enum abc
+  abc ast builtins collections datetime decimal
+  functools hashlib hmac http inspect io itertools
+  logging math operator os pathlib pickle platform
+  queue random re shutil signal socket ssl stat string
+  struct subprocess sys tempfile threading time types
+  typing unittest urllib uuid warnings weakref
+  numpy pandas requests flask django pytest
+)
+
+SHADOW_FOUND=0
+for mod in "${PYTHON_STDLIB_MODULES[@]}"; do
+  shadow_file="${TARGET_DIR}/${mod}.py"
+  if [[ -f "$shadow_file" ]]; then
+    rel_path="${shadow_file#${TARGET_DIR}/}"
+    red "库影子文件: ${rel_path} (shadows '${mod}' module)"
+    SHADOW_FOUND=$((SHADOW_FOUND + 1))
+    ISSUES=$((ISSUES + 1))
+  fi
+done
+
+# JavaScript/TypeScript 库影子检测
+JS_STDLIB_MODULES=(
+  path fs os crypto http https url util events
+  assert stream buffer process child_process
+)
+for mod in "${JS_STDLIB_MODULES[@]}"; do
+  for ext in js ts mjs cjs; do
+    shadow_file="${TARGET_DIR}/${mod}.${ext}"
+    if [[ -f "$shadow_file" ]]; then
+      rel_path="${shadow_file#${TARGET_DIR}/}"
+      red "库影子文件: ${rel_path} (shadows Node.js '${mod}' module)"
+      SHADOW_FOUND=$((SHADOW_FOUND + 1))
+      ISSUES=$((ISSUES + 1))
+    fi
+  done
+done
+
+if [[ "$SHADOW_FOUND" -eq 0 ]]; then
+  echo "  未发现库影子文件"
+fi
+
+# =========================================================
+# 2. 空断言测试函数检测 (Python)
+# =========================================================
+echo "检查空断言测试函数 (Python)..."
+
+EMPTY_STUBS=$(python3 -c '
+import ast
+import sys
+import os
+
+target = sys.argv[1]
+violations = []
+
+def find_test_files(root):
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Skip common non-test directories
+        dirnames[:] = [d for d in dirnames if d not in {
+            "node_modules", ".git", "target", "dist", "build",
+            "__pycache__", ".venv", "vendor", ".mypy_cache"
+        }]
+        for fname in filenames:
+            if fname.startswith("test_") or fname.endswith("_test.py"):
+                yield os.path.join(dirpath, fname)
+
+def has_assertion(func_node):
+    """Check if a function node contains any assertion-like calls."""
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Assert):
+            return True
+        if isinstance(node, ast.Call):
+            func = node.func
+            # assert* methods (unittest style)
+            if isinstance(func, ast.Attribute) and func.attr.startswith("assert"):
+                return True
+            # pytest.raises, pytest.warns, etc.
+            if isinstance(func, ast.Attribute) and func.attr in ("raises", "warns", "approx"):
+                return True
+            # expect() calls (jest/chai style via pytest-bdd etc.)
+            if isinstance(func, ast.Name) and func.id in ("expect", "raises"):
+                return True
+    return False
+
+for fpath in find_test_files(target):
+    try:
+        source = open(fpath, encoding="utf-8", errors="replace").read()
+        tree = ast.parse(source, filename=fpath)
+    except (SyntaxError, OSError):
+        continue
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith("test_") and node.name != "test":
+            continue
+        # Skip functions with only pass/... body (explicit stubs)
+        body = node.body
+        if all(
+            isinstance(s, (ast.Pass, ast.Expr)) and (
+                isinstance(s, ast.Pass) or
+                (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant) and s.value.value in (None, ...))
+            )
+            for s in body
+        ):
+            continue
+        if not has_assertion(node):
+            rel = os.path.relpath(fpath, target)
+            violations.append(f"{rel}:{node.lineno}: {node.name}() has no assertions")
+
+for v in violations:
+    print(v)
+' "$TARGET_DIR" 2>/dev/null || true)
+
+if [[ -n "$EMPTY_STUBS" ]]; then
+  COUNT=$(echo "$EMPTY_STUBS" | wc -l | tr -d ' ')
+  yellow "无断言测试函数: ${COUNT} 处"
+  echo "$EMPTY_STUBS" | head -10
+  [[ "$COUNT" -gt 10 ]] && echo "  ... 还有 $((COUNT - 10)) 处"
+  ISSUES=$((ISSUES + COUNT))
+else
+  echo "  未发现无断言测试函数"
+fi
+
+# =========================================================
+# 3. 空断言测试函数检测 (TypeScript/JavaScript)
+# =========================================================
+echo "检查空断言测试函数 (TypeScript/JavaScript)..."
+
+JS_EMPTY_STUBS=$(grep -rn \
+  --include='*.test.ts' --include='*.test.js' \
+  --include='*.spec.ts' --include='*.spec.js' \
+  --include='*.test.tsx' --include='*.spec.tsx' \
+  --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git \
+  -E '^\s*(it|test)\s*\(' \
+  "$TARGET_DIR" 2>/dev/null | while IFS= read -r line; do
+    file=$(echo "$line" | cut -d: -f1)
+    lineno=$(echo "$line" | cut -d: -f2)
+    # Check the next 10 lines for expect(
+    if ! sed -n "${lineno},$((lineno + 15))p" "$file" 2>/dev/null | grep -qE 'expect\s*\(|assert\s*\(|should\.|\.toBe|\.toEqual|\.toContain|\.toThrow'; then
+      echo "${file#${TARGET_DIR}/}:${lineno}"
+    fi
+  done 2>/dev/null | head -20 || true)
+
+if [[ -n "$JS_EMPTY_STUBS" ]]; then
+  COUNT=$(echo "$JS_EMPTY_STUBS" | wc -l | tr -d ' ')
+  yellow "无断言测试块 (JS/TS): ${COUNT} 处 (需人工确认)"
+  echo "$JS_EMPTY_STUBS" | head -10
+  # Don't increment ISSUES for JS — heuristic is less reliable
+fi
+
+# =========================================================
+# 总结
+# =========================================================
+echo ""
+echo "---"
+if [[ "$ISSUES" -gt 0 ]]; then
+  red "发现 ${ISSUES} 个测试完整性问题 (W-12)"
+  exit 1
+else
+  green "测试完整性检测通过"
+  exit 0
+fi

--- a/guards/universal/check_test_integrity.sh
+++ b/guards/universal/check_test_integrity.sh
@@ -190,14 +190,20 @@ else
   rm -f "$_GREP_ERR"
   JS_EMPTY_STUBS=""
   if [[ -n "$_GREP_OUT" ]]; then
-    JS_EMPTY_STUBS=$(echo "$_GREP_OUT" | while IFS= read -r line; do
+    # Write to a temp file first to avoid SIGPIPE (141) under set -euo pipefail:
+    # piping a while loop into `head -20` causes head to exit early, sending
+    # SIGPIPE to the upstream while, which the shell treats as an error.
+    _JS_TMP=$(mktemp)
+    echo "$_GREP_OUT" | while IFS= read -r line; do
       file=$(echo "$line" | cut -d: -f1)
       lineno=$(echo "$line" | cut -d: -f2)
       # Check the next 15 lines for expect(
       if ! sed -n "${lineno},$((lineno + 15))p" "$file" 2>/dev/null | grep -qE 'expect\s*\(|assert\s*\(|should\.|\.toBe|\.toEqual|\.toContain|\.toThrow'; then
         echo "${file#${TARGET_DIR}/}:${lineno}"
       fi
-    done | head -20)
+    done > "$_JS_TMP"
+    JS_EMPTY_STUBS=$(head -20 "$_JS_TMP")
+    rm -f "$_JS_TMP"
   fi
 fi
 

--- a/guards/universal/check_test_integrity.sh
+++ b/guards/universal/check_test_integrity.sh
@@ -51,6 +51,14 @@ for mod in "${PYTHON_STDLIB_MODULES[@]}"; do
     SHADOW_FOUND=$((SHADOW_FOUND + 1))
     ISSUES=$((ISSUES + 1))
   fi
+  # Also check package-style shadow: json/__init__.py can shadow the 'json' module
+  shadow_pkg="${TARGET_DIR}/${mod}/__init__.py"
+  if [[ -f "$shadow_pkg" ]]; then
+    rel_path="${shadow_pkg#${TARGET_DIR}/}"
+    red "库影子包: ${rel_path} (shadows '${mod}' package)"
+    SHADOW_FOUND=$((SHADOW_FOUND + 1))
+    ISSUES=$((ISSUES + 1))
+  fi
 done
 
 # JavaScript/TypeScript 库影子检测
@@ -79,7 +87,8 @@ fi
 # =========================================================
 echo "检查空断言测试函数 (Python)..."
 
-EMPTY_STUBS=$(python3 -c '
+_SCAN_ERR=$(mktemp)
+if ! EMPTY_STUBS=$(python3 -c '
 import ast
 import sys
 import os
@@ -136,7 +145,14 @@ for fpath in find_test_files(target):
 
 for v in violations:
     print(v)
-' "$TARGET_DIR" 2>/dev/null || true)
+' "$TARGET_DIR" 2>"$_SCAN_ERR"); then
+  red "扫描器错误：Python 空断言检测失败，测试完整性检测中止（fail-safe）"
+  cat "$_SCAN_ERR" >&2
+  rm -f "$_SCAN_ERR"
+  ISSUES=$((ISSUES + 1))
+else
+  rm -f "$_SCAN_ERR"
+fi
 
 if [[ -n "$EMPTY_STUBS" ]]; then
   COUNT=$(echo "$EMPTY_STUBS" | wc -l | tr -d ' ')
@@ -153,20 +169,34 @@ fi
 # =========================================================
 echo "检查空断言测试函数 (TypeScript/JavaScript)..."
 
-JS_EMPTY_STUBS=$(grep -rn \
+_GREP_ERR=$(mktemp)
+_GREP_OUT=""
+_GREP_EXIT=0
+_GREP_OUT=$(grep -rn \
   --include='*.test.ts' --include='*.test.js' \
   --include='*.spec.ts' --include='*.spec.js' \
   --include='*.test.tsx' --include='*.spec.tsx' \
   --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git \
   -E '^\s*(it|test)\s*\(' \
-  "$TARGET_DIR" 2>/dev/null | while IFS= read -r line; do
+  "$TARGET_DIR" 2>"$_GREP_ERR") || _GREP_EXIT=$?
+# grep exit 1 = no matches (normal); exit 2+ = real error (fail-safe)
+if [[ "$_GREP_EXIT" -gt 1 ]]; then
+  red "扫描器错误：grep JS/TS 空断言检测失败 (exit ${_GREP_EXIT})，测试完整性检测中止（fail-safe）"
+  cat "$_GREP_ERR" >&2
+  rm -f "$_GREP_ERR"
+  ISSUES=$((ISSUES + 1))
+  JS_EMPTY_STUBS=""
+else
+  rm -f "$_GREP_ERR"
+  JS_EMPTY_STUBS=$(echo "$_GREP_OUT" | while IFS= read -r line; do
     file=$(echo "$line" | cut -d: -f1)
     lineno=$(echo "$line" | cut -d: -f2)
-    # Check the next 10 lines for expect(
+    # Check the next 15 lines for expect(
     if ! sed -n "${lineno},$((lineno + 15))p" "$file" 2>/dev/null | grep -qE 'expect\s*\(|assert\s*\(|should\.|\.toBe|\.toEqual|\.toContain|\.toThrow'; then
       echo "${file#${TARGET_DIR}/}:${lineno}"
     fi
-  done 2>/dev/null | head -20 || true)
+  done | head -20)
+fi
 
 if [[ -n "$JS_EMPTY_STUBS" ]]; then
   COUNT=$(echo "$JS_EMPTY_STUBS" | wc -l | tr -d ' ')

--- a/hooks/pre-edit-guard.sh
+++ b/hooks/pre-edit-guard.sh
@@ -39,7 +39,8 @@ print("CHECK")
 print(file_path)
 
 # W-12: Block edits to test infrastructure files
-basename = os.path.basename(file_path)
+# Use lowercased basename for case-insensitive filesystem safety (e.g. default macOS HFS+)
+basename = os.path.basename(file_path).lower()
 PROTECTED_EXACT = {"conftest.py", "pytest.ini", ".coveragerc", "setup.cfg"}
 PROTECTED_PATTERNS = [
     r"^jest\.config\.",

--- a/hooks/pre-edit-guard.sh
+++ b/hooks/pre-edit-guard.sh
@@ -14,7 +14,7 @@ INPUT=$(cat)
 # 直接在 Python 中完成全部检查，避免 bash 变量传递破坏 old_string
 # （<<<heredoc 追加 \n、$() 吞尾部换行、echo 转义特殊字符）
 CHECK_RESULT=$(python3 -c '
-import json, sys
+import json, sys, os, re
 
 data = json.load(sys.stdin)
 
@@ -38,7 +38,20 @@ if not file_path:
 print("CHECK")
 print(file_path)
 
-import os
+# W-12: Block edits to test infrastructure files
+basename = os.path.basename(file_path)
+PROTECTED_EXACT = {"conftest.py", "pytest.ini", ".coveragerc", "setup.cfg"}
+PROTECTED_PATTERNS = [
+    r"^jest\.config\.",
+    r"^vitest\.config\.",
+    r"^karma\.config\.",
+    r"^babel\.config\.",
+]
+is_protected = basename in PROTECTED_EXACT or any(re.match(p, basename) for p in PROTECTED_PATTERNS)
+if is_protected:
+    print("TEST_INFRA_PROTECTED")
+    sys.exit(0)
+
 if not os.path.isfile(file_path):
     print("FILE_NOT_FOUND")
     sys.exit(0)
@@ -59,6 +72,17 @@ DETAIL=$(echo "$CHECK_RESULT" | sed -n '3p')
 
 # 无 file_path 或解析错误 → 放行
 if [[ "$CHECK_STATUS" != "CHECK" ]]; then
+  exit 0
+fi
+
+if [[ "$DETAIL" == "TEST_INFRA_PROTECTED" ]]; then
+  vg_log "pre-edit-guard" "Edit" "block" "测试基础设施文件保护 (W-12)" "$FILE_PATH"
+  cat <<BLOCK_EOF
+{
+  "decision": "block",
+  "reason": "VIBEGUARD W-12 拦截：禁止修改测试基础设施文件 — ${FILE_PATH}。AI 代理不得修改 conftest.py/jest.config/pytest.ini/.coveragerc 等测试框架配置文件，此类修改可能导致测试被绕过而非真正修复代码问题。请修复被测代码，而非操纵测试框架。"
+}
+BLOCK_EOF
   exit 0
 fi
 

--- a/hooks/pre-edit-guard.sh
+++ b/hooks/pre-edit-guard.sh
@@ -39,8 +39,10 @@ print("CHECK")
 print(file_path)
 
 # W-12: Block edits to test infrastructure files
+# Resolve symlinks first to prevent bypass via aliases (e.g. safe.txt -> conftest.py)
+real_path = os.path.realpath(file_path)
 # Use lowercased basename for case-insensitive filesystem safety (e.g. default macOS HFS+)
-basename = os.path.basename(file_path).lower()
+basename = os.path.basename(real_path).lower()
 PROTECTED_EXACT = {"conftest.py", "pytest.ini", ".coveragerc", "setup.cfg"}
 PROTECTED_PATTERNS = [
     r"^jest\.config\.",

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -17,8 +17,34 @@ INPUT=$(cat)
 
 FILE_PATH=$(echo "$INPUT" | vg_json_field "tool_input.file_path")
 
-# 无法解析或文件已存在（编辑） → 放行
-if [[ -z "$FILE_PATH" ]] || [[ -e "$FILE_PATH" ]]; then
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# W-12: Block writes to test infrastructure files (new or existing)
+BASENAME=$(basename "$FILE_PATH")
+_is_test_infra=false
+case "$BASENAME" in
+  conftest.py|pytest.ini|.coveragerc|setup.cfg|\
+  jest.config.js|jest.config.ts|jest.config.cjs|jest.config.mjs|jest.config.json|\
+  vitest.config.js|vitest.config.ts|vitest.config.mts|\
+  karma.config.js|karma.config.ts|\
+  babel.config.js|babel.config.ts|babel.config.cjs|babel.config.json)
+    _is_test_infra=true ;;
+esac
+if [[ "$_is_test_infra" == "true" ]]; then
+  vg_log "pre-write-guard" "Write" "block" "测试基础设施文件保护 (W-12)" "$FILE_PATH"
+  cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "VIBEGUARD W-12 拦截：禁止写入测试基础设施文件。AI 代理不得创建或覆盖 conftest.py/jest.config/pytest.ini/.coveragerc/babel.config 等测试框架配置文件，此类修改可能导致测试被绕过而非真正修复代码问题。请修复被测代码，而非操纵测试框架。"
+}
+EOF
+  exit 0
+fi
+
+# 文件已存在（编辑） → 放行
+if [[ -e "$FILE_PATH" ]]; then
   exit 0
 fi
 

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -22,16 +22,16 @@ if [[ -z "$FILE_PATH" ]]; then
 fi
 
 # W-12: Block writes to test infrastructure files (new or existing)
-BASENAME=$(basename "$FILE_PATH")
+# Resolve symlinks first to prevent bypass via aliases (e.g. safe.txt -> conftest.py)
+_REAL_PATH=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+BASENAME=$(basename "$_REAL_PATH")
 # Normalise to lowercase for case-insensitive filesystem safety (e.g. default macOS HFS+)
 BASENAME_LOWER=$(echo "$BASENAME" | tr '[:upper:]' '[:lower:]')
 _is_test_infra=false
 case "$BASENAME_LOWER" in
-  conftest.py|pytest.ini|.coveragerc|setup.cfg|\
-  jest.config.js|jest.config.ts|jest.config.cjs|jest.config.mjs|jest.config.cts|jest.config.json|\
-  vitest.config.js|vitest.config.ts|vitest.config.mts|vitest.config.cjs|vitest.config.mjs|vitest.config.cts|\
-  karma.config.js|karma.config.ts|karma.config.mjs|\
-  babel.config.js|babel.config.ts|babel.config.cjs|babel.config.mjs|babel.config.json)
+  conftest.py|pytest.ini|.coveragerc|setup.cfg)
+    _is_test_infra=true ;;
+  jest.config.*|vitest.config.*|karma.config.*|babel.config.*)
     _is_test_infra=true ;;
 esac
 if [[ "$_is_test_infra" == "true" ]]; then

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -23,13 +23,15 @@ fi
 
 # W-12: Block writes to test infrastructure files (new or existing)
 BASENAME=$(basename "$FILE_PATH")
+# Normalise to lowercase for case-insensitive filesystem safety (e.g. default macOS HFS+)
+BASENAME_LOWER=$(echo "$BASENAME" | tr '[:upper:]' '[:lower:]')
 _is_test_infra=false
-case "$BASENAME" in
+case "$BASENAME_LOWER" in
   conftest.py|pytest.ini|.coveragerc|setup.cfg|\
-  jest.config.js|jest.config.ts|jest.config.cjs|jest.config.mjs|jest.config.json|\
-  vitest.config.js|vitest.config.ts|vitest.config.mts|\
-  karma.config.js|karma.config.ts|\
-  babel.config.js|babel.config.ts|babel.config.cjs|babel.config.json)
+  jest.config.js|jest.config.ts|jest.config.cjs|jest.config.mjs|jest.config.cts|jest.config.json|\
+  vitest.config.js|vitest.config.ts|vitest.config.mts|vitest.config.cjs|vitest.config.mjs|vitest.config.cts|\
+  karma.config.js|karma.config.ts|karma.config.mjs|\
+  babel.config.js|babel.config.ts|babel.config.cjs|babel.config.mjs|babel.config.json)
     _is_test_infra=true ;;
 esac
 if [[ "$_is_test_infra" == "true" ]]; then

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "scripts/quality-grader.sh",
     "scripts/stats.sh",
     "scripts/worktree-guard.sh",
+    "scripts/install-systemd.sh",
+    "scripts/systemd/",
     "mcp-server/",
     ".claude/commands/vibeguard",
     "claude-md/",

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -340,9 +340,11 @@ def update_scorecard(
     reset to zero so that the scorecard stays consistent with triage truth
     (e.g. after a triage window rotation or manual cleanup).
 
-    When *has_parse_errors* is True the reset pass is skipped: some records
-    may have been lost to parse failures, so absence from triage is
-    ambiguous and must not be treated as "zero samples".
+    When *has_parse_errors* is True two passes are skipped:
+    - the reset pass: absent rules may simply have had records lost to corrupt
+      lines, so zeroing them would silently pollute the scorecard.
+    - lifecycle transitions: stats computed from incomplete data could
+      spuriously trigger warn→error or warn→demoted, polluting rule stages.
 
     Returns (updated_scorecard, list of transition messages).
     """
@@ -390,14 +392,18 @@ def update_scorecard(
                 entry["last_fp_ts"] = None
                 entry["precision"] = None
 
-    # Apply lifecycle transitions for all rules
-    for rule, entry in rules.items():
-        new_stage = next_stage(entry)
-        if new_stage is not None:
-            old_stage = entry["stage"]
-            entry["stage"] = new_stage
-            entry["stage_entered_ts"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-            transitions.append(f"{rule}: {old_stage} → {new_stage}")
+    # Apply lifecycle transitions for all rules.
+    # Skipped when parse errors exist: stats computed from incomplete triage
+    # data could spuriously trigger warn→error or warn→demoted transitions
+    # and pollute production rule stages.
+    if not has_parse_errors:
+        for rule, entry in rules.items():
+            new_stage = next_stage(entry)
+            if new_stage is not None:
+                old_stage = entry["stage"]
+                entry["stage"] = new_stage
+                entry["stage_entered_ts"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                transitions.append(f"{rule}: {old_stage} → {new_stage}")
 
     return scorecard, transitions
 
@@ -582,7 +588,8 @@ def main(argv: list[str] | None = None) -> int:
             if invalid_count:
                 print(
                     f"[WARN] {invalid_count} invalid triage line(s) detected; "
-                    "missing-rule reset skipped to prevent data corruption. "
+                    "missing-rule reset and lifecycle transitions skipped to "
+                    "prevent data corruption. "
                     "Fix or remove the invalid lines and re-run.",
                     file=sys.stderr,
                 )

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -331,6 +331,7 @@ def next_stage(rule_entry: dict[str, Any]) -> str | None:
 def update_scorecard(
     scorecard: dict[str, Any],
     triage_records: list[dict[str, Any]],
+    has_parse_errors: bool = False,
 ) -> tuple[dict[str, Any], list[str]]:
     """
     Recompute stats from triage records, apply lifecycle transitions.
@@ -338,6 +339,10 @@ def update_scorecard(
     Rules present in scorecard but absent from triage have their counters
     reset to zero so that the scorecard stays consistent with triage truth
     (e.g. after a triage window rotation or manual cleanup).
+
+    When *has_parse_errors* is True the reset pass is skipped: some records
+    may have been lost to parse failures, so absence from triage is
+    ambiguous and must not be treated as "zero samples".
 
     Returns (updated_scorecard, list of transition messages).
     """
@@ -372,14 +377,18 @@ def update_scorecard(
     # Reset stats for rules no longer present in triage (window rotation /
     # manual cleanup).  Stage and notes are preserved so the history is
     # visible, but counters reflect the current triage truth.
-    for rule, entry in rules.items():
-        if rule not in stats:
-            entry["tp"] = 0
-            entry["fp"] = 0
-            entry["acceptable"] = 0
-            entry["samples"] = 0
-            entry["last_fp_ts"] = None
-            entry["precision"] = None
+    # Skip this pass when parse errors exist: absent rules may simply have
+    # had their records lost to corrupt lines, so zeroing them would
+    # silently pollute the scorecard and misfire lifecycle transitions.
+    if not has_parse_errors:
+        for rule, entry in rules.items():
+            if rule not in stats:
+                entry["tp"] = 0
+                entry["fp"] = 0
+                entry["acceptable"] = 0
+                entry["samples"] = 0
+                entry["last_fp_ts"] = None
+                entry["precision"] = None
 
     # Apply lifecycle transitions for all rules
     for rule, entry in rules.items():
@@ -566,15 +575,21 @@ def main(argv: list[str] | None = None) -> int:
     if args.update_scorecard:
         with _scorecard_write_lock(scorecard_path):
             triage, invalid_count = load_triage(triage_path)
-            if invalid_count > 0:
+            # Invalid lines are already logged as [ERROR] by load_triage;
+            # valid records are still processed so callers don't block.
+            # Pass has_parse_errors so update_scorecard skips the reset-to-zero
+            # pass — absent rules may reflect lost records, not zero samples.
+            if invalid_count:
                 print(
-                    f"[ERROR] triage.jsonl contains {invalid_count} invalid record(s); "
-                    "refusing to update scorecard to avoid incorrect lifecycle transitions.",
+                    f"[WARN] {invalid_count} invalid triage line(s) detected; "
+                    "missing-rule reset skipped to prevent data corruption. "
+                    "Fix or remove the invalid lines and re-run.",
                     file=sys.stderr,
                 )
-                return 1
             scorecard = load_scorecard(scorecard_path)
-            scorecard, transitions = update_scorecard(scorecard, triage)
+            scorecard, transitions = update_scorecard(
+                scorecard, triage, has_parse_errors=bool(invalid_count)
+            )
             save_scorecard(scorecard, scorecard_path)
         if transitions:
             print("Lifecycle transitions:")

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -195,8 +195,8 @@ TOTAL=$((TOTAL + 1))
 # stdin 格式: <local-ref> <local-sha> <remote-ref> <remote-sha>
 tmp_repo_push="$(mktemp -d)"
 git -C "$tmp_repo_push" init -q
-git -C "$tmp_repo_push" config user.email "test@example.com"
-git -C "$tmp_repo_push" config user.name "Test User"
+git -C "$tmp_repo_push" config user.email "test@vibeguard.test"
+git -C "$tmp_repo_push" config user.name "VibeGuard Test"
 git -C "$tmp_repo_push" commit --allow-empty -m "base"
 BASE_SHA=$(git -C "$tmp_repo_push" rev-parse HEAD)
 git -C "$tmp_repo_push" commit --allow-empty -m "local"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -247,6 +247,31 @@ assert_contains "$result" '"decision": "block"' "路径含单引号安全处理"
 result=$(echo '{"tool_input":{"file_path":"hooks/log.sh","old_string":""}}' | bash hooks/pre-edit-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "已存在文件+空 old_string 放行"
 
+# W-12: 测试基础设施文件应被拦截（conftest.py）
+result=$(echo '{"tool_input":{"file_path":"/any/path/conftest.py","old_string":""}}' | bash hooks/pre-edit-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截编辑 conftest.py"
+assert_contains "$result" "W-12" "W-12: 错误消息包含规则编号"
+
+# W-12: jest.config.ts 应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/jest.config.ts","old_string":""}}' | bash hooks/pre-edit-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截编辑 jest.config.ts"
+
+# W-12: jest.config.js 应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/jest.config.js","old_string":""}}' | bash hooks/pre-edit-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截编辑 jest.config.js"
+
+# W-12: pytest.ini 应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/pytest.ini","old_string":""}}' | bash hooks/pre-edit-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截编辑 pytest.ini"
+
+# W-12: .coveragerc 应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/.coveragerc","old_string":""}}' | bash hooks/pre-edit-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截编辑 .coveragerc"
+
+# W-12: 普通源码文件不应被测试基础设施规则拦截
+result=$(echo '{"tool_input":{"file_path":"hooks/log.sh","old_string":""}}' | bash hooks/pre-edit-guard.sh)
+assert_not_contains "$result" "W-12" "W-12: 普通文件不触发测试基础设施保护"
+
 # =========================================================
 header "pre-write-guard.sh — 先搜后写"
 # =========================================================
@@ -280,6 +305,31 @@ assert_contains "$result" "VIBEGUARD" "新建 .tsx 源码文件触发 guard"
 # tests/ 目录下的源码文件应放行
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_nonexist_test/tests/helper.py"}}' | bash hooks/pre-write-guard.sh)
 assert_not_contains "$result" "VIBEGUARD" "tests/ 目录下源码文件放行"
+
+# W-12: 写入 conftest.py 应被拦截（新文件，正确 basename）
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_nonexist_dir/conftest.py"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截写入新 conftest.py"
+assert_contains "$result" "W-12" "W-12: write guard 错误消息包含规则编号"
+
+# W-12: 写入已有 conftest.py 路径（含目录）也应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/tests/conftest.py"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截写入已有 conftest.py 路径（含目录）"
+
+# W-12: jest.config.ts 写入应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/jest.config.ts"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截写入 jest.config.ts"
+
+# W-12: vitest.config.ts 写入应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/vitest.config.ts"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截写入 vitest.config.ts"
+
+# W-12: babel.config.js 写入应被拦截
+result=$(echo '{"tool_input":{"file_path":"/project/babel.config.js"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "W-12: 拦截写入 babel.config.js"
+
+# W-12: 普通 config.json 不应被测试基础设施规则拦截
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_nonexist_myconfig.json"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" "W-12" "W-12: 普通 config.json 不触发测试基础设施保护"
 
 # =========================================================
 header "post-edit-guard.sh — 质量警告"

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -317,11 +317,12 @@ sc = json.load(open('$SCORECARD_BAD'))
 print(sc['rules']['RS-04']['samples'])
 ")
 TOTAL=$((TOTAL + 1))
-if [[ "$valid_samples" == "0" ]]; then
-  green "含错误行时 scorecard 未被修改（拒绝部分提交）"
+# Valid records (1 tp + 1 fp) are still processed; only invalid lines are skipped.
+if [[ "$valid_samples" == "2" ]]; then
+  green "有效记录被正常处理（samples=2），无效行被隔离"
   PASS=$((PASS + 1))
 else
-  red "含错误行时 scorecard 不应被修改（期望 samples=0，实际 $valid_samples）"
+  red "有效记录应被处理（期望 samples=2，实际 $valid_samples）"
   FAIL=$((FAIL + 1))
 fi
 
@@ -593,11 +594,12 @@ sc = json.load(open('$SCORECARD_NAIVE'))
 print(sc['rules']['NZ-01']['samples'])
 ")
 TOTAL=$((TOTAL + 1))
-if [[ "$naive_samples" == "0" ]]; then
-  green "含错误行时 scorecard 未被修改（拒绝部分提交）"
+# The valid tp record is still processed; only the invalid fp (no tz) is skipped.
+if [[ "$naive_samples" == "1" ]]; then
+  green "有效 tp 被正常处理（samples=1），无时区 fp 被隔离"
   PASS=$((PASS + 1))
 else
-  red "含错误行时 scorecard 不应被修改（期望 samples=0，实际 $naive_samples）"
+  red "有效 tp 应被处理（期望 samples=1，实际 $naive_samples）"
   FAIL=$((FAIL + 1))
 fi
 

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -601,6 +601,53 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "parse errors 时生命周期迁移被冻结（issue: lifecycle freeze）"
+# When triage has parse errors, lifecycle transitions must NOT fire even if
+# stats would normally trigger a promotion/demotion, to prevent stage pollution.
+TRIAGE_PERR="${TMPDIR_TEST}/triage_perr.jsonl"
+SCORECARD_PERR="${TMPDIR_TEST}/scorecard_perr.json"
+python3 -c "
+import json
+scorecard = {
+  'rules': {
+    'RS-LC': {
+      'stage': 'experimental', 'precision': None, 'samples': 0,
+      'tp': 0, 'fp': 0, 'acceptable': 0, 'last_fp_ts': None,
+      'stage_entered_ts': '2026-01-01T00:00:00Z', 'notes': ''
+    }
+  }
+}
+print(json.dumps(scorecard, indent=2))
+" > "$SCORECARD_PERR"
+# 10 valid tp records (enough to trigger experimental→warn) + 1 corrupt line
+{
+  for i in $(seq 1 10); do
+    printf '{"ts":"2026-03-0%dT00:00:00Z","rule":"RS-LC","verdict":"tp"}\n' "$((i % 9 + 1))"
+  done
+  printf 'NOT_JSON\n'
+} > "$TRIAGE_PERR"
+
+perr_out=$(python3 "$TRACKER" \
+  --triage-file "$TRIAGE_PERR" \
+  --scorecard-file "$SCORECARD_PERR" \
+  --update-scorecard 2>&1)
+# Warn message must mention transitions skipped
+assert_contains "$perr_out" "lifecycle transitions skipped" "parse errors 时警告包含 transitions skipped"
+# Stage must remain experimental — transition must not have fired
+perr_stage=$(python3 -c "
+import json
+sc = json.load(open('$SCORECARD_PERR'))
+print(sc['rules']['RS-LC']['stage'])
+")
+TOTAL=$((TOTAL + 1))
+if [[ "$perr_stage" == "experimental" ]]; then
+  green "parse errors 时生命周期迁移被冻结（stage 保持 experimental）"
+  PASS=$((PASS + 1))
+else
+  red "parse errors 时 stage 意外变更（期望 experimental，实际 $perr_stage）"
+  FAIL=$((FAIL + 1))
+fi
+
 # =========================================================
 echo
 echo "=============================="


### PR DESCRIPTION
## Summary

- Block `Edit` and `Write` to test infra files (`conftest.py`, `jest.config.*`, `pytest.ini`, `.coveragerc`, `vitest.config.*`, `babel.config.*`) via pre-edit-guard and pre-write-guard hooks
- Add `guards/universal/check_test_integrity.sh` for library shadow detection and empty-stub test function detection
- Covers attack vectors #5–#7 from Baker et al. (2025) not previously protected by W-12

Closes #27

## Test plan

- [ ] `bash tests/test_hooks.sh` — 81 tests, 0 failures
- [ ] `npm test` — all suites pass
- [ ] Manual: `echo '{"tool_input":{"file_path":"/project/conftest.py"}}' | bash hooks/pre-edit-guard.sh` should return `"decision": "block"`