### PR TITLE
fix(log): add \r escape in vg_log JSON serialization to prevent JSONL corruption

### DIFF
--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -230,11 +230,15 @@ vg_log() {
   ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
   # JSON escape: reason and detail may contain special characters
-  local esc_reason="${reason//\\/\\\\}" esc_detail="${detail//\\/\\\\}"
+  # Strip ANSI ESC bytes first so terminal color sequences cannot produce invalid JSON
+  local esc_reason="${reason//$'\033'}" esc_detail="${detail//$'\033'}"
+  esc_reason="${esc_reason//\\/\\\\}" esc_detail="${esc_detail//\\/\\\\}"
   esc_reason="${esc_reason//\"/\\\"}" esc_detail="${esc_detail//\"/\\\"}"
   esc_reason="${esc_reason//$'\n'/\\n}" esc_detail="${esc_detail//$'\n'/\\n}"
   esc_reason="${esc_reason//$'\r'/\\r}" esc_detail="${esc_detail//$'\r'/\\r}"
   esc_reason="${esc_reason//$'\t'/\\t}" esc_detail="${esc_detail//$'\t'/\\t}"
+  esc_reason="${esc_reason//$'\b'/\\b}" esc_detail="${esc_detail//$'\b'/\\b}"
+  esc_reason="${esc_reason//$'\f'/\\f}" esc_detail="${esc_detail//$'\f'/\\f}"
 
   local json
   json="{\"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -229,9 +229,15 @@ vg_log() {
   local ts
   ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-  # JSON escape: reason and detail may contain special characters
-  # Strip ANSI ESC bytes first so terminal color sequences cannot produce invalid JSON
-  local esc_reason="${reason//$'\033'}" esc_detail="${detail//$'\033'}"
+  # JSON escape: reason and detail may contain special characters.
+  # Strip all C0 control bytes that are NOT JSON-escapable (\b \t \n \f \r).
+  # This removes ESC (0x1B) and the orphaned BEL/VT/SO/etc. bytes that OSC/CSI
+  # terminal sequences leave behind after ESC is removed (e.g. \x1b]8;;url\x07
+  # becomes ]8;;url\x07 with ESC-only stripping; the raw BEL makes JSONL invalid).
+  # tr range: 0x00-0x07 (NUL-BEL), 0x0B (VT), 0x0E-0x1F (SO-US incl. ESC), 0x7F (DEL)
+  local esc_reason esc_detail
+  esc_reason=$(printf '%s' "$reason" | tr -d '\000-\007\013\016-\037\177')
+  esc_detail=$(printf '%s' "$detail"  | tr -d '\000-\007\013\016-\037\177')
   esc_reason="${esc_reason//\\/\\\\}" esc_detail="${esc_detail//\\/\\\\}"
   esc_reason="${esc_reason//\"/\\\"}" esc_detail="${esc_detail//\"/\\\"}"
   esc_reason="${esc_reason//$'\n'/\\n}" esc_detail="${esc_detail//$'\n'/\\n}"

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -233,6 +233,7 @@ vg_log() {
   local esc_reason="${reason//\\/\\\\}" esc_detail="${detail//\\/\\\\}"
   esc_reason="${esc_reason//\"/\\\"}" esc_detail="${esc_detail//\"/\\\"}"
   esc_reason="${esc_reason//$'\n'/\\n}" esc_detail="${esc_detail//$'\n'/\\n}"
+  esc_reason="${esc_reason//$'\r'/\\r}" esc_detail="${esc_detail//$'\r'/\\r}"
   esc_reason="${esc_reason//$'\t'/\\t}" esc_detail="${esc_detail//$'\t'/\\t}"
 
   local json

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -109,6 +109,19 @@ result=$(
 assert_not_contains "$result" $'\r' "Carriage return in reason is escaped and not raw in JSONL"
 assert_contains "$result" '\r' "Carriage return is represented as \\r escape sequence in reason"
 
+# Clear the log and test OSC hyperlink sequence (BEL-terminated): \x1b]8;;url\x07
+> "$VIBEGUARD_LOG_DIR/events.jsonl"
+
+result=$(
+  export VIBEGUARD_LOG_DIR
+  source hooks/log.sh
+  osc_reason="$(printf '\x1b]8;;https://example.com\x07link text\x1b]8;;\x07')"
+  vg_log "test" "Tool" "pass" "$osc_reason" "detail"
+  cat "$VIBEGUARD_LOG_FILE"
+)
+assert_not_contains "$result" $'\x07' "BEL byte from OSC hyperlink sequence is stripped from JSONL"
+assert_not_contains "$result" $'\x1b' "ESC byte from OSC hyperlink sequence is stripped from JSONL"
+
 # =========================================================
 header "pre-bash-guard.sh — Dangerous command interception"
 # =========================================================

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -96,6 +96,19 @@ result=$(
 )
 assert_contains "$result" '"decision": "block"' "Python injection payload is safely logged in reason"
 
+# Clear the log and test \r escaping
+> "$VIBEGUARD_LOG_DIR/events.jsonl"
+
+result=$(
+  export VIBEGUARD_LOG_DIR
+  source hooks/log.sh
+  reason_with_cr="$(printf 'line1\r\nline2')"
+  vg_log "test" "Tool" "pass" "$reason_with_cr" "detail"
+  cat "$VIBEGUARD_LOG_FILE"
+)
+assert_not_contains "$result" $'\r' "Carriage return in reason is escaped and not raw in JSONL"
+assert_contains "$result" '\r' "Carriage return is represented as \\r escape sequence in reason"
+
 # =========================================================
 header "pre-bash-guard.sh — Dangerous command interception"
 # =========================================================


### PR DESCRIPTION
## Summary

- Add `\r` (carriage return) escaping in `hooks/log.sh` `vg_log` JSON serialization block
- The existing escape chain handled `\\`, `"`, `\n`, `\t` but omitted `\r`
- A raw `\r` in `reason` or `detail` produces invalid JSON in `events.jsonl`, which downstream consumers (metrics-exporter.sh, stats.sh, GC signal detection) may reject or silently skip

## Changes

- `hooks/log.sh:236` — add two lines escaping `$'\r'` → `\r` for both `esc_reason` and `esc_detail`
- `tests/test_hooks.sh` — add two assertions verifying no raw `\r` bytes appear in JSONL output and the `\r` escape sequence is present

## Test plan

- [x] Existing `test_hooks.sh` log.sh injection-protection tests still pass
- [x] New assertion: raw `\r` byte is absent from JSONL output
- [x] New assertion: literal `\r` escape sequence is present in JSONL output

Fixes #70