### PR TITLE
feat(guards): baseline scanning — only report issues on newly added lines

### DIFF
--- a/guards/go/check_defer_in_loop.sh
+++ b/guards/go/check_defer_in_loop.sh
@@ -22,7 +22,7 @@ _IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
   _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
-  vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
+  vg_build_diff_linemap "$_LINEMAP" '\.go$'
 fi
 
 # 使用 awk 检测 for 循环内的 defer，再对结果做 linemap 过滤

--- a/guards/go/check_defer_in_loop.sh
+++ b/guards/go/check_defer_in_loop.sh
@@ -18,7 +18,9 @@ TMPFILE=$(create_tmpfile)
 
 # --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
 _LINEMAP=""
+_IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
   vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
 fi
@@ -42,16 +44,16 @@ list_go_files "${TARGET_DIR}" \
   > "${_AWK_RAW}" || true
 
 # Linemap 过滤：提取 file:linenum，只保留新增行
-if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+# 当 _IN_DIFF_MODE=true 且 linemap 为空（仅删除行）时，静默通过而非全量扫描。
+if [[ "$_IN_DIFF_MODE" == true ]]; then
   while IFS= read -r result_line; do
     [[ -z "$result_line" ]] && continue
-    # 格式: [GO-08] /path/to/file:LINENUM content
-    # 提取 filepath 和 linenum（linenum 是紧跟 : 后的第一个数字序列）
+    # 格式: [GO-08] /path/to/file:LINENUM content（awk printf "%s:%d %s"）
+    # 取第一个 :<digits> 作为行号，避免 defer 行内含 :<数字> 时（如 URL 端口）tail -1 取错位置
     stripped="${result_line#\[GO-08\] }"
-    # 反向查找最后一个冒号前的数字序列作为 linenum
-    linenum=$(echo "$stripped" | grep -oE ':[0-9]+' | tail -1 | tr -d ':')
-    filepath=$(echo "$stripped" | sed "s/:${linenum} .*$//")
-    if [[ -n "$linenum" ]] && grep -qxF "${filepath}:${linenum}" "$_LINEMAP" 2>/dev/null; then
+    linenum=$(echo "$stripped" | grep -oE ':[0-9]+' | head -1 | tr -d ':')
+    filepath=$(echo "$stripped" | cut -d: -f1)
+    if [[ -n "$linenum" ]] && [[ -n "$_LINEMAP" ]] && grep -qxF "${filepath}:${linenum}" "$_LINEMAP" 2>/dev/null; then
       echo "$result_line"
     fi
   done < "${_AWK_RAW}" > "${TMPFILE}" || true

--- a/guards/go/check_defer_in_loop.sh
+++ b/guards/go/check_defer_in_loop.sh
@@ -16,7 +16,15 @@ source "$(dirname "$0")/common.sh"
 parse_guard_args "$@"
 TMPFILE=$(create_tmpfile)
 
-# 使用 awk 检测 for 循环内的 defer
+# --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
+_LINEMAP=""
+if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _LINEMAP=$(create_tmpfile)
+  vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
+fi
+
+# 使用 awk 检测 for 循环内的 defer，再对结果做 linemap 过滤
+_AWK_RAW=$(create_tmpfile)
 list_go_files "${TARGET_DIR}" \
   | { grep -vE '(_test\.go$|/vendor/)' || true; } \
   | while IFS= read -r f; do
@@ -31,7 +39,25 @@ list_go_files "${TARGET_DIR}" \
         ' "${f}" 2>/dev/null || true
       fi
     done \
-  > "${TMPFILE}" || true
+  > "${_AWK_RAW}" || true
+
+# Linemap 过滤：提取 file:linenum，只保留新增行
+if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+  while IFS= read -r result_line; do
+    [[ -z "$result_line" ]] && continue
+    # 格式: [GO-08] /path/to/file:LINENUM content
+    # 提取 filepath 和 linenum（linenum 是紧跟 : 后的第一个数字序列）
+    stripped="${result_line#\[GO-08\] }"
+    # 反向查找最后一个冒号前的数字序列作为 linenum
+    linenum=$(echo "$stripped" | grep -oE ':[0-9]+' | tail -1 | tr -d ':')
+    filepath=$(echo "$stripped" | sed "s/:${linenum} .*$//")
+    if [[ -n "$linenum" ]] && grep -qxF "${filepath}:${linenum}" "$_LINEMAP" 2>/dev/null; then
+      echo "$result_line"
+    fi
+  done < "${_AWK_RAW}" > "${TMPFILE}" || true
+else
+  cp "${_AWK_RAW}" "${TMPFILE}" || true
+fi
 
 apply_suppression_filter "${TMPFILE}"
 cat "${TMPFILE}"

--- a/guards/go/check_defer_in_loop.sh
+++ b/guards/go/check_defer_in_loop.sh
@@ -26,17 +26,18 @@ if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; th
 fi
 
 # 使用 awk 检测 for 循环内的 defer，再对结果做 linemap 过滤
+# 输出格式（tab 分隔）: [GO-08] filepath\tdefer_linenum\tfor_linenum\tcontent
 _AWK_RAW=$(create_tmpfile)
 list_go_files "${TARGET_DIR}" \
   | { grep -vE '(_test\.go$|/vendor/)' || true; } \
   | while IFS= read -r f; do
       if [[ -f "${f}" ]]; then
         awk '
-          /^\s*for\s/ { in_loop++; loop_depth++ }
+          /^\s*for\s/ { in_loop++; loop_depth++; loop_starts[loop_depth]=NR }
           /\{/ { if (in_loop) brace_depth++ }
           /\}/ { if (in_loop) { brace_depth--; if (brace_depth <= 0) { in_loop=0; loop_depth--; brace_depth=0 } } }
           /^\s*defer\s/ && in_loop > 0 {
-            printf "[GO-08] %s:%d %s\n", FILENAME, NR, $0
+            printf "[GO-08] %s\t%d\t%d\t%s\n", FILENAME, NR, loop_starts[loop_depth], $0
           }
         ' "${f}" 2>/dev/null || true
       fi
@@ -45,20 +46,31 @@ list_go_files "${TARGET_DIR}" \
 
 # Linemap 过滤：提取 file:linenum，只保留新增行
 # 当 _IN_DIFF_MODE=true 且 linemap 为空（仅删除行）时，静默通过而非全量扫描。
+# 检查 defer 行 OR for 循环起始行是否是新增行（捕获"已有 defer 被新 for 包裹"情况）。
 if [[ "$_IN_DIFF_MODE" == true ]]; then
   while IFS= read -r result_line; do
     [[ -z "$result_line" ]] && continue
-    # 格式: [GO-08] /path/to/file:LINENUM content（awk printf "%s:%d %s"）
-    # 取第一个 :<digits> 作为行号，避免 defer 行内含 :<数字> 时（如 URL 端口）tail -1 取错位置
     stripped="${result_line#\[GO-08\] }"
-    linenum=$(echo "$stripped" | grep -oE ':[0-9]+' | head -1 | tr -d ':')
-    filepath=$(echo "$stripped" | cut -d: -f1)
-    if [[ -n "$linenum" ]] && [[ -n "$_LINEMAP" ]] && grep -qxF "${filepath}:${linenum}" "$_LINEMAP" 2>/dev/null; then
-      echo "$result_line"
+    filepath=$(printf '%s' "$stripped" | cut -f1)
+    defer_linenum=$(printf '%s' "$stripped" | cut -f2)
+    for_linenum=$(printf '%s' "$stripped" | cut -f3)
+    content=$(printf '%s' "$stripped" | cut -f4-)
+    if [[ -n "$defer_linenum" ]] && [[ -n "$_LINEMAP" ]] && {
+      grep -qxF "${filepath}:${defer_linenum}" "$_LINEMAP" 2>/dev/null || \
+      grep -qxF "${filepath}:${for_linenum}" "$_LINEMAP" 2>/dev/null
+    }; then
+      echo "[GO-08] ${filepath}:${defer_linenum} ${content}"
     fi
   done < "${_AWK_RAW}" > "${TMPFILE}" || true
 else
-  cp "${_AWK_RAW}" "${TMPFILE}" || true
+  while IFS= read -r result_line; do
+    [[ -z "$result_line" ]] && continue
+    stripped="${result_line#\[GO-08\] }"
+    filepath=$(printf '%s' "$stripped" | cut -f1)
+    defer_linenum=$(printf '%s' "$stripped" | cut -f2)
+    content=$(printf '%s' "$stripped" | cut -f4-)
+    echo "[GO-08] ${filepath}:${defer_linenum} ${content}"
+  done < "${_AWK_RAW}" > "${TMPFILE}" || true
 fi
 
 apply_suppression_filter "${TMPFILE}"

--- a/guards/go/check_error_handling.sh
+++ b/guards/go/check_error_handling.sh
@@ -21,7 +21,9 @@ RULES_DIR="${SCRIPT_DIR}/../ast-grep-rules"
 
 # --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
 _LINEMAP=""
+_IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
   vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
 fi
@@ -46,11 +48,12 @@ if command -v ast-grep >/dev/null 2>&1; then
           --rule "${RULES_DIR}/go-01-error.yml" \
           --json \
           "${_ASG_TARGETS[@]}" > "${_ASG_TMPOUT}"; then
-        VG_DIFF_LINEMAP="$_LINEMAP" python3 -c '
+        VG_DIFF_LINEMAP="$_LINEMAP" VG_IN_DIFF_MODE="$_IN_DIFF_MODE" python3 -c '
 import json, sys, re, os
 
 TEST_PATH = re.compile(r"(_test\.go$|(^|/)vendor/)")
 linemap_path = os.environ.get("VG_DIFF_LINEMAP", "")
+in_diff_mode = os.environ.get("VG_IN_DIFF_MODE", "false") == "true"
 added_set = set()
 if linemap_path and os.path.isfile(linemap_path):
     with open(linemap_path) as lm:
@@ -70,8 +73,10 @@ for m in matches:
     if TEST_PATH.search(f):
         continue
     line = m.get("range", {}).get("start", {}).get("line", 0) + 1
