### PR TITLE
fix(hooks): make cmd_upsert_vibeguard idempotent for arbitrary wrapper paths

### DIFF
--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -81,11 +81,19 @@ def _ensure_hooks_root(data: dict[str, Any]) -> dict[str, Any]:
 def _is_vibeguard_command(command: str) -> bool:
     if not isinstance(command, str):
         return False
+    # Legacy direct calls that don't use the "bash <wrapper> <script>" pattern.
     if any(marker in command for marker in ("session-tagger.sh", "cognitive-reminder.sh", "post-guard-check.sh")):
         return True
-    if "run-hook-codex.sh" not in command:
-        return False
-    return any(marker in command for marker in MANAGED_MARKERS)
+    # Standard or arbitrary wrapper pattern: "bash <wrapper> <vibeguard-script>"
+    # The last whitespace-separated token must be a managed VibeGuard script name.
+    # This covers both run-hook-codex.sh wrappers and arbitrary wrapper paths.
+    parts = command.split()
+    if len(parts) >= 3 and parts[0] == "bash":
+        return parts[-1] in MANAGED_MARKERS
+    # Fallback for run-hook-codex.sh in unusual/malformed command strings.
+    if "run-hook-codex.sh" in command:
+        return any(marker in command for marker in MANAGED_MARKERS)
+    return False
 
 
 def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
@@ -231,6 +239,30 @@ def cmd_remove_vibeguard(args: argparse.Namespace) -> int:
     return 0
 
 
+def _has_stale_vibeguard_entries(data: dict[str, Any], current_wrapper: str) -> bool:
+    """Return True if any VibeGuard entries exist for a wrapper other than current_wrapper."""
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    expected_commands = {f"bash {current_wrapper} {spec['script']}" for spec in MANAGED_SPECS}
+    for entries in hooks.values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                continue
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    continue
+                command = str(hook.get("command", ""))
+                if _is_vibeguard_command(command) and command not in expected_commands:
+                    return True
+    return False
+
+
 def cmd_check_vibeguard(args: argparse.Namespace) -> int:
     hooks_path = Path(args.hooks_file)
     data = load_hooks(hooks_path)
@@ -248,6 +280,9 @@ def cmd_check_vibeguard(args: argparse.Namespace) -> int:
         expected_matcher = spec.get("matcher")
         if not _has_entry(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None):
             return 1
+
+    if _has_stale_vibeguard_entries(data, args.wrapper):
+        return 1
     return 0
 
 

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -50,7 +50,13 @@ LEGACY_MARKERS = {
     "cognitive-reminder.sh",
 }
 
-MANAGED_MARKERS = LEGACY_MARKERS | {spec["script"] for spec in MANAGED_SPECS}
+# Current VibeGuard script names — all carry the unambiguous "vibeguard-" prefix.
+# Used for marker-based detection in the "bash <wrapper> <script>" pattern so that
+# third-party hooks whose last token happens to match a generic legacy name (e.g.
+# "bash /other-tool/wrapper.sh pre-bash-guard.sh") are NOT mis-classified.
+CURRENT_SCRIPT_NAMES = {spec["script"] for spec in MANAGED_SPECS}
+
+MANAGED_MARKERS = LEGACY_MARKERS | CURRENT_SCRIPT_NAMES
 
 
 def load_hooks(path: Path) -> dict[str, Any]:
@@ -85,11 +91,12 @@ def _is_vibeguard_command(command: str) -> bool:
     if any(marker in command for marker in ("session-tagger.sh", "cognitive-reminder.sh", "post-guard-check.sh")):
         return True
     # Standard or arbitrary wrapper pattern: "bash <wrapper> <vibeguard-script>"
-    # The last whitespace-separated token must be a managed VibeGuard script name.
-    # This covers both run-hook-codex.sh wrappers and arbitrary wrapper paths.
+    # Only match against CURRENT_SCRIPT_NAMES (all carry the "vibeguard-" prefix) to
+    # avoid false-positives where a third-party hook's last token coincidentally matches
+    # a generic legacy marker name such as "pre-bash-guard.sh" or "stop-guard.sh".
     parts = command.split()
     if len(parts) >= 3 and parts[0] == "bash":
