### PR TITLE
fix: escape \r in vg_log JSON serialization to prevent JSONL corruption

### DIFF
--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -245,10 +245,32 @@ vg_log() {
   esc_reason=$(printf '%s' "$esc_reason" | tr -d '\000-\007\013\016-\032\034-\037')
   esc_detail=$(printf '%s' "$esc_detail" | tr -d '\000-\007\013\016-\032\034-\037')
 
+  # Escape environment-sourced fields that may contain untrusted characters.
+  local esc_session="${VIBEGUARD_SESSION_ID//\\/\\\\}"
+  esc_session="${esc_session//\"/\\\"}"
+  esc_session="${esc_session//$'\n'/\\n}"
+  esc_session="${esc_session//$'\t'/\\t}"
+  esc_session="${esc_session//$'\r'/\\r}"
+  esc_session="${esc_session//$'\b'/\\b}"
+  esc_session="${esc_session//$'\f'/\\f}"
+  esc_session="${esc_session//$'\x1b'/\\u001b}"
+  esc_session=$(printf '%s' "$esc_session" | tr -d '\000-\007\013\016-\032\034-\037')
+
+  local esc_agent="${VIBEGUARD_AGENT_TYPE:-}"
+  esc_agent="${esc_agent//\\/\\\\}"
+  esc_agent="${esc_agent//\"/\\\"}"
+  esc_agent="${esc_agent//$'\n'/\\n}"
+  esc_agent="${esc_agent//$'\t'/\\t}"
+  esc_agent="${esc_agent//$'\r'/\\r}"
+  esc_agent="${esc_agent//$'\b'/\\b}"
+  esc_agent="${esc_agent//$'\f'/\\f}"
+  esc_agent="${esc_agent//$'\x1b'/\\u001b}"
+  esc_agent=$(printf '%s' "$esc_agent" | tr -d '\000-\007\013\016-\032\034-\037')
+
   local json
-  json="{\"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""
+  json="{\"ts\": \"${ts}\", \"session\": \"${esc_session}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""
   [[ -n "$duration_ms" ]] && json="${json}, \"duration_ms\": ${duration_ms}"
-  [[ -n "${VIBEGUARD_AGENT_TYPE:-}" ]] && json="${json}, \"agent\": \"${VIBEGUARD_AGENT_TYPE}\""
+  [[ -n "${VIBEGUARD_AGENT_TYPE:-}" ]] && json="${json}, \"agent\": \"${esc_agent}\""
   json="${json}}"
 
   printf '%s\n' "$json" >> "$VIBEGUARD_LOG_FILE"

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -229,12 +229,21 @@ vg_log() {
   local ts
   ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-  # JSON escape: reason and detail may contain special characters
+  # JSON escape: reason and detail may contain special characters.
+  # All U+0000-U+001F control characters must be escaped per RFC 8259.
   local esc_reason="${reason//\\/\\\\}" esc_detail="${detail//\\/\\\\}"
   esc_reason="${esc_reason//\"/\\\"}" esc_detail="${esc_detail//\"/\\\"}"
   esc_reason="${esc_reason//$'\n'/\\n}" esc_detail="${esc_detail//$'\n'/\\n}"
   esc_reason="${esc_reason//$'\t'/\\t}" esc_detail="${esc_detail//$'\t'/\\t}"
   esc_reason="${esc_reason//$'\r'/\\r}" esc_detail="${esc_detail//$'\r'/\\r}"
+  esc_reason="${esc_reason//$'\b'/\\b}" esc_detail="${esc_detail//$'\b'/\\b}"
+  esc_reason="${esc_reason//$'\f'/\\f}" esc_detail="${esc_detail//$'\f'/\\f}"
+  # ESC (0x1B) is common in ANSI-coloured command output; escape as \u001b.
+  esc_reason="${esc_reason//$'\x1b'/\\u001b}" esc_detail="${esc_detail//$'\x1b'/\\u001b}"
+  # Strip any remaining JSON-forbidden control characters (U+0000-U+001F)
+  # that have no named two-char JSON escape (NUL, SOH-BEL, VT, SO-SUB, FS-US).
+  esc_reason=$(printf '%s' "$esc_reason" | tr -d '\000-\007\013\016-\032\034-\037')
+  esc_detail=$(printf '%s' "$esc_detail" | tr -d '\000-\007\013\016-\032\034-\037')
 
   local json
   json="{\"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -234,6 +234,7 @@ vg_log() {
   esc_reason="${esc_reason//\"/\\\"}" esc_detail="${esc_detail//\"/\\\"}"
   esc_reason="${esc_reason//$'\n'/\\n}" esc_detail="${esc_detail//$'\n'/\\n}"
   esc_reason="${esc_reason//$'\t'/\\t}" esc_detail="${esc_detail//$'\t'/\\t}"
+  esc_reason="${esc_reason//$'\r'/\\r}" esc_detail="${esc_detail//$'\r'/\\r}"
 
   local json
   json="{\"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""


### PR DESCRIPTION
## Summary

- Add `\r` (carriage return) escape step in `vg_log`'s pure-bash JSON serializer, immediately after the existing `\t` escape lines
- Prevents malformed JSON records in `events.jsonl` when reason/detail values contain carriage returns (e.g. from Windows-edited commit messages, terminal control sequences, or CRLF file paths)

## Root Cause

`hooks/log.sh` escaped `\`, `"`, `\n`, and `\t` but omitted `\r`. A single unescaped CR produces an invalid JSONL record, causing silent data loss in downstream consumers: `metrics-exporter.sh`, `stats.sh`, and GC signal detection.

## Test plan

- [ ] Verify `events.jsonl` records remain valid JSON when a commit message containing `\r\n` line endings is processed
- [ ] Confirm downstream `stats.sh` parses all records without error after the fix