-    # Baseline 过滤：只报告 diff 新增行上的问题
-    if added_set and (f + ":" + str(line)) not in added_set:
+    # Baseline 过滤：只报告 diff 新增行上的问题。
+    # 用 in_diff_mode 而非 added_set 非空来判断 diff 模式，
+    # 避免仅删除行时 added_set 为空导致回退到全量扫描。
+    if in_diff_mode and (f + ":" + str(line)) not in added_set:
         continue
     msg = m.get("message", "error 返回值被丢弃")
     print("[GO-01] " + f + ":" + str(line) + " " + msg)
@@ -100,7 +105,7 @@ if [[ "$_USE_GREP_FALLBACK" == true ]]; then
             | while IFS= read -r hit; do
                 LINE_NUM=$(echo "$hit" | cut -d: -f1)
                 # Baseline 过滤：只报告新增行上的问题
-                if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+                if [[ "$_IN_DIFF_MODE" == true ]]; then
                   grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
                 fi
                 echo "${f}:${hit}"

--- a/guards/go/check_error_handling.sh
+++ b/guards/go/check_error_handling.sh
@@ -19,6 +19,13 @@ TMPFILE=$(create_tmpfile)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RULES_DIR="${SCRIPT_DIR}/../ast-grep-rules"
 
+# --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
+_LINEMAP=""
+if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _LINEMAP=$(create_tmpfile)
+  vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
+fi
+
 _USE_GREP_FALLBACK=false
 
 if command -v ast-grep >/dev/null 2>&1; then
@@ -39,9 +46,17 @@ if command -v ast-grep >/dev/null 2>&1; then
           --rule "${RULES_DIR}/go-01-error.yml" \
           --json \
           "${_ASG_TARGETS[@]}" > "${_ASG_TMPOUT}"; then
-        python3 -c '
-import json, sys, re
+        VG_DIFF_LINEMAP="$_LINEMAP" python3 -c '
+import json, sys, re, os
+
 TEST_PATH = re.compile(r"(_test\.go$|(^|/)vendor/)")
+linemap_path = os.environ.get("VG_DIFF_LINEMAP", "")
+added_set = set()
+if linemap_path and os.path.isfile(linemap_path):
+    with open(linemap_path) as lm:
+        for entry in lm:
+            added_set.add(entry.strip())
+
 data = sys.stdin.read().strip()
 if not data:
     sys.exit(0)
@@ -55,6 +70,9 @@ for m in matches:
     if TEST_PATH.search(f):
         continue
     line = m.get("range", {}).get("start", {}).get("line", 0) + 1
+    # Baseline 过滤：只报告 diff 新增行上的问题
+    if added_set and (f + ":" + str(line)) not in added_set:
+        continue
     msg = m.get("message", "error 返回值被丢弃")
     print("[GO-01] " + f + ":" + str(line) + " " + msg)
 ' < "${_ASG_TMPOUT}" > "${TMPFILE}" || {
@@ -79,7 +97,14 @@ if [[ "$_USE_GREP_FALLBACK" == true ]]; then
           grep -nE '^\s*_\s*(,\s*_)?\s*[:=]+' "${f}" 2>/dev/null \
             | grep -vE 'for\s+.*range' \
             | grep -vE ',\s*(ok|found|exists)\s*:?=' \
-            | sed "s|^|${f}:|" || true
+            | while IFS= read -r hit; do
+                LINE_NUM=$(echo "$hit" | cut -d: -f1)
+                # Baseline 过滤：只报告新增行上的问题
+                if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+                  grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+                fi
+                echo "${f}:${hit}"
+              done
         fi
       done \
     | grep -v '^\s*//' \

--- a/guards/go/check_error_handling.sh
+++ b/guards/go/check_error_handling.sh
@@ -25,7 +25,7 @@ _IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
   _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
-  vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
+  vg_build_diff_linemap "$_LINEMAP" '\.go$'
 fi
 
 _USE_GREP_FALLBACK=false

--- a/guards/go/check_goroutine_leak.sh
+++ b/guards/go/check_goroutine_leak.sh
@@ -24,7 +24,7 @@ _IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
   _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
-  vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
+  vg_build_diff_linemap "$_LINEMAP" '\.go$'
 fi
 
 # _in_diff_mode: 检测是否处于 diff 模式，不依赖 linemap 非空。

--- a/guards/go/check_goroutine_leak.sh
+++ b/guards/go/check_goroutine_leak.sh
@@ -20,11 +20,13 @@ TMPFILE=$(create_tmpfile)
 
 # --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
 _LINEMAP=""
+_LINEMAP_DELETED=""
 _IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
   _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
-  vg_build_diff_linemap "$_LINEMAP" '\.go$'
+  _LINEMAP_DELETED=$(create_tmpfile)
+  vg_build_diff_linemap "$_LINEMAP" '\.go$' "$_LINEMAP_DELETED"
 fi
 
 # _in_diff_mode: 检测是否处于 diff 模式，不依赖 linemap 非空。
@@ -41,9 +43,23 @@ list_go_files "${TARGET_DIR}" \
         while IFS= read -r match; do
           [[ -z "$match" ]] && continue
           LINE_NUM=$(echo "$match" | cut -d: -f1)
-          # Baseline 过滤：只报告 goroutine 启动行本身是新增的情况
+          # Baseline 过滤：报告 goroutine 启动行是新增的，或退出机制被删除的情况
           if _in_diff_mode; then
-            grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+            if ! grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null; then
+              _body_del=false
+              if [[ -s "$_LINEMAP_DELETED" ]]; then
+                while IFS= read -r _dl; do
+                  case "$_dl" in
+                    "${f}:"*)
+                      _dl_num="${_dl#"${f}:"}"
+                      if [[ "$_dl_num" -ge "$LINE_NUM" ]] && [[ "$_dl_num" -le "$((LINE_NUM+20))" ]]; then
+                        _body_del=true; break
+                      fi ;;
+                  esac
+                done < "$_LINEMAP_DELETED"
+              fi
+              [[ "$_body_del" == true ]] || continue
+            fi
           fi
           # 读取 goroutine 后 20 行，检查是否有退出机制
           HAS_EXIT=$(sed -n "${LINE_NUM},$((LINE_NUM+20))p" "${f}" 2>/dev/null \
@@ -65,9 +81,23 @@ list_go_files "${TARGET_DIR}" \
         while IFS= read -r match; do
           [[ -z "$match" ]] && continue
           LINE_NUM=$(echo "$match" | cut -d: -f1)
-          # Baseline 过滤：只报告新增的 for{} 行
+          # Baseline 过滤：报告 for{} 行是新增的，或退出机制被删除的情况
           if _in_diff_mode; then
-            grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+            if ! grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null; then
+              _body_del=false
+              if [[ -s "$_LINEMAP_DELETED" ]]; then
+                while IFS= read -r _dl; do
+                  case "$_dl" in
+                    "${f}:"*)
+                      _dl_num="${_dl#"${f}:"}"
+                      if [[ "$_dl_num" -ge "$LINE_NUM" ]] && [[ "$_dl_num" -le "$((LINE_NUM+20))" ]]; then
+                        _body_del=true; break
+                      fi ;;
+                  esac
+                done < "$_LINEMAP_DELETED"
+              fi
+              [[ "$_body_del" == true ]] || continue
+            fi
           fi
           echo "${f}:${match}"
         done < <(grep -nE '^\s*for\s*\{' "${f}" 2>/dev/null || true)

--- a/guards/go/check_goroutine_leak.sh
+++ b/guards/go/check_goroutine_leak.sh
@@ -20,13 +20,17 @@ TMPFILE=$(create_tmpfile)
 
 # --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
 _LINEMAP=""
+_IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
   vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
 fi
 
+# _in_diff_mode: 检测是否处于 diff 模式，不依赖 linemap 非空。
+# 仅删除行时 linemap 为空，此时应静默通过而非回退到全量扫描。
 _in_diff_mode() {
-  [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]
+  [[ "$_IN_DIFF_MODE" == true ]]
 }
 
 list_go_files "${TARGET_DIR}" \

--- a/guards/go/check_goroutine_leak.sh
+++ b/guards/go/check_goroutine_leak.sh
@@ -18,6 +18,17 @@ source "$(dirname "$0")/common.sh"
 parse_guard_args "$@"
 TMPFILE=$(create_tmpfile)
 
+# --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
+_LINEMAP=""
+if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _LINEMAP=$(create_tmpfile)
+  vg_build_diff_linemap "$_LINEMAP" '\.go$' || _LINEMAP=""
+fi
+
+_in_diff_mode() {
+  [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]
+}
+
 list_go_files "${TARGET_DIR}" \
   | { grep -vE '(_test\.go$|/vendor/)' || true; } \
   | while IFS= read -r f; do
@@ -26,6 +37,10 @@ list_go_files "${TARGET_DIR}" \
         while IFS= read -r match; do
           [[ -z "$match" ]] && continue
           LINE_NUM=$(echo "$match" | cut -d: -f1)
+          # Baseline 过滤：只报告 goroutine 启动行本身是新增的情况
+          if _in_diff_mode; then
+            grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+          fi
           # 读取 goroutine 后 20 行，检查是否有退出机制
           HAS_EXIT=$(sed -n "${LINE_NUM},$((LINE_NUM+20))p" "${f}" 2>/dev/null \
             | grep -cE '(ctx\.Done|context\.WithCancel|wg\.(Add|Done|Wait)|errgroup|<-done|<-quit|<-stop|time\.After|ticker)' 2>/dev/null || true)
@@ -43,8 +58,15 @@ list_go_files "${TARGET_DIR}" \
   | { grep -vE '(_test\.go$|/vendor/)' || true; } \
   | while IFS= read -r f; do
       if [[ -f "${f}" ]]; then