-        return parts[-1] in MANAGED_MARKERS
+        return parts[-1] in CURRENT_SCRIPT_NAMES
     # Fallback for run-hook-codex.sh in unusual/malformed command strings.
     if "run-hook-codex.sh" in command:
         return any(marker in command for marker in MANAGED_MARKERS)
@@ -187,6 +194,25 @@ def _has_entry(entries: list[Any], expected_command: str, expected_matcher: str 
     return False
 
 
+def _count_entries(entries: list[Any], expected_command: str, expected_matcher: str | None) -> int:
+    """Count occurrences of expected_command (with matching matcher) across all entries."""
+    count = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if expected_matcher is not None and entry.get("matcher") != expected_matcher:
+            continue
+        hook_entries = entry.get("hooks")
+        if not isinstance(hook_entries, list):
+            continue
+        for hook in hook_entries:
+            if not isinstance(hook, dict):
+                continue
+            if hook.get("command") == expected_command:
+                count += 1
+    return count
+
+
 def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
     hooks_path = Path(args.hooks_file)
     data = load_hooks(hooks_path)
@@ -278,7 +304,8 @@ def cmd_check_vibeguard(args: argparse.Namespace) -> int:
 
         expected_command = f"bash {args.wrapper} {spec['script']}"
         expected_matcher = spec.get("matcher")
-        if not _has_entry(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None):
+        # Exactly one occurrence required: 0 means missing, >1 means duplicate (fires multiple times).
+        if _count_entries(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None) != 1:
             return 1
 
     if _has_stale_vibeguard_entries(data, args.wrapper):

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -194,7 +194,10 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
         if not isinstance(entries, list):
             entries = []
             hooks[event] = entries
-        entries.append(_build_entry(args.wrapper, spec))
+        expected_command = f"bash {args.wrapper} {spec['script']}"
+        expected_matcher = spec.get("matcher")
+        if not _has_entry(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None):
+            entries.append(_build_entry(args.wrapper, spec))
 
     after = json.dumps(data, sort_keys=True, ensure_ascii=False)
     if after != before:

--- a/scripts/lib/test_codex_hooks_json.py
+++ b/scripts/lib/test_codex_hooks_json.py
@@ -14,11 +14,13 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from codex_hooks_json import (
     MANAGED_SPECS,
+    cmd_check_vibeguard,
+    cmd_remove_vibeguard,
     cmd_upsert_vibeguard,
 )
 
 
-def _make_args(hooks_file: str, wrapper: str) -> argparse.Namespace:
+def _make_args(hooks_file: str, wrapper: str = "") -> argparse.Namespace:
     ns = argparse.Namespace()
     ns.hooks_file = hooks_file
     ns.wrapper = wrapper
@@ -110,3 +112,124 @@ class TestUpsertIdempotencyArbitraryWrapper:
         assert content_after_first == content_after_second, (
             "hooks.json was modified by a no-op second upsert"
         )
+
+
+class TestWrapperPathChange:
+    """Upsert with a new wrapper path must prune stale entries from the old path."""
+
+    def test_wrapper_change_removes_old_entries(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        old_wrapper = str(tmp_path / "old-wrapper.sh")
+        new_wrapper = str(tmp_path / "new-wrapper.sh")
+
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), old_wrapper))
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), new_wrapper))
+
+        data = json.loads(hooks_file.read_text())
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            old_command = f"bash {old_wrapper} {spec['script']}"
+            new_command = f"bash {new_wrapper} {spec['script']}"
+            assert _count_entries(data, event, old_command) == 0, (
+                f"Stale entry for old wrapper still present after wrapper change: {event}/{spec['script']}"
+            )
+            assert _count_entries(data, event, new_command) == 1, (
+                f"New wrapper entry missing after wrapper change: {event}/{spec['script']}"
+            )
+
+    def test_wrapper_change_from_standard_to_arbitrary(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        standard_wrapper = str(tmp_path / "run-hook-codex.sh")
+        arbitrary_wrapper = str(tmp_path / "my-custom-wrapper.sh")
+
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), standard_wrapper))
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), arbitrary_wrapper))
+
+        data = json.loads(hooks_file.read_text())
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            old_command = f"bash {standard_wrapper} {spec['script']}"
+            assert _count_entries(data, event, old_command) == 0, (
+                f"Standard wrapper entry survived switch to arbitrary wrapper: {event}/{spec['script']}"
+            )
+
+
+class TestRemoveArbitraryWrapper:
+    """remove-vibeguard must uninstall arbitrary-wrapper entries."""
+
+    def test_remove_clears_arbitrary_wrapper_entries(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "arbitrary-wrapper.sh")
+
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), wrapper))
+        result = cmd_remove_vibeguard(_make_args(str(hooks_file)))
+
+        assert result == 0
+        import json as _json
+        data = _json.loads(hooks_file.read_text()) if hooks_file.exists() else {}
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            command = f"bash {wrapper} {spec['script']}"
+            assert _count_entries(data, event, command) == 0, (
+                f"Arbitrary wrapper entry not removed by remove-vibeguard: {event}/{spec['script']}"
+            )
+
+    def test_remove_after_standard_wrapper_install(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "run-hook-codex.sh")
+
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), wrapper))
+        result = cmd_remove_vibeguard(_make_args(str(hooks_file)))
+
+        assert result == 0
+        data = json.loads(hooks_file.read_text()) if hooks_file.exists() else {}
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            command = f"bash {wrapper} {spec['script']}"
+            assert _count_entries(data, event, command) == 0, (
+                f"Standard wrapper entry not removed by remove-vibeguard: {event}/{spec['script']}"
+            )
+
+
+class TestCheckVibeGuard:
+    """check-vibeguard must fail when stale duplicate entries exist."""
+
+    def test_check_passes_clean_install(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "wrapper.sh")
+
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), wrapper))
+        result = cmd_check_vibeguard(_make_args(str(hooks_file), wrapper))
+
+        assert result == 0, "check-vibeguard should succeed after clean upsert"
+
+    def test_check_fails_when_stale_entries_exist(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        old_wrapper = str(tmp_path / "old-wrapper.sh")
+        new_wrapper = str(tmp_path / "new-wrapper.sh")
+
+        # Manually install old wrapper entries, then install new wrapper WITHOUT pruning,
+        # to simulate stale + new entries coexisting.
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), old_wrapper))
+
+        # Directly append new-wrapper entries without pruning old ones (simulate the bug).
+        data = json.loads(hooks_file.read_text())
+        from codex_hooks_json import _build_entry, _ensure_hooks_root, MANAGED_SPECS as _SPECS
+        hooks = _ensure_hooks_root(data)
+        for spec in _SPECS:
+            event = str(spec["event"])
+            entries = hooks.setdefault(event, [])
+            entries.append(_build_entry(new_wrapper, spec))
+        hooks_file.write_text(json.dumps(data, indent=2) + "\n")
+
+        result = cmd_check_vibeguard(_make_args(str(hooks_file), new_wrapper))
+
+        assert result == 1, "check-vibeguard should fail when stale old-wrapper entries exist alongside new ones"
+
+    def test_check_fails_missing_entries(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "wrapper.sh")
+
+        result = cmd_check_vibeguard(_make_args(str(hooks_file), wrapper))
+
+        assert result == 1, "check-vibeguard should fail when no entries are installed"

