### PR TITLE
fix(guards): RS-14 restore persistence-method check with safe path iteration

### DIFF
--- a/guards/rust/check_declaration_execution_gap.sh
+++ b/guards/rust/check_declaration_execution_gap.sh
@@ -167,6 +167,32 @@ for m in matches:
   exit 0
 }
 
+# RS-14 persistence-method check: verify save/load/persist/restore are called at startup.
+# Collects startup files into an array with while-read to avoid word-splitting on paths
+# containing spaces (replaces the old buggy `for file in $startup_files` pattern).
+_pm_startup_files=()
+while IFS= read -r _f; do
+  [[ -f "${_f}" ]] && _pm_startup_files+=("${_f}")
+done < <(find "${TARGET_DIR}" \( -name 'main.rs' -o -name 'lib.rs' \) 2>/dev/null | head -5)
+
+if [[ ${#_pm_startup_files[@]} -gt 0 ]]; then
+  for _method in save load persist restore; do
+    if grep -rqE "fn[[:space:]]+${_method}[[:space:]]*\(" \
+        --include='*.rs' "${TARGET_DIR}" 2>/dev/null; then
+      _called=false
+      for _file in "${_pm_startup_files[@]}"; do
+        if grep -qE "\b${_method}[[:space:]]*\(" "${_file}" 2>/dev/null; then
+          _called=true
+          break
+        fi
+      done
+      if [[ "${_called}" == "false" ]]; then
+        echo "[RS-14] Persistence method '${_method}()' is declared but not called at startup (main.rs / lib.rs). Fix: invoke ${_method}() in the startup path, or add // vibeguard-disable-next-line RS-14 if intentional." >> "$TMPFILE"
+      fi
+    fi
+  done
+fi
+
 apply_suppression_filter "$TMPFILE"
 FOUND=$(wc -l < "$TMPFILE" | tr -d ' ')
 

--- a/guards/rust/check_declaration_execution_gap.sh
+++ b/guards/rust/check_declaration_execution_gap.sh
@@ -168,49 +168,118 @@ for m in matches:
 }
 
 # RS-14 persistence-method check: verify save/load/persist/restore are called at startup.
-# Collects startup files into an array with while-read to avoid word-splitting on paths
-# containing spaces (replaces the old buggy `for file in $startup_files` pattern).
-# Excludes build artifacts (target/) and non-production dirs to avoid false results from
-# workspace members or generated code masking a missing call in the real entrypoint.
+# Fix (Issue 3): scan src/bin/*.rs alongside main.rs/lib.rs; remove head -5 truncation
+#   so workspace members with >5 startup files or bin/ entrypoints are fully covered.
+# Fix (Issue 1): per-(type,method) tracking — python3 extracts the impl-type name for
+#   each declaration so that an unrelated load( call on a different type cannot satisfy
+#   the check (false-negative where "anything named load" collapses to one _called flag).
+# Fix (Issue 2): inline // comment stripping + string-literal exclusion in call-site
+#   grep so that `foo(); // load(` and `"load("` do not count as startup invocations.
 _pm_startup_files=()
 while IFS= read -r _f; do
   [[ -f "${_f}" ]] && _pm_startup_files+=("${_f}")
 done < <(find "${TARGET_DIR}" \
-    \( -name 'main.rs' -o -name 'lib.rs' \) \
+    \( -name 'main.rs' -o -name 'lib.rs' -o -path '*/bin/*.rs' \) \
     -not -path '*/target/*' \
     -not -path '*/examples/*' \
     -not -path '*/benches/*' \
     -not -path '*/tests/*' \
-    2>/dev/null | head -5)
+    2>/dev/null)
 
 if [[ ${#_pm_startup_files[@]} -gt 0 ]]; then
   for _method in save load persist restore; do
-    # Only flag methods declared in production code; exclude build artifacts and test dirs
-    # so that a method declared only in tests/examples never triggers startup enforcement.
-    if grep -rqE "fn[[:space:]]+${_method}[[:space:]]*\(" \
-        --include='*.rs' \
-        --exclude-dir=target \
-        --exclude-dir=examples \
-        --exclude-dir=benches \
-        --exclude-dir=tests \
-        "${TARGET_DIR}" 2>/dev/null; then
-      _called=false
-      for _file in "${_pm_startup_files[@]}"; do
-        # Match actual call sites only: strip fn-declaration lines and comment lines first
-        # so that `fn load(`, `// load(`, and `/* load(` do not count as a startup call
-        # (false negative guard — prevents CI passing when method is never invoked at runtime).
-        if grep -E "\b${_method}[[:space:]]*\(" "${_file}" 2>/dev/null \
-            | grep -vE "^\s*(//|/\*|\*)" \
-            | grep -vE "\bfn[[:space:]]+${_method}[[:space:]]*\(" \
+    # Extract all impl-type names that declare fn <_method>( in production code.
+    # python3 tracks brace-depth to stay inside each impl block, preventing
+    # cross-type pollution when multiple types in the same file define the same
+    # method name.  Only production (non-test, non-example) files are scanned.
+    _decl_types=$(python3 - "${_method}" "${TARGET_DIR}" <<'PYEOF'
+import sys, re, subprocess
+
+method  = sys.argv[1]
+tgt_dir = sys.argv[2]
+
+TEST_PATH = re.compile(r'((^|/)tests[/._]|/test_|_test\.rs$|tests\.rs$|(^|/)examples/|(^|/)benches/)')
+
+try:
+    res = subprocess.run(
+        ["grep", "-rlE", r"fn\s+" + re.escape(method) + r"\s*\(",
+         "--include=*.rs",
+         "--exclude-dir=target", "--exclude-dir=examples",
+         "--exclude-dir=benches", "--exclude-dir=tests",
+         tgt_dir],
+        capture_output=True, text=True
+    )
+    decl_files = [f for f in res.stdout.strip().splitlines() if not TEST_PATH.search(f)]
+except Exception:
+    sys.exit(0)
+
+_ng = r"[^<>]*(?:<[^<>]*>[^<>]*)*"
+impl_pat = re.compile(
+    r'^\s*impl(?:<' + _ng + r'>)?\s+'
+    r'(?:[\w:]+(?:<' + _ng + r'>)?\s+for\s+)?'
+    r'(\w+)(?:<' + _ng + r'>)?\s*(?:\{|where\b|$)'
+)
+method_pat  = re.compile(r'\bfn\s+' + re.escape(method) + r'\s*\(')
+comment_pat = re.compile(r'^\s*(//|/\*|\*)')
+
+types_found = set()
+for filepath in decl_files:
+    try:
+        with open(filepath, 'r', errors='ignore') as fh:
+            lines = fh.readlines()
+    except Exception:
+        continue
+    i = 0
+    while i < len(lines):
+        m = impl_pat.search(lines[i])
+        if m:
+            type_name = m.group(1)
+            depth = lines[i].count('{') - lines[i].count('}')
+            j = i + 1
+            while j < len(lines) and depth <= 0:
+                depth += lines[j].count('{') - lines[j].count('}')
+                j += 1
+            while j < len(lines) and depth > 0:
+                depth += lines[j].count('{') - lines[j].count('}')
+                if method_pat.search(lines[j]) and not comment_pat.search(lines[j]):
+                    types_found.add(type_name)
+                    break
+                j += 1
+            i = j
+        else:
+            i += 1
+
+for t in sorted(types_found):
+    print(t)
+PYEOF
+    )
+    [[ -z "${_decl_types}" ]] && continue
+
+    # For each declaring type, verify a call anchored to that specific type exists
+    # in at least one startup file.  Five-stage filter pipeline per startup file:
+    #  1. initial grep: require Type:: or . prefix so the match is anchored to this type
+    #  2. drop full-line comment/doc lines (// /* *)
+    #  3. drop fn-declaration lines (false call — it's a definition, not invocation)
+    #  4. drop lines where the match falls inside an inline // comment
+    #  5. drop lines where the match is inside a double-quoted string literal
+    while IFS= read -r _type; do
+      [[ -z "${_type}" ]] && continue
+      _type_called=false
+      for _startup in "${_pm_startup_files[@]}"; do
+        if grep -E "(${_type}[[:space:]]*::|\.)[[:space:]]*${_method}[[:space:]]*\(" "${_startup}" 2>/dev/null \
+            | grep -vE '^\s*(//|/\*|\*)' \
+            | grep -vE '\bfn[[:space:]]+'"${_method}"'[[:space:]]*\(' \
+            | grep -vE '//.*\b'"${_method}"'[[:space:]]*\(' \
+            | grep -vE '"[^"]*\b'"${_method}"'[[:space:]]*\([^"]*"' \
             | grep -q .; then
-          _called=true
+          _type_called=true
           break
         fi
       done
-      if [[ "${_called}" == "false" ]]; then
-        echo "[RS-14] Persistence method '${_method}()' is declared but not called at startup (main.rs / lib.rs). Fix: invoke ${_method}() in the startup path, or add // vibeguard-disable-next-line RS-14 if intentional." >> "$TMPFILE"
+      if [[ "${_type_called}" == "false" ]]; then
+        echo "[RS-14] Persistence method '${_type}::${_method}()' is declared but not called at startup (main.rs / lib.rs / src/bin/*.rs). Fix: invoke ${_type}::${_method}() in the startup path, or add // vibeguard-disable-next-line RS-14 if intentional." >> "$TMPFILE"
       fi
-    fi
+    done <<< "${_decl_types}"
   done
 fi
 

--- a/guards/rust/check_declaration_execution_gap.sh
+++ b/guards/rust/check_declaration_execution_gap.sh
@@ -170,18 +170,39 @@ for m in matches:
 # RS-14 persistence-method check: verify save/load/persist/restore are called at startup.
 # Collects startup files into an array with while-read to avoid word-splitting on paths
 # containing spaces (replaces the old buggy `for file in $startup_files` pattern).
+# Excludes build artifacts (target/) and non-production dirs to avoid false results from
+# workspace members or generated code masking a missing call in the real entrypoint.
 _pm_startup_files=()
 while IFS= read -r _f; do
   [[ -f "${_f}" ]] && _pm_startup_files+=("${_f}")
-done < <(find "${TARGET_DIR}" \( -name 'main.rs' -o -name 'lib.rs' \) 2>/dev/null | head -5)
+done < <(find "${TARGET_DIR}" \
+    \( -name 'main.rs' -o -name 'lib.rs' \) \
+    -not -path '*/target/*' \
+    -not -path '*/examples/*' \
+    -not -path '*/benches/*' \
+    -not -path '*/tests/*' \
+    2>/dev/null | head -5)
 
 if [[ ${#_pm_startup_files[@]} -gt 0 ]]; then
   for _method in save load persist restore; do
+    # Only flag methods declared in production code; exclude build artifacts and test dirs
+    # so that a method declared only in tests/examples never triggers startup enforcement.
     if grep -rqE "fn[[:space:]]+${_method}[[:space:]]*\(" \
-        --include='*.rs' "${TARGET_DIR}" 2>/dev/null; then
+        --include='*.rs' \
+        --exclude-dir=target \
+        --exclude-dir=examples \
+        --exclude-dir=benches \
+        --exclude-dir=tests \
+        "${TARGET_DIR}" 2>/dev/null; then
       _called=false
       for _file in "${_pm_startup_files[@]}"; do
-        if grep -qE "\b${_method}[[:space:]]*\(" "${_file}" 2>/dev/null; then
+        # Match actual call sites only: strip fn-declaration lines and comment lines first
+        # so that `fn load(`, `// load(`, and `/* load(` do not count as a startup call
+        # (false negative guard — prevents CI passing when method is never invoked at runtime).
+        if grep -E "\b${_method}[[:space:]]*\(" "${_file}" 2>/dev/null \
+            | grep -vE "^\s*(//|/\*|\*)" \
+            | grep -vE "\bfn[[:space:]]+${_method}[[:space:]]*\(" \
+            | grep -q .; then
           _called=true
           break
         fi


### PR DESCRIPTION
## Summary

- The original `check_declaration_execution_gap.sh` had a `check_persistence_methods()` function that used `for file in $startup_files` where `startup_files` was captured from `find`. Unquoted word-splitting silently corrupted paths containing spaces, causing `rg`/`grep` to receive invalid file arguments and silently skipping persistence-method checks for affected projects (U-17).
- The subsequent ast-grep rewrite removed the buggy function entirely, eliminating the crash but also dropping persistence-method coverage completely.
- This PR restores the check using the safe array + `while IFS= read -r` pattern recommended by the finding.

## Changes

**`guards/rust/check_declaration_execution_gap.sh`**

Replaces the old pattern:
```bash
# BUGGY (word-splits paths with spaces)
local startup_files=$(find . -name 'main.rs' -o -name 'lib.rs')
for file in $startup_files; do ...
```

With the safe pattern:
```bash
_pm_startup_files=()
while IFS= read -r _f; do
  [[ -f "${_f}" ]] && _pm_startup_files+=("${_f}")
done < <(find "${TARGET_DIR}" \( -name 'main.rs' -o -name 'lib.rs' \) 2>/dev/null | head -5)
for _file in "${_pm_startup_files[@]}"; do ...
```

## Test plan

- [ ] Run `bash -n guards/rust/check_declaration_execution_gap.sh` — syntax check passes
- [ ] Run the script against a Rust project with a `save()` method not invoked in `main.rs` — should emit `[RS-14]` finding
- [ ] Run against a project whose paths contain spaces — no false negatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)