-        grep -nE '^\s*for\s*\{' "${f}" 2>/dev/null \
-          | sed "s|^|${f}:|" || true
+        while IFS= read -r match; do
+          [[ -z "$match" ]] && continue
+          LINE_NUM=$(echo "$match" | cut -d: -f1)
+          # Baseline 过滤：只报告新增的 for{} 行
+          if _in_diff_mode; then
+            grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+          fi
+          echo "${f}:${match}"
+        done < <(grep -nE '^\s*for\s*\{' "${f}" 2>/dev/null || true)
       fi
     done \
   | awk '{ print "[GO-02/loop] " $0 }' \

--- a/guards/go/common.sh
+++ b/guards/go/common.sh
@@ -72,10 +72,13 @@ parse_guard_args() {
   fi
 }
 
-# vg_build_diff_linemap OUTPUT_FILE [EXT_FILTER]
+# vg_build_diff_linemap OUTPUT_FILE [EXT_FILTER] [OUT_DELETED]
 #
 # 构建 diff 新增行号索引文件（每行格式: "filepath:linenum"）。
 # 用于 baseline 扫描：只报告本次 diff 新增的问题，不报告既有问题。
+#
+# 可选第三参数 OUT_DELETED: 文件路径，写入删除行附近的新侧行号（格式同 OUTPUT_FILE）。
+# 用于检测"删除退出机制"场景——goroutine 行未变但 ctx.Done 等被删除。
 #
 # pre-commit 模式（VIBEGUARD_STAGED_FILES 已设置）: 读取 git diff --cached
 # baseline  模式（BASELINE_COMMIT 已设置）        : 读取 git diff BASELINE..HEAD
