### PR TITLE
fix: quote wrapper path in codex hook commands to handle spaces in HOME

### DIFF
--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -161,7 +162,7 @@ def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
 def _build_entry(wrapper: str, spec: HookSpec) -> dict[str, Any]:
     hook: dict[str, Any] = {
         "type": "command",
-        "command": f"bash {wrapper} {spec['script']}",
+        "command": f"bash {shlex.quote(wrapper)} {spec['script']}",
     }
     timeout = spec.get("timeout")
     if isinstance(timeout, int):
@@ -227,7 +228,7 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
         if not isinstance(entries, list):
             entries = []
             hooks[event] = entries
-        expected_command = f"bash {args.wrapper} {spec['script']}"
+        expected_command = f"bash {shlex.quote(args.wrapper)} {spec['script']}"
         expected_matcher = spec.get("matcher") if isinstance(spec.get("matcher"), str) else None
         expected_timeout = spec.get("timeout") if isinstance(spec.get("timeout"), int) else None
         if not _has_entry(entries, expected_command, expected_matcher, expected_timeout):
@@ -278,7 +279,7 @@ def cmd_check_vibeguard(args: argparse.Namespace) -> int:
         if not isinstance(entries, list):
             return 1
 
-        expected_command = f"bash {args.wrapper} {spec['script']}"
+        expected_command = f"bash {shlex.quote(args.wrapper)} {spec['script']}"
         expected_matcher = spec.get("matcher")
         expected_timeout = spec.get("timeout") if isinstance(spec.get("timeout"), int) else None
         if not _has_entry(entries, expected_command, expected_matcher if isinstance(expected_matcher, str) else None, expected_timeout):


### PR DESCRIPTION
## Summary

- Use `shlex.quote()` when constructing the bash command string in `_build_entry`, `cmd_upsert_vibeguard`, and `cmd_check_vibeguard`
- Without quoting, paths like `/Users/John Doe/.vibeguard/run-hook-codex.sh` are split by the shell, causing all VibeGuard hooks to silently stop firing
- The `_has_entry` check in `cmd_check_vibeguard` also used the unquoted form, so the consistency check was comparing against the wrong string

## Test plan

- [ ] Verify `_build_entry` produces a quoted wrapper path when `$HOME` contains spaces
- [ ] Verify `cmd_upsert_vibeguard` writes the quoted command to `hooks.json`
- [ ] Verify `cmd_check_vibeguard` correctly detects the quoted entry

Fixes #69