### PR TITLE
Harden observability against malformed event logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,16 @@ jobs:
         shell: bash
         run: bash tests/test_hook_health.sh
 
+      - name: Stats regression tests
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash tests/test_stats.sh
+
+      - name: Quality grader regression tests
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash tests/test_quality_grader.sh
+
       - name: Guard unit tests
         if: runner.os != 'Windows'
         shell: bash

--- a/guards/rust/check_nested_locks.sh
+++ b/guards/rust/check_nested_locks.sh
@@ -18,9 +18,13 @@ TMPFILE=$(create_tmpfile)
 
 # Pre-commit mode: only scan new lines in staged diff
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-  STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" \
-    | { grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" || true; } \
-    | { grep -vE "${VIBEGUARD_TEST_FILE_PATTERN}" || true; })
+  if ! grep -q '\.rs$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null; then
+    STAGED_RS=""
+  else
+    STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" \
+      | { grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" || true; } \
+      | { grep -vE "${VIBEGUARD_TEST_FILE_PATTERN}" || true; })
+  fi
 
   if [[ -n "${STAGED_RS}" ]]; then
     while IFS= read -r f; do

--- a/guards/rust/check_unwrap_in_prod.sh
+++ b/guards/rust/check_unwrap_in_prod.sh
@@ -29,7 +29,12 @@ RULES_DIR="${SCRIPT_DIR}/../ast-grep-rules"
 
 # --- Pre-commit mode: grep diff new lines (ast-grep does not process diff text) ---
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-  STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" | { grep -vE "${TEST_PATH_PATTERN}" || true; })
+  if ! grep -q '\.rs$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null; then
+    STAGED_RS=""
+  else
+    STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" \
+      | { grep -vE "${TEST_PATH_PATTERN}" || true; })
+  fi
 
   if [[ -n "${STAGED_RS}" ]]; then
     while IFS= read -r f; do

--- a/guards/rust/common.sh
+++ b/guards/rust/common.sh
@@ -18,7 +18,9 @@ VIBEGUARD_TEST_FILE_PATTERN='(/tests/|/test_|_test\.rs$|tests\.rs$|test_helpers\
 list_rs_files() {
   local dir="$1"
   if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-    grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" | { grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" || true; }