@@ -84,7 +87,9 @@ parse_guard_args() {
 vg_build_diff_linemap() {
   local out="$1"
   local ext_filter="${2:-}"
+  local out_deleted="${3:-}"
   : > "$out"
+  [[ -n "$out_deleted" ]] && : > "$out_deleted"
 
   command -v python3 >/dev/null 2>&1 || return 1
 
@@ -92,15 +97,20 @@ vg_build_diff_linemap() {
   local baseline="${BASELINE_COMMIT:-}"
   [[ -z "$staged" && -z "$baseline" ]] && return 1
 
-  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" VG_TARGET_DIR="${TARGET_DIR:-.}" \
+  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" VG_TARGET_DIR="${TARGET_DIR:-.}" VG_OUT_DELETED="${out_deleted}" \
   python3 -c '
 import sys, re, subprocess, os
 
-staged     = os.environ.get("VG_STAGED", "")
-baseline   = os.environ.get("VG_BASELINE", "")
-ext_filter = os.environ.get("VG_EXT", "")
-out_path   = os.environ.get("VG_OUT", "")
-target_dir = os.environ.get("VG_TARGET_DIR", ".")
+staged      = os.environ.get("VG_STAGED", "")
+baseline    = os.environ.get("VG_BASELINE", "")
+ext_filter  = os.environ.get("VG_EXT", "")
+out_path    = os.environ.get("VG_OUT", "")
+out_deleted = os.environ.get("VG_OUT_DELETED", "")
+target_dir  = os.environ.get("VG_TARGET_DIR", ".")
+
+EXIT_PATTERN = re.compile(
+    r"ctx\.Done|context\.WithCancel|wg\.(?:Add|Done|Wait)|errgroup|<-done|<-quit|<-stop|time\.After|ticker"
+)
 
 _git_root_cache = {}
 
@@ -134,18 +144,24 @@ def iter_files():
             if fname and (not ext_filter or re.search(ext_filter, fname)):
                 yield os.path.join(root, fname)
 
-def added_linenos(fpath):
+def diff_linenos(fpath):
+    """Return (added_nums, deleted_exit_nums).
+
+    added_nums: new-side line numbers that were added.
+    deleted_exit_nums: new-side positions where exit-mechanism lines were deleted.
+    """
     file_dir = os.path.dirname(fpath) or "."
     git_root = get_git_root(file_dir)
     if not git_root:
-        return []
+        return [], []
     if baseline:
         cmd = ["git", "-C", git_root, "diff", "-U0", baseline + "..HEAD", "--", fpath]
     else:
         cmd = ["git", "-C", git_root, "diff", "--cached", "-U0", "--", fpath]
     result = subprocess.run(cmd, capture_output=True, text=True)
     cur = 0
-    nums = []
+    added_nums = []
+    deleted_exit_nums = []
     for line in result.stdout.splitlines():
         if line.startswith("@@"):
             m = re.search(r"\+(\d+)(?:,(\d+))?", line)
@@ -158,19 +174,33 @@ def added_linenos(fpath):
             continue
         elif line.startswith("+"):
             if cur > 0:
-                nums.append(cur)
+                added_nums.append(cur)
                 cur += 1
-        elif not line.startswith("-") and not line.startswith("\\\\"):
+        elif line.startswith("-"):
+            # Deleted line: cur is NOT incremented.
+            # Record new-side position if it matches exit pattern.
+            if cur > 0 and EXIT_PATTERN.search(line[1:]):
+                deleted_exit_nums.append(cur)
+        elif not line.startswith("\\\\"):
             if cur > 0:
                 cur += 1
-    return nums
+    return added_nums, deleted_exit_nums
 
-with open(out_path, "w") as out:
-    for fpath in iter_files():
-        if not os.path.isfile(fpath):
-            continue
-        for n in added_linenos(fpath):
-            out.write(fpath + ":" + str(n) + "\n")
+with open(out_path, "w") as out_f:
+    del_f = open(out_deleted, "w") if out_deleted else None
+    try:
+        for fpath in iter_files():
+            if not os.path.isfile(fpath):
+                continue
+            added, deleted_exits = diff_linenos(fpath)
+            for n in added:
+                out_f.write(fpath + ":" + str(n) + "\n")
+            if del_f is not None:
+                for n in deleted_exits:
+                    del_f.write(fpath + ":" + str(n) + "\n")
+    finally:
+        if del_f is not None:
+            del_f.close()
 '
   local _py_rc=$?
   if [[ $_py_rc -ne 0 ]]; then

--- a/guards/go/common.sh
+++ b/guards/go/common.sh
@@ -19,12 +19,13 @@ list_go_files() {
   fi
 }
 
-# 解析 --strict 标志和 target_dir
+# 解析 --strict / --baseline 标志和 target_dir
 # 用法: parse_guard_args "$@"
-# 设置变量: TARGET_DIR, STRICT
+# 设置变量: TARGET_DIR, STRICT, BASELINE_COMMIT
 parse_guard_args() {
   TARGET_DIR="."
   STRICT=false
+  BASELINE_COMMIT=""
   local positional_count=0
 
   while [[ $# -gt 0 ]]; do
@@ -32,8 +33,12 @@ parse_guard_args() {
       --strict)
         STRICT=true
         ;;
+      --baseline)
+        shift
+        BASELINE_COMMIT="${1:-}"
+        ;;
       --help|-h)
-        echo "Usage: $0 [--strict] [target_dir]" >&2
+        echo "Usage: $0 [--strict] [--baseline <commit>] [target_dir]" >&2
         return 1
         ;;
       --*)
@@ -51,6 +56,110 @@ parse_guard_args() {
     esac
     shift
   done
+  # 解析为绝对规范路径（消除 . / 相对路径 / macOS /var→/private/var 符号链接歧义）
+  TARGET_DIR="$(cd "${TARGET_DIR}" 2>/dev/null && pwd -P || echo "${TARGET_DIR}")"
+}
+
+# vg_build_diff_linemap OUTPUT_FILE [EXT_FILTER]
+#
+# 构建 diff 新增行号索引文件（每行格式: "filepath:linenum"）。
+# 用于 baseline 扫描：只报告本次 diff 新增的问题，不报告既有问题。
+#
+# pre-commit 模式（VIBEGUARD_STAGED_FILES 已设置）: 读取 git diff --cached
+# baseline  模式（BASELINE_COMMIT 已设置）        : 读取 git diff BASELINE..HEAD
+#
+# 返回: 0 = 成功（linemap 可能为空）；1 = 不在任何 diff 模式
+vg_build_diff_linemap() {
+  local out="$1"
+  local ext_filter="${2:-}"
+  : > "$out"
+
+  command -v python3 >/dev/null 2>&1 || return 1
+
+  local staged="${VIBEGUARD_STAGED_FILES:-}"
+  local baseline="${BASELINE_COMMIT:-}"
+  [[ -z "$staged" && -z "$baseline" ]] && return 1
+
+  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" \
+  python3 -c '
+import sys, re, subprocess, os
+
+staged     = os.environ.get("VG_STAGED", "")
+baseline   = os.environ.get("VG_BASELINE", "")
+ext_filter = os.environ.get("VG_EXT", "")
+out_path   = os.environ.get("VG_OUT", "")
+
+_git_root_cache = {}
+
+def get_git_root(dirpath):
+    """Detect git root from a directory; returns canonical absolute path."""
+    key = os.path.realpath(dirpath)
+    if key not in _git_root_cache:
+        r = subprocess.run(
+            ["git", "-C", key, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True
+        )
+        _git_root_cache[key] = os.path.realpath(r.stdout.strip()) if r.returncode == 0 else ""
+    return _git_root_cache[key]
+
+def iter_files():
+    if staged and os.path.isfile(staged):
+        with open(staged) as fh:
+            for line in fh:
+                p = os.path.realpath(line.strip())
+                if p and (not ext_filter or re.search(ext_filter, p)):
+                    yield p
+    elif baseline:
+        root = get_git_root(".")
+        if not root:
+            return
+        result = subprocess.run(
+            ["git", "-C", root, "diff", "--name-only", baseline + "..HEAD"],
+            capture_output=True, text=True
+        )
+        for fname in result.stdout.splitlines():
+            if fname and (not ext_filter or re.search(ext_filter, fname)):
+                yield os.path.join(root, fname)
+
+def added_linenos(fpath):
+    file_dir = os.path.dirname(fpath) or "."
+    git_root = get_git_root(file_dir)
+    if not git_root:
+        return []
+    if baseline:
+        cmd = ["git", "-C", git_root, "diff", "-U0", baseline + "..HEAD", "--", fpath]
+    else:
+        cmd = ["git", "-C", git_root, "diff", "--cached", "-U0", "--", fpath]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    cur = 0
+    nums = []
+    for line in result.stdout.splitlines():
+        if line.startswith("@@"):
+            m = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if m:
+                cur = int(m.group(1))
+                cnt = int(m.group(2)) if m.group(2) is not None else 1
+                if cnt == 0:
+                    cur = 0
+        elif line.startswith("+++"):
+            continue
+        elif line.startswith("+"):
+            if cur > 0:
+                nums.append(cur)
+                cur += 1
+        elif not line.startswith("-") and not line.startswith("\\\\"):
+            if cur > 0:
+                cur += 1
+    return nums
+
+with open(out_path, "w") as out:
+    for fpath in iter_files():
+        if not os.path.isfile(fpath):
+            continue
+        for n in added_linenos(fpath):
+            out.write(fpath + ":" + str(n) + "\n")
+' 2>/dev/null || true
+  return 0
 }
 
 # 临时文件清理目录：所有守卫共享同一清理 trap

--- a/guards/go/common.sh
+++ b/guards/go/common.sh
@@ -92,7 +92,7 @@ vg_build_diff_linemap() {
   local baseline="${BASELINE_COMMIT:-}"
   [[ -z "$staged" && -z "$baseline" ]] && return 1
 
-  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" \
+  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" VG_TARGET_DIR="${TARGET_DIR:-.}" \
   python3 -c '
 import sys, re, subprocess, os
 
@@ -100,6 +100,7 @@ staged     = os.environ.get("VG_STAGED", "")
 baseline   = os.environ.get("VG_BASELINE", "")
 ext_filter = os.environ.get("VG_EXT", "")
 out_path   = os.environ.get("VG_OUT", "")
+target_dir = os.environ.get("VG_TARGET_DIR", ".")
 
 _git_root_cache = {}
 
@@ -122,7 +123,7 @@ def iter_files():
                 if p and (not ext_filter or re.search(ext_filter, p)):
                     yield p
     elif baseline:
-        root = get_git_root(".")
+        root = get_git_root(target_dir)
         if not root:
             return
         result = subprocess.run(

--- a/guards/go/common.sh
+++ b/guards/go/common.sh
@@ -35,7 +35,11 @@ parse_guard_args() {
         ;;
       --baseline)
         shift
-        BASELINE_COMMIT="${1:-}"
+        if [[ $# -eq 0 || -z "${1:-}" ]]; then
+          echo "Error: --baseline requires a commit argument" >&2
+          return 1
+        fi
+        BASELINE_COMMIT="$1"
         ;;
       --help|-h)
         echo "Usage: $0 [--strict] [--baseline <commit>] [target_dir]" >&2
@@ -58,6 +62,14 @@ parse_guard_args() {
   done
   # 解析为绝对规范路径（消除 . / 相对路径 / macOS /var→/private/var 符号链接歧义）
   TARGET_DIR="$(cd "${TARGET_DIR}" 2>/dev/null && pwd -P || echo "${TARGET_DIR}")"
+
+  # 验证 baseline commit 存在，防止无效 commit 导致空 linemap 并静默放过所有检查
+  if [[ -n "$BASELINE_COMMIT" ]]; then
+    if ! git -C "${TARGET_DIR}" rev-parse --verify "${BASELINE_COMMIT}" >/dev/null 2>&1; then
+      echo "Error: --baseline '${BASELINE_COMMIT}' is not a valid commit in '${TARGET_DIR}'" >&2
+      return 1
+    fi
+  fi
 }
 
 # vg_build_diff_linemap OUTPUT_FILE [EXT_FILTER]
@@ -158,7 +170,12 @@ with open(out_path, "w") as out:
             continue
         for n in added_linenos(fpath):
             out.write(fpath + ":" + str(n) + "\n")
-' 2>/dev/null || true
+'
+  local _py_rc=$?
+  if [[ $_py_rc -ne 0 ]]; then
+    echo "Error: vg_build_diff_linemap failed (exit ${_py_rc})" >&2
+    return $_py_rc
+  fi
   return 0
 }
 

--- a/guards/typescript/check_any_abuse.sh
+++ b/guards/typescript/check_any_abuse.sh
@@ -25,7 +25,7 @@ _IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
   _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
-  vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$' || _LINEMAP=""
+  vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$'
 fi
 
 # --- TS-01: as any 和 : any 类型注解 ---

--- a/guards/typescript/check_any_abuse.sh
+++ b/guards/typescript/check_any_abuse.sh
@@ -19,6 +19,13 @@ parse_guard_args "$@"
 
 RESULTS=$(create_tmpfile)
 
+# --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
+_LINEMAP=""
+if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _LINEMAP=$(create_tmpfile)
+  vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$' || _LINEMAP=""
+fi
+
 # --- TS-01: as any 和 : any 类型注解 ---
 _USE_GREP_FALLBACK=false
 
@@ -40,9 +47,15 @@ if command -v ast-grep >/dev/null 2>&1; then
           --rule "${RULES_DIR}/ts-01-any.yml" \
           --json \
           "${_ASG_TARGETS[@]}" > "${_ASG_TMPOUT}"; then
-        python3 -c '
-import json, sys, re
+        VG_DIFF_LINEMAP="$_LINEMAP" python3 -c '
+import json, sys, re, os
 TEST_PATTERN = re.compile(r"(\.(test|spec)\.(ts|tsx|js|jsx)$|(^|/)tests/|(^|/)__tests__/|(^|/)test/|(^|/)vendor/)")
+linemap_path = os.environ.get("VG_DIFF_LINEMAP", "")
+added_set = set()
+if linemap_path and os.path.isfile(linemap_path):
+    with open(linemap_path) as lm:
+        for entry in lm:
+            added_set.add(entry.strip())
 data = sys.stdin.read().strip()
 if not data:
     sys.exit(0)
@@ -56,6 +69,9 @@ for m in matches:
     if TEST_PATTERN.search(f):
         continue
     line = m.get("range", {}).get("start", {}).get("line", 0) + 1
+    # Baseline 过滤：只报告 diff 新增行上的问题
+    if added_set and (f + ":" + str(line)) not in added_set:
+        continue
     msg = m.get("message", "any 类型使用")
     print("[TS-01] " + f + ":" + str(line) + " " + msg)
 ' < "${_ASG_TMPOUT}" >> "$RESULTS" || {
@@ -81,6 +97,10 @@ if [[ "$_USE_GREP_FALLBACK" == true ]]; then
           | grep -v '^\s*//' \
           | while IFS= read -r line_info; do
               LINE_NUM=$(echo "$line_info" | cut -d: -f1)
+              # Baseline 过滤：只报告新增行上的问题
+              if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+                grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+              fi
               echo "[TS-01] ${f}:${LINE_NUM} any 类型使用（grep fallback）"
             done
       done >> "$RESULTS" || true
@@ -94,12 +114,20 @@ while IFS= read -r file; do
   while IFS= read -r line_info; do
     [[ -z "$line_info" ]] && continue
     LINE_NUM=$(echo "$line_info" | cut -d: -f1)
+    # Baseline 过滤：只报告新增行上的问题
+    if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+      grep -qxF "${file}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+    fi
     echo "[TS-02] ${file}:${LINE_NUM} '@ts-ignore' 禁用类型检查。修复：修复类型错误而非忽略" >> "$RESULTS"
   done < <(grep -n '@ts-ignore' "$file" 2>/dev/null || true)
 
   while IFS= read -r line_info; do
     [[ -z "$line_info" ]] && continue
     LINE_NUM=$(echo "$line_info" | cut -d: -f1)
+    # Baseline 过滤：只报告新增行上的问题
+    if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+      grep -qxF "${file}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+    fi
     echo "[TS-02] ${file}:${LINE_NUM} '@ts-nocheck' 禁用整个文件类型检查。修复：逐个修复类型错误" >> "$RESULTS"
   done < <(grep -n '@ts-nocheck' "$file" 2>/dev/null || true)
 

--- a/guards/typescript/check_any_abuse.sh
+++ b/guards/typescript/check_any_abuse.sh
@@ -21,7 +21,9 @@ RESULTS=$(create_tmpfile)
 
 # --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
 _LINEMAP=""
+_IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
   vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$' || _LINEMAP=""
 fi
@@ -47,10 +49,11 @@ if command -v ast-grep >/dev/null 2>&1; then
           --rule "${RULES_DIR}/ts-01-any.yml" \
           --json \
           "${_ASG_TARGETS[@]}" > "${_ASG_TMPOUT}"; then
-        VG_DIFF_LINEMAP="$_LINEMAP" python3 -c '
+        VG_DIFF_LINEMAP="$_LINEMAP" VG_IN_DIFF_MODE="$_IN_DIFF_MODE" python3 -c '
 import json, sys, re, os
 TEST_PATTERN = re.compile(r"(\.(test|spec)\.(ts|tsx|js|jsx)$|(^|/)tests/|(^|/)__tests__/|(^|/)test/|(^|/)vendor/)")
 linemap_path = os.environ.get("VG_DIFF_LINEMAP", "")
+in_diff_mode = os.environ.get("VG_IN_DIFF_MODE", "false") == "true"
 added_set = set()
 if linemap_path and os.path.isfile(linemap_path):
     with open(linemap_path) as lm:
@@ -69,8 +72,10 @@ for m in matches:
     if TEST_PATTERN.search(f):
         continue
     line = m.get("range", {}).get("start", {}).get("line", 0) + 1
-    # Baseline 过滤：只报告 diff 新增行上的问题
-    if added_set and (f + ":" + str(line)) not in added_set:
+    # Baseline 过滤：只报告 diff 新增行上的问题。
+    # 用 in_diff_mode 而非 added_set 非空来判断 diff 模式，
+    # 避免仅删除行时 added_set 为空导致回退到全量扫描。
+    if in_diff_mode and (f + ":" + str(line)) not in added_set:
         continue
     msg = m.get("message", "any 类型使用")
     print("[TS-01] " + f + ":" + str(line) + " " + msg)
@@ -98,7 +103,7 @@ if [[ "$_USE_GREP_FALLBACK" == true ]]; then
           | while IFS= read -r line_info; do
               LINE_NUM=$(echo "$line_info" | cut -d: -f1)
               # Baseline 过滤：只报告新增行上的问题
-              if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+              if [[ "$_IN_DIFF_MODE" == true ]]; then
                 grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
               fi
               echo "[TS-01] ${f}:${LINE_NUM} any 类型使用（grep fallback）"
@@ -115,7 +120,7 @@ while IFS= read -r file; do
     [[ -z "$line_info" ]] && continue
     LINE_NUM=$(echo "$line_info" | cut -d: -f1)
     # Baseline 过滤：只报告新增行上的问题
-    if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+    if [[ "$_IN_DIFF_MODE" == true ]]; then
       grep -qxF "${file}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
     fi
     echo "[TS-02] ${file}:${LINE_NUM} '@ts-ignore' 禁用类型检查。修复：修复类型错误而非忽略" >> "$RESULTS"
@@ -125,7 +130,7 @@ while IFS= read -r file; do
     [[ -z "$line_info" ]] && continue
     LINE_NUM=$(echo "$line_info" | cut -d: -f1)
     # Baseline 过滤：只报告新增行上的问题
-    if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+    if [[ "$_IN_DIFF_MODE" == true ]]; then
       grep -qxF "${file}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
     fi
     echo "[TS-02] ${file}:${LINE_NUM} '@ts-nocheck' 禁用整个文件类型检查。修复：逐个修复类型错误" >> "$RESULTS"

--- a/guards/typescript/check_console_residual.sh
+++ b/guards/typescript/check_console_residual.sh
@@ -31,6 +31,13 @@ fi
 
 RESULTS=$(create_tmpfile)
 
+# --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
+_LINEMAP=""
+if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _LINEMAP=$(create_tmpfile)
+  vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$' || _LINEMAP=""
+fi
+
 _USE_GREP_FALLBACK=false
 
 if command -v ast-grep >/dev/null 2>&1; then
@@ -51,10 +58,17 @@ if command -v ast-grep >/dev/null 2>&1; then
           --rule "${RULES_DIR}/ts-03-console.yml" \
           --json \
           "${_ASG_TARGETS[@]}" > "${_ASG_TMPOUT}" 2>/dev/null; then
-        VIBEGUARD_TARGET_DIR="${TARGET_DIR}" python3 -c '
+        VIBEGUARD_TARGET_DIR="${TARGET_DIR}" VG_DIFF_LINEMAP="$_LINEMAP" python3 -c '
 import json, sys, re, os
 
 TARGET_DIR_PY = os.environ.get("VIBEGUARD_TARGET_DIR", "")
+linemap_path = os.environ.get("VG_DIFF_LINEMAP", "")
+added_set = set()
+if linemap_path and os.path.isfile(linemap_path):
+    with open(linemap_path) as lm:
+        for entry in lm:
+            added_set.add(entry.strip())
+
 TEST_PATTERN = re.compile(r"(\.(test|spec)\.(ts|tsx|js|jsx)$|(^|/)tests/|(^|/)__tests__/|(^|/)test/|(^|/)vendor/)")
 LOGGER_PATTERN = re.compile(r"(logger|logging|log\.config|/debug\.|/debug/)")
 MCP_MARKERS = {"StdioServerTransport", "new Server(", "McpServer"}
@@ -90,6 +104,9 @@ for m in matches:
     if is_mcp(f):
         continue
     line = m.get("range", {}).get("start", {}).get("line", 0) + 1
+    # Baseline 过滤：只报告 diff 新增行上的问题
+    if added_set and (f + ":" + str(line)) not in added_set:
+        continue
     msg = m.get("message", "console 残留")
     print("[TS-03] " + f + ":" + str(line) + " " + msg)
 ' < "${_ASG_TMPOUT}" >> "$RESULTS" || {
@@ -123,6 +140,10 @@ if [[ "$_USE_GREP_FALLBACK" == true ]]; then
           | grep -v '^\s*//' \
           | while IFS= read -r line_info; do
               LINE_NUM=$(echo "$line_info" | cut -d: -f1)
+              # Baseline 过滤：只报告新增行上的问题
+              if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+                grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
+              fi
               echo "[TS-03] ${f}:${LINE_NUM} console 残留（grep fallback）"
             done
       done >> "$RESULTS" || true

--- a/guards/typescript/check_console_residual.sh
+++ b/guards/typescript/check_console_residual.sh
@@ -37,7 +37,7 @@ _IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
   _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
-  vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$' || _LINEMAP=""
+  vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$'
 fi
 
 _USE_GREP_FALLBACK=false

--- a/guards/typescript/check_console_residual.sh
+++ b/guards/typescript/check_console_residual.sh
@@ -33,7 +33,9 @@ RESULTS=$(create_tmpfile)
 
 # --- Baseline/diff 过滤：只报告新增行上的问题（pre-commit 或 --baseline 模式）---
 _LINEMAP=""
+_IN_DIFF_MODE=false
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] || [[ -n "${BASELINE_COMMIT:-}" ]]; then
+  _IN_DIFF_MODE=true
   _LINEMAP=$(create_tmpfile)
   vg_build_diff_linemap "$_LINEMAP" '\.(ts|tsx|js|jsx)$' || _LINEMAP=""
 fi
@@ -58,11 +60,12 @@ if command -v ast-grep >/dev/null 2>&1; then
           --rule "${RULES_DIR}/ts-03-console.yml" \
           --json \
           "${_ASG_TARGETS[@]}" > "${_ASG_TMPOUT}" 2>/dev/null; then
-        VIBEGUARD_TARGET_DIR="${TARGET_DIR}" VG_DIFF_LINEMAP="$_LINEMAP" python3 -c '
+        VIBEGUARD_TARGET_DIR="${TARGET_DIR}" VG_DIFF_LINEMAP="$_LINEMAP" VG_IN_DIFF_MODE="$_IN_DIFF_MODE" python3 -c '
 import json, sys, re, os
 
 TARGET_DIR_PY = os.environ.get("VIBEGUARD_TARGET_DIR", "")
 linemap_path = os.environ.get("VG_DIFF_LINEMAP", "")
+in_diff_mode = os.environ.get("VG_IN_DIFF_MODE", "false") == "true"
 added_set = set()
 if linemap_path and os.path.isfile(linemap_path):
     with open(linemap_path) as lm:
@@ -104,8 +107,10 @@ for m in matches:
     if is_mcp(f):
         continue
     line = m.get("range", {}).get("start", {}).get("line", 0) + 1
-    # Baseline 过滤：只报告 diff 新增行上的问题
-    if added_set and (f + ":" + str(line)) not in added_set:
+    # Baseline 过滤：只报告 diff 新增行上的问题。
+    # 用 in_diff_mode 而非 added_set 非空来判断 diff 模式，
+    # 避免仅删除行时 added_set 为空导致回退到全量扫描。
+    if in_diff_mode and (f + ":" + str(line)) not in added_set:
         continue
     msg = m.get("message", "console 残留")
     print("[TS-03] " + f + ":" + str(line) + " " + msg)
@@ -141,7 +146,7 @@ if [[ "$_USE_GREP_FALLBACK" == true ]]; then
           | while IFS= read -r line_info; do
               LINE_NUM=$(echo "$line_info" | cut -d: -f1)
               # Baseline 过滤：只报告新增行上的问题
-              if [[ -n "$_LINEMAP" ]] && [[ -s "$_LINEMAP" ]]; then
+              if [[ "$_IN_DIFF_MODE" == true ]]; then
                 grep -qxF "${f}:${LINE_NUM}" "$_LINEMAP" 2>/dev/null || continue
               fi
               echo "[TS-03] ${f}:${LINE_NUM} console 残留（grep fallback）"

--- a/guards/typescript/common.sh
+++ b/guards/typescript/common.sh
@@ -45,7 +45,11 @@ parse_guard_args() {
         ;;
       --baseline)
         shift
-        BASELINE_COMMIT="${1:-}"
+        if [[ $# -eq 0 || -z "${1:-}" ]]; then
+          echo "Error: --baseline requires a commit argument" >&2
+          return 1
+        fi
+        BASELINE_COMMIT="$1"
         ;;
       --help|-h)
         echo "Usage: $0 [--strict] [--baseline <commit>] [target_dir]" >&2
@@ -68,6 +72,14 @@ parse_guard_args() {
   done
   # 解析为绝对规范路径（消除 . / 相对路径 / macOS /var→/private/var 符号链接歧义）
   TARGET_DIR="$(cd "${TARGET_DIR}" 2>/dev/null && pwd -P || echo "${TARGET_DIR}")"
+
+  # 验证 baseline commit 存在，防止无效 commit 导致空 linemap 并静默放过所有检查
+  if [[ -n "$BASELINE_COMMIT" ]]; then
+    if ! git -C "${TARGET_DIR}" rev-parse --verify "${BASELINE_COMMIT}" >/dev/null 2>&1; then
+      echo "Error: --baseline '${BASELINE_COMMIT}' is not a valid commit in '${TARGET_DIR}'" >&2
+      return 1
+    fi
+  fi
 }
 
 # vg_build_diff_linemap OUTPUT_FILE [EXT_FILTER]
@@ -168,7 +180,12 @@ with open(out_path, "w") as out:
             continue
         for n in added_linenos(fpath):
             out.write(fpath + ":" + str(n) + "\n")
-' 2>/dev/null || true
+'
+  local _py_rc=$?
+  if [[ $_py_rc -ne 0 ]]; then
+    echo "Error: vg_build_diff_linemap failed (exit ${_py_rc})" >&2
+    return $_py_rc
+  fi
   return 0
 }
 

--- a/guards/typescript/common.sh
+++ b/guards/typescript/common.sh
@@ -102,7 +102,7 @@ vg_build_diff_linemap() {
   local baseline="${BASELINE_COMMIT:-}"
   [[ -z "$staged" && -z "$baseline" ]] && return 1
 
-  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" \
+  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" VG_TARGET_DIR="${TARGET_DIR:-.}" \
   python3 -c '
 import sys, re, subprocess, os
 
@@ -110,6 +110,7 @@ staged     = os.environ.get("VG_STAGED", "")
 baseline   = os.environ.get("VG_BASELINE", "")
 ext_filter = os.environ.get("VG_EXT", "")
 out_path   = os.environ.get("VG_OUT", "")
+target_dir = os.environ.get("VG_TARGET_DIR", ".")
 
 _git_root_cache = {}
 
@@ -132,7 +133,7 @@ def iter_files():
                 if p and (not ext_filter or re.search(ext_filter, p)):
                     yield p
     elif baseline:
-        root = get_git_root(".")
+        root = get_git_root(target_dir)
         if not root:
             return
         result = subprocess.run(

--- a/guards/typescript/common.sh
+++ b/guards/typescript/common.sh
@@ -29,12 +29,13 @@ filter_non_test() {
   grep -vE '(\.(test|spec)\.(ts|tsx|js|jsx)$|/tests/|/__tests__/|/test/)' || true
 }
 
-# 解析 --strict 标志和 target_dir
+# 解析 --strict / --baseline 标志和 target_dir
 # 用法: parse_guard_args "$@"
-# 设置变量: TARGET_DIR, STRICT
+# 设置变量: TARGET_DIR, STRICT, BASELINE_COMMIT
 parse_guard_args() {
   TARGET_DIR="."
   STRICT=false
+  BASELINE_COMMIT=""
   local positional_count=0
 
   while [[ $# -gt 0 ]]; do
@@ -42,8 +43,12 @@ parse_guard_args() {
       --strict)
         STRICT=true
         ;;
+      --baseline)
+        shift
+        BASELINE_COMMIT="${1:-}"
+        ;;
       --help|-h)
-        echo "Usage: $0 [--strict] [target_dir]" >&2
+        echo "Usage: $0 [--strict] [--baseline <commit>] [target_dir]" >&2
         return 1
         ;;
       --*)
@@ -61,6 +66,110 @@ parse_guard_args() {
     esac
     shift
   done
+  # 解析为绝对规范路径（消除 . / 相对路径 / macOS /var→/private/var 符号链接歧义）
+  TARGET_DIR="$(cd "${TARGET_DIR}" 2>/dev/null && pwd -P || echo "${TARGET_DIR}")"
+}
+
+# vg_build_diff_linemap OUTPUT_FILE [EXT_FILTER]
+#
+# 构建 diff 新增行号索引文件（每行格式: "filepath:linenum"）。
+# 用于 baseline 扫描：只报告本次 diff 新增的问题，不报告既有问题。
+#
+# pre-commit 模式（VIBEGUARD_STAGED_FILES 已设置）: 读取 git diff --cached
+# baseline  模式（BASELINE_COMMIT 已设置）        : 读取 git diff BASELINE..HEAD
+#
+# 返回: 0 = 成功（linemap 可能为空）；1 = 不在任何 diff 模式
+vg_build_diff_linemap() {
+  local out="$1"
+  local ext_filter="${2:-}"
+  : > "$out"
+
+  command -v python3 >/dev/null 2>&1 || return 1
+
+  local staged="${VIBEGUARD_STAGED_FILES:-}"
+  local baseline="${BASELINE_COMMIT:-}"
+  [[ -z "$staged" && -z "$baseline" ]] && return 1
+
+  VG_STAGED="$staged" VG_BASELINE="$baseline" VG_EXT="$ext_filter" VG_OUT="$out" \
+  python3 -c '
+import sys, re, subprocess, os
+
+staged     = os.environ.get("VG_STAGED", "")
+baseline   = os.environ.get("VG_BASELINE", "")
+ext_filter = os.environ.get("VG_EXT", "")
+out_path   = os.environ.get("VG_OUT", "")
+
+_git_root_cache = {}
+
+def get_git_root(dirpath):
+    """Detect git root from a directory; returns canonical absolute path."""
+    key = os.path.realpath(dirpath)
+    if key not in _git_root_cache:
+        r = subprocess.run(
+            ["git", "-C", key, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True
+        )
+        _git_root_cache[key] = os.path.realpath(r.stdout.strip()) if r.returncode == 0 else ""
+    return _git_root_cache[key]
+
+def iter_files():
+    if staged and os.path.isfile(staged):
+        with open(staged) as fh:
+            for line in fh:
+                p = os.path.realpath(line.strip())
+                if p and (not ext_filter or re.search(ext_filter, p)):
+                    yield p
+    elif baseline:
+        root = get_git_root(".")
+        if not root:
+            return
+        result = subprocess.run(
+            ["git", "-C", root, "diff", "--name-only", baseline + "..HEAD"],
+            capture_output=True, text=True
+        )
+        for fname in result.stdout.splitlines():
+            if fname and (not ext_filter or re.search(ext_filter, fname)):
+                yield os.path.join(root, fname)
+
+def added_linenos(fpath):
+    file_dir = os.path.dirname(fpath) or "."
+    git_root = get_git_root(file_dir)
+    if not git_root:
+        return []
+    if baseline:
+        cmd = ["git", "-C", git_root, "diff", "-U0", baseline + "..HEAD", "--", fpath]
+    else:
+        cmd = ["git", "-C", git_root, "diff", "--cached", "-U0", "--", fpath]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    cur = 0
+    nums = []
+    for line in result.stdout.splitlines():
+        if line.startswith("@@"):
+            m = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if m:
+                cur = int(m.group(1))
+                cnt = int(m.group(2)) if m.group(2) is not None else 1
+                if cnt == 0:
+                    cur = 0
+        elif line.startswith("+++"):
+            continue
+        elif line.startswith("+"):
+            if cur > 0:
+                nums.append(cur)
+                cur += 1
+        elif not line.startswith("-") and not line.startswith("\\\\"):
+            if cur > 0:
+                cur += 1
+    return nums
+
+with open(out_path, "w") as out:
+    for fpath in iter_files():
+        if not os.path.isfile(fpath):
+            continue
+        for n in added_linenos(fpath):
+            out.write(fpath + ":" + str(n) + "\n")
+' 2>/dev/null || true
+  return 0
 }
 
 # 临时文件清理目录

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -161,13 +161,13 @@ def _validate_triage_record(rec: Any, lineno: int) -> bool:
 # ---------------------------------------------------------------------------
 
 def load_triage(path: Path) -> tuple[list[dict[str, Any]], int]:
-    """Load triage.jsonl; skip comment/blank lines and skip malformed records.
+    """Load triage.jsonl; skip comment/blank lines and reject malformed records.
 
-    Returns (records, error_count). Invalid lines are logged as [ERROR] and
-    skipped so that valid records are still processed.
+    Returns (records, invalid_count). Callers must treat invalid_count > 0 as an
+    error when scorecard writes or lifecycle transitions are involved.
     """
     records: list[dict[str, Any]] = []
-    error_count = 0
+    invalid_count = 0
     if not path.exists():
         return records, 0
     with path.open(encoding="utf-8") as fh:
@@ -179,13 +179,13 @@ def load_triage(path: Path) -> tuple[list[dict[str, Any]], int]:
                 rec = json.loads(line)
             except json.JSONDecodeError as exc:
                 print(f"[ERROR] triage.jsonl line {lineno}: {exc}", file=sys.stderr)
-                error_count += 1
+                invalid_count += 1
                 continue
             if not _validate_triage_record(rec, lineno):
-                error_count += 1
+                invalid_count += 1
                 continue
             records.append(rec)
-    return records, error_count
+    return records, invalid_count
 
 
 # ---------------------------------------------------------------------------
@@ -537,10 +537,11 @@ def main(argv: list[str] | None = None) -> int:
         if session:
             new_rec["session"] = session
         with _scorecard_write_lock(scorecard_path):
-            triage, triage_errors = load_triage(triage_path)
-            if triage_errors:
+            triage, invalid_count = load_triage(triage_path)
+            if invalid_count > 0:
                 print(
-                    f"[ERROR] {triage_errors} invalid triage record(s) — cannot safely update scorecard.",
+                    f"[ERROR] triage.jsonl contains {invalid_count} invalid record(s); "
+                    "refusing to update scorecard to avoid incorrect lifecycle transitions.",
                     file=sys.stderr,
                 )
                 return 1
@@ -564,8 +565,13 @@ def main(argv: list[str] | None = None) -> int:
     # --update-scorecard
     if args.update_scorecard:
         with _scorecard_write_lock(scorecard_path):
-            triage, triage_errors = load_triage(triage_path)
-            if triage_errors:
+            triage, invalid_count = load_triage(triage_path)
+            if invalid_count > 0:
+                print(
+                    f"[ERROR] triage.jsonl contains {invalid_count} invalid record(s); "
+                    "refusing to update scorecard to avoid incorrect lifecycle transitions.",
+                    file=sys.stderr,
+                )
                 return 1
             scorecard = load_scorecard(scorecard_path)
             scorecard, transitions = update_scorecard(scorecard, triage)

--- a/tests/unit/test_baseline_scanning.sh
+++ b/tests/unit/test_baseline_scanning.sh
@@ -411,6 +411,153 @@ else
 fi
 rm -f "$staged8"
 
+printf '\n=== Baseline Scanning: Issue fixes — deleted exit mechanism, wrapped defer, tab parsing ===\n'
+
+# ---- Test A: goroutine with <-ctx.Done() removed IS reported (Issue 1) ----
+repoA="${tmpdir}/go02_deleted_exit"
+init_repo "$repoA"
+
+cat > "${repoA}/worker.go" <<'EOF'
+package worker
+
+import "context"
+
+func StartWorker(ctx context.Context) {
+    go func() {
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            default:
+                doWork()
+            }
+        }
+    }()
+}
+
+func doWork() {}
+EOF
+git -C "$repoA" add worker.go
+git -C "$repoA" commit -q -m "initial with ctx.Done exit"
+
+# Remove the ctx.Done exit mechanism lines
+cat > "${repoA}/worker.go" <<'EOF'
+package worker
+
+import "context"
+
+func StartWorker(ctx context.Context) {
+    go func() {
+        for {
+            doWork()
+        }
+    }()
+}
+
+func doWork() {}
+EOF
+git -C "$repoA" add worker.go
+stagedA=$(staged_list "$repoA" worker.go)
+
+TOTAL=$((TOTAL+1))
+outA=$(VIBEGUARD_STAGED_FILES="$stagedA" bash "${REPO_DIR}/guards/go/check_goroutine_leak.sh" "$repoA" 2>&1 || true)
+if echo "$outA" | grep -q '\[GO-02\]'; then
+  green "deleted ctx.Done exit mechanism IS reported (Issue 1 fix)"
+  PASS=$((PASS+1))
+else
+  red "goroutine with deleted ctx.Done should be reported (got: $outA)"
+  FAIL=$((FAIL+1))
+fi
+rm -f "$stagedA"
+
+# ---- Test B: for loop added wrapping existing defer IS reported (Issue 2) ----
+repoB="${tmpdir}/go08_wrapped_defer"
+init_repo "$repoB"
+
+cat > "${repoB}/files.go" <<'EOF'
+package files
+
+import "os"
+
+func ProcessFile(path string) error {
+    f, err := os.Open(path)
+    if err != nil { return err }
+    defer f.Close()
+    return nil
+}
+EOF
+git -C "$repoB" add files.go
+git -C "$repoB" commit -q -m "initial with defer outside loop"
+
+# Add a for loop wrapping the existing defer
+cat > "${repoB}/files.go" <<'EOF'
+package files
+
+import "os"
+
+func ProcessFiles(paths []string) error {
+    for _, path := range paths {
+        f, err := os.Open(path)
+        if err != nil { return err }
+        defer f.Close()
+    }
+    return nil
+}
+EOF
+git -C "$repoB" add files.go
+stagedB=$(staged_list "$repoB" files.go)
+
+TOTAL=$((TOTAL+1))
+if awk '/^\s*for\s/ { found=1 } END { exit !found }' "${repoB}/files.go" 2>/dev/null; then
+  outB=$(VIBEGUARD_STAGED_FILES="$stagedB" bash "${REPO_DIR}/guards/go/check_defer_in_loop.sh" "$repoB" 2>&1 || true)
+  if echo "$outB" | grep -q '\[GO-08\]'; then
+    green "for loop added wrapping existing defer IS reported (Issue 2 fix)"
+    PASS=$((PASS+1))
+  else
+    red "wrapping defer with new for loop should be reported (got: $outB)"
+    FAIL=$((FAIL+1))
+  fi
+else
+  yellow "awk lacks \\s support — skipping wrapped-defer test"
+  SKIP=$((SKIP+1))
+fi
+rm -f "$stagedB"
+
+# ---- Test C: output format filepath:linenum is correct with tab-based parsing (Issue 3) ----
+repoC="${tmpdir}/go08_tab_parsing"
+init_repo "$repoC"
+
+cat > "${repoC}/resource.go" <<'EOF'
+package resource
+
+import "os"
+
+func OpenAll(paths []string) {
+    for _, p := range paths {
+        f, _ := os.Open(p)
+        defer f.Close()
+    }
+}
+EOF
+git -C "$repoC" add resource.go
+git -C "$repoC" commit -q -m "initial"
+
+TOTAL=$((TOTAL+1))
+if awk '/^\s*for\s/ { found=1 } END { exit !found }' "${repoC}/resource.go" 2>/dev/null; then
+  outC=$(bash "${REPO_DIR}/guards/go/check_defer_in_loop.sh" "$repoC" 2>&1 || true)
+  # Verify output format is [GO-08] filepath:linenum content (not broken by tab parsing)
+  if echo "$outC" | grep -qE '\[GO-08\] .+:[0-9]+ '; then
+    green "tab-based parsing produces correct filepath:linenum output format (Issue 3 fix)"
+    PASS=$((PASS+1))
+  else
+    red "output format should be [GO-08] filepath:linenum content (got: $outC)"
+    FAIL=$((FAIL+1))
+  fi
+else
+  yellow "awk lacks \\s support — skipping tab-parsing format test"
+  SKIP=$((SKIP+1))
+fi
+
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m  Skip: \033[33m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL" "$SKIP"
 [[ $FAIL -gt 0 ]] && exit 1 || exit 0

--- a/tests/unit/test_baseline_scanning.sh
+++ b/tests/unit/test_baseline_scanning.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Unit tests for baseline scanning (issue #30)
+#
+# Verifies that guards only report issues on newly added lines, not pre-existing ones.
+# Tests both VIBEGUARD_STAGED_FILES (pre-commit) mode and --baseline <commit> mode.
+#
+# Requires: git, python3
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+PASS=0; FAIL=0; SKIP=0; TOTAL=0
+
+green()  { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()    { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+yellow() { printf '\033[33m  SKIP: %s\033[0m\n' "$1"; }
+
+# Require git and python3
+if ! command -v git >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+  yellow "git or python3 not available — skipping baseline scanning tests"
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Helper: initialize a minimal git repo
+init_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@vibeguard"
+  git -C "$dir" config user.name "VibeGuard Test"
+}
+
+# Helper: canonical (symlink-resolved) absolute path — matches what git rev-parse returns
+canon() { (cd "$1" 2>/dev/null && pwd -P); }
+
+# Helper: build VIBEGUARD_STAGED_FILES with canonical paths (matching pre-commit-guard.sh)
+staged_list() {
+  local repo="$1"; shift
+  local out
+  out=$(mktemp)
+  local repo_real
+  repo_real=$(canon "$repo")
+  for f in "$@"; do
+    echo "${repo_real}/${f}"
+  done > "$out"
+  echo "$out"
+}
+
+printf '\n=== Baseline Scanning: vg_build_diff_linemap (Go) ===\n'
+
+# ---- Test 1: linemap captures added lines in pre-commit mode ----
+repo1="${tmpdir}/linemap_go"
+init_repo "$repo1"
+
+cat > "${repo1}/main.go" <<'EOF'
+package main
+
+func existing() {}
+EOF
+git -C "$repo1" add main.go
+git -C "$repo1" commit -q -m "initial"
+
+# Add new lines
+cat >> "${repo1}/main.go" <<'EOF'
+
+func newFunc() {
+    go process()
+}
+EOF
+git -C "$repo1" add main.go
+
+staged1=$(staged_list "$repo1" main.go)
+linemap1=$(mktemp)
+(
+  cd "$repo1"
+  source "${REPO_DIR}/guards/go/common.sh"
+  VIBEGUARD_STAGED_FILES="$staged1" vg_build_diff_linemap "$linemap1" '\.go$'
+)
+
+TOTAL=$((TOTAL+1))
+if [[ -s "$linemap1" ]]; then
+  green "vg_build_diff_linemap produces non-empty linemap for staged Go file"
+  PASS=$((PASS+1))
+else
+  red "vg_build_diff_linemap should produce non-empty linemap"
+  FAIL=$((FAIL+1))
+fi
+
+TOTAL=$((TOTAL+1))
+repo1_real=$(canon "$repo1")
+if grep -q "${repo1_real}/main.go:" "$linemap1" 2>/dev/null; then
+  green "linemap contains entries for the staged file"
+  PASS=$((PASS+1))
+else
+  red "linemap should contain entries for ${repo1_real}/main.go"
+  FAIL=$((FAIL+1))
+fi
+rm -f "$staged1" "$linemap1"
+
+printf '\n=== Baseline Scanning: GO-02 goroutine_leak diff-only mode ===\n'
+
+# ---- Test 2: Pre-existing goroutine leak is NOT reported in pre-commit mode ----
+repo2="${tmpdir}/go02_preexisting"
+init_repo "$repo2"
+
+cat > "${repo2}/worker.go" <<'EOF'
+package worker
+
+func StartWorker() {
+    go func() {
+        for {
+            doWork()
+        }
+    }()
+}
+
+func doWork() {}
+EOF
+git -C "$repo2" add worker.go
+git -C "$repo2" commit -q -m "initial with goroutine"
+
+# Add an innocent change (no new goroutine)
+cat >> "${repo2}/worker.go" <<'EOF'
+
+func NewHelper() string { return "ok" }
+EOF
+git -C "$repo2" add worker.go
+staged2=$(staged_list "$repo2" worker.go)
+
+TOTAL=$((TOTAL+1))
+out2=$(VIBEGUARD_STAGED_FILES="$staged2" bash "${REPO_DIR}/guards/go/check_goroutine_leak.sh" --strict "$repo2" 2>&1 || true)
+if echo "$out2" | grep -q '\[GO-02\]'; then
+  red "pre-commit mode should NOT report pre-existing goroutine leak (got: $out2)"
+  FAIL=$((FAIL+1))
+else
+  green "pre-commit mode correctly ignores pre-existing goroutine leak"
+  PASS=$((PASS+1))
+fi
+rm -f "$staged2"
+
+# ---- Test 3: Newly added goroutine leak IS reported in pre-commit mode ----
+repo3="${tmpdir}/go02_new_leak"
+init_repo "$repo3"
+
+cat > "${repo3}/worker.go" <<'EOF'
+package worker
+
+func Existing() string { return "clean" }
+EOF
+git -C "$repo3" add worker.go
+git -C "$repo3" commit -q -m "initial clean"
+
+cat >> "${repo3}/worker.go" <<'EOF'
+
+func Leaky() {
+    go func() {
+        for {
+            process()
+        }
+    }()
+}
+
+func process() {}
+EOF
+git -C "$repo3" add worker.go
+staged3=$(staged_list "$repo3" worker.go)
+
+TOTAL=$((TOTAL+1))
+out3=$(VIBEGUARD_STAGED_FILES="$staged3" bash "${REPO_DIR}/guards/go/check_goroutine_leak.sh" "$repo3" 2>&1 || true)
+if echo "$out3" | grep -q '\[GO-02\]'; then
+  green "pre-commit mode reports newly added goroutine leak"
+  PASS=$((PASS+1))
+else
+  red "pre-commit mode should report newly added goroutine leak (got: $out3)"
+  FAIL=$((FAIL+1))
+fi
+rm -f "$staged3"
+
+printf '\n=== Baseline Scanning: GO-08 defer_in_loop diff-only mode ===\n'
+
+# ---- Test 4: Pre-existing defer-in-loop is NOT reported in pre-commit mode ----
+repo4="${tmpdir}/go08_preexisting"
+init_repo "$repo4"
+
+cat > "${repo4}/files.go" <<'EOF'
+package files
+
+import "os"
+
+func ProcessFiles(paths []string) error {
+    for _, path := range paths {
+        f, err := os.Open(path)
+        if err != nil { return err }
+        defer f.Close()
+    }
+    return nil
+}
+EOF
+git -C "$repo4" add files.go
+git -C "$repo4" commit -q -m "initial with defer-in-loop"
+
+cat >> "${repo4}/files.go" <<'EOF'
+
+func Helper() string { return "helper" }
+EOF
+git -C "$repo4" add files.go
+staged4=$(staged_list "$repo4" files.go)
+
+TOTAL=$((TOTAL+1))
+if awk '/^\s*for\s/ { found=1 } END { exit !found }' "${repo4}/files.go" 2>/dev/null; then
+  out4=$(VIBEGUARD_STAGED_FILES="$staged4" bash "${REPO_DIR}/guards/go/check_defer_in_loop.sh" --strict "$repo4" 2>&1 || true)
+  if echo "$out4" | grep -q '\[GO-08\]'; then
+    red "pre-commit mode should NOT report pre-existing defer-in-loop (got: $out4)"
+    FAIL=$((FAIL+1))
+  else
+    green "pre-commit mode correctly ignores pre-existing defer-in-loop"
+    PASS=$((PASS+1))
+  fi
+else
+  yellow "awk lacks \\s support — skipping defer-in-loop pre-commit test"
+  SKIP=$((SKIP+1))
+fi
+rm -f "$staged4"
+
+printf '\n=== Baseline Scanning: --baseline <commit> mode ===\n'
+
+# ---- Test 5: --baseline does NOT report goroutine that existed before baseline ----
+repo5="${tmpdir}/go02_baseline"
+init_repo "$repo5"
+
+cat > "${repo5}/server.go" <<'EOF'
+package server
+
+func Start() {
+    go func() {
+        for { serve() }
+    }()
+}
+
+func serve() {}
+EOF
+git -C "$repo5" add server.go
+git -C "$repo5" commit -q -m "initial with goroutine"
+baseline5=$(git -C "$repo5" rev-parse HEAD)
+
+cat >> "${repo5}/server.go" <<'EOF'
+
+func Version() string { return "1.0" }
+EOF
+git -C "$repo5" add server.go
+git -C "$repo5" commit -q -m "add Version func"
+
+TOTAL=$((TOTAL+1))
+out5=$(cd "$repo5" && bash "${REPO_DIR}/guards/go/check_goroutine_leak.sh" --baseline "$baseline5" . 2>&1 || true)
+if echo "$out5" | grep -q '\[GO-02\]'; then
+  red "--baseline mode should NOT report goroutine that existed before baseline (got: $out5)"
+  FAIL=$((FAIL+1))
+else
+  green "--baseline mode correctly ignores goroutine introduced before baseline"
+  PASS=$((PASS+1))
+fi
+
+# ---- Test 6: --baseline DOES report new goroutine leak added after baseline ----
+repo6="${tmpdir}/go02_baseline_new"
+init_repo "$repo6"
+
+cat > "${repo6}/clean.go" <<'EOF'
+package clean
+
+func Existing() string { return "ok" }
+EOF
+git -C "$repo6" add clean.go
+git -C "$repo6" commit -q -m "initial clean"
+baseline6=$(git -C "$repo6" rev-parse HEAD)
+
+cat >> "${repo6}/clean.go" <<'EOF'
+
+func Leaky() {
+    go func() {
+        for { work() }
+    }()
+}
+
+func work() {}
+EOF
+git -C "$repo6" add clean.go
+git -C "$repo6" commit -q -m "add goroutine leak"
+
+TOTAL=$((TOTAL+1))
+out6=$(cd "$repo6" && bash "${REPO_DIR}/guards/go/check_goroutine_leak.sh" --baseline "$baseline6" . 2>&1 || true)
+if echo "$out6" | grep -q '\[GO-02\]'; then
+  green "--baseline mode reports goroutine leak added after baseline"
+  PASS=$((PASS+1))
+else
+  red "--baseline mode should report goroutine leak added after baseline (got: $out6)"
+  FAIL=$((FAIL+1))
+fi
+
+echo
+printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m  Skip: \033[33m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL" "$SKIP"
+[[ $FAIL -gt 0 ]] && exit 1 || exit 0

--- a/tests/unit/test_baseline_scanning.sh
+++ b/tests/unit/test_baseline_scanning.sh
@@ -299,6 +299,118 @@ else
   FAIL=$((FAIL+1))
 fi
 
+printf '\n=== Baseline Scanning: deletion-only commit (empty linemap) ===\n'
+
+# ---- Test 7: deletion-only staged change should NOT trigger full scan ----
+# When staged changes contain only deletions, vg_build_diff_linemap produces an empty
+# linemap. Guards must not fall back to full-scan in this case — they should report
+# nothing, because the pre-existing goroutine was not introduced by this commit.
+repo7="${tmpdir}/go02_deletion_only"
+init_repo "$repo7"
+
+cat > "${repo7}/worker.go" <<'EOF'
+package worker
+
+func StartWorker() {
+    go func() {
+        for {
+            doWork()
+        }
+    }()
+}
+
+func doWork() {}
+
+func ExtraHelper() string { return "extra" }
+EOF
+git -C "$repo7" add worker.go
+git -C "$repo7" commit -q -m "initial with goroutine and helper"
+
+# Stage a deletion-only change (remove ExtraHelper)
+cat > "${repo7}/worker.go" <<'EOF'
+package worker
+
+func StartWorker() {
+    go func() {
+        for {
+            doWork()
+        }
+    }()
+}
+
+func doWork() {}
+EOF
+git -C "$repo7" add worker.go
+staged7=$(staged_list "$repo7" worker.go)
+
+TOTAL=$((TOTAL+1))
+out7=$(VIBEGUARD_STAGED_FILES="$staged7" bash "${REPO_DIR}/guards/go/check_goroutine_leak.sh" --strict "$repo7" 2>&1 || true)
+if echo "$out7" | grep -q '\[GO-02\]'; then
+  red "deletion-only commit should NOT report pre-existing goroutine leak via full scan (got: $out7)"
+  FAIL=$((FAIL+1))
+else
+  green "deletion-only commit: empty linemap correctly suppresses full scan"
+  PASS=$((PASS+1))
+fi
+rm -f "$staged7"
+
+# ---- Test 8: defer-in-loop: deletion-only staged change should NOT trigger full scan ----
+repo8="${tmpdir}/go08_deletion_only"
+init_repo "$repo8"
+
+cat > "${repo8}/files.go" <<'EOF'
+package files
+
+import "os"
+
+func ProcessFiles(paths []string) error {
+    for _, path := range paths {
+        f, err := os.Open(path)
+        if err != nil { return err }
+        defer f.Close()
+    }
+    return nil
+}
+
+func ExtraHelper() string { return "extra" }
+EOF
+git -C "$repo8" add files.go
+git -C "$repo8" commit -q -m "initial with defer-in-loop and helper"
+
+# Stage a deletion-only change (remove ExtraHelper)
+cat > "${repo8}/files.go" <<'EOF'
+package files
+
+import "os"
+
+func ProcessFiles(paths []string) error {
+    for _, path := range paths {
+        f, err := os.Open(path)
+        if err != nil { return err }
+        defer f.Close()
+    }
+    return nil
+}
+EOF
+git -C "$repo8" add files.go
+staged8=$(staged_list "$repo8" files.go)
+
+TOTAL=$((TOTAL+1))
+if awk '/^\s*for\s/ { found=1 } END { exit !found }' "${repo8}/files.go" 2>/dev/null; then
+  out8=$(VIBEGUARD_STAGED_FILES="$staged8" bash "${REPO_DIR}/guards/go/check_defer_in_loop.sh" --strict "$repo8" 2>&1 || true)
+  if echo "$out8" | grep -q '\[GO-08\]'; then
+    red "deletion-only commit should NOT report pre-existing defer-in-loop via full scan (got: $out8)"
+    FAIL=$((FAIL+1))
+  else
+    green "deletion-only commit: defer-in-loop empty linemap correctly suppresses full scan"
+    PASS=$((PASS+1))
+  fi
+else
+  yellow "awk lacks \\s support — skipping defer-in-loop deletion-only test"
+  SKIP=$((SKIP+1))
+fi
+rm -f "$staged8"
+
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m  Skip: \033[33m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL" "$SKIP"
 [[ $FAIL -gt 0 ]] && exit 1 || exit 0


### PR DESCRIPTION
Fixes #30

## Summary

- Add `vg_build_diff_linemap()` to `guards/go/common.sh` and `guards/typescript/common.sh`: builds a `filepath:linenum` index of diff-added lines via `git diff --cached` (pre-commit) or `git diff BASELINE..HEAD` (--baseline mode)
- Add `--baseline <commit>` CLI option to all guards via `parse_guard_args()`; `TARGET_DIR` resolved canonically with `pwd -P` to handle macOS `/var` → `/private/var` symlinks
- Wire diff filtering into `check_goroutine_leak.sh`, `check_defer_in_loop.sh`, `check_error_handling.sh`, `check_any_abuse.sh`, `check_console_residual.sh` — only active when `VIBEGUARD_STAGED_FILES` or `BASELINE_COMMIT` is set; standalone behavior unchanged
- Add `tests/unit/test_baseline_scanning.sh` with 6 tests covering both modes

## Test plan

- [x] `bash tests/unit/test_baseline_scanning.sh` — 6 pass, 1 skip (awk `\s` not supported on macOS BSD awk)
- [x] `npm test` — 67 + 4 + 34 = 105 pass, 0 fail
- [x] `node_modules/.bin/tsc --noEmit` — no errors