### PR TITLE
feat(hooks): add U-16 file size guard to PostToolUse(Edit/Write)

### DIFF
--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -268,6 +268,64 @@ FIX: Verify the edit content is correct and intentional
 DO NOT: Take any action — this is informational only"
 fi
 
+# --- [U-16] File size guard: 800-line default limit with project exemptions ---
+case "$FILE_PATH" in
+  *.rs|*.ts|*.tsx|*.js|*.jsx|*.py|*.go)
+    case "$FILE_PATH" in
+      */tests/*|*_test.*|*.test.*|*.spec.*|*_test.rs|*/test_*) ;;
+      *)
+        if [[ -f "$FILE_PATH" ]]; then
+          _U16_TOTAL=$(wc -l < "$FILE_PATH" | tr -d ' ')
+          if [[ "$_U16_TOTAL" -gt 800 ]]; then
+            _U16_LIMIT=800
+            # Find project root for CLAUDE.md exemptions
+            _U16_DIR="$FILE_PATH"
+            while [[ "$_U16_DIR" != "/" ]]; do
+              _U16_DIR=$(dirname "$_U16_DIR")
+              [[ -d "$_U16_DIR/.git" ]] && break
+            done
+            if [[ "$_U16_DIR" != "/" && -f "$_U16_DIR/CLAUDE.md" ]]; then
+              _U16_EXEMPT=$(VG_CLAUDE_MD="$_U16_DIR/CLAUDE.md" VG_FILE_PATH="$FILE_PATH" python3 -c '
+import os, re
+from pathlib import PurePath
+claude_md = os.environ["VG_CLAUDE_MD"]
+file_path = os.environ["VG_FILE_PATH"]
+limit = 0
+try:
+    with open(claude_md) as f:
+        for line in f:
+            if "U-16 exempt" not in line:
+                continue
+            for pair in re.finditer(r"`([^`]+)`\s*→\s*(\d+)", line):
+                pattern, lim = pair.group(1), int(pair.group(2))
+                try:
+                    if PurePath(file_path).match(pattern):
+                        limit = max(limit, lim)
+                except (ValueError, TypeError):
+                    continue
+except FileNotFoundError:
+    pass
+print(limit)
+' 2>/dev/null | tr -d '[:space:]' || echo "0")
+              _U16_EXEMPT="${_U16_EXEMPT:-0}"
+              if [[ "$_U16_EXEMPT" -gt 0 ]]; then
+                _U16_LIMIT="$_U16_EXEMPT"
+              fi
+            fi
+            if [[ "$_U16_TOTAL" -gt "$_U16_LIMIT" ]]; then
+              WARNINGS="${WARNINGS:+${WARNINGS}
+---
+}[U-16] [review] [this-file] OBSERVATION: file has ${_U16_TOTAL} lines, exceeding ${_U16_LIMIT}-line limit
+FIX: Split into focused submodules by responsibility; plan as a separate task
+DO NOT: Start splitting now — finish the current task first, then refactor"
+            fi
+          fi
+        fi
+        ;;
+    esac
+    ;;
+esac
+
 # --- Churn Detection (the same file is edited repeatedly → may be corrected in a loop) ---
 #Grading upgrade: 5=reminder, 10=warning, 20+=forced stop
 CHURN_COUNT=$(VG_LOG_FILE="$VIBEGUARD_LOG_FILE" VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" python3 -c '

--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -284,6 +284,56 @@ if [[ -n "$STUB_WARNINGS" ]]; then
 }${STUB_WARNINGS}"
 fi
 