--- a/scripts/lib/test_codex_hooks_json.py
+++ b/scripts/lib/test_codex_hooks_json.py
@@ -14,6 +14,9 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from codex_hooks_json import (
     MANAGED_SPECS,
+    _build_entry,
+    _ensure_hooks_root,
+    _is_vibeguard_command,
     cmd_check_vibeguard,
     cmd_remove_vibeguard,
     cmd_upsert_vibeguard,
@@ -191,6 +194,34 @@ class TestRemoveArbitraryWrapper:
             )
 
 
+class TestIsVibeGuardCommandThirdPartyIsolation:
+    """_is_vibeguard_command() must not claim third-party hooks that happen to end with
+    a generic legacy marker name (Issue 1 from round-2 review)."""
+
+    def test_third_party_hook_with_legacy_pre_bash_guard_name(self) -> None:
+        # A command from another tool that ends with a legacy ambiguous script name.
+        assert not _is_vibeguard_command("bash /other-tool/wrapper.sh pre-bash-guard.sh"), (
+            "Third-party hook ending with 'pre-bash-guard.sh' must not be classified as VibeGuard"
+        )
+
+    def test_third_party_hook_with_legacy_stop_guard_name(self) -> None:
+        assert not _is_vibeguard_command("bash /other-tool/wrapper.sh stop-guard.sh"), (
+            "Third-party hook ending with 'stop-guard.sh' must not be classified as VibeGuard"
+        )
+
+    def test_third_party_shell_flag_with_legacy_name(self) -> None:
+        # "bash -lc stop-guard.sh" — 3 tokens, starts with bash, ends with legacy name.
+        assert not _is_vibeguard_command("bash -lc stop-guard.sh"), (
+            "'bash -lc stop-guard.sh' must not be classified as VibeGuard"
+        )
+
+    def test_vibeguard_prefixed_script_is_claimed(self) -> None:
+        # A valid VibeGuard command with a vibeguard- prefixed script must still match.
+        assert _is_vibeguard_command(
+            "bash /some/arbitrary/wrapper.sh vibeguard-pre-bash-guard.sh"
+        ), "Arbitrary wrapper with current vibeguard-prefixed script must be classified as VibeGuard"
+
+
 class TestCheckVibeGuard:
     """check-vibeguard must fail when stale duplicate entries exist."""
 