+    grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null \
+      | { grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" || true; } \
+      || true
   elif git -C "${dir}" rev-parse --is-inside-work-tree &>/dev/null; then
     git -C "${dir}" ls-files '*.rs' \
       | { grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" || true; } \

--- a/hooks/_lib/event_log.py
+++ b/hooks/_lib/event_log.py
@@ -9,7 +9,7 @@ without crashing and should skip only truly broken JSON records.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import BinaryIO, Iterator
 
 
@@ -17,7 +17,10 @@ def parse_ts(ts: object) -> datetime | None:
     if not isinstance(ts, str) or not ts:
         return None
     try:
-        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
     except ValueError:
         return None
 

--- a/hooks/_lib/event_log.py
+++ b/hooks/_lib/event_log.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Shared JSONL event-log helpers.
+
+Event logs are written by shell hooks and may contain malformed UTF-8 if an
+upstream shell truncates a multibyte string. Readers must tolerate that
+without crashing and should skip only truly broken JSON records.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import BinaryIO, Iterator
+
+
+def parse_ts(ts: object) -> datetime | None:
+    if not isinstance(ts, str) or not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def iter_events_from_stream(
+    stream: BinaryIO,
+    *,
+    since: datetime | None = None,
+) -> Iterator[dict]:
+    for raw_line in stream:
+        line = raw_line.decode("utf-8", errors="replace").strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+
+        if since is not None:
+            event_ts = parse_ts(event.get("ts"))
+            if event_ts is None or event_ts < since:
+                continue
+            event = dict(event)
+            event["_parsed_ts"] = event_ts
+
+        yield event
+
+
+def load_events_from_file(
+    log_file: str,
+    *,
+    since: datetime | None = None,
+) -> list[dict]:
+    with open(log_file, "rb") as f:
+        return list(iter_events_from_stream(f, since=since))

--- a/hooks/_lib/session_metrics.py
+++ b/hooks/_lib/session_metrics.py
@@ -40,14 +40,11 @@ session_id = os.environ.get("VIBEGUARD_SESSION_ID", "")
 cutoff = datetime.now(timezone.utc) - timedelta(minutes=30)
 skip_hooks = {"stop-guard", "learn-evaluator"}
 events = []
-for event in load_events_from_file(log_file):
+for event in load_events_from_file(log_file, since=cutoff):
     if event.get("hook", "") in skip_hooks:
         continue
     evt_session = event.get("session", "")
     if evt_session and session_id and evt_session != session_id:
-        continue
-    evt_time = parse_ts(event.get("ts", ""))
-    if evt_time is not None and evt_time < cutoff:
         continue
     events.append(event)
 

--- a/hooks/_lib/session_metrics.py
+++ b/hooks/_lib/session_metrics.py
@@ -29,6 +29,9 @@ import os
 from collections import Counter, defaultdict
 from datetime import datetime, timezone, timedelta
 
+sys.path.insert(0, os.path.dirname(__file__))
+from event_log import load_events_from_file, parse_ts
+
 log_file = os.environ["VIBEGUARD_LOG_FILE"]
 if not os.path.exists(log_file):
     sys.exit(0)
@@ -37,29 +40,16 @@ session_id = os.environ.get("VIBEGUARD_SESSION_ID", "")
 cutoff = datetime.now(timezone.utc) - timedelta(minutes=30)
 skip_hooks = {"stop-guard", "learn-evaluator"}
 events = []
-with open(log_file) as f:
-    for line in f:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-            if event.get("hook", "") in skip_hooks:
-                continue
-            # Filter to current session only — parallel agents in the same repo share the
-            # same project log; without this filter their events contaminate warn_ratio and
-            # Signal 10 baseline, producing false LEARN_SUGGESTED stops.
-            evt_session = event.get("session", "")
-            if evt_session and session_id and evt_session != session_id:
-                continue
-            ts = event.get("ts", "")
-            if ts:
-                evt_time = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-                if evt_time < cutoff:
-                    continue
-            events.append(event)
-        except (json.JSONDecodeError, ValueError):
-            continue
+for event in load_events_from_file(log_file):
+    if event.get("hook", "") in skip_hooks:
+        continue
+    evt_session = event.get("session", "")
+    if evt_session and session_id and evt_session != session_id:
+        continue
+    evt_time = parse_ts(event.get("ts", ""))
+    if evt_time is not None and evt_time < cutoff:
+        continue
+    events.append(event)
 
 if len(events) < 3:
     sys.exit(0)

--- a/hooks/analysis-paralysis-guard.sh
+++ b/hooks/analysis-paralysis-guard.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer
+VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "$0")/_lib" && pwd)}"
 
 # CI guard: analysis-paralysis warnings are not actionable in CI
 vg_is_ci && exit 0
@@ -30,19 +31,18 @@ CONSECUTIVE=$(tail -300 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
   | if [[ -n "$_VG_HELPER" ]]; then
       "$_VG_HELPER" paralysis-count "$VIBEGUARD_SESSION_ID"
     else
-      VG_SESSION="$VIBEGUARD_SESSION_ID" python3 -c '
-import json, sys, os
+      VG_SESSION="$VIBEGUARD_SESSION_ID" VG_EVENT_LOG_LIB="$VG_EVENT_LOG_LIB" python3 -c '
+import sys, os
+sys.path.insert(0, os.environ["VG_EVENT_LOG_LIB"])
+from event_log import iter_events_from_stream
+
 session = os.environ.get("VG_SESSION", "")
 research_tools = {"Read", "Glob", "Grep"}
 action_tools = {"Write", "Edit", "Bash"}
 events = []
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    try:
-        e = json.loads(line)
-        if e.get("session") == session: events.append(e)
-    except: continue
+for e in iter_events_from_stream(sys.stdin.buffer):
+    if e.get("session") == session:
+        events.append(e)
 consecutive = 0
 for e in reversed(events):
     hook, decision = e.get("hook", ""), e.get("decision", "")

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -228,13 +228,12 @@ print substr($s, 0, $limit);
   fi
 
   if command -v python3 &>/dev/null; then
-    printf '%s' "$text" | python3 - "$limit" <<'PY'
+    printf '%s' "$text" | python3 -c '
 import sys
-
 limit = int(sys.argv[1])
 data = sys.stdin.buffer.read().decode("utf-8", errors="replace")
 sys.stdout.write(data[:limit])
-PY
+' "$limit"
     return 0
   fi
 

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -206,6 +206,41 @@ vg_start_timer() {
   fi
 }
 
+vg_truncate_utf8() {
+  local text="$1"
+  local limit="${2:-200}"
+
+  if [[ "${#text}" -le "$limit" ]]; then
+    printf '%s' "$text"
+    return 0
+  fi
+
+  if command -v perl &>/dev/null; then
+    printf '%s' "$text" | perl -CS -e '
+use strict;
+use warnings;
+my $limit = shift @ARGV;
+local $/;
+my $s = <STDIN> // q{};
+print substr($s, 0, $limit);
+' "$limit"
+    return 0
+  fi
+
+  if command -v python3 &>/dev/null; then
+    printf '%s' "$text" | python3 - "$limit" <<'PY'
+import sys
+
+limit = int(sys.argv[1])
+data = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+sys.stdout.write(data[:limit])
+PY
+    return 0
+  fi
+
+  printf '%s' "$text" | head -c "$limit"
+}
+
 vg_log() {
   local hook="$1"
   local tool="$2"
@@ -214,7 +249,7 @@ vg_log() {
   local detail="${5:-}"
 
   # Truncate detail to 200 chars
-  detail="${detail:0:200}"
+  detail="$(vg_truncate_utf8 "$detail" 200)"
 
   # Calculation time
   local duration_ms=""

--- a/hooks/post-build-check.sh
+++ b/hooks/post-build-check.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/log.sh"
 vg_start_timer
+VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "$0")/_lib" && pwd)}"
 
 INPUT=$(cat)
 
@@ -99,21 +100,24 @@ CONSECUTIVE_FAILS=$(tail -200 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
   | if [[ -n "$_VG_HELPER" ]]; then
       "$_VG_HELPER" build-fails "$VIBEGUARD_SESSION_ID" "$PROJECT_ROOT"
     else
-      VG_SESSION="$VIBEGUARD_SESSION_ID" VG_PROJECT="$PROJECT_ROOT" python3 -c '
-import json, sys, os
+      VG_SESSION="$VIBEGUARD_SESSION_ID" VG_PROJECT="$PROJECT_ROOT" VG_EVENT_LOG_LIB="$VG_EVENT_LOG_LIB" python3 -c '
+import sys, os
+sys.path.insert(0, os.environ["VG_EVENT_LOG_LIB"])
+from event_log import iter_events_from_stream
+
 session, project = os.environ["VG_SESSION"], os.environ["VG_PROJECT"]
 count, prefix = 0, project.rstrip("/") + "/"
-for line in reversed(sys.stdin.read().splitlines()):
-    line = line.strip()
-    if not line: continue
-    try:
-        e = json.loads(line)
-        if e.get("hook") != "post-build-check" or e.get("session") != session: continue
-        d = e.get("detail", "")
-        if project and d and not d.startswith(prefix): continue
-        if e.get("decision") == "pass": break
-        if e.get("decision") == "warn": count += 1
-    except: continue
+events = list(iter_events_from_stream(sys.stdin.buffer))
+for e in reversed(events):
+    if e.get("hook") != "post-build-check" or e.get("session") != session:
+        continue
+    d = e.get("detail", "")
+    if project and d and not d.startswith(prefix):
+        continue
+    if e.get("decision") == "pass":
+        break
+    if e.get("decision") == "warn":
+        count += 1
 print(count)
 '
     fi 2>/dev/null | tr -d '[:space:]' || echo "0")

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/_lib/stub_detect.sh"
 vg_start_timer
+VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "$0")/_lib" && pwd)}"
 
 INPUT=$(cat)
 
@@ -306,19 +307,17 @@ CHURN_COUNT=$(tail -500 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
   | if [[ -n "$_VG_HELPER" ]]; then
       "$_VG_HELPER" churn-count "$VIBEGUARD_SESSION_ID" "$FILE_PATH"
     else
-      VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" python3 -c '
-import json, sys, os
+      VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" VG_EVENT_LOG_LIB="$VG_EVENT_LOG_LIB" python3 -c '
+import sys, os
+sys.path.insert(0, os.environ["VG_EVENT_LOG_LIB"])
+from event_log import iter_events_from_stream
+
 file_path = os.environ.get("VG_FILE_PATH", "")
 session = os.environ.get("VG_SESSION", "")
 count = 0
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    try:
-        e = json.loads(line)
-        if e.get("session") == session and e.get("tool") == "Edit" and file_path in e.get("detail", ""):
-            count += 1
-    except (json.JSONDecodeError, KeyError): continue
+for e in iter_events_from_stream(sys.stdin.buffer):
+    if e.get("session") == session and e.get("tool") == "Edit" and file_path in e.get("detail", ""):
+        count += 1
 print(count)
 '
     fi 2>/dev/null | tr -d '[:space:]' || echo "0")
@@ -354,20 +353,18 @@ fi
 # Note: W-15 spec also requires "±10 lines region" check; the event log does not
 # capture line numbers, so this is a file-level proxy (coarser than full spec).
 PAST_CONSECUTIVE=$(tail -200 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
-  | VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" python3 -c '
-import json, sys, os
+  | VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" VG_EVENT_LOG_LIB="$VG_EVENT_LOG_LIB" python3 -c '
+import sys, os
+sys.path.insert(0, os.environ["VG_EVENT_LOG_LIB"])
+from event_log import iter_events_from_stream
+
 file_path = os.environ.get("VG_FILE_PATH", "")
 session = os.environ.get("VG_SESSION", "")
 edits = []
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    try:
-        e = json.loads(line)
-        if (e.get("session") == session and e.get("tool") == "Edit"
-                and e.get("hook") == "post-edit-guard"):
-            edits.append(e.get("detail", "").split("||")[0].strip())
-    except (json.JSONDecodeError, KeyError): continue
+for e in iter_events_from_stream(sys.stdin.buffer):
+    if (e.get("session") == session and e.get("tool") == "Edit"
+            and e.get("hook") == "post-edit-guard"):
+        edits.append(e.get("detail", "").split("||")[0].strip())
 consec = 0
 for ep in reversed(edits):
     if ep == file_path: consec += 1
@@ -400,19 +397,17 @@ WARN_COUNT_FOR_FILE=$(tail -500 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
   | if [[ -n "$_VG_HELPER" ]]; then
       "$_VG_HELPER" warn-count "$VIBEGUARD_SESSION_ID" "$FILE_PATH"
     else
-      VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" python3 -c '
-import json, sys, os
+      VG_FILE_PATH="$FILE_PATH" VG_SESSION="$VIBEGUARD_SESSION_ID" VG_EVENT_LOG_LIB="$VG_EVENT_LOG_LIB" python3 -c '
+import sys, os
+sys.path.insert(0, os.environ["VG_EVENT_LOG_LIB"])
+from event_log import iter_events_from_stream
+
 file_path = os.environ.get("VG_FILE_PATH", "")
 session = os.environ.get("VG_SESSION", "")
 count = 0
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    try:
-        e = json.loads(line)
-        if e.get("session") == session and e.get("hook") == "post-edit-guard" and e.get("decision") == "warn" and e.get("detail", "").split("||")[0].strip() == file_path:
-            count += 1
-    except (json.JSONDecodeError, KeyError): continue
+for e in iter_events_from_stream(sys.stdin.buffer):
+    if e.get("session") == session and e.get("hook") == "post-edit-guard" and e.get("decision") == "warn" and e.get("detail", "").split("||")[0].strip() == file_path:
+        count += 1
 print(count)
 '
     fi 2>/dev/null | tr -d '[:space:]' || echo "0")

--- a/scripts/hook-health.sh
+++ b/scripts/hook-health.sh
@@ -8,6 +8,7 @@
 
 set -euo pipefail
 
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HOURS="${1:-24}"
 LOG_FILE="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/events.jsonl"
 
@@ -21,21 +22,15 @@ if [[ ! -f "${LOG_FILE}" ]]; then
   exit 0
 fi
 
-VG_HOURS="${HOURS}" VG_LOG_FILE="${LOG_FILE}" python3 - <<'PY'
-import json
+VG_HOURS="${HOURS}" VG_LOG_FILE="${LOG_FILE}" VG_REPO_DIR="${REPO_DIR}" python3 - <<'PY'
 import os
 import sys
+from pathlib import Path
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 
-
-def parse_ts(ts: str):
-    if not ts:
-        return None
-    try:
-        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
-    except ValueError:
-        return None
+sys.path.insert(0, str(Path(os.environ["VG_REPO_DIR"]) / "hooks" / "_lib"))
+from event_log import load_events_from_file
 
 
 hours = int(os.environ["VG_HOURS"])
@@ -43,22 +38,7 @@ log_file = os.environ["VG_LOG_FILE"]
 now = datetime.now(timezone.utc)
 cutoff = now - timedelta(hours=hours)
 
-events = []
-with open(log_file, "r", encoding="utf-8") as f:
-    for line in f:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        event_ts = parse_ts(event.get("ts", ""))
-        if event_ts is None:
-            continue
-        if event_ts >= cutoff:
-            event["_parsed_ts"] = event_ts
-            events.append(event)
+events = load_events_from_file(log_file, since=cutoff)
 
 if not events:
     print(f"No log data for the last {hours} hours.")

--- a/scripts/quality-grader.sh
+++ b/scripts/quality-grader.sh
@@ -40,10 +40,14 @@ NATIVE_RULES_DIR="${HOME}/.claude/rules/vibeguard"
 
 VG_DAYS="$DAYS" VG_LOG_FILE="$LOG_FILE" VG_GUARDS_DIR="$GUARDS_DIR" \
   VG_RULES_DIR="$RULES_DIR" VG_NATIVE_RULES_DIR="$NATIVE_RULES_DIR" \
-  VG_JSON="$JSON_OUTPUT" python3 -c '
+  VG_JSON="$JSON_OUTPUT" VG_REPO_DIR="$REPO_DIR" python3 -c '
 import json, sys, os, glob
 from datetime import datetime, timezone, timedelta
 from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(os.environ["VG_REPO_DIR"]) / "hooks" / "_lib"))
+from event_log import load_events_from_file
 
 days = os.environ.get("VG_DAYS", "30")
 log_file = os.environ.get("VG_LOG_FILE", "")
@@ -52,30 +56,17 @@ rules_dir = os.environ.get("VG_RULES_DIR", "")
 native_rules_dir = os.environ.get("VG_NATIVE_RULES_DIR", "")
 json_output = os.environ.get("VG_JSON", "false") == "true"
 
-#Read events
-events = []
-with open(log_file) as f:
-    for line in f:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            events.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-
-if not events:
-    print("No log data.")
-    sys.exit(0)
-
-# Time filter
-if days != "all":
+if days == "all":
+    events = load_events_from_file(log_file)
+else:
     cutoff = datetime.now(timezone.utc) - timedelta(days=int(days))
-    cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
-    events = [e for e in events if e.get("ts", "") >= cutoff_str]
+    events = load_events_from_file(log_file, since=cutoff)
 
 if not events:
-    print(f"There is no log data in the last {days} days.")
+    if days == "all":
+        print("No log data.")
+    else:
+        print(f"There is no log data in the last {days} days.")
     sys.exit(0)
 
 total = len(events)

--- a/scripts/stats.sh
+++ b/scripts/stats.sh
@@ -9,6 +9,7 @@
 
 set -euo pipefail
 
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 DAYS="${1:-7}"
 LOG_FILE="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/events.jsonl"
 
@@ -17,38 +18,29 @@ if [[ ! -f "$LOG_FILE" ]]; then
   exit 0
 fi
 
-VG_DAYS="$DAYS" VG_LOG_FILE="$LOG_FILE" python3 -c "
-import json, sys, os
+VG_DAYS="$DAYS" VG_LOG_FILE="$LOG_FILE" VG_REPO_DIR="$REPO_DIR" python3 -c "
+import sys, os
 from datetime import datetime, timezone, timedelta
 from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(os.environ['VG_REPO_DIR']) / 'hooks' / '_lib'))