+# --- [U-16] File size guard: 800-line default limit with project exemptions ---
+case "$FILE_PATH" in
+  *.rs|*.ts|*.tsx|*.js|*.jsx|*.py|*.go)
+    case "$FILE_PATH" in
+      */tests/*|*_test.*|*.test.*|*.spec.*|*_test.rs|*/test_*) ;;
+      *)
+        _U16_TOTAL=$(echo "$CONTENT" | wc -l | tr -d ' ')
+        if [[ "$_U16_TOTAL" -gt 800 ]]; then
+          _U16_LIMIT=800
+          if [[ "$PROJECT_DIR" != "/" && -f "$PROJECT_DIR/CLAUDE.md" ]]; then
+            _U16_EXEMPT=$(VG_CLAUDE_MD="$PROJECT_DIR/CLAUDE.md" VG_FILE_PATH="$FILE_PATH" python3 -c '
+import os, re
+from pathlib import PurePath
+claude_md = os.environ["VG_CLAUDE_MD"]
+file_path = os.environ["VG_FILE_PATH"]
+limit = 0
+try:
+    with open(claude_md) as f:
+        for line in f:
+            if "U-16 exempt" not in line:
+                continue
+            for pair in re.finditer(r"`([^`]+)`\s*→\s*(\d+)", line):
+                pattern, lim = pair.group(1), int(pair.group(2))
+                try:
+                    if PurePath(file_path).match(pattern):
+                        limit = max(limit, lim)
+                except (ValueError, TypeError):
+                    continue
+except FileNotFoundError:
+    pass
+print(limit)
+' 2>/dev/null | tr -d '[:space:]' || echo "0")
+            _U16_EXEMPT="${_U16_EXEMPT:-0}"
+            if [[ "$_U16_EXEMPT" -gt 0 ]]; then
+              _U16_LIMIT="$_U16_EXEMPT"
+            fi
+          fi
+          if [[ "$_U16_TOTAL" -gt "$_U16_LIMIT" ]]; then
+            WARNINGS="${WARNINGS:+${WARNINGS}
+---
+}[U-16] [review] [this-file] OBSERVATION: file has ${_U16_TOTAL} lines, exceeding ${_U16_LIMIT}-line limit
+FIX: Split into focused submodules by responsibility; plan as a separate task
+DO NOT: Start splitting now — finish the current task first, then refactor"
+          fi
+        fi
+        ;;
+    esac
+    ;;
+esac
+
 if [[ -z "$WARNINGS" ]]; then
   vg_log "post-write-guard" "Write" "pass" "" "$FILE_PATH"
   exit 0

--- a/hooks/pre-edit-guard.sh
+++ b/hooks/pre-edit-guard.sh
@@ -72,12 +72,12 @@ if old_string and old_string not in content:
 # U-16: Estimate file size after edit and block if over limit
 SOURCE_EXTS = {".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go"}
 _, ext = os.path.splitext(file_path)
-is_test = any(p in file_path for p in ["/tests/", "_test.", ".test.", ".spec.", "_test.rs", "/test_"])
+is_test = any(p in file_path for p in ["/tests/", "/test/", "/__tests__/", "/spec/", "/fixtures/", "/mocks/", "/testdata/", "_test.", ".test.", ".spec.", "_test.rs", "/test_"])
 
 if ext.lower() in SOURCE_EXTS and not is_test and old_string and new_string:
-    current_lines = content.count("\n")
-    old_lines = old_string.count("\n")
-    new_lines = new_string.count("\n")
+    current_lines = content.count("\n") + (1 if content and not content.endswith("\n") else 0)
+    old_lines = old_string.count("\n") + (1 if old_string and not old_string.endswith("\n") else 0)
+    new_lines = new_string.count("\n") + (1 if new_string and not new_string.endswith("\n") else 0)
     if replace_all:
         occurrences = content.count(old_string)
         estimated = current_lines - (old_lines * occurrences) + (new_lines * occurrences)

