### PR TITLE
fix: SEC-01 eliminate shell-variable injection in gc-scheduled.sh

### DIFF
--- a/.vibeguard-doc-paths-allowlist
+++ b/.vibeguard-doc-paths-allowlist
@@ -11,6 +11,9 @@ python/quality.md
 # Script referenced in systemic issues report (removed after cleanup)
 scripts/verify-package-contents.sh
 
+# Conceptual example paths in documentation (not real repo files)
+project/.claude/CLAUDE.md
+
 # Paths in docs that reference removed/external files
 tests/test_post_write_perf.sh
 vibeguard/claude-md/vibeguard-rules.md

--- a/scripts/gc/gc-scheduled.sh
+++ b/scripts/gc/gc-scheduled.sh
@@ -36,25 +36,28 @@ mkdir -p "${LOG_DIR}"
     for mf in "${LOG_DIR}"/projects/*/session-metrics.jsonl; do
       [[ -f "${mf}" ]] || continue
       BEFORE=$(wc -l < "${mf}" | tr -d ' ')
-      python3 -c "
-import sys
-cutoff = '${CUTOFF}'
+      METRICS_FILE="${mf}" CUTOFF="${CUTOFF}" python3 - <<'PYEOF' 2>/dev/null || true
+import os
+mf_path = os.environ['METRICS_FILE']
+cutoff = os.environ['CUTOFF']
 kept = []
-with open('${mf}') as f:
+original = 0
+with open(mf_path) as f:
     for line in f:
+        original += 1
         if line.strip():
-            if '\"ts\"' in line:
-                idx = line.find('\"ts\"')
-                ts_start = line.find('\"', idx + 4) + 1
+            if '"ts"' in line:
+                idx = line.find('"ts"')
+                ts_start = line.find('"', idx + 4) + 1
                 ts_val = line[ts_start:ts_start+10]
                 if ts_val >= cutoff[:10]:
                     kept.append(line)
             else:
                 kept.append(line)
-with open('${mf}', 'w') as f:
+with open(mf_path, 'w') as f:
     f.writelines(kept)
-print(f' {len(kept)} reserved items (original ${BEFORE} items)')
-" 2>/dev/null || true
+print(f' {len(kept)} reserved items (original {original} items)')
+PYEOF
       AFTER=$(wc -l < "${mf}" | tr -d ' ')
       DIFF=$((BEFORE - AFTER))
       [[ ${DIFF} -gt 0 ]] && CLEANED=$((CLEANED + DIFF))
@@ -67,13 +70,13 @@ print(f' {len(kept)} reserved items (original ${BEFORE} items)')
 
   echo "--- Regular learning (event log + code scanning unified signal source) ---"
   VIBEGUARD_DIR="${SCRIPT_DIR}/.."
-  python3 -c "
+  LOG_DIR="${LOG_DIR}" VIBEGUARD_DIR="${VIBEGUARD_DIR}" python3 - <<'PYEOF' 2>&1 || echo "[ERROR] learn-digest failed"
 import json, os, sys, subprocess
 from collections import Counter
 from datetime import datetime, timezone, timedelta
 
-log_dir = '${LOG_DIR}'
-vibeguard_dir = '${VIBEGUARD_DIR}'
+log_dir = os.environ['LOG_DIR']
+vibeguard_dir = os.environ['VIBEGUARD_DIR']
 projects_dir = os.path.join(log_dir, 'projects')
 digest_file = os.path.join(log_dir, 'learn-digest.jsonl')
 
@@ -121,7 +124,7 @@ def run_guard(script, project_root):
         if not output:
             return 0, []
         # Count the offending lines marked by [XX-NN]
-        violations = [l for l in output.split('\\n') if l.startswith('[')]
+        violations = [l for l in output.split('\n') if l.startswith('[')]
         return len(violations), violations[:3] # Keep up to 3 examples
     except (subprocess.TimeoutExpired, OSError):
         return 0, []
@@ -266,19 +269,19 @@ if signals_found == 0:
     print('No need to learn signals')
 else:
     print(f' A total of {signals_found} signals have been written to learn-digest.jsonl')
-" 2>&1 || echo "[ERROR] learn-digest failed"
+PYEOF
   echo
 
   echo "---Session Quality Reflection (Reflection Automation) ---"
   REFLECTION_FILE="${LOG_DIR}/reflection-digest.md"
-  python3 -c "
+  LOG_DIR="${LOG_DIR}" REFLECTION_FILE="${REFLECTION_FILE}" python3 - <<'PYEOF' 2>&1 || echo "[ERROR] reflection failed"
 import json, os, sys
 from collections import Counter
 from datetime import datetime, timezone, timedelta
 
-log_dir = '${LOG_DIR}'
+log_dir = os.environ['LOG_DIR']
 projects_dir = os.path.join(log_dir, 'projects')
-output_file = '${REFLECTION_FILE}'
+output_file = os.environ['REFLECTION_FILE']
 
 if not os.path.isdir(projects_dir):
     print('No project data, skip')
@@ -442,7 +445,7 @@ print(f' Sessions: {total_sessions}, Events: {total_events}, Friction rate: {ove
 if suggestions:
     for s in suggestions:
         print(f'    - {s}')
-" 2>&1 || echo "[ERROR] reflection failed"
+PYEOF
   echo
 
   echo "GC completed"

--- a/scripts/gc/gc-scheduled.sh
+++ b/scripts/gc/gc-scheduled.sh
@@ -259,11 +259,11 @@ for proj in os.listdir(projects_dir):
         for s in signals:
             src = s.get('source', '')
             if s['type'] == 'linter_violations':
-                print(f' - [code scan] {s[\"guard\"]}: {s[\"count\"]} violations')
+                print(f' - [code scan] {s["guard"]}: {s["count"]} violations')
             else:
                 detail = s.get('reason', s.get('file', ''))
                 count = s.get('count', s.get('edits', ''))
-                print(f' - [Event Log] {s[\"type\"]}: {detail} ({count})')
+                print(f' - [Event Log] {s["type"]}: {detail} ({count})')
 
 if signals_found == 0:
     print('No need to learn signals')
@@ -372,14 +372,14 @@ for s in all_sessions:
 report = []
 report.append(f'# VibeGuard Weekly Reflection Report')
 report.append(f'')
-report.append(f'> Generation time: {now.strftime(\"%Y-%m-%d %H:%M UTC\")}')
+report.append(f'> Generation time: {now.strftime("%Y-%m-%d %H:%M UTC")}')
 report.append(f'>Coverage: Last 7 days')
 report.append(f'')
 report.append(f'## overview')
 report.append(f'')
 report.append(f'- Number of sessions: {total_sessions}')
 report.append(f'-Total number of events: {total_events}')
-report.append(f'- pass: {decision_totals.get(\"pass\", 0)} | warn: {decision_totals.get(\"warn\", 0)} | block: {decision_totals.get(\"block\", 0)} | escalate: {decision_totals.get(\"escalate\", 0)}')
+report.append(f'- pass: {decision_totals.get("pass", 0)} | warn: {decision_totals.get("warn", 0)} | block: {decision_totals.get("block", 0)} | escalate: {decision_totals.get("escalate", 0)}')
 total_decisions = sum(decision_totals.values())
 overall_warn_rate = (decision_totals.get('warn', 0) + decision_totals.get('block', 0) + decision_totals.get('escalate', 0)) / max(total_decisions, 1)
 report.append(f'- overall friction rate: {overall_warn_rate:.0%}')


### PR DESCRIPTION
## Summary

- Replace all three `python3 -c "...${VAR}..."` invocations with `<<'PYEOF'` heredocs so the shell never expands variables inside Python source
- Pass `LOG_DIR`, `VIBEGUARD_DIR`, `REFLECTION_FILE`, `mf`, and `CUTOFF` via the command's environment (`VAR=value python3 -`) and read them with `os.environ[...]`
- Block 1 (metrics loop): Python now tracks the original line count internally, removing the `${BEFORE}` interpolation
- Block 2 (learn-digest): also fixes `output.split('\\n')` → `output.split('\n')` (was only correct by accident in the `-c "..."` context)

## Root cause

`${LOG_DIR}` derives from `VIBEGUARD_LOG_DIR` env var (line 12). A value containing a single-quote (e.g. `/tmp/x'; import os; os.system('id') #`) breaks the embedded Python syntax and enables arbitrary code execution when the scheduled GC job runs under systemd/launchd.

## Test plan

- [ ] `bash -n scripts/gc/gc-scheduled.sh` passes (syntax OK)
- [ ] Manual smoke-test: set `VIBEGUARD_LOG_DIR` to a path containing a single-quote; confirm the script exits cleanly rather than executing injected code
- [ ] Existing shell-script tests in `tests/` continue to pass

Closes #56