+from event_log import load_events_from_file
 
 days = os.environ.get('VG_DAYS', '7')
 log_file = os.environ.get('VG_LOG_FILE', '')
 
-#Read events
-events = []
-with open(log_file) as f:
-    for line in f:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            events.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-
-if not events:
-    print('No log data.')
-    sys.exit(0)
-
-# Time filter
-if days != 'all':
+if days == 'all':
+    events = load_events_from_file(log_file)
+else:
     cutoff = datetime.now(timezone.utc) - timedelta(days=int(days))
-    cutoff_str = cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')
-    events = [e for e in events if e.get('ts', '') >= cutoff_str]
+    events = load_events_from_file(log_file, since=cutoff)
 
 if not events:
-    print(f'No log data for the last {days} days.')
+    if days == 'all':
+        print('No log data.')
+    else:
+        print(f'No log data for the last {days} days.')
     sys.exit(0)
 
 period = f'all history' if days == 'all' else f'last {days} days'

--- a/tests/test_hook_health.sh
+++ b/tests/test_hook_health.sh
@@ -123,6 +123,55 @@ assert_contains "${health_out}" "Risk Hook Top 5:" "Output risk hook ranking"
 assert_contains "${health_out}" "Top 10 recent risk events:" "Output the latest risk events"
 assert_contains "${health_out}" "stop-guard | gate" "Risk event contains gate"
 