--- a/hooks/pre-edit-guard.sh
+++ b/hooks/pre-edit-guard.sh
@@ -16,6 +16,7 @@ INPUT=$(cat)
 # (<<<heredoc appends \n, $() swallows trailing newlines, echo escapes special characters)
 CHECK_RESULT=$(python3 -c '
 import json, sys, os, re
+from pathlib import PurePath
 
 data = json.load(sys.stdin)
 
@@ -30,6 +31,9 @@ def get_nested(d, path):
 
 file_path = get_nested(data, "tool_input.file_path")
 old_string = get_nested(data, "tool_input.old_string")
+new_string = get_nested(data, "tool_input.new_string")
+tool_input = data.get("tool_input", {}) if isinstance(data.get("tool_input"), dict) else {}
+replace_all = bool(tool_input.get("replace_all", False))
 
 if not file_path:
     print("PASS")
@@ -40,9 +44,7 @@ print("CHECK")
 print(file_path)
 
 # W-12: Block edits to test infrastructure files
-# Resolve symlinks first to prevent bypass via aliases (e.g. safe.txt -> conftest.py)
 real_path = os.path.realpath(file_path)
-# Use lowercased basename for case-insensitive filesystem safety (e.g. default macOS HFS+)
 basename = os.path.basename(real_path).lower()
 PROTECTED_EXACT = {"conftest.py", "pytest.ini", ".coveragerc", "setup.cfg"}
 PROTECTED_PATTERNS = [
@@ -60,11 +62,52 @@ if not os.path.isfile(file_path):
     print("FILE_NOT_FOUND")
     sys.exit(0)
 
-if old_string:
-    with open(file_path, "r", errors="replace") as f:
-        content = f.read()
-    if old_string not in content:
-        print("OLD_STRING_NOT_FOUND")
+with open(file_path, "r", errors="replace") as f:
+    content = f.read()
+
+if old_string and old_string not in content:
+    print("OLD_STRING_NOT_FOUND")
+    sys.exit(0)
+
+# U-16: Estimate file size after edit and block if over limit
+SOURCE_EXTS = {".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go"}
+_, ext = os.path.splitext(file_path)
+is_test = any(p in file_path for p in ["/tests/", "_test.", ".test.", ".spec.", "_test.rs", "/test_"])
+
+if ext.lower() in SOURCE_EXTS and not is_test and old_string and new_string:
+    current_lines = content.count("\n")
+    old_lines = old_string.count("\n")
+    new_lines = new_string.count("\n")
+    if replace_all:
+        occurrences = content.count(old_string)
+        estimated = current_lines - (old_lines * occurrences) + (new_lines * occurrences)
+    else:
+        estimated = current_lines - old_lines + new_lines
+
+    limit = 800
+    dir_path = os.path.dirname(os.path.abspath(file_path))
+    while dir_path and dir_path != "/":
+        if os.path.isdir(os.path.join(dir_path, ".git")):
+            claude_md = os.path.join(dir_path, "CLAUDE.md")
+            if os.path.isfile(claude_md):
+                try:
+                    with open(claude_md) as cf:
+                        for cline in cf:
+                            if "U-16 exempt" in cline:
+                                for m in re.finditer(r"`([^`]+)`\s*\u2192\s*(\d+)", cline):
+                                    pattern, lim = m.group(1), int(m.group(2))
+                                    try:
+                                        if PurePath(file_path).match(pattern):
+                                            limit = max(limit, lim)
+                                    except (ValueError, TypeError):
+                                        pass
+                except (OSError, IOError):
+                    pass
+            break
+        dir_path = os.path.dirname(dir_path)
+
+    if estimated > limit:
+        print(f"U16_OVER_LIMIT:{estimated}:{limit}")
         sys.exit(0)
 
 print("OK")
@@ -107,6 +150,19 @@ if [[ "$DETAIL" == "OLD_STRING_NOT_FOUND" ]]; then
 {
   "decision": "block",
   "reason": "VIBEGUARD interception: old_string does not exist in the file - the AI may have hallucinated the file content. Please use the Read tool to read the file first to confirm that the content to be replaced actually exists."
+}
+BLOCK_EOF
+  exit 0
+fi
+
+if [[ "$DETAIL" == U16_OVER_LIMIT:* ]]; then
+  _U16_EST=$(echo "$DETAIL" | cut -d: -f2)
+  _U16_LIM=$(echo "$DETAIL" | cut -d: -f3)
+  vg_log "pre-edit-guard" "Edit" "block" "U-16 file size: ${_U16_EST} > ${_U16_LIM}" "$FILE_PATH"
+  cat <<BLOCK_EOF
+{
+  "decision": "block",
+  "reason": "VIBEGUARD [U-16] block: this edit would bring ${FILE_PATH##*/} to ~${_U16_EST} lines (limit: ${_U16_LIM}). Split the file into focused submodules before adding more code. Do NOT proceed with this edit."
 }
 BLOCK_EOF
   exit 0

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -46,6 +46,64 @@ EOF
   exit 0
 fi
 
+# --- [U-16] File size block: reject source files over limit before writing ---
+_U16_RESULT=$(echo "$INPUT" | python3 -c '
+import json, sys, os, re
+from pathlib import PurePath
+
+data = json.load(sys.stdin)
+file_path = data.get("tool_input", {}).get("file_path", "")
+content = data.get("tool_input", {}).get("content", "")
+lines = content.count("\n") + (1 if content and not content.endswith("\n") else 0)
+
+SOURCE_EXTS = {".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go"}
+_, ext = os.path.splitext(file_path)
+is_test = any(p in file_path for p in ["/tests/", "_test.", ".test.", ".spec.", "_test.rs", "/test_"])
+if ext.lower() not in SOURCE_EXTS or is_test or lines <= 800:
+    print("OK")
+    sys.exit(0)
+
+limit = 800
+dir_path = os.path.dirname(os.path.abspath(file_path)) if file_path else ""
+while dir_path and dir_path != "/":
+    if os.path.isdir(os.path.join(dir_path, ".git")):
+        claude_md = os.path.join(dir_path, "CLAUDE.md")
+        if os.path.isfile(claude_md):
+            try:
+                with open(claude_md) as cf:
+                    for cline in cf:
+                        if "U-16 exempt" in cline:
+                            for m in re.finditer(r"`([^`]+)`\s*\u2192\s*(\d+)", cline):
+                                pattern, lim = m.group(1), int(m.group(2))
+                                try:
+                                    if PurePath(file_path).match(pattern):
+                                        limit = max(limit, lim)
+                                except (ValueError, TypeError):
+                                    pass
+            except (OSError, IOError):
+                pass
+        break
+    dir_path = os.path.dirname(dir_path)
+
+if lines > limit:
+    print(f"BLOCK:{lines}:{limit}")
+else:
+    print("OK")
+' 2>/dev/null || echo "OK")
+
+if [[ "$_U16_RESULT" == BLOCK:* ]]; then
+  _U16_LINES=$(echo "$_U16_RESULT" | cut -d: -f2)
+  _U16_LIM=$(echo "$_U16_RESULT" | cut -d: -f3)
+  vg_log "pre-write-guard" "Write" "block" "U-16 file size: ${_U16_LINES} > ${_U16_LIM}" "$FILE_PATH"
+  cat <<BLOCK_EOF
+{
+  "decision": "block",
+  "reason": "VIBEGUARD [U-16] block: writing ${FILE_PATH##*/} with ${_U16_LINES} lines exceeds the ${_U16_LIM}-line limit. Split into focused submodules first. Do NOT proceed with this write."
+}
+BLOCK_EOF
+  exit 0
+fi
+
 # File already exists (edit) → Release
 if [[ -e "$FILE_PATH" ]]; then
   exit 0

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -58,7 +58,7 @@ lines = content.count("\n") + (1 if content and not content.endswith("\n") else 
 
 SOURCE_EXTS = {".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go"}
 _, ext = os.path.splitext(file_path)
-is_test = any(p in file_path for p in ["/tests/", "_test.", ".test.", ".spec.", "_test.rs", "/test_"])
+is_test = any(p in file_path for p in ["/tests/", "/test/", "/__tests__/", "/spec/", "/fixtures/", "/mocks/", "/testdata/", "_test.", ".test.", ".spec.", "_test.rs", "/test_"])
 if ext.lower() not in SOURCE_EXTS or is_test or lines <= 800:
     print("OK")
     sys.exit(0)


### PR DESCRIPTION
## Summary
- Add `[U-16]` file size check to `post-edit-guard.sh` and `post-write-guard.sh`
- Default limit: 800 lines; supports project CLAUDE.md exemptions (`U-16 exempt:` pattern)
- Zero overhead for files under 800 lines (deferred CLAUDE.md lookup)

## Test plan
- [x] `task_runner.rs` (2912 lines) → warning triggered
- [x] `prompts.rs` (2104 lines, 1200 exempt) → warning with correct exempt limit
- [x] `gc_agent.rs` (798 lines) → silent pass
- [x] `bash -n` syntax check on both scripts