@@ -233,3 +264,31 @@ class TestCheckVibeGuard:
         result = cmd_check_vibeguard(_make_args(str(hooks_file), wrapper))
 
         assert result == 1, "check-vibeguard should fail when no entries are installed"
+
+    def test_check_fails_same_wrapper_duplicates(self, tmp_path: Path) -> None:
+        """check-vibeguard must return 1 when same-wrapper entries are duplicated (Issue 2).
+
+        Duplicated entries cause hooks to fire multiple times in production.
+        cmd_check_vibeguard() must catch this even when stale-check passes (same wrapper).
+        """
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "wrapper.sh")
+
+        # First install via the normal path.
+        cmd_upsert_vibeguard(_make_args(str(hooks_file), wrapper))
+
+        # Manually inject a second copy of every entry (simulates corrupted state).
+        data = json.loads(hooks_file.read_text())
+        hooks = _ensure_hooks_root(data)
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            entries = hooks.setdefault(event, [])
+            entries.append(_build_entry(wrapper, spec))
+        hooks_file.write_text(json.dumps(data, indent=2) + "\n")
+
+        result = cmd_check_vibeguard(_make_args(str(hooks_file), wrapper))
+
+        assert result == 1, (
+            "check-vibeguard must fail when same-wrapper entries are duplicated — "
+            "duplicate hooks fire multiple times per event"
+        )