+header "Malformed UTF-8 and broken JSON lines are tolerated"
+python3 - "${TMP_DIR}/log/events-malformed.jsonl" <<'PY'
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+path = sys.argv[1]
+now = datetime.now(timezone.utc)
+
+good_events = [
+    {
+        "ts": (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        "session": "utf8-1",
+        "hook": "pre-bash-guard",
+        "tool": "Bash",
+        "decision": "pass",
+        "reason": "",
+        "detail": "cargo check",
+    },
+    {
+        "ts": (now - timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+        "session": "utf8-2",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "reason": "contains replacement char",
+        "detail": "src/lib.rs",
+    },
+]
+
+recoverable_bad_utf8 = (
+    b'{"ts":"'
+    + (now - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%SZ").encode("ascii")
+    + b'","session":"utf8-3","hook":"pre-bash-guard","tool":"Bash","decision":"warn","reason":"bad utf8","detail":"python3 -c \\"# \xe7\\""}\n'
+)
+
+with open(path, "wb") as f:
+    f.write(recoverable_bad_utf8)
+    for event in good_events:
+        f.write(json.dumps(event, ensure_ascii=False).encode("utf-8") + b"\n")
+    f.write(b'{"ts":"broken-json"\n')
+PY
+
+cp "${TMP_DIR}/log/events-malformed.jsonl" "${TMP_DIR}/log/events.jsonl"
+malformed_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/log" bash "${SCRIPT}" 24 2>&1)"
+assert_contains "${malformed_out}" "Total triggers: 3" "Recoverable malformed UTF-8 line is counted and broken JSON line is skipped"
+assert_contains "${malformed_out}" "Risk (non-pass): 2" "Malformed UTF-8 line still contributes to decision counts"
+assert_contains "${malformed_out}" "pre-bash-guard: 1" "Recovered line participates in non-pass hook aggregation"
+
 header "illegal parameter"
 set +e
 bad_arg_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/log" bash "${SCRIPT}" abc 2>&1)"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -122,6 +122,33 @@ result=$(
 assert_not_contains "$result" $'\x07' "BEL byte from OSC hyperlink sequence is stripped from JSONL"
 assert_not_contains "$result" $'\x1b' "ESC byte from OSC hyperlink sequence is stripped from JSONL"
 
+# Clear the log and ensure multibyte truncation stays valid UTF-8
+> "$VIBEGUARD_LOG_DIR/events.jsonl"
+
+result=$(
+  export VIBEGUARD_LOG_DIR
+  source hooks/log.sh
+  : > "$VIBEGUARD_LOG_FILE"
+  long_detail="$(python3 - <<'PY'
+print("查" * 250, end="")
+PY
+)"
+  vg_log "test" "Tool" "pass" "" "$long_detail"
+  python3 - "$VIBEGUARD_LOG_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    event = json.loads(next(f))
+
+detail = event["detail"]
+print("utf8-ok")
+print(f"detail_len={len(detail)}")
+PY
+)
+assert_contains "$result" "utf8-ok" "Multibyte detail truncation keeps log UTF-8 decodable"
+assert_contains "$result" "detail_len=200" "Multibyte detail truncation still enforces the 200-char cap"
+
 # =========================================================
 header "pre-bash-guard.sh — Dangerous command interception"
 # =========================================================

--- a/tests/test_quality_grader.sh
+++ b/tests/test_quality_grader.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# VibeGuard quality-grader regression testing
+#
+# Usage: bash tests/test_quality_grader.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_DIR}/scripts/quality-grader.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+header "Malformed UTF-8 and broken JSON lines are tolerated"
+mkdir -p "${TMP_DIR}/log"
+python3 - "${TMP_DIR}/log/events.jsonl" <<'PY'
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+path = sys.argv[1]
+now = datetime.now(timezone.utc)
+
+good_events = [
+    {
+        "ts": (now - timedelta(days=1)).isoformat().replace("+00:00", "Z"),
+        "session": "q1",
+        "hook": "pre-bash-guard",
+        "tool": "Bash",
+        "decision": "pass",
+        "reason": "",
+        "detail": "cargo check",
+        "duration_ms": 200,
+    },
+    {
+        "ts": (now - timedelta(hours=6)).isoformat().replace("+00:00", "Z"),
+        "session": "q2",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "reason": "warned once",
+        "detail": "src/lib.rs",
+        "duration_ms": 800,
+    },
+]
+
+recoverable_bad_utf8 = (
+    b'{"ts":"'
+    + (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ").encode("ascii")
+    + b'","session":"q3","hook":"pre-bash-guard","tool":"Bash","decision":"block","reason":"bad utf8","detail":"python3 -c \\"# \xe7\\"","duration_ms":150}\n'
+)
+
+with open(path, "wb") as f:
+    f.write(recoverable_bad_utf8)
+    for event in good_events:
+        f.write(json.dumps(event, ensure_ascii=False).encode("utf-8") + b"\n")
+    f.write(b'{"ts":"broken-json"\n')
+PY
+
+grader_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/log" bash "${SCRIPT}" 7 --json 2>&1)"
+assert_contains "${grader_out}" '"events_analyzed": 3' "Recoverable malformed UTF-8 line is included in grading"
+assert_contains "${grader_out}" '"grade": "' "JSON output still returns a grade"
+assert_contains "${grader_out}" '"security":' "Security metric is present"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# VibeGuard stats regression testing
+#
+# Usage: bash tests/test_stats.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_DIR}/scripts/stats.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+header "Malformed UTF-8 and broken JSON lines are tolerated"
+mkdir -p "${TMP_DIR}/log"
+python3 - "${TMP_DIR}/log/events.jsonl" <<'PY'
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+path = sys.argv[1]
+now = datetime.now(timezone.utc)
+
+good_events = [
+    {
+        "ts": (now - timedelta(days=1)).isoformat().replace("+00:00", "Z"),
+        "session": "s1",
+        "hook": "pre-bash-guard",
+        "tool": "Bash",
+        "decision": "pass",
+        "reason": "",
+        "detail": "cargo check",
+    },
+    {
+        "ts": (now - timedelta(hours=3)).isoformat().replace("+00:00", "Z"),
+        "session": "s2",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "reason": "warned once",
+        "detail": "src/lib.rs",
+    },
+]
+
+recoverable_bad_utf8 = (
+    b'{"ts":"'
+    + (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ").encode("ascii")
+    + b'","session":"s3","hook":"pre-bash-guard","tool":"Bash","decision":"block","reason":"bad utf8","detail":"python3 -c \\"# \xe7\\""}\n'
+)
+
+with open(path, "wb") as f:
+    for event in good_events:
+        f.write(json.dumps(event, ensure_ascii=False).encode("utf-8") + b"\n")
+    f.write(recoverable_bad_utf8)
+    f.write(b'{"ts":"broken-json"\n')
+PY
+
+stats_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/log" bash "${SCRIPT}" 7 2>&1)"
+assert_contains "${stats_out}" "VibeGuard Statistics (last 7 days)" "Title is correct"
+assert_contains "${stats_out}" "Total triggers: 3 times" "Recoverable malformed UTF-8 line is included"
+assert_contains "${stats_out}" "Interception (block): 1 times" "Block count includes recovered malformed line"
+assert_contains "${stats_out}" "Warning: 1 times" "Warn count is correct"
+assert_contains "${stats_out}" "pre-bash-guard: 2 times" "Hook aggregation remains correct"
+assert_contains "${stats_out}" "post-edit-guard: 1 times" "Secondary hook aggregation remains correct"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/vg-helper/src/log_query.rs
+++ b/vg-helper/src/log_query.rs
@@ -8,17 +8,24 @@ type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 fn read_events(session: &str) -> Vec<Value> {
     let stdin = io::stdin();
+    let mut reader = io::BufReader::new(stdin.lock());
     let mut events = Vec::new();
-    for line in stdin.lock().lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-        let line = line.trim().to_string();
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+        // Use lossy decoding so malformed UTF-8 bytes become U+FFFD rather than
+        // dropping the entire line — preserves recoverable JSONL events.
+        let line = String::from_utf8_lossy(&buf);
+        let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        if let Ok(v) = serde_json::from_str::<Value>(&line) {
+        if let Ok(v) = serde_json::from_str::<Value>(line) {
             if v.get("session").and_then(Value::as_str) == Some(session) {
                 events.push(v);
             }
@@ -61,11 +68,9 @@ pub fn warn_count(args: &[String]) -> Result {
         .filter(|e| {
             e.get("hook").and_then(Value::as_str) == Some("post-edit-guard")
                 && e.get("decision").and_then(Value::as_str) == Some("warn")
-                && e.get("detail")
-                    .and_then(Value::as_str)
-                    .is_some_and(|d| {
-                        d.split("||").next().unwrap_or("").trim() == file_path.as_str()
-                    })
+                && e.get("detail").and_then(Value::as_str).is_some_and(|d| {
+                    d.split("||").next().unwrap_or("").trim() == file_path.as_str()
+                })
         })
         .count();
     println!("{count}");

--- a/vg-helper/src/pkg_rewrite.rs
+++ b/vg-helper/src/pkg_rewrite.rs
@@ -41,14 +41,33 @@ fn try_npm(cmd: &str) -> Option<String> {
     let rest = pkg_install.replace(cmd, "").trim().to_string();
     let tokens: Vec<&str> = rest.split_whitespace().collect();
 
-    const KNOWN: &[&str] = &["--save-dev", "-D", "--save", "-S", "--save-optional", "-O", "--save-exact", "-E"];
-    if tokens.iter().any(|t| *t == "-g" || *t == "--global" || t.starts_with("--location=global")) {
+    const KNOWN: &[&str] = &[
+        "--save-dev",
+        "-D",
+        "--save",
+        "-S",
+        "--save-optional",
+        "-O",
+        "--save-exact",
+        "-E",
+    ];
+    if tokens
+        .iter()
+        .any(|t| *t == "-g" || *t == "--global" || t.starts_with("--location=global"))
+    {
         return None;
     }
-    if tokens.iter().any(|t| t.starts_with('-') && !KNOWN.contains(t)) {
+    if tokens
+        .iter()
+        .any(|t| t.starts_with('-') && !KNOWN.contains(t))
+    {
         return None;
     }
-    let packages: Vec<&str> = tokens.iter().filter(|t| !t.starts_with('-')).copied().collect();
+    let packages: Vec<&str> = tokens
+        .iter()
+        .filter(|t| !t.starts_with('-'))
+        .copied()
+        .collect();
     if packages.is_empty() {
         return None;
     }
@@ -79,11 +98,30 @@ fn try_yarn(cmd: &str) -> Option<String> {
     let rest = add.replace(cmd, "").to_string();
     let tokens: Vec<&str> = rest.split_whitespace().collect();
 
-    const KNOWN: &[&str] = &["-D", "--dev", "--save-dev", "-O", "--optional", "-E", "--exact", "-P", "--save-peer", "-W", "--ignore-workspace-root-check"];
-    if tokens.iter().any(|t| t.starts_with('-') && !KNOWN.contains(t)) {
+    const KNOWN: &[&str] = &[
+        "-D",
+        "--dev",
+        "--save-dev",
+        "-O",
+        "--optional",
+        "-E",
+        "--exact",
+        "-P",
+        "--save-peer",
+        "-W",
+        "--ignore-workspace-root-check",
+    ];
+    if tokens
+        .iter()
+        .any(|t| t.starts_with('-') && !KNOWN.contains(t))
+    {
         return None;
     }
-    let packages: Vec<&str> = tokens.iter().filter(|t| !t.starts_with('-')).copied().collect();
+    let packages: Vec<&str> = tokens
+        .iter()
+        .filter(|t| !t.starts_with('-'))
+        .copied()
+        .collect();
     if packages.is_empty() {
         return None;
     }
@@ -123,12 +161,34 @@ fn try_python_pip(cmd: &str) -> Option<String> {
 
 fn check_pip_flags(rest: &str) -> Option<()> {
     const KNOWN: &[&str] = &[
-        "-r", "--requirement", "-e", "--editable", "-U", "--upgrade", "--pre", "--no-deps",
-        "-i", "--index-url", "--extra-index-url", "--no-index", "-f", "--find-links",
-        "-c", "--constraint", "-v", "--verbose", "-q", "--quiet", "-t", "--target",
+        "-r",
+        "--requirement",
+        "-e",
+        "--editable",
+        "-U",
+        "--upgrade",
+        "--pre",
+        "--no-deps",
+        "-i",
+        "--index-url",
+        "--extra-index-url",
+        "--no-index",
+        "-f",
+        "--find-links",
+        "-c",
+        "--constraint",
+        "-v",
+        "--verbose",
+        "-q",
+        "--quiet",
+        "-t",
+        "--target",
     ];
     let tokens: Vec<&str> = rest.split_whitespace().collect();
-    if tokens.iter().any(|t| t.starts_with('-') && !KNOWN.contains(t)) {
+    if tokens
+        .iter()
+        .any(|t| t.starts_with('-') && !KNOWN.contains(t))
+    {
         return None;
     }
     Some(())

--- a/vg-helper/src/session_metrics.rs
+++ b/vg-helper/src/session_metrics.rs
@@ -42,7 +42,11 @@ fn parse_iso_ts(ts: &str) -> Option<u64> {
 
     let is_leap = |y: i64| (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
     let month_days: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    let max_day = if month == 2 && is_leap(year) { 29 } else { month_days[(month - 1) as usize] };
+    let max_day = if month == 2 && is_leap(year) {
+        29
+    } else {
+        month_days[(month - 1) as usize]
+    };
     if day < 1 || day > max_day {
         return None;
     }
@@ -407,10 +411,7 @@ mod tests {
 
     #[test]
     fn test_parse_plus00_suffix() {
-        assert_eq!(
-            parse_iso_ts("1970-01-01T00:00:00+00:00"),
-            Some(0)
-        );
+        assert_eq!(parse_iso_ts("1970-01-01T00:00:00+00:00"), Some(0));
     }
 
     #[test]
@@ -502,14 +503,22 @@ mod tests {
     fn test_non_string_ts_is_excluded_by_filter() {
         // ts present as number, object, or array — must be excluded, not silently admitted.
         let cutoff = now_unix_secs().saturating_sub(30 * 60);
-        assert!(!event_passes_time_filter(&serde_json::json!({"ts": 123456789}), cutoff),
-            "numeric ts must be excluded");
-        assert!(!event_passes_time_filter(&serde_json::json!({"ts": {}}), cutoff),
-            "object ts must be excluded");
-        assert!(!event_passes_time_filter(&serde_json::json!({"ts": []}), cutoff),
-            "array ts must be excluded");
-        assert!(!event_passes_time_filter(&serde_json::json!({"ts": null}), cutoff),
-            "null ts must be excluded");
+        assert!(
+            !event_passes_time_filter(&serde_json::json!({"ts": 123456789}), cutoff),
+            "numeric ts must be excluded"
+        );
+        assert!(
+            !event_passes_time_filter(&serde_json::json!({"ts": {}}), cutoff),
+            "object ts must be excluded"
+        );
+        assert!(
+            !event_passes_time_filter(&serde_json::json!({"ts": []}), cutoff),
+            "array ts must be excluded"
+        );
+        assert!(
+            !event_passes_time_filter(&serde_json::json!({"ts": null}), cutoff),
+            "null ts must be excluded"
+        );
     }
 
     #[test]
@@ -542,22 +551,28 @@ mod tests {
     #[test]
     fn test_different_session_is_excluded() {
         let e = serde_json::json!({"session": "sess-B", "hook": "test"});
-        assert!(!event_passes_session_filter(&e, "sess-A"),
-            "event from different session must be excluded");
+        assert!(
+            !event_passes_session_filter(&e, "sess-A"),
+            "event from different session must be excluded"
+        );
     }
 
     #[test]
     fn test_same_session_is_included() {
         let e = serde_json::json!({"session": "sess-A", "hook": "test"});
-        assert!(event_passes_session_filter(&e, "sess-A"),
-            "event from same session must be included");
+        assert!(
+            event_passes_session_filter(&e, "sess-A"),
+            "event from same session must be included"
+        );
     }
 
     #[test]
     fn test_missing_session_field_is_included() {
         let e = serde_json::json!({"hook": "test"});
-        assert!(event_passes_session_filter(&e, "sess-A"),
-            "event with no session field must be included");
+        assert!(
+            event_passes_session_filter(&e, "sess-A"),
+            "event with no session field must be included"
+        );
     }
 
     // --- run() integration tests: exercise the full production path via run_inner ---
@@ -588,9 +603,21 @@ mod tests {
             "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\"}\n",
         );
         let mut out = Vec::<u8>::new();
-        run_inner(&make_args(dir.to_str().unwrap()), io::Cursor::new(input), &mut out, 0).unwrap();
-        assert!(out.is_empty(), "no output expected when event count < 3 after skip filtering");
-        assert!(!metrics_path.exists(), "metrics file must not be written when event count < 3");
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            0,
+        )
+        .unwrap();
+        assert!(
+            out.is_empty(),
+            "no output expected when event count < 3 after skip filtering"
+        );
+        assert!(
+            !metrics_path.exists(),
+            "metrics file must not be written when event count < 3"
+        );
     }
 
     #[test]
@@ -606,9 +633,21 @@ mod tests {
             "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\"}\n",
         );
         let mut out = Vec::<u8>::new();
-        run_inner(&make_args(dir.to_str().unwrap()), io::Cursor::new(input), &mut out, 0).unwrap();
-        assert!(out.is_empty(), "no output expected when event count < 3 after session filtering");
-        assert!(!metrics_path.exists(), "metrics file must not be written when event count < 3");
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            0,
+        )
+        .unwrap();
+        assert!(
+            out.is_empty(),
+            "no output expected when event count < 3 after session filtering"
+        );
+        assert!(
+            !metrics_path.exists(),
+            "metrics file must not be written when event count < 3"
+        );
     }
 
     #[test]
@@ -626,9 +665,21 @@ mod tests {
         );
         let cutoff = 60u64;
         let mut out = Vec::<u8>::new();
-        run_inner(&make_args(dir.to_str().unwrap()), io::Cursor::new(input), &mut out, cutoff).unwrap();
-        assert!(out.is_empty(), "no output expected when event count < 3 after time filtering");
-        assert!(!metrics_path.exists(), "metrics file must not be written when event count < 3");
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            cutoff,
+        )
+        .unwrap();
+        assert!(
+            out.is_empty(),
+            "no output expected when event count < 3 after time filtering"
+        );
+        assert!(
+            !metrics_path.exists(),
+            "metrics file must not be written when event count < 3"
+        );
     }
 
     #[test]
@@ -646,10 +697,22 @@ mod tests {
             "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\"}\n",
         );
         let mut out = Vec::<u8>::new();
-        run_inner(&make_args(dir.to_str().unwrap()), io::Cursor::new(input), &mut out, 0).unwrap();
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            0,
+        )
+        .unwrap();
         let stdout_text = String::from_utf8(out).unwrap();
-        assert!(stdout_text.contains("LEARN_SUGGESTED"), "expected LEARN_SUGGESTED in stdout");
-        assert!(metrics_path.exists(), "metrics file must be written when ≥3 events processed");
+        assert!(
+            stdout_text.contains("LEARN_SUGGESTED"),
+            "expected LEARN_SUGGESTED in stdout"
+        );
+        assert!(
+            metrics_path.exists(),
+            "metrics file must be written when ≥3 events processed"
+        );
         let file_content = std::fs::read_to_string(&metrics_path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(file_content.trim()).unwrap();
         assert_eq!(parsed["session"], "sess-A");
@@ -669,9 +732,21 @@ mod tests {
             "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\"}\n",
         );
         let mut out = Vec::<u8>::new();
-        run_inner(&make_args(dir.to_str().unwrap()), io::Cursor::new(input), &mut out, 0).unwrap();
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            0,
+        )
+        .unwrap();
         let stdout_text = String::from_utf8(out).unwrap();
-        assert!(!stdout_text.contains("LEARN_SUGGESTED"), "no signal expected for clean session");
-        assert!(metrics_path.exists(), "metrics file must still be written even with no signals");
+        assert!(
+            !stdout_text.contains("LEARN_SUGGESTED"),
+            "no signal expected for clean session"
+        );
+        assert!(
+            metrics_path.exists(),
+            "metrics file must still be written even with no signals"
+        );
     }
 }

--- a/vg-helper/src/session_metrics.rs
+++ b/vg-helper/src/session_metrics.rs
@@ -1,7 +1,7 @@
 //! Session metrics collection + correction signal detection.
 //! Replaces hooks/_lib/session_metrics.py.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{self, BufRead, Write};
@@ -109,12 +109,17 @@ fn run_inner(
     let mut events: Vec<Value> = Vec::new();
     let skip = ["stop-guard", "learn-evaluator"];
     for line in stdin.lines() {
-        let line = line?;
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
         let line = line.trim().to_string();
         if line.is_empty() {
             continue;
         }
-        let Ok(e) = serde_json::from_str::<Value>(&line) else { continue };
+        let Ok(e) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
         let hook = e.get("hook").and_then(Value::as_str).unwrap_or("");
         if skip.contains(&hook) {
             continue;
@@ -145,7 +150,10 @@ fn run_inner(
     let mut durations_ms: Vec<u64> = Vec::new();
 
     for e in &events {
-        let d = e.get("decision").and_then(Value::as_str).unwrap_or("unknown");
+        let d = e
+            .get("decision")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
         *decisions.entry(d.into()).or_default() += 1;
         let h = e.get("hook").and_then(Value::as_str).unwrap_or("unknown");
         *hooks.entry(h.into()).or_default() += 1;
@@ -227,18 +235,28 @@ fn run_inner(
                 if !seen.contains(&r) {
                     seen.push(r);
                 }
-                if seen.len() >= 3 { break; }
+                if seen.len() >= 3 {
+                    break;
+                }
             }
             seen
         };
-        let joined = unique.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("; ");
+        let joined = unique
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
         signals.push(format!("{blocks} block(s): {joined}"));
     }
 
     // Signal 6: paralysis
     let paralysis: Vec<_> = events
         .iter()
-        .filter(|e| e.get("reason").and_then(Value::as_str).is_some_and(|r| r.contains("paralysis")))
+        .filter(|e| {
+            e.get("reason")
+                .and_then(Value::as_str)
+                .is_some_and(|r| r.contains("paralysis"))
+        })
         .collect();
     if paralysis.len() >= 2 {
         signals.push(format!("Analysis paralysis: {} triggers", paralysis.len()));
@@ -248,7 +266,9 @@ fn run_inner(
     let mut rule_counts: HashMap<String, u64> = HashMap::new();
     for e in &events {
         let d = e.get("decision").and_then(Value::as_str).unwrap_or("");
-        if !["warn", "block", "escalate"].contains(&d) { continue; }
+        if !["warn", "block", "escalate"].contains(&d) {
+            continue;
+        }
         let reason = e.get("reason").and_then(Value::as_str).unwrap_or("");
         if let Some(end) = reason.find(']') {
             let tag = &reason[..=end];
@@ -262,19 +282,27 @@ fn run_inner(
     }
 
     // Signal 8: build failure cluster
-    let bf = events.iter().filter(|e| {
-        let r = e.get("reason").and_then(Value::as_str).unwrap_or("");
-        let rl = r.to_lowercase();
-        r.contains("构建错误") || rl.contains("build fail") || rl.contains("build error")
-    }).count();
+    let bf = events
+        .iter()
+        .filter(|e| {
+            let r = e.get("reason").and_then(Value::as_str).unwrap_or("");
+            let rl = r.to_lowercase();
+            r.contains("构建错误") || rl.contains("build fail") || rl.contains("build error")
+        })
+        .count();
     if bf >= 3 {
         signals.push(format!("{bf} build failures in session (spiral risk)"));
     }
 
     // Signal 9: circuit breaker trips
-    let cb = events.iter().filter(|e| {
-        e.get("reason").and_then(Value::as_str).is_some_and(|r| r.contains("CB tripped"))
-    }).count();
+    let cb = events
+        .iter()
+        .filter(|e| {
+            e.get("reason")
+                .and_then(Value::as_str)
+                .is_some_and(|r| r.contains("CB tripped"))
+        })
+        .count();
     if cb > 0 {
         signals.push(format!("Circuit breaker tripped {cb} time(s)"));
     }
@@ -327,7 +355,11 @@ fn run_inner(
         "warn_ratio": (warn_ratio * 100.0).round() / 100.0,
     });
 
-    if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(&metrics_path) {
+    if let Ok(mut f) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&metrics_path)
+    {
         let _ = writeln!(f, "{}", serde_json::to_string(&metrics)?);
     }
 
@@ -343,7 +375,9 @@ fn run_inner(
 
 fn chrono_now() -> String {
     // Simple UTC timestamp without chrono crate dependency
-    let output = std::process::Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]).output();
+    let output = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output();
     match output {
         Ok(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
         Err(_) => "1970-01-01T00:00:00Z".into(),


### PR DESCRIPTION
## Summary
- centralize tolerant event-log parsing in a shared helper for observability consumers
- harden `vg_log` detail truncation so multibyte text is cut on UTF-8 boundaries
- add regression coverage and CI entries for malformed UTF-8 / broken JSON log lines

## Testing
- `bash tests/test_hooks.sh`
- `bash tests/test_hook_health.sh`
- `bash tests/test_stats.sh`
- `bash tests/test_quality_grader.sh`
- `bash scripts/hook-health.sh 24`
- `bash scripts/stats.sh 7`
- `bash scripts/quality-grader.sh 7 --json`

## Notes
- GC / archival readers under `scripts/gc/` still have independent parsing paths and can be migrated in a follow-up.
