### PR TITLE
fix(hooks): make cmd_upsert_vibeguard idempotent via _has_entry dedup

### DIFF
--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -52,6 +52,11 @@ LEGACY_MARKERS = {
 
 MANAGED_MARKERS = LEGACY_MARKERS | {spec["script"] for spec in MANAGED_SPECS}
 
+# Namespaced vibeguard-* script names from MANAGED_SPECS.  These are
+# unambiguous enough to identify VibeGuard entries without inspecting the
+# wrapper path, so removal works even when a non-standard wrapper is used.
+_MANAGED_SCRIPT_NAMES: frozenset[str] = frozenset(spec["script"] for spec in MANAGED_SPECS)
+
 
 def load_hooks(path: Path) -> dict[str, Any]:
     if not path.exists():
@@ -81,8 +86,15 @@ def _ensure_hooks_root(data: dict[str, Any]) -> dict[str, Any]:
 def _is_vibeguard_command(command: str) -> bool:
     if not isinstance(command, str):
         return False
+    # Pure-legacy hooks that were never invoked via run-hook-codex.sh.
     if any(marker in command for marker in ("session-tagger.sh", "cognitive-reminder.sh", "post-guard-check.sh")):
         return True
+    # Namespaced vibeguard-* scripts are unambiguous regardless of wrapper path,
+    # so custom-wrapper installs are correctly detected during removal.
+    if any(script in command for script in _MANAGED_SCRIPT_NAMES):
+        return True
+    # Un-namespaced legacy markers still require the canonical wrapper name to
+    # avoid false positives against user scripts with similar short names.
     if "run-hook-codex.sh" not in command:
         return False
     return any(marker in command for marker in MANAGED_MARKERS)
@@ -162,7 +174,17 @@ def _build_entry(wrapper: str, spec: HookSpec) -> dict[str, Any]:
     return entry
 
 
-def _has_entry(entries: list[Any], expected_command: str, expected_matcher: str | None) -> bool:
+def _has_entry(
+    entries: list[Any],
+    expected_command: str,
+    expected_matcher: str | None,
+    expected_timeout: int | None,
+) -> bool:
+    """Return True only when a fully-conformant managed entry exists.
+
+    Checks ``command``, ``type``, ``matcher``, and ``timeout`` so that a stale
+    entry with the right command but wrong metadata does not block repair.
+    """
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -174,8 +196,19 @@ def _has_entry(entries: list[Any], expected_command: str, expected_matcher: str 
         for hook in hook_entries:
             if not isinstance(hook, dict):
                 continue
-            if hook.get("command") == expected_command:
-                return True
+            if hook.get("command") != expected_command:
+                continue
+            if hook.get("type") != "command":
+                continue
+            # timeout must be present-and-matching when the spec demands it,
+            # and absent when the spec has none (Stop entries).
+            if expected_timeout is not None:
+                if hook.get("timeout") != expected_timeout:
+                    continue
+            else:
+                if "timeout" in hook:
+                    continue
+            return True
     return False
 
 
@@ -196,7 +229,8 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
             hooks[event] = entries
         expected_command = f"bash {args.wrapper} {spec['script']}"
         expected_matcher = spec.get("matcher") if isinstance(spec.get("matcher"), str) else None
-        if not _has_entry(entries, expected_command, expected_matcher):
+        expected_timeout = spec.get("timeout") if isinstance(spec.get("timeout"), int) else None
+        if not _has_entry(entries, expected_command, expected_matcher, expected_timeout):
             entries.append(_build_entry(args.wrapper, spec))
 
     after = json.dumps(data, sort_keys=True, ensure_ascii=False)
@@ -246,7 +280,8 @@ def cmd_check_vibeguard(args: argparse.Namespace) -> int:
 
         expected_command = f"bash {args.wrapper} {spec['script']}"
         expected_matcher = spec.get("matcher")
-        if not _has_entry(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None):
+        expected_timeout = spec.get("timeout") if isinstance(spec.get("timeout"), int) else None
+        if not _has_entry(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None, expected_timeout):
             return 1
     return 0
 

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -188,7 +188,7 @@ def _has_entry(
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        if expected_matcher is not None and entry.get("matcher") != expected_matcher:
+        if entry.get("matcher") != expected_matcher:
             continue
         hook_entries = entry.get("hooks")
         if not isinstance(hook_entries, list):

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -194,7 +194,10 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
         if not isinstance(entries, list):
             entries = []
             hooks[event] = entries
-        entries.append(_build_entry(args.wrapper, spec))
+        expected_command = f"bash {args.wrapper} {spec['script']}"
+        expected_matcher = spec.get("matcher") if isinstance(spec.get("matcher"), str) else None
+        if not _has_entry(entries, expected_command, expected_matcher):
+            entries.append(_build_entry(args.wrapper, spec))
 
     after = json.dumps(data, sort_keys=True, ensure_ascii=False)
     if after != before:

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -237,6 +237,24 @@ with open('${_STALE_HOOKS}', 'w') as f:
     json.dump(data, f, indent=2)
 "
 assert_cmd "check-vibeguard rejects Stop entry with spurious timeout" bash -c "! python3 '${CODEX_HOOKS_HELPER}' check-vibeguard --hooks-file '${_STALE_HOOKS}' --wrapper '${_STALE_WRAPPER}'"
+# Write a Stop entry with correct command+type but a spurious matcher (Stop spec has none).
+python3 -c "
+import json
+data = {
+  'hooks': {
+    'Stop': [{
+      'matcher': 'Bash',
+      'hooks': [{'type': 'command', 'command': 'bash ${_STALE_WRAPPER} vibeguard-stop-guard.sh'}]
+    }]
+  }
+}
+with open('${_STALE_HOOKS}', 'w') as f:
+    json.dump(data, f, indent=2)
+"
+assert_cmd "check-vibeguard rejects Stop entry with spurious matcher" bash -c "! python3 '${CODEX_HOOKS_HELPER}' check-vibeguard --hooks-file '${_STALE_HOOKS}' --wrapper '${_STALE_WRAPPER}'"
+# After upsert the entry must be repaired and check must pass.
+python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}" >/dev/null
+assert_cmd "upsert repairs Stop entry with spurious matcher; check-vibeguard then passes" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}"
 
 header "setup --clean"
 clean_out="$(bash "${REPO_DIR}/setup.sh" --clean)"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -178,6 +178,21 @@ assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'sessi
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 
+header "upsert idempotency with non-standard wrapper path"
+# Run upsert twice with a wrapper path that does not contain 'run-hook-codex.sh'.
+# Without the _has_entry dedup fix, the second upsert would append duplicates.
+_IDEMPOTENT_HOOKS="${TMP_HOME}/.codex/hooks-idempotent.json"
+_IDEMPOTENT_WRAPPER="${TMP_HOME}/test/wrapper.sh"
+python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${_IDEMPOTENT_HOOKS}" --wrapper "${_IDEMPOTENT_WRAPPER}" >/dev/null
+python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${_IDEMPOTENT_HOOKS}" --wrapper "${_IDEMPOTENT_WRAPPER}" >/dev/null
+assert_cmd "double-upsert with non-standard wrapper produces exactly 4 Stop entries (not 8)" python3 -c "
+import json
+data = json.load(open('${_IDEMPOTENT_HOOKS}'))
+stop_entries = data.get('hooks', {}).get('Stop', [])
+raise SystemExit(0 if len(stop_entries) == 2 else 1)
+"
+assert_cmd "double-upsert with non-standard wrapper: check-vibeguard passes" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${_IDEMPOTENT_HOOKS}" --wrapper "${_IDEMPOTENT_WRAPPER}"
+
 header "setup --clean"
 clean_out="$(bash "${REPO_DIR}/setup.sh" --clean)"
 assert_contains "${clean_out}" "VibeGuard cleaned." "--clean route to cleanup process"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -193,6 +193,51 @@ raise SystemExit(0 if len(stop_entries) == 2 else 1)
 "
 assert_cmd "double-upsert with non-standard wrapper: check-vibeguard passes" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${_IDEMPOTENT_HOOKS}" --wrapper "${_IDEMPOTENT_WRAPPER}"
 
+header "remove-vibeguard cleans custom-wrapper-path hooks"
+# Issue fix: _is_vibeguard_command must recognise vibeguard-* scripts even when
+# the wrapper path does not contain 'run-hook-codex.sh'.
+python3 "${CODEX_HOOKS_HELPER}" remove-vibeguard --hooks-file "${_IDEMPOTENT_HOOKS}"
+assert_cmd "remove-vibeguard removes custom-wrapper vibeguard hooks" bash -c "! grep -q 'vibeguard-pre-bash-guard.sh' '${_IDEMPOTENT_HOOKS}'"
+assert_cmd "remove-vibeguard removes all managed hook scripts" bash -c "! grep -qE 'vibeguard-(pre-bash-guard|post-build-check|stop-guard|learn-evaluator)\\.sh' '${_IDEMPOTENT_HOOKS}'"
+
+header "_has_entry validates type and timeout (Issue 2 guard)"
+# A stale entry that has the correct command but is missing 'type: command' or
+# has a spurious timeout must NOT satisfy check-vibeguard (silent false positive).
+_STALE_HOOKS="${TMP_HOME}/.codex/hooks-stale.json"
+_STALE_WRAPPER="${TMP_HOME}/test/stale-wrapper.sh"
+# Write an entry with correct command but no 'type' field and no 'timeout'.
+python3 -c "
+import json, sys
+data = {
+  'hooks': {
+    'PreToolUse': [{
+      'matcher': 'Bash',
+      'hooks': [{'command': 'bash ${_STALE_WRAPPER} vibeguard-pre-bash-guard.sh'}]
+    }]
+  }
+}
+with open('${_STALE_HOOKS}', 'w') as f:
+    json.dump(data, f, indent=2)
+"
+assert_cmd "check-vibeguard rejects stale entry missing type field" bash -c "! python3 '${CODEX_HOOKS_HELPER}' check-vibeguard --hooks-file '${_STALE_HOOKS}' --wrapper '${_STALE_WRAPPER}'"
+# After upsert the entry must be repaired and check must pass.
+python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}" >/dev/null
+assert_cmd "upsert repairs stale entry; check-vibeguard then passes" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}"
+# Write a Stop entry with correct command but a spurious timeout (Stop spec has none).
+python3 -c "
+import json
+data = {
+  'hooks': {
+    'Stop': [{
+      'hooks': [{'type': 'command', 'command': 'bash ${_STALE_WRAPPER} vibeguard-stop-guard.sh', 'timeout': 99}]
+    }]
+  }
+}
+with open('${_STALE_HOOKS}', 'w') as f:
+    json.dump(data, f, indent=2)
+"
+assert_cmd "check-vibeguard rejects Stop entry with spurious timeout" bash -c "! python3 '${CODEX_HOOKS_HELPER}' check-vibeguard --hooks-file '${_STALE_HOOKS}' --wrapper '${_STALE_WRAPPER}'"
+
 header "setup --clean"
 clean_out="$(bash "${REPO_DIR}/setup.sh" --clean)"
 assert_contains "${clean_out}" "VibeGuard cleaned." "--clean route to cleanup process"


### PR DESCRIPTION
## Summary

- `cmd_upsert_vibeguard` called `entries.append()` unconditionally after `_prune_vibeguard_entries`, which only removes entries whose command contains `run-hook-codex.sh`. A wrapper at any other path bypassed the prune, producing duplicate hook entries on every subsequent install.
- Added a `_has_entry` check (the helper already existed at line 165) before each `entries.append()` — upsert is now idempotent regardless of wrapper path.
- Two new test assertions in `tests/test_setup.sh` verify double-upsert with `/test/wrapper.sh` yields exactly 2 Stop entries and `check-vibeguard` passes.

## Test plan

- [x] `bash tests/test_setup.sh` — 54/54 pass (includes 2 new idempotency assertions)