--- a/scripts/lib/test_codex_hooks_json.py
+++ b/scripts/lib/test_codex_hooks_json.py
@@ -1,0 +1,112 @@
+"""Tests for codex_hooks_json.py — focuses on idempotency of cmd_upsert_vibeguard."""
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Allow import from the same directory.
+import sys
+sys.path.insert(0, str(Path(__file__).parent))
+
+from codex_hooks_json import (
+    MANAGED_SPECS,
+    cmd_upsert_vibeguard,
+)
+
+
+def _make_args(hooks_file: str, wrapper: str) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.hooks_file = hooks_file
+    ns.wrapper = wrapper
+    return ns
+
+
+def _count_entries(data: dict, event: str, command: str) -> int:
+    """Count how many hook entries with the given command exist under the event."""
+    hooks = data.get("hooks", {})
+    entries = hooks.get(event, [])
+    count = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        for hook in entry.get("hooks", []):
+            if isinstance(hook, dict) and hook.get("command") == command:
+                count += 1
+    return count
+
+
+class TestUpsertIdempotencyStandardWrapper:
+    """Wrapper containing run-hook-codex.sh — the existing happy path."""
+
+    def test_double_upsert_no_duplicates(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "run-hook-codex.sh")
+        args = _make_args(str(hooks_file), wrapper)
+
+        cmd_upsert_vibeguard(args)
+        cmd_upsert_vibeguard(args)
+
+        data = json.loads(hooks_file.read_text())
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            expected_command = f"bash {wrapper} {spec['script']}"
+            assert _count_entries(data, event, expected_command) == 1, (
+                f"Duplicate entry detected for {event}/{spec['script']} with standard wrapper"
+            )
+
+
+class TestUpsertIdempotencyArbitraryWrapper:
+    """Wrapper at an arbitrary path NOT containing run-hook-codex.sh — the bug case."""
+
+    def test_double_upsert_no_duplicates(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "wrapper.sh")
+        args = _make_args(str(hooks_file), wrapper)
+
+        cmd_upsert_vibeguard(args)
+        cmd_upsert_vibeguard(args)
+
+        data = json.loads(hooks_file.read_text())
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            expected_command = f"bash {wrapper} {spec['script']}"
+            assert _count_entries(data, event, expected_command) == 1, (
+                f"Duplicate entry detected for {event}/{spec['script']} with arbitrary wrapper"
+            )
+
+    def test_triple_upsert_no_duplicates(self, tmp_path: Path) -> None:
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "wrapper.sh")
+        args = _make_args(str(hooks_file), wrapper)
+
+        cmd_upsert_vibeguard(args)
+        cmd_upsert_vibeguard(args)
+        cmd_upsert_vibeguard(args)
+
+        data = json.loads(hooks_file.read_text())
+        for spec in MANAGED_SPECS:
+            event = str(spec["event"])
+            expected_command = f"bash {wrapper} {spec['script']}"
+            assert _count_entries(data, event, expected_command) == 1, (
+                f"Entry multiplied beyond 1 after triple upsert for {event}/{spec['script']}"
+            )
+
+    def test_second_upsert_returns_skip(self, tmp_path: Path) -> None:
+        """Second upsert with no changes should print SKIP (no-op)."""
+        hooks_file = tmp_path / "hooks.json"
+        wrapper = str(tmp_path / "wrapper.sh")
+        args = _make_args(str(hooks_file), wrapper)
+
+        cmd_upsert_vibeguard(args)
+        content_after_first = hooks_file.read_text()
+
+        cmd_upsert_vibeguard(args)
+        content_after_second = hooks_file.read_text()
+
+        assert content_after_first == content_after_second, (
+            "hooks.json was modified by a no-op second upsert"
+        )


### PR DESCRIPTION
## Summary
- `cmd_upsert_vibeguard` was non-idempotent when the wrapper path didn't contain `run-hook-codex.sh` — `_prune_vibeguard_entries` found nothing to remove and every call appended duplicate entries
- Added a `_has_entry` dedup guard before `entries.append(...)` in `cmd_upsert_vibeguard`, using the same helper already used in `cmd_check_vibeguard`
- Added 4 pytest cases covering double/triple upsert with both standard and arbitrary wrapper paths

Closes #62

## Test plan
- [ ] `python3 -m pytest scripts/lib/test_codex_hooks_json.py -v` — all 4 tests pass
- [ ] Double upsert with `/test/wrapper.sh` produces exactly 1 entry per spec (not 2)
- [ ] Second upsert is a no-op (hooks.json unchanged)