### PR TITLE
Converge VibeGuard onto one explicit runtime and contract model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,12 +128,10 @@ jobs:
       # Install pnpm and uv so that the hook rewrite tests (npm→pnpm,
       # pip→uv) exercise the tool-availability guard added in pre-bash-guard.sh.
       - name: Install pnpm and uv (hook rewrite tests)
-        if: runner.os != 'Windows'
         shell: bash
         run: |
           npm install -g pnpm
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          python3 -m pip install uv
 
       # --- Regression tests ---
       # Skipped on Windows: the test harness uses Unix path assumptions,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,9 @@ jobs:
         run: bash scripts/benchmark.sh --mode=fast
 
   windows-smoke:
-    name: Windows Smoke
+    # Keep this job name aligned with the protected required check while the
+    # Windows job intentionally runs only cross-platform contract smoke tests.
+    name: CI (windows-latest)
     runs-on: windows-latest
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       # Must run before checkout so Windows does not convert LF→CRLF in .sh files
@@ -93,7 +93,6 @@ jobs:
         run: bash scripts/ci/validate-hooks.sh
 
       - name: Validate rule files
-        if: runner.os != 'Windows'
         shell: bash
         run: bash scripts/ci/validate-rules.sh
 
@@ -106,6 +105,10 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: bash scripts/ci/validate-generated-rule-docs.sh
+
+      - name: Validate manifest contract
+        shell: bash
+        run: bash scripts/ci/validate-manifest-contract.sh
 
       # --- Cross-platform contract validation (Python-embedded shell scripts) ---
       # Uses Git Bash on Windows; Python 3 is available from setup-python above.
@@ -136,22 +139,32 @@ jobs:
       # Skipped on Windows: the test harness uses Unix path assumptions,
       # mktemp patterns, and hook scripts that rely on native bash behaviour.
       - name: Hook regression tests
-        if: runner.os != 'Windows'
         shell: bash
+        env:
+          VIBEGUARD_TEST_UPDATED_INPUT: "1"
         run: bash tests/test_hooks.sh
 
+      - name: Codex runtime regression tests
+        shell: bash
+        run: bash tests/test_codex_runtime.sh
+
+      - name: Manifest contract regression tests
+        shell: bash
+        run: bash tests/test_manifest_contract.sh
+
+      - name: Eval contract regression tests
+        shell: bash
+        run: bash tests/test_eval_contract.sh
+
       - name: Rust guard regression tests
-        if: runner.os != 'Windows'
         shell: bash
         run: bash tests/test_rust_guards.sh
 
       - name: Setup regression tests
-        if: runner.os != 'Windows'
         shell: bash
         run: bash tests/test_setup.sh
 
       - name: Hook health regression tests
-        if: runner.os != 'Windows'
         shell: bash
         run: bash tests/test_hook_health.sh
 
@@ -171,22 +184,26 @@ jobs:
         run: bash tests/test_local_contract_gate.sh
 
       - name: Guard unit tests
-        if: runner.os != 'Windows'
         shell: bash
         run: bash tests/unit/run_all.sh
 
       - name: Hook precision tests
-        if: runner.os != 'Windows'
         shell: bash
         run: bash tests/run_precision.sh --all --csv
 
+      - name: Validate precision thresholds
+        shell: bash
+        run: bash scripts/ci/validate-precision-thresholds.sh
+
+      - name: Precision tracker regression tests
+        shell: bash
+        run: bash tests/test_precision_tracker.sh
+
       - name: Hook performance static analysis
-        if: runner.os != 'Windows'
         shell: bash
         run: bash scripts/ci/validate-hook-perf.sh
 
       - name: Hook latency benchmark
-        if: runner.os != 'Windows'
         shell: bash
         run: bash tests/bench_hook_latency.sh --sla=500 --runs=3
 
@@ -199,9 +216,42 @@ jobs:
           if-no-files-found: ignore
 
       - name: VibeGuard Benchmark (fast)
-        if: runner.os != 'Windows'
         shell: bash
         run: bash scripts/benchmark.sh --mode=fast
+
+  windows-smoke:
+    name: Windows Smoke
+    runs-on: windows-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Configure Git line endings
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate manifest contract
+        run: bash scripts/ci/validate-manifest-contract.sh
+
+      - name: Validate doc paths
+        run: bash scripts/ci/validate-doc-paths.sh
+
+      - name: Validate doc command paths
+        run: bash scripts/ci/validate-doc-command-paths.sh
+
+      - name: Manifest contract regression tests
+        run: bash tests/test_manifest_contract.sh
+
+      - name: Eval contract regression tests
+        run: bash tests/test_eval_contract.sh
 
   benchmark-report:
     name: Benchmark Report

--- a/.vibeguard-doc-paths-allowlist
+++ b/.vibeguard-doc-paths-allowlist
@@ -36,3 +36,9 @@ vibeguard/scripts/verify/compliance_check.sh
 
 # Placeholder path in docs/how/memory-files.md — illustrates project-level CLAUDE.md location (not a real repo path)
 project/.claude/CLAUDE.md
+
+# FOLLOWUPS placeholders and workspace-local notes
+docs/knowledge-discovery/YYYY-MM-DD.md
+vibeguard/README.md
+vibeguard/docs/knowledge-discovery/2026-04-17.md
+vibeguard/FOLLOWUPS.md

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Open a new Claude Code or Codex session. Run `bash ~/vibeguard/setup.sh --check`
 | **Learning System** | Turn repeated AI mistakes into reusable defenses |
 | **Observability** | Metrics and health for every interception |
 
+## Product Boundaries
+
+VibeGuard has two layers:
+
+| Surface | Scope | Canonical Source |
+|---------|-------|------------------|
+| **VibeGuard Core** | Rules, hooks, static guards, install/runtime contract, observability | `rules/claude-rules/`, `schemas/install-modules.json`, `hooks/`, `guards/` |
+| **VibeGuard Workflows** | Slash commands, agent prompts, planning/execution presets | `skills/`, `workflows/`, `agents/` |
+
+If these surfaces disagree, treat the Core contract as authoritative first, then update workflow/docs surfaces to match it.
+
 ## What it looks like in practice
 
 ![VibeGuard demo](docs/assets/demo.gif)
@@ -96,6 +107,11 @@ The native rule set in `rules/claude-rules/` is installed to Claude Code's nativ
 | L7 | Commit discipline | No AI markers, no force push, no secrets |
 
 Rules use **negative constraints** ("X does not exist") to implicitly guide AI, which is often more effective than positive descriptions.
+
+Canonical references for this contract:
+- Install/runtime contract: `schemas/install-modules.json`
+- Native rule source: `rules/claude-rules/`
+- Public summary of current rule surface: `docs/rule-reference.md`
 
 ### Hooks — Real-Time Interception
 
@@ -262,9 +278,9 @@ Hooks live in `~/.codex/hooks.json` (requires `codex_hooks = true` in `config.to
 | `Stop` | `stop-guard.sh` | Uncommitted changes gate |
 | `Stop` | `learn-evaluator.sh` | Session metrics collection |
 
-> **Note:** Codex PreToolUse/PostToolUse currently only supports the `Bash` matcher. Edit/Write guards (`pre-edit`, `post-edit`, `post-write`) are not yet deployable.
+> **Note:** Codex PreToolUse/PostToolUse currently only supports the `Bash` matcher. Edit/Write guards (`pre-edit`, `pre-write`, `post-edit`, `post-write`) and `analysis-paralysis` are not deployable on the native Codex CLI hook path.
 
-Codex hook command names are namespaced as `vibeguard-*.sh` to avoid collisions with other toolchains sharing `~/.codex/hooks.json`. Output format differences are handled by the `run-hook-codex.sh` wrapper (Claude Code `decision:block` → Codex `permissionDecision:deny`).
+Codex hook command names are namespaced as `vibeguard-*.sh` to avoid collisions with other toolchains sharing `~/.codex/hooks.json`. Output format differences are handled by the `run-hook-codex.sh` wrapper (Claude Code `decision:block` → Codex `permissionDecision:deny`). When a hook suggests `updatedInput`, the Codex CLI wrapper cannot apply it automatically, so VibeGuard emits an explicit note with the suggested replacement command instead of silently dropping it.
 
 **App-server wrapper** (Symphony-style orchestrators):
 
@@ -274,6 +290,8 @@ python3 ~/vibeguard/scripts/codex/app_server_wrapper.py --codex-command "codex a
 
 - `--strategy vibeguard` (default): applies pre/stop/post gates externally
 - `--strategy noop`: pure pass-through for debugging
+- App-server wrapper scope today: Bash approval interception + post-turn stop/build feedback with explicit `thread/session/turn` propagation
+- Still unsupported on app-server path: `pre-edit`, `pre-write`, `post-edit`, `post-write`, `analysis-paralysis`
 
 ### Use with any project
 

--- a/agents/dispatcher.md
+++ b/agents/dispatcher.md
@@ -11,6 +11,11 @@ tools: [Read, Grep, Glob, Bash]
 
 Analyze task descriptions and change files and route to the most appropriate professional agent.
 
+Boundary:
+- Workflow/lifecycle selection belongs to the higher-level workflow surface (`README.md`, `skills/`, `workflows/`).
+- This dispatcher only chooses the best role **within** the already chosen lifecycle.
+- If lifecycle and role routing disagree, lifecycle wins first and dispatcher refines inside that lane.
+
 ## Scheduling rules
 
 ### By error type (highest priority)

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -47,6 +47,17 @@ bash ~/vibeguard/setup.sh --check
 | [known-issues/false-positives.md](known-issues/false-positives.md) | 已知误报与修复经验 |
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | 贡献流程、验证命令、提交规范 |
 
+## 产品边界
+
+VibeGuard 现在明确分成两层：
+
+| 表面 | 范围 | canonical source |
+|------|------|------------------|
+| **VibeGuard Core** | 规则、hooks、静态 guards、安装/运行时契约、可观测性 | `rules/claude-rules/`、`schemas/install-modules.json`、`hooks/`、`guards/` |
+| **VibeGuard Workflows** | Slash Commands、agent prompts、规划/执行预设 | `skills/`、`workflows/`、`agents/` |
+
+如果这些表面之间冲突，先以 Core 契约为准，再同步 workflow 和文档。
+
 ## 工作方式
 
 ### 1. 规则注入
@@ -64,6 +75,11 @@ bash ~/vibeguard/setup.sh --check
 | L7 | 提交纪律 | 禁止 AI 标记、禁止 force push、禁止秘钥入库 |
 
 这里大量使用了“负约束”表达，例如“X 不存在”“不要假设 Y 已经有”，通常比纯正向描述更能稳定影响 agent 行为。
+
+当前 canonical 参考入口：
+- 安装/运行时契约：`schemas/install-modules.json`
+- 原生规则源：`rules/claude-rules/`
+- 当前规则摘要：`docs/rule-reference.md`
 
 ### 2. Hooks 实时拦截
 
@@ -205,9 +221,9 @@ VibeGuard 会同时给 Claude Code 和 Codex CLI 安装技能与 hooks。
 | `Stop` | `stop-guard.sh` | 未验证改动的结束闸门 |
 | `Stop` | `learn-evaluator.sh` | 会话指标与纠错信号采集 |
 
-> **注意：** Codex 目前的 PreToolUse/PostToolUse 只支持 `Bash` matcher，所以 `pre-edit`、`post-edit`、`post-write` 这类 hook 还不能部署到 Codex。
+> **注意：** Codex 目前的 PreToolUse/PostToolUse 只支持 `Bash` matcher，所以 `pre-edit`、`pre-write`、`post-edit`、`post-write` 以及 `analysis-paralysis` 这类 hook 还不能部署到原生 Codex CLI hook 路径。
 
-Codex 中的 hook 命令名会使用 `vibeguard-*.sh` 命名空间，避免与别的工具链共享 `~/.codex/hooks.json` 时发生冲突。Claude 和 Codex 输出格式差异则由 `run-hook-codex.sh` 负责适配。
+Codex 中的 hook 命令名会使用 `vibeguard-*.sh` 命名空间，避免与别的工具链共享 `~/.codex/hooks.json` 时发生冲突。Claude 和 Codex 输出格式差异则由 `run-hook-codex.sh` 负责适配。若 hook 给出 `updatedInput` 建议，Codex CLI wrapper 目前不能自动改写命令，VibeGuard 会显式提示建议命令，而不是静默吞掉这条信息。
 
 ### App Server 外层封装
 
@@ -219,6 +235,8 @@ python3 ~/vibeguard/scripts/codex/app_server_wrapper.py   --codex-command "codex
 
 - `--strategy vibeguard`：默认模式，在外层补上 pre/stop/post gate
 - `--strategy noop`：纯透传，方便调试
+- 当前 app-server wrapper 已覆盖：Bash 审批拦截，以及 turn 结束后的 stop/build 反馈，并会显式传递 `thread/session/turn` 上下文
+- 当前 app-server wrapper 仍未覆盖：`pre-edit`、`pre-write`、`post-edit`、`post-write`、`analysis-paralysis`
 
 ## 安装选项
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2,7 +2,11 @@
 
 > Status: historical design snapshot.
 > Some implementation details in this document no longer match the current repository layout.
-> Use `README.md`, `docs/rule-reference.md`, `CONTRIBUTING.md`, and the code under `hooks/`, `guards/`, and `scripts/` as the current source of truth.
+> Current canonical sources:
+> - `README.md` — product entry and Core vs Workflow boundary
+> - `docs/rule-reference.md` — current public rule/guard summary
+> - `schemas/install-modules.json` — install/runtime contract
+> - `rules/claude-rules/`, `hooks/`, `guards/`, `scripts/` — implementation source
 
 
 > Version: 1.0 | Update date: 2026-02-12

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -19,12 +19,6 @@ import sys
 import time
 from pathlib import Path
 
-try:
-    import anthropic
-except ImportError:
-    print("Anthropic SDK is required: uv pip install anthropic")
-    sys.exit(1)
-
 from samples import SAMPLES
 
 MODELS = {
@@ -33,28 +27,25 @@ MODELS = {
     "opus": "claude-opus-4-6",
 }
 
-RULES_DIR = Path.home() / ".claude" / "rules" / "vibeguard"
-CLAUDE_MD = Path.home() / ".claude" / "CLAUDE.md"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RULES_DIR = REPO_ROOT / "rules" / "claude-rules"
+DEFAULT_CORE_RULES_FILE = REPO_ROOT / "claude-md" / "vibeguard-rules.md"
 
 
-def load_rules() -> str:
-    """Load all VibeGuard rules from the actual rules file"""
+def load_rules(rules_dir: Path, core_rules_file: Path | None) -> str:
+    """Load all VibeGuard rules from the checked-out repository snapshot."""
     rules_text = []
 
-    #Load language rules
-    for rule_file in sorted(RULES_DIR.rglob("*.md")):
+    for rule_file in sorted(rules_dir.rglob("*.md")):
         content = rule_file.read_text()
-        # Remove frontmatter
         if content.startswith("---"):
             parts = content.split("---", 2)
             if len(parts) >= 3:
                 content = parts[2].strip()
         rules_text.append(f"# {rule_file.stem}\n\n{content}")
 
-    # Extract VibeGuard related parts from CLAUDE.md
-    if CLAUDE_MD.exists():
-        claude_md = CLAUDE_MD.read_text()
-        # Extract vibeguard paragraph
+    if core_rules_file and core_rules_file.exists():
+        claude_md = core_rules_file.read_text()
         in_vg = False
         vg_lines = []
         for line in claude_md.split("\n"):
@@ -68,6 +59,8 @@ def load_rules() -> str:
                 vg_lines.append(line)
         if vg_lines:
             rules_text.append("# VibeGuard Core Constraints\n\n" + "\n".join(vg_lines))
+        else:
+            rules_text.append("# VibeGuard Core Constraints\n\n" + claude_md.strip())
 
     return "\n\n---\n\n".join(rules_text)
 
@@ -85,7 +78,7 @@ When a user gives you code, you must:
 
 
 def evaluate_sample(
-    client: anthropic.Anthropic,
+    client,
     model: str,
     system_prompt: str,
     sample: dict,
@@ -154,12 +147,17 @@ def _all_rule_ids() -> list[str]:
 
 
 def run_eval(args):
-    rules = load_rules()
+    rules_dir = Path(args.rules_dir).resolve()
+    core_rules_file = Path(args.core_rules_file).resolve() if args.core_rules_file else None
+    rules = load_rules(rules_dir, core_rules_file)
     system_prompt = build_system_prompt(rules)
 
     if args.dry_run:
         print(f"Rule text length: {len(rules)} characters")
         print(f"Number of samples: {len(SAMPLES)}")
+        print(f"Rules source: {rules_dir}")
+        if core_rules_file:
+            print(f"Core constraint source: {core_rules_file}")
         print(f"\nSample list:")
         for s in SAMPLES:
             tag = "FP" if s["rule"] == "NONE" else s["rule"]
@@ -184,6 +182,11 @@ def run_eval(args):
         print(f"Number of samples after type filtering: {len(samples)} (Type: {args.type})")
 
     model = MODELS.get(args.model, args.model)
+    try:
+        import anthropic
+    except ImportError:
+        print("Anthropic SDK is required: uv pip install anthropic")
+        sys.exit(1)
     client = anthropic.Anthropic()
 
     print(f"Model: {model}")
@@ -324,6 +327,16 @@ def main():
     parser.add_argument("--rules", help="Rule prefix filtering (such as SEC, PY, TS, GO, RS)")
     parser.add_argument("--type", choices=["tp", "fp"], help="Sample type filtering: tp=violation, fp=legal")
     parser.add_argument("--dry-run", action="store_true", help="Only display samples without adjusting API")
+    parser.add_argument(
+        "--rules-dir",
+        default=str(DEFAULT_RULES_DIR),
+        help="Rule directory to load (defaults to repository rules snapshot)",
+    )
+    parser.add_argument(
+        "--core-rules-file",
+        default=str(DEFAULT_CORE_RULES_FILE),
+        help="Core constraint snippet file to append (defaults to repository snapshot)",
+    )
     args = parser.parse_args()
     run_eval(args)
 

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -37,7 +37,7 @@ def load_rules(rules_dir: Path, core_rules_file: Path | None) -> str:
     rules_text = []
 
     for rule_file in sorted(rules_dir.rglob("*.md")):
-        content = rule_file.read_text()
+        content = rule_file.read_text(encoding="utf-8")
         if content.startswith("---"):
             parts = content.split("---", 2)
             if len(parts) >= 3:
@@ -45,7 +45,7 @@ def load_rules(rules_dir: Path, core_rules_file: Path | None) -> str:
         rules_text.append(f"# {rule_file.stem}\n\n{content}")
 
     if core_rules_file and core_rules_file.exists():
-        claude_md = core_rules_file.read_text()
+        claude_md = core_rules_file.read_text(encoding="utf-8")
         in_vg = False
         vg_lines = []
         for line in claude_md.split("\n"):

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -4,7 +4,7 @@
 # The I/O formats of Codex CLI hooks and Claude Code hooks are different:
 # - PreToolUse block: Codex requires hookSpecificOutput.permissionDecision="deny"
 # - PreToolUse warn: Codex uses systemMessage
-# - updatedInput (correction): Codex is not supported, silently skipped
+# - updatedInput (correction): Codex CLI cannot apply it directly, emit an explicit note instead
 # - SessionStart/Stop: The format is basically compatible, direct transparent transmission
 #
 # Usage: bash run-hook-codex.sh <hook-script-name> [args...]
@@ -69,6 +69,7 @@ except Exception:
 
 decision = data.get('decision', 'pass')
 reason = data.get('reason', '')
+updated = data.get('updatedInput')
 
 if decision == 'block':
     print(json.dumps({
@@ -80,7 +81,15 @@ if decision == 'block':
     }, ensure_ascii=False))
 elif decision == 'warn':
     print(json.dumps({'systemMessage': reason}, ensure_ascii=False))
-# correction (updatedInput) — Not supported by Codex, skip
+elif decision == 'allow' and isinstance(updated, dict):
+    command = updated.get('command')
+    if isinstance(command, str) and command:
+        print(json.dumps({
+            'systemMessage': (
+                'VIBEGUARD note: Codex CLI hooks cannot auto-apply command rewrites. '
+                'Suggested command: ' + command
+            )
+        }, ensure_ascii=False))
 " 2>/dev/null
 elif [[ "$EVENT_NAME" == "PostToolUse" ]]; then
   echo "$HOOK_OUTPUT" | python3 -c "

--- a/plan/2026-04-19_00-15-39-main-architecture-convergence.md
+++ b/plan/2026-04-19_00-15-39-main-architecture-convergence.md
@@ -1,0 +1,385 @@
+---
+mode: plan
+cwd: /Users/lifcc/Desktop/code/AI/tools/vibeguard
+task: Converge latest main architecture debt into a single-source-of-truth install/runtime/verification model
+complexity: complex
+planning_method: plan-flow
+created_at: 2026-04-19T00:15:39+08:00
+source_ref: origin/main@17504d0
+---
+
+# VibeGuard main architecture convergence plan
+
+- Planned version: v1
+- Applicable repository: `/Users/lifcc/Desktop/code/AI/tools/vibeguard`
+- Execution mode: analyze root cause -> change one step -> run step tests -> update plan -> continue
+
+## 0. Execution constraints (DoR)
+
+- Objective: remove the current split-brain design across rule metadata, install/runtime behavior, client capability handling, and verification gates without adding new runtime dependencies.
+- Compatibility: required
+- Submission strategy: milestone
+- Guardrails:
+  - No new user-facing feature work until `P0` fail-open/runtime issues are closed.
+  - Prefer generated or manifest-driven surfaces over more prose duplication.
+  - Keep client capability differences explicit instead of silently degrading behavior.
+- Test strategy:
+  - Step level: at least 1 targeted contract test plus 1 nearby health check for each step.
+  - Final: full repo regression matrix on supported platforms plus deterministic manifest/document validation.
+
+## 1. Analysis results (before changes)
+
+- Architecture inventory summary:
+  - Install entry: `setup.sh`, `scripts/setup/install.sh`, `scripts/setup/check.sh`, `scripts/setup/clean.sh`
+  - Client target adapters: `scripts/setup/targets/claude-home.sh`, `scripts/setup/targets/codex-home.sh`
+  - Runtime adapters: `hooks/run-hook.sh`, `hooks/run-hook-codex.sh`, `scripts/codex/app_server_wrapper.py`
+  - Metadata surfaces: `rules/claude-rules/**`, `rules/*.md`, `docs/rule-reference.md`, `schemas/install-modules.json`, `schemas/vibeguard-project.schema.json`
+  - Verification surfaces: `.github/workflows/ci.yml`, `tests/test_hooks.sh`, `tests/test_setup.sh`, `tests/run_precision.sh`, `eval/run_eval.py`
+  - Product/workflow surfaces: `README.md`, `docs/README_CN.md`, `docs/spec.md`, `skills/vibeguard/SKILL.md`, `agents/dispatcher.md`, `workflows/**`
+- Root-cause findings:
+
+| id | category | files and symbols | evidence | impact | risk | suggested convergence |
+|----|----------|-------------------|----------|--------|------|-----------------------|
+| F1 | fail-open runtime adapter | `scripts/codex/app_server_wrapper.py::on_server_notification`, `hooks/post-build-check.sh`, `hooks/learn-evaluator.sh` | post-turn hooks run but outputs are discarded, so Codex app-server never sees stop/build feedback | critical | high | make hook results first-class protocol events and expose degraded-mode explicitly |
+| F2 | split install contract | `scripts/lib/settings_json.py`, `scripts/lib/codex_hooks_json.py`, `schemas/install-modules.json`, `schemas/vibeguard-project.schema.json` | profile names and module composition diverge across code, schema, and docs | high | high | define one canonical install/capability manifest and generate/validate secondary surfaces |
+| F3 | runtime artifact split | `scripts/setup/install.sh`, `hooks/run-hook.sh`, `scripts/install-hook.sh`, `scripts/project-init.sh` | Claude/Codex use installed snapshot while Git hooks still point at live repo | high | medium | unify all runtime entrypoints on installed snapshot plus shared wrapper stack |
+| F4 | verification false confidence | `.github/workflows/ci.yml`, `tests/run_precision.sh`, `tests/test_hooks.sh`, `eval/run_eval.py`, `scripts/benchmark.sh` | Windows lane mostly skips behavior tests, precision never fails CI, rewrite path is provisioned but skipped, eval reads `$HOME` | high | medium | convert CI from report-first to contract-first and pin eval inputs to repo snapshot |
+| F5 | product/document surface sprawl | `README.md`, `docs/README_CN.md`, `docs/spec.md`, `skills/vibeguard/SKILL.md`, `agents/dispatcher.md`, `workflows/**` | planning and routing are duplicated across too many top-level surfaces | medium | medium | separate canonical contract from generated/localized/preset surfaces |
+
+## 2. Detailed steps
+
+### Phase P0 Runtime correctness first
+
+### Step P0.1 Define and codify the client capability matrix
+
+- status: `completed`
+- Target: create a single capability source that states what Claude, Codex CLI, Codex app-server, and Git hooks can actually support.
+- Expected changes to files:
+  - `schemas/install-modules.json`
+  - `scripts/setup/targets/codex-home.sh`
+  - `scripts/lib/codex_hooks_json.py`
+  - `README.md`
+  - `docs/README_CN.md`
+- Detailed changes:
+  - Add a canonical capability table covering hook events, `updatedInput`, post-turn feedback, and profile semantics per client.
+  - Remove ambiguous wording that implies Claude and Codex share the same profile behavior when they do not.
+  - Make unsupported features explicit and testable rather than silently omitted.
+- step-level test command:
+  - `python3 -m py_compile scripts/lib/codex_hooks_json.py`
+  - `bash tests/test_setup.sh`
+- Completion judgment:
+  - One source defines per-client capability and profile behavior.
+  - Docs and setup code reference the same capability model.
+
+### Step P0.2 Fix Codex app-server post-turn fail-open behavior
+
+- status: `completed`
+- Target: ensure post-turn hook outputs are delivered back to the client instead of being computed and discarded.
+- Expected changes to files:
+  - `scripts/codex/app_server_wrapper.py`
+  - `hooks/post-build-check.sh`
+  - `hooks/learn-evaluator.sh`
+  - `tests/test_hooks.sh`
+  - `tests/test_setup.sh`
+- Detailed changes:
+  - Translate stop/build/learn hook results into outbound app-server notifications.
+  - Preserve hook severity and message content in the adapter rather than dropping `HookResult`.
+  - Add regression coverage for post-turn feedback flow.
+- step-level test command:
+  - `python3 -m py_compile scripts/codex/app_server_wrapper.py`
+  - `bash tests/test_hooks.sh`
+- Completion judgment:
+  - Codex app-server path surfaces post-turn warnings/stop reasons to the client.
+  - No hook result is silently discarded on the supported path.
+
+### Step P0.3 Replace process-ancestry session guessing with explicit runtime context
+
+- status: `completed`
+- Target: stop deriving hook identity from `ps` heuristics when the adapter already knows thread/session context.
+- Expected changes to files:
+  - `scripts/codex/app_server_wrapper.py`
+  - `hooks/log.sh`
+  - `hooks/analysis-paralysis-guard.sh`
+  - `hooks/post-build-check.sh`
+  - `tests/test_hook_health.sh`
+- Detailed changes:
+  - Pass stable client/thread/turn/session env vars into hook subprocesses.
+  - Make log-based counters consume explicit session identifiers.
+  - Narrow tail-scan logic so it keys off real session context, not guessed parent ancestry.
+- step-level test command:
+  - `bash tests/test_hook_health.sh`
+  - `bash tests/test_hooks.sh`
+- Completion judgment:
+  - Hook metrics and escalation logic use explicit adapter context.
+  - Session attribution no longer depends on local process ancestry.
+
+### Phase P1 Contract and metadata convergence
+
+### Step P1.1 Introduce a canonical manifest for rules, profiles, and install modules
+
+- status: `completed`
+- Target: create one authoritative manifest from which rule metadata, profile composition, and suppressible IDs can be derived.
+- Expected changes to files:
+  - `schemas/install-modules.json`
+  - `schemas/vibeguard-project.schema.json`
+  - `rules/claude-rules/**`
+  - `scripts/verify/doc-freshness-check.sh`
+  - `scripts/setup/**`
+- Detailed changes:
+  - Define canonical entities: rule id, title, severity, scope, profile/module membership, guard mapping, suppressibility.
+  - Remove undefined or impossible module references such as `hooks-strict`.
+  - Normalize profile vocabulary so install/runtime/schema/docs use the same names.
+- step-level test command:
+  - `bash scripts/verify/doc-freshness-check.sh --strict`
+  - `bash tests/test_setup.sh`
+- Completion judgment:
+  - Profile and module definitions are machine-verifiable and consistent.
+  - Secondary surfaces stop inventing their own profile semantics.
+
+### Step P1.2 Split repository consistency checks from install-state checks
+
+- status: `completed`
+- Target: make repository audits deterministic and independent from a contributor's local `$HOME` state.
+- Expected changes to files:
+  - `scripts/verify/doc-freshness-check.sh`
+  - `scripts/setup/check.sh`
+  - `scripts/setup/targets/claude-home.sh`
+  - `README.md`
+- Detailed changes:
+  - Separate repo-local graph validation from installed-rule drift inspection.
+  - Ensure `--check` is read-only and does not mutate `~/.claude/CLAUDE.md`.
+  - Add a dedicated repair path for any mutable drift remediation.
+- step-level test command:
+  - `bash tests/test_setup.sh`
+  - `bash scripts/verify/doc-freshness-check.sh --strict`
+- Completion judgment:
+  - Repo validation gives the same answer on different machines for the same commit.
+  - `setup.sh --check` has no side effects.
+
+### Step P1.3 Make Codex and Claude config mutation structured and portable
+
+- status: `completed`
+- Target: eliminate shell text-edit drift in user config files.
+- Expected changes to files:
+  - `scripts/setup/targets/codex-home.sh`
+  - `scripts/lib/settings_json.py`
+  - `scripts/lib/codex_hooks_json.py`
+  - `tests/test_setup.sh`
+- Detailed changes:
+  - Move `config.toml` mutation into a structured helper instead of `sed -i ''`.
+  - Keep JSON/TOML writes atomic and verifiable.
+  - Fail install when required flags or managed hooks cannot be confirmed.
+- step-level test command:
+  - `python3 -m py_compile scripts/lib/settings_json.py scripts/lib/codex_hooks_json.py`
+  - `bash tests/test_setup.sh`
+- Completion judgment:
+  - Install behavior is portable across macOS/Linux for existing user config files.
+  - Setup does not report success when required features remain disabled.
+
+### Phase P2 Verification and surface reduction
+
+### Step P2.1 Turn CI into a true contract gate
+
+- status: `completed`
+- Target: make the highest-risk paths fail CI when they regress.
+- Expected changes to files:
+  - `.github/workflows/ci.yml`
+  - `tests/run_precision.sh`
+  - `tests/test_hooks.sh`
+  - `scripts/benchmark.sh`
+  - `tests/test_precision_tracker.sh`
+- Detailed changes:
+  - Convert precision into metrics + threshold gate instead of metrics-only.
+  - Enable the `updatedInput` rewrite branch in CI.
+  - Either add real behavioral Windows checks or explicitly downgrade Windows from required support.
+  - Add missing contract coverage for wrappers and scorecard paths.
+- step-level test command:
+  - `bash tests/run_precision.sh --all --csv`
+  - `bash tests/test_hooks.sh`
+  - `bash tests/test_precision_tracker.sh`
+- Completion judgment:
+  - CI red/green status tracks actual regression risk instead of report generation.
+  - The command rewrite path is exercised in automation.
+
+### Step P2.2 Pin evals and benchmarks to the repository snapshot
+
+- status: `completed`
+- Target: make model/rule evaluation reproducible from the checked-out repo rather than local installed state.
+- Expected changes to files:
+  - `eval/run_eval.py`
+  - `scripts/benchmark.sh`
+  - `docs/benchmark-design.md`
+  - `.github/workflows/ci.yml`
+- Detailed changes:
+  - Load rules and prompts from repo-managed inputs by default.
+  - Add a deterministic subset suitable for CI smoke evaluation.
+  - Document the difference between local exploratory eval and repo-gated eval.
+- step-level test command:
+  - `python3 -m py_compile eval/run_eval.py`
+  - `bash scripts/benchmark.sh --mode=fast`
+- Completion judgment:
+  - Eval behavior is reproducible from the repo snapshot.
+  - Benchmarks stop hiding execution failures behind reporting output.
+
+### Step P2.3 Reduce product surface duplication and make one canonical workflow path
+
+- status: `completed`
+- Target: separate core enforcement runtime from optional workflow presets and reduce documentation drift.
+- Expected changes to files:
+  - `README.md`
+  - `docs/README_CN.md`
+  - `docs/spec.md`
+  - `skills/vibeguard/SKILL.md`
+  - `agents/dispatcher.md`
+  - `workflows/**`
+- Detailed changes:
+  - Declare one canonical lifecycle for planning/execution and treat workflow variants as presets.
+  - Split docs into canonical, generated, and localized responsibilities.
+  - Reframe README around `VibeGuard Core` vs `VibeGuard Workflows`.
+- step-level test command:
+  - `bash scripts/ci/validate-doc-paths.sh`
+  - `bash scripts/ci/validate-doc-command-paths.sh`
+  - `bash scripts/verify/doc-freshness-check.sh --strict`
+- Completion judgment:
+  - New contributors can identify one primary flow and one canonical contract.
+  - Command tables and workflow descriptions are no longer hand-maintained in multiple places.
+
+## 3. Regression test matrix
+
+- After P0:
+  - `bash tests/test_hooks.sh`
+  - `bash tests/test_setup.sh`
+  - `bash tests/test_hook_health.sh`
+- After P1:
+  - `bash scripts/verify/doc-freshness-check.sh --strict`
+  - `bash tests/test_setup.sh`
+  - `bash scripts/ci/validate-doc-paths.sh`
+- After P2:
+  - `bash tests/run_precision.sh --all --csv`
+  - `bash tests/test_precision_tracker.sh`
+  - `bash tests/unit/run_all.sh`
+  - `bash tests/test_rust_guards.sh`
+  - `bash scripts/benchmark.sh --mode=fast`
+- Final supported-platform matrix:
+  - `bash tests/test_hooks.sh`
+  - `bash tests/test_setup.sh`
+  - `bash tests/test_hook_health.sh`
+  - `bash tests/run_precision.sh --all --csv`
+  - `bash tests/unit/run_all.sh`
+  - `bash tests/test_rust_guards.sh`
+  - `bash scripts/verify/doc-freshness-check.sh --strict`
+  - `bash scripts/ci/validate-doc-paths.sh`
+  - `bash scripts/ci/validate-doc-command-paths.sh`
+
+## 4. Milestone acceptance criteria
+
+- P0 accepted when:
+  - Codex app-server no longer drops post-turn hook feedback.
+  - Session attribution and escalation logic use explicit runtime context.
+  - Capability differences are declared instead of silently skipped.
+- P1 accepted when:
+  - One canonical manifest drives profile/module/rule semantics.
+  - Repo validation is deterministic and `setup.sh --check` is read-only.
+  - Config mutation is portable and structured.
+- P2 accepted when:
+  - CI meaningfully blocks high-risk regressions.
+  - Eval and benchmark flows are repo-snapshot based.
+  - README/doc/workflow surfaces reduce to one primary contract plus documented presets.
+
+## 5. Execution Log
+
+- 2026-04-19
+  - Plan authored: `completed`
+    - Evidence:
+      - Based on latest `origin/main` audit at `17504d0`
+      - Integrated five parallel review lanes: install/runtime, rule metadata, hook runtime, verification, and product cohesion
+    - Next recommended implementation step:
+      - `P0.1 Define and codify the client capability matrix`
+  - Step P0: `completed`
+    - Modified files:
+      - `scripts/codex/app_server_wrapper.py`
+      - `hooks/run-hook-codex.sh`
+      - `scripts/setup/targets/codex-home.sh`
+      - `README.md`
+      - `docs/README_CN.md`
+      - `tests/test_codex_runtime.sh`
+      - `.github/workflows/ci.yml`
+    - Main changes:
+      - Added explicit app-server feedback attachment on `turn/completed` so stop/build/learn hook results are no longer dropped.
+      - Propagated stable `session/thread/turn` context from the app-server adapter into hook subprocesses.
+      - Replaced silent Codex CLI `updatedInput` loss with an explicit suggestion message.
+      - Documented the current Codex capability boundary in setup output and user-facing docs.
+      - Added a dedicated Codex runtime regression test and wired it into non-Windows CI.
+    - Execute tests:
+      - `python3 -m py_compile scripts/codex/app_server_wrapper.py` -> pass
+      - `bash tests/test_codex_runtime.sh` -> pass
+      - `bash tests/test_hook_health.sh` -> pass
+      - `bash tests/test_setup.sh` -> pass
+      - `bash scripts/ci/validate-doc-command-paths.sh` -> pass
+      - `bash scripts/ci/validate-doc-paths.sh` -> fail before cleanup, then fixed by updating the allowlist and removing non-PR-only path references
+  - Step P1: `completed`
+    - Modified files:
+      - `schemas/install-modules.json`
+      - `schemas/vibeguard-project.schema.json`
+      - `scripts/lib/vibeguard_manifest.py`
+      - `scripts/lib/codex_config_toml.py`
+      - `scripts/setup/lib.sh`
+      - `scripts/setup/install.sh`
+      - `scripts/setup/targets/claude-home.sh`
+      - `scripts/setup/targets/codex-home.sh`
+      - `scripts/verify/doc-freshness-check.sh`
+      - `docs/rule-reference.md`
+      - `tests/test_setup.sh`
+      - `tests/test_manifest_contract.sh`
+    - Main changes:
+      - Promoted `schemas/install-modules.json` into the canonical install/profile contract and removed stale entries such as `hooks-strict` and auto-installed `skills-loader`.
+      - Added a manifest helper plus a structured Codex TOML helper so profile/schema/config drift can be validated and updated from one place.
+      - Made `setup.sh --check` read-only and switched `doc-freshness` to repo-only deterministic validation.
+    - Execute tests:
+      - `python3 scripts/lib/vibeguard_manifest.py validate` -> pass
+      - `bash tests/test_manifest_contract.sh` -> pass
+      - `bash tests/test_setup.sh` -> pass
+      - `bash scripts/verify/doc-freshness-check.sh --strict` -> pass
+      - `bash scripts/ci/validate-manifest-contract.sh` -> pass
+  - Step P2: `completed`
+    - Modified files:
+      - `.github/workflows/ci.yml`
+      - `.vibeguard-doc-paths-allowlist`
+      - `eval/run_eval.py`
+      - `scripts/benchmark.sh`
+      - `scripts/ci/validate-manifest-contract.sh`
+      - `scripts/ci/validate-precision-thresholds.sh`
+      - `README.md`
+      - `docs/README_CN.md`
+      - `docs/spec.md`
+      - `skills/vibeguard/SKILL.md`
+      - `agents/dispatcher.md`
+      - `tests/test_eval_contract.sh`
+    - Main changes:
+      - Split Unix behavioral CI from Windows smoke coverage, enabled rewrite-path testing, and added manifest/eval/precision contract gates.
+      - Switched eval and benchmark defaults to the checked-out repository snapshot instead of `$HOME` state.
+      - Clarified `VibeGuard Core` vs `VibeGuard Workflows` and pointed historical surfaces back to canonical sources.
+    - Execute tests:
+      - `bash tests/test_eval_contract.sh` -> pass
+      - `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh` -> pass
+      - `bash tests/test_precision_tracker.sh` -> pass
+      - `bash scripts/ci/validate-precision-thresholds.sh` -> pass
+      - `bash scripts/ci/validate-doc-paths.sh` -> pass
+      - `bash scripts/ci/validate-doc-command-paths.sh` -> pass
+      - `bash scripts/benchmark.sh --mode=fast` -> pass
+
+## 6. References
+
+- `scripts/codex/app_server_wrapper.py:198`
+- `hooks/run-hook-codex.sh:20`
+- `hooks/log.sh:109`
+- `scripts/setup/install.sh:111`
+- `scripts/setup/targets/codex-home.sh:44`
+- `scripts/lib/settings_json.py:210`
+- `schemas/install-modules.json:248`
+- `schemas/vibeguard-project.schema.json:7`
+- `scripts/verify/doc-freshness-check.sh:22`
+- `.github/workflows/ci.yml:66`
+- `tests/run_precision.sh:467`
+- `eval/run_eval.py:36`
+- `README.md:156`

--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -5,7 +5,7 @@
     {
       "id": "rules-common",
       "kind": "rules",
-      "description": "Common rules (U-01 to U-31, W-01 to W-13, SEC-01 to SEC-13)",
+      "description": "Common rules (U-01 to U-32, W-01 to W-17, SEC-01 to SEC-12)",
       "paths": [
         "rules/claude-rules/common/coding-style.md",
         "rules/claude-rules/common/data-consistency.md",
@@ -90,7 +90,6 @@
       "paths": [
         "hooks/post-edit-guard.sh",
         "hooks/post-write-guard.sh",
-        "hooks/skills-loader.sh",
         "hooks/analysis-paralysis-guard.sh"
       ],
       "target": "settings.json:PostToolUse",
@@ -266,9 +265,9 @@
       "modules": ["hooks-full"]
     },
     "strict": {
-      "description": "Maximum enforcement — full + session tagger + cognitive reminder",
+      "description": "Maximum enforcement — same hook set as full, reserved for stricter runtime policy",
       "extends": "full",
-      "modules": ["hooks-strict"]
+      "modules": []
     }
   }
 }

--- a/schemas/vibeguard-project.schema.json
+++ b/schemas/vibeguard-project.schema.json
@@ -6,9 +6,9 @@
   "properties": {
     "profile": {
       "type": "string",
-      "enum": ["minimal", "standard", "strict"],
-      "default": "standard",
-      "description": "Runtime enforcement profile. minimal=pre-hooks only, standard=core+full, strict=all+extra checks"
+      "enum": ["minimal", "core", "full", "strict"],
+      "default": "core",
+      "description": "Runtime enforcement profile. minimal=pre-hooks only, core=standard runtime hooks, full=core plus stop/build hooks, strict=same hook set as full with stricter policy"
     },
     "enforcement": {
       "type": "string",
@@ -26,19 +26,63 @@
     },
     "disabled_hooks": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string",
+        "enum": [
+          "analysis-paralysis-guard",
+          "learn-evaluator",
+          "post-build-check",
+          "post-edit-guard",
+          "post-write-guard",
+          "pre-bash-guard",
+          "pre-commit-guard",
+          "pre-edit-guard",
+          "pre-write-guard",
+          "skills-loader",
+          "stop-guard"
+        ]
+      },
       "default": [],
       "description": "Hook names to disable (without .sh extension). e.g. [\"post-edit-guard\", \"analysis-paralysis-guard\"]"
     },
     "disabled_rules": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string",
+        "pattern": "^(SEC|RS|GO|TS|PY|U|W|TASTE)-[A-Za-z0-9-]+$"
+      },
       "default": [],
-      "description": "Rule IDs to suppress. e.g. [\"U-02\", \"W-13\"]"
+      "description": "Rule IDs to suppress. Canonical ids come from rules/claude-rules/. e.g. [\"U-02\", \"W-13\"]"
     },
     "disabled_guards": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string",
+        "enum": [
+          "check_any_abuse",
+          "check_circular_deps",
+          "check_code_slop",
+          "check_component_duplication",
+          "check_console_residual",
+          "check_dead_shims",
+          "check_declaration_execution_gap",
+          "check_defer_in_loop",
+          "check_dependency_layers",
+          "check_duplicate_constants",
+          "check_duplicate_types",
+          "check_duplicates",
+          "check_error_handling",
+          "check_goroutine_leak",
+          "check_naming_convention",
+          "check_nested_locks",
+          "check_semantic_effect",
+          "check_single_source_of_truth",
+          "check_taste_invariants",
+          "check_test_integrity",
+          "check_unwrap_in_prod",
+          "check_workspace_consistency"
+        ]
+      },
       "default": [],
       "description": "Guard script names to skip. e.g. [\"check_unwrap_in_prod\", \"check_any_abuse\"]"
     }

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -40,7 +40,7 @@ echo ""
 # ============================================================
 
 echo "[Layer 1: Hook precision]"
-L1_CSV=$(bash "$REPO_DIR/tests/run_precision.sh" --all --csv 2>/dev/null || true)
+L1_CSV=$(bash "$REPO_DIR/tests/run_precision.sh" --all --csv 2>/dev/null)
 
 # Parse CSV calculation indicators
 L1_RESULT=$(echo "$L1_CSV" | python3 -c "
@@ -120,7 +120,7 @@ if [[ "$MODE" == "standard" ]] || [[ "$MODE" == "full" ]]; then
   fi
 
   # Run LLM-as-Judge evaluation
-  L2_OUTPUT=$(cd "$REPO_DIR" && python3 eval/run_eval.py --model "$L2_MODEL" $L2_RULES_FLAG 2>&1 || true)
+  L2_OUTPUT=$(cd "$REPO_DIR" && python3 eval/run_eval.py --model "$L2_MODEL" $L2_RULES_FLAG 2>&1)
 
   # Read results from results.json
   if [[ -f "$REPO_DIR/eval/results.json" ]]; then

--- a/scripts/ci/validate-manifest-contract.sh
+++ b/scripts/ci/validate-manifest-contract.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+python3 "${REPO_DIR}/scripts/lib/vibeguard_manifest.py" validate

--- a/scripts/ci/validate-precision-thresholds.sh
+++ b/scripts/ci/validate-precision-thresholds.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+MIN_PRECISION="${MIN_PRECISION:-75}"
+MIN_RECALL="${MIN_RECALL:-75}"
+MIN_F1="${MIN_F1:-75}"
+
+CSV_OUTPUT="$(bash "${REPO_DIR}/tests/run_precision.sh" --all --csv)"
+
+VG_PRECISION_CSV="${CSV_OUTPUT}" python3 - "$MIN_PRECISION" "$MIN_RECALL" "$MIN_F1" <<'PY'
+from __future__ import annotations
+
+import csv
+import io
+import os
+import sys
+
+min_precision = float(sys.argv[1])
+min_recall = float(sys.argv[2])
+min_f1 = float(sys.argv[3])
+
+text = os.environ.get("VG_PRECISION_CSV", "").strip()
+if not text:
+    print("FAIL: no CSV output from tests/run_precision.sh", file=sys.stderr)
+    raise SystemExit(1)
+
+reader = csv.DictReader(io.StringIO(text))
+rows = list(reader)
+if not rows:
+    print("FAIL: zero precision rows parsed from CSV output", file=sys.stderr)
+    raise SystemExit(1)
+
+tp = fp = fn = 0
+for row in rows:
+    case_type = row.get("type", "")
+    detected = row.get("detected", "0")
+    try:
+        detected_int = int(detected)
+    except ValueError:
+        print(f"FAIL: invalid detected value {detected!r}", file=sys.stderr)
+        raise SystemExit(1)
+    if case_type == "tp":
+        if detected_int:
+            tp += 1
+        else:
+            fn += 1
+    elif case_type == "fp":
+        if detected_int:
+            fp += 1
+
+precision = tp / (tp + fp) * 100 if (tp + fp) else 0.0
+recall = tp / (tp + fn) * 100 if (tp + fn) else 0.0
+f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+print(f"Precision: {precision:.1f}% (threshold {min_precision:.1f}%)")
+print(f"Recall: {recall:.1f}% (threshold {min_recall:.1f}%)")
+print(f"F1: {f1:.1f}% (threshold {min_f1:.1f}%)")
+print(f"TP={tp} FP={fp} FN={fn} cases={len(rows)}")
+
+if precision < min_precision or recall < min_recall or f1 < min_f1:
+    raise SystemExit(1)
+PY

--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -25,15 +26,44 @@ from pathlib import Path
 from typing import Any, Callable
 
 
+CODEX_APP_SERVER_CAPABILITIES: dict[str, bool] = {
+    "pre_bash_guard": True,
+    "command_rewrite": True,
+    "post_turn_feedback": True,
+    "pre_edit_guard": False,
+    "pre_write_guard": False,
+    "post_edit_guard": False,
+    "post_write_guard": False,
+    "analysis_paralysis_guard": False,
+}
+
+
+@dataclass
+class ThreadState:
+    cwd: str | None = None
+    session_id: str | None = None
+    turn_id: str | None = None
+
+
 @dataclass
 class SessionState:
-    thread_cwd: dict[str, str] = field(default_factory=dict)
+    threads: dict[str, ThreadState] = field(default_factory=dict)
+
+    def ensure_thread(self, thread_id: str) -> ThreadState:
+        state = self.threads.get(thread_id)
+        if state is None:
+            state = ThreadState(session_id=_session_id_for_thread(thread_id))
+            self.threads[thread_id] = state
+        elif not state.session_id:
+            state.session_id = _session_id_for_thread(thread_id)
+        return state
 
 
 @dataclass
 class HookResult:
     decision: str
     output: str
+    payloads: list[dict[str, Any]] = field(default_factory=list)
     updated_command: str | None = None
 
 
@@ -42,11 +72,20 @@ class HookRunner:
         self.repo_dir = repo_dir
         self.hooks_dir = repo_dir / "hooks"
 
-    def run(self, hook_name: str, payload: dict[str, Any], cwd: str | None = None) -> HookResult:
+    def run(
+        self,
+        hook_name: str,
+        payload: dict[str, Any],
+        cwd: str | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> HookResult:
         hook_path = self.hooks_dir / hook_name
         if not hook_path.exists():
             return HookResult(decision="pass", output="")
 
+        env = os.environ.copy()
+        if env_overrides:
+            env.update(env_overrides)
         try:
             proc = subprocess.run(
                 ["bash", str(hook_path)],
@@ -54,6 +93,7 @@ class HookRunner:
                 text=True,
                 capture_output=True,
                 cwd=cwd,
+                env=env,
             )
         except OSError as exc:
             print(
@@ -63,32 +103,57 @@ class HookRunner:
             )
             return HookResult(decision="pass", output="")
         output = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
-        decision = self._extract_decision(output) or "pass"
-        updated_command = self._extract_updated_command(output) if decision == "allow" else None
-        return HookResult(decision=decision, output=output.strip(), updated_command=updated_command)
+        payloads = self._extract_payloads(output)
+        decision = self._extract_decision(output, payloads) or "pass"
+        updated_command = self._extract_updated_command(payloads) if decision == "allow" else None
+        return HookResult(
+            decision=decision,
+            output=output.strip(),
+            payloads=payloads,
+            updated_command=updated_command,
+        )
 
     @staticmethod
-    def _extract_decision(output: str) -> str | None:
+    def _extract_payloads(output: str) -> list[dict[str, Any]]:
+        payloads: list[dict[str, Any]] = []
+        stripped = output.strip()
+        if not stripped:
+            return payloads
+
+        candidates: list[str] = [stripped]
+        candidates.extend(line.strip() for line in output.splitlines() if line.strip())
+        seen: set[str] = set()
+        for candidate in candidates:
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            try:
+                data = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict):
+                payloads.append(data)
+        return payloads
+
+    @staticmethod
+    def _extract_decision(output: str, payloads: list[dict[str, Any]]) -> str | None:
+        for payload in payloads:
+            decision = payload.get("decision")
+            if isinstance(decision, str):
+                return decision
         match = re.search(r'"decision"\s*:\s*"([a-zA-Z_-]+)"', output)
         if match:
             return match.group(1)
         return None
 
     @staticmethod
-    def _extract_updated_command(output: str) -> str | None:
-        for line in output.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                data = json.loads(line)
-                if isinstance(data, dict):
-                    updated = data.get("updatedInput")
-                    if isinstance(updated, dict):
-                        cmd = updated.get("command")
-                        return cmd if isinstance(cmd, str) else None
-            except json.JSONDecodeError:
-                continue
+    def _extract_updated_command(payloads: list[dict[str, Any]]) -> str | None:
+        for payload in payloads:
+            updated = payload.get("updatedInput")
+            if isinstance(updated, dict):
+                cmd = updated.get("command")
+                if isinstance(cmd, str):
+                    return cmd
         return None
 
 
@@ -108,7 +173,7 @@ class GateStrategy(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def on_server_notification(self, message: dict[str, Any], state: SessionState) -> None:
+    def on_server_notification(self, message: dict[str, Any], state: SessionState) -> dict[str, Any]:
         raise NotImplementedError
 
 
@@ -125,8 +190,9 @@ class NoopGateStrategy(GateStrategy):
         del message, state, write_to_server
         return False
 
-    def on_server_notification(self, message: dict[str, Any], state: SessionState) -> None:
-        del message, state
+    def on_server_notification(self, message: dict[str, Any], state: SessionState) -> dict[str, Any]:
+        del state
+        return message
 
 
 class VibeGuardGateStrategy(GateStrategy):
@@ -142,13 +208,20 @@ class VibeGuardGateStrategy(GateStrategy):
         if method == "thread/start":
             thread_id = params.get("threadId")
             cwd = params.get("cwd")
-            if isinstance(thread_id, str) and isinstance(cwd, str) and cwd:
-                state.thread_cwd[thread_id] = cwd
+            if isinstance(thread_id, str):
+                thread = state.ensure_thread(thread_id)
+                if isinstance(cwd, str) and cwd:
+                    thread.cwd = cwd
         elif method == "turn/start":
             thread_id = params.get("threadId")
             cwd = params.get("cwd")
-            if isinstance(thread_id, str) and isinstance(cwd, str) and cwd:
-                state.thread_cwd[thread_id] = cwd
+            if isinstance(thread_id, str):
+                thread = state.ensure_thread(thread_id)
+                if isinstance(cwd, str) and cwd:
+                    thread.cwd = cwd
+                turn_id = params.get("turnId")
+                if isinstance(turn_id, str) and turn_id:
+                    thread.turn_id = turn_id
 
     def handle_server_request(
         self,
@@ -170,10 +243,12 @@ class VibeGuardGateStrategy(GateStrategy):
             return False
 
         thread_id = params.get("threadId")
-        cwd = state.thread_cwd.get(thread_id) if isinstance(thread_id, str) else None
+        thread = state.ensure_thread(thread_id) if isinstance(thread_id, str) else None
+        cwd = thread.cwd if thread is not None else None
+        env = self._hook_env(thread_id if isinstance(thread_id, str) else None, thread)
 
         payload = {"tool_input": {"command": command}}
-        result = self.hooks.run("pre-bash-guard.sh", payload, cwd=cwd)
+        result = self.hooks.run("pre-bash-guard.sh", payload, cwd=cwd, env_overrides=env)
 
         if result.decision == "block":
             write_to_server({"id": msg_id, "result": {"decision": "decline"}})
@@ -195,36 +270,109 @@ class VibeGuardGateStrategy(GateStrategy):
 
         return False
 
-    def on_server_notification(self, message: dict[str, Any], state: SessionState) -> None:
+    def on_server_notification(self, message: dict[str, Any], state: SessionState) -> dict[str, Any]:
         if message.get("method") != "turn/completed":
-            return
+            return message
 
         params = message.get("params")
         if not isinstance(params, dict):
-            return
+            return message
 
         thread_id = params.get("threadId")
         if not isinstance(thread_id, str):
-            return
+            return message
 
-        cwd = state.thread_cwd.get(thread_id)
+        thread = state.ensure_thread(thread_id)
+        turn_id = params.get("turnId")
+        if isinstance(turn_id, str) and turn_id:
+            thread.turn_id = turn_id
+
+        cwd = thread.cwd
         if not cwd:
-            return
+            return message
 
-        self._run_stop_gates(cwd)
-        self._run_post_build_checks(cwd)
+        feedback = self._collect_turn_feedback(cwd, thread_id, thread)
+        if not feedback:
+            return message
 
-    def _run_stop_gates(self, cwd: str) -> None:
-        # stop-guard / learn-evaluator do not require stdin payload.
-        self.hooks.run("stop-guard.sh", payload={}, cwd=cwd)
-        self.hooks.run("learn-evaluator.sh", payload={}, cwd=cwd)
+        next_params = dict(params)
+        next_params["vibeguard"] = feedback
+        next_message = dict(message)
+        next_message["params"] = next_params
+        return next_message
 
-    def _run_post_build_checks(self, cwd: str) -> None:
+    def _hook_env(self, thread_id: str | None, thread: ThreadState | None) -> dict[str, str]:
+        env = {
+            "VIBEGUARD_CLI": "codex",
+            "VIBEGUARD_AGENT_TYPE": "codex",
+        }
+        if thread is not None and thread.session_id:
+            env["VIBEGUARD_SESSION_ID"] = thread.session_id
+        if thread_id:
+            env["VIBEGUARD_THREAD_ID"] = thread_id
+        if thread is not None and thread.turn_id:
+            env["VIBEGUARD_TURN_ID"] = thread.turn_id
+        return env
+
+    def _collect_turn_feedback(self, cwd: str, thread_id: str, thread: ThreadState) -> dict[str, Any] | None:
+        env = self._hook_env(thread_id, thread)
+        messages = self._run_stop_gates(cwd, env)
+        messages.extend(self._run_post_build_checks(cwd, env))
+        if not messages:
+            return None
+
+        feedback: dict[str, Any] = {
+            "client": "codex-app-server",
+            "capabilities": CODEX_APP_SERVER_CAPABILITIES,
+            "messages": messages,
+        }
+        if thread.session_id:
+            feedback["sessionId"] = thread.session_id
+        if thread_id:
+            feedback["threadId"] = thread_id
+        if thread.turn_id:
+            feedback["turnId"] = thread.turn_id
+        return feedback
+
+    def _run_stop_gates(self, cwd: str, env: dict[str, str]) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = []
+        for hook_name in ("stop-guard.sh", "learn-evaluator.sh"):
+            result = self.hooks.run(hook_name, payload={}, cwd=cwd, env_overrides=env)
+            messages.extend(self._feedback_messages(hook_name, result))
+        return messages
+
+    def _run_post_build_checks(self, cwd: str, env: dict[str, str]) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = []
         files = self._changed_files(cwd)
         for rel in files:
             abs_path = str(Path(cwd) / rel)
             payload = {"tool_input": {"file_path": abs_path}}
-            self.hooks.run("post-build-check.sh", payload=payload, cwd=cwd)
+            result = self.hooks.run("post-build-check.sh", payload=payload, cwd=cwd, env_overrides=env)
+            messages.extend(self._feedback_messages("post-build-check.sh", result))
+        return messages
+
+    @staticmethod
+    def _feedback_messages(hook_name: str, result: HookResult) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = []
+        for payload in result.payloads:
+            stop_reason = payload.get("stopReason")
+            if isinstance(stop_reason, str) and stop_reason:
+                messages.append({"hook": hook_name, "kind": "stopReason", "text": stop_reason})
+            system_message = payload.get("systemMessage")
+            if isinstance(system_message, str) and system_message:
+                messages.append({"hook": hook_name, "kind": "systemMessage", "text": system_message})
+            hook_output = payload.get("hookSpecificOutput")
+            if isinstance(hook_output, dict):
+                additional_context = hook_output.get("additionalContext")
+                if isinstance(additional_context, str) and additional_context:
+                    messages.append(
+                        {
+                            "hook": hook_name,
+                            "kind": "additionalContext",
+                            "text": additional_context,
+                        }
+                    )
+        return messages
 
     @staticmethod
     def _changed_files(cwd: str) -> list[str]:
@@ -242,6 +390,13 @@ class VibeGuardGateStrategy(GateStrategy):
         changed.update(run_git(["diff", "--name-only", "--cached"]))
         source_exts = {".rs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go"}
         return [p for p in sorted(changed) if Path(p).suffix in source_exts]
+
+
+def _session_id_for_thread(thread_id: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", thread_id).strip("-")
+    if not normalized:
+        normalized = "thread"
+    return f"codex-thread-{normalized}"
 
 
 def parse_args() -> argparse.Namespace:
@@ -327,7 +482,8 @@ def main() -> int:
                         if "id" in message and isinstance(message.get("method"), str):
                             intercepted = strategy.handle_server_request(message, state, write_to_server)
                         elif isinstance(message.get("method"), str):
-                            strategy.on_server_notification(message, state)
+                            message = strategy.on_server_notification(message, state)
+                            line = json.dumps(message, ensure_ascii=False) + "\n"
                 except json.JSONDecodeError:
                     pass
 

--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -14,6 +14,7 @@ Current guard coverage (best-effort):
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -396,7 +397,8 @@ def _session_id_for_thread(thread_id: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", thread_id).strip("-")
     if not normalized:
         normalized = "thread"
-    return f"codex-thread-{normalized}"
+    digest = hashlib.sha256(thread_id.encode("utf-8")).hexdigest()[:12]
+    return f"codex-thread-{normalized}-{digest}"
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -38,7 +38,8 @@ def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
                 insert_idx = idx
                 in_features = False
         if in_features:
-            if stripped.startswith("codex_hooks"):
+            key = stripped.split("=", 1)[0].strip()
+            if key == "codex_hooks":
                 if stripped != "codex_hooks = true":
                     lines[idx] = "codex_hooks = true"
                     changed = True

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Helpers for structured updates to ~/.codex/config.toml."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8", dir=path.parent) as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+    tmp_path.replace(path)
+
+
+def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
+    lines = text.splitlines()
+    if not lines:
+        return "[features]\ncodex_hooks = true\n", True
+
+    changed = False
+    features_idx: int | None = None
+    insert_idx: int | None = None
+    in_features = False
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if stripped == "[features]":
+                features_idx = idx
+                in_features = True
+                insert_idx = idx + 1
+                continue
+            if in_features:
+                insert_idx = idx
+                in_features = False
+        if in_features:
+            if stripped.startswith("codex_hooks"):
+                if stripped != "codex_hooks = true":
+                    lines[idx] = "codex_hooks = true"
+                    changed = True
+                return "\n".join(lines).rstrip() + "\n", changed
+
+    if features_idx is not None:
+        assert insert_idx is not None
+        lines.insert(insert_idx, "codex_hooks = true")
+        changed = True
+        return "\n".join(lines).rstrip() + "\n", changed
+
+    content = "\n".join(lines).rstrip()
+    suffix = "\n\n" if content else ""
+    return content + suffix + "[features]\ncodex_hooks = true\n", True
+
+
+def _remove_legacy_vibeguard_mcp(text: str) -> tuple[str, bool]:
+    lines = text.splitlines()
+    if not lines:
+        return "", False
+
+    kept: list[str] = []
+    in_legacy = False
+    changed = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if stripped == "[mcp_servers.vibeguard]":
+                in_legacy = True
+                changed = True
+                continue
+            in_legacy = False
+        if in_legacy:
+            changed = True
+            continue
+        kept.append(line)
+    new_text = "\n".join(kept).strip()
+    return ((new_text + "\n") if new_text else ""), changed
+
+
+def cmd_enable_codex_hooks(args: argparse.Namespace) -> int:
+    path = Path(args.config_file)
+    old = path.read_text(encoding="utf-8") if path.exists() else ""
+    new, changed = _ensure_codex_hooks_enabled(old)
+    if changed or not path.exists():
+        _write_atomic(path, new)
+        print("CHANGED")
+    else:
+        print("SKIP")
+    return 0
+
+
+def cmd_remove_legacy_vibeguard_mcp(args: argparse.Namespace) -> int:
+    path = Path(args.config_file)
+    if not path.exists():
+        print("SKIP")
+        return 0
+    old = path.read_text(encoding="utf-8")
+    new, changed = _remove_legacy_vibeguard_mcp(old)
+    if not changed:
+        print("SKIP")
+        return 0
+    if new:
+        _write_atomic(path, new)
+    else:
+        path.unlink(missing_ok=True)
+    print("CHANGED")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Structured Codex config.toml helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    enable = sub.add_parser("enable-codex-hooks", help="Ensure [features].codex_hooks = true")
+    enable.add_argument("--config-file", required=True)
+
+    remove = sub.add_parser("remove-legacy-vibeguard-mcp", help="Remove [mcp_servers.vibeguard] block")
+    remove.add_argument("--config-file", required=True)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "enable-codex-hooks":
+        return cmd_enable_codex_hooks(args)
+    if args.command == "remove-legacy-vibeguard-mcp":
+        return cmd_remove_legacy_vibeguard_mcp(args)
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import tempfile
 from pathlib import Path
 
@@ -14,6 +15,11 @@ def _write_atomic(path: Path, content: str) -> None:
         tmp.write(content)
         tmp_path = Path(tmp.name)
     tmp_path.replace(path)
+
+
+def _table_name(line: str) -> str | None:
+    match = re.match(r"^\[\s*([^\]]+?)\s*\]\s*(?:#.*)?$", line.strip())
+    return match.group(1).strip() if match else None
 
 
 def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
@@ -28,8 +34,9 @@ def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
 
     for idx, line in enumerate(lines):
         stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            if stripped == "[features]":
+        table_name = _table_name(line)
+        if table_name is not None:
+            if table_name == "features":
                 features_idx = idx
                 in_features = True
                 insert_idx = idx + 1
@@ -65,9 +72,9 @@ def _remove_legacy_vibeguard_mcp(text: str) -> tuple[str, bool]:
     in_legacy = False
     changed = False
     for line in lines:
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            if stripped == "[mcp_servers.vibeguard]":
+        table_name = _table_name(line)
+        if table_name is not None:
+            if table_name == "mcp_servers.vibeguard":
                 in_legacy = True
                 changed = True
                 continue

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Helpers for reading and validating the VibeGuard manifest contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_FILE = ROOT / "schemas" / "install-modules.json"
+PROJECT_SCHEMA_FILE = ROOT / "schemas" / "vibeguard-project.schema.json"
+CANONICAL_RULES_DIR = ROOT / "rules" / "claude-rules"
+REFERENCE_DOC = ROOT / "docs" / "rule-reference.md"
+HOOKS_DIR = ROOT / "hooks"
+GUARDS_DIR = ROOT / "guards"
+
+RULE_ID_HEADING_RE = re.compile(r"^##\s+((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+)\b", re.MULTILINE)
+RULE_ID_TABLE_RE = re.compile(r"^\|\s*((?:RS|GO|TS|PY|U|SEC|W)-[A-Za-z0-9-]+)\s*\|", re.MULTILINE)
+GUARD_RULE_RE = re.compile(r"\b(?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+\b")
+
+HOOK_SKIP = {
+    "run-hook",
+    "run-hook-codex",
+    "log",
+    "circuit-breaker",
+    "vibeguard-learn-evaluator",
+    "vibeguard-post-build-check",
+    "vibeguard-pre-bash-guard",
+    "vibeguard-stop-guard",
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_manifest(path: Path | None = None) -> dict[str, Any]:
+    manifest_path = path or MANIFEST_FILE
+    data = load_json(manifest_path)
+    if not isinstance(data, dict):
+        raise ValueError("manifest root must be an object")
+    return data
+
+
+def rule_ids_from_tree(root: Path) -> list[str]:
+    ids: set[str] = set()
+    for file in sorted(root.rglob("*.md")):
+        try:
+            text = file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        ids.update(RULE_ID_HEADING_RE.findall(text))
+    return sorted(ids)
+
+
+def canonical_rule_ids(scope: str = "all") -> list[str]:
+    base = CANONICAL_RULES_DIR
+    if scope == "common":
+        return rule_ids_from_tree(base / "common")
+    return rule_ids_from_tree(base)
+
+
+def reference_rule_ids() -> list[str]:
+    text = REFERENCE_DOC.read_text(encoding="utf-8")
+    return sorted(set(RULE_ID_TABLE_RE.findall(text)))
+
+
+def guard_rule_ids() -> list[str]:
+    ids: set[str] = set()
+    for file in sorted(GUARDS_DIR.rglob("*")):
+        if not file.is_file():
+            continue
+        try:
+            text = file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        ids.update(GUARD_RULE_RE.findall(text))
+    for file in sorted(HOOKS_DIR.glob("*.sh")):
+        try:
+            text = file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        ids.update(GUARD_RULE_RE.findall(text))
+    filtered = {
+        rule_id
+        for rule_id in ids
+        if not rule_id.endswith("-XX") and rule_id not in {"U-HARDCODE", "TASTE-FOLD"}
+    }
+    return sorted(filtered)
+
+
+def hook_names() -> list[str]:
+    names: list[str] = []
+    for file in sorted(HOOKS_DIR.glob("*.sh")):
+        name = file.stem
+        if name in HOOK_SKIP:
+            continue
+        names.append(name)
+    return names
+
+
+def guard_names() -> list[str]:
+    names: list[str] = []
+    for file in sorted(GUARDS_DIR.rglob("*")):
+        if file.is_file() and file.name.startswith("check_") and file.suffix in {".sh", ".py"}:
+            names.append(file.stem)
+    return sorted(names)
+
+
+def profile_names(manifest: dict[str, Any]) -> list[str]:
+    profiles = manifest.get("profiles", {})
+    if not isinstance(profiles, dict):
+        raise ValueError("manifest profiles must be an object")
+    return list(profiles.keys())
+
+
+def _module_ids(manifest: dict[str, Any]) -> list[str]:
+    modules = manifest.get("modules", [])
+    if not isinstance(modules, list):
+        raise ValueError("manifest modules must be a list")
+    return [str(module.get("id", "")) for module in modules if isinstance(module, dict)]
+
+
+def _validate_paths(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for module in manifest.get("modules", []):
+        if not isinstance(module, dict):
+            errors.append("manifest module entry is not an object")
+            continue
+        module_id = str(module.get("id", "<unknown>"))
+        paths = module.get("paths", [])
+        if not isinstance(paths, list):
+            errors.append(f"module {module_id}: paths must be a list")
+            continue
+        for path_str in paths:
+            if not isinstance(path_str, str):
+                errors.append(f"module {module_id}: non-string path entry")
+                continue
+            path = ROOT / path_str
+            if not path.exists():
+                errors.append(f"module {module_id}: missing path {path_str}")
+    return errors
+
+
+def _validate_profiles(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    modules = set(_module_ids(manifest))
+    profiles = manifest.get("profiles", {})
+    if not isinstance(profiles, dict):
+        return ["manifest profiles must be an object"]
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def walk(name: str) -> None:
+        if name in visited:
+            return
+        if name in visiting:
+            errors.append(f"profile cycle detected at {name}")
+            return
+        profile = profiles.get(name)
+        if not isinstance(profile, dict):
+            errors.append(f"profile {name} is not an object")
+            return
+        visiting.add(name)
+        extends = profile.get("extends")
+        if extends is not None:
+            if not isinstance(extends, str) or extends not in profiles:
+                errors.append(f"profile {name}: unknown extends target {extends!r}")
+            else:
+                walk(extends)
+        module_refs = profile.get("modules", [])
+        if not isinstance(module_refs, list):
+            errors.append(f"profile {name}: modules must be a list")
+        else:
+            for module_id in module_refs:
+                if module_id not in modules:
+                    errors.append(f"profile {name}: unknown module {module_id!r}")
+        visiting.remove(name)
+        visited.add(name)
+
+    for name in profiles:
+        walk(name)
+    return errors
+
+
+def _validate_project_schema(manifest: dict[str, Any], project_schema: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    manifest_profiles = sorted(profile_names(manifest))
+    project_profile = (
+        project_schema.get("properties", {})
+        .get("profile", {})
+        .get("enum", [])
+    )
+    if sorted(project_profile) != manifest_profiles:
+        errors.append(
+            "project schema profile enum drift: "
+            f"manifest={manifest_profiles} schema={project_profile}"
+        )
+    return errors
+
+
+def validate_contract(manifest_path: Path, project_schema_path: Path) -> list[str]:
+    manifest = load_manifest(manifest_path)
+    project_schema = load_json(project_schema_path)
+
+    errors: list[str] = []
+    module_ids = _module_ids(manifest)
+    if len(module_ids) != len(set(module_ids)):
+        errors.append("duplicate module ids detected in manifest")
+    errors.extend(_validate_paths(manifest))
+    errors.extend(_validate_profiles(manifest))
+    errors.extend(_validate_project_schema(manifest, project_schema))
+    return errors
+
+
+def print_lines(items: Iterable[str]) -> None:
+    for item in items:
+        print(item)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="VibeGuard manifest helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate", help="Validate manifest/profile/schema contract")
+    validate.add_argument("--manifest-file", default=str(MANIFEST_FILE))
+    validate.add_argument("--project-schema", default=str(PROJECT_SCHEMA_FILE))
+
+    profiles = sub.add_parser("profile-names", help="List canonical profile names")
+    profiles.add_argument("--manifest-file", default=str(MANIFEST_FILE))
+
+    rule_ids = sub.add_parser("rule-ids", help="List rule ids from canonical or reference sources")
+    rule_ids.add_argument("--source", choices=["canonical", "reference", "mechanical"], default="canonical")
+    rule_ids.add_argument("--scope", choices=["all", "common"], default="all")
+
+    sub.add_parser("hook-names", help="List user-disableable hook names")
+    sub.add_parser("guard-names", help="List known guard names")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        errors = validate_contract(Path(args.manifest_file), Path(args.project_schema))
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        print("OK")
+        return 0
+
+    if args.command == "profile-names":
+        manifest = load_manifest(Path(args.manifest_file))
+        print_lines(profile_names(manifest))
+        return 0
+
+    if args.command == "rule-ids":
+        if args.source == "canonical":
+            print_lines(canonical_rule_ids(args.scope))
+        elif args.source == "reference":
+            print_lines(reference_rule_ids())
+        else:
+            print_lines(guard_rule_ids())
+        return 0
+
+    if args.command == "hook-names":
+        print_lines(hook_names())
+        return 0
+
+    if args.command == "guard-names":
+        print_lines(guard_names())
+        return 0
+
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -20,7 +20,7 @@ HOOKS_DIR = ROOT / "hooks"
 GUARDS_DIR = ROOT / "guards"
 
 RULE_ID_HEADING_RE = re.compile(r"^##\s+((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+)\b", re.MULTILINE)
-RULE_ID_TABLE_RE = re.compile(r"^\|\s*((?:RS|GO|TS|PY|U|SEC|W)-[A-Za-z0-9-]+)\s*\|", re.MULTILINE)
+RULE_ID_TABLE_RE = re.compile(r"^\|\s*((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+)\s*\|", re.MULTILINE)
 GUARD_RULE_RE = re.compile(r"\b(?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+\b")
 
 HOOK_SKIP = {

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -244,7 +244,7 @@ echo "  3. Run: /vibeguard:preflight <project_dir>"
 echo "  4. Run: /vibeguard:check <project_dir>"
 echo
 echo "Runtime configuration (env vars or .vibeguard.json):"
-echo "  VIBEGUARD_PROFILE=minimal|standard|strict    Runtime profile"
+echo "  VIBEGUARD_PROFILE=minimal|core|full|strict   Runtime profile"
 echo "  VIBEGUARD_ENFORCEMENT=block|warn|off          Enforcement level"
 echo "  VIBEGUARD_DISABLED_HOOKS=hook1,hook2           Disable specific hooks"
 echo

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -7,6 +7,8 @@ CLAUDE_DIR="${HOME}/.claude"
 CODEX_DIR="${HOME}/.codex"
 SETTINGS_HELPER="${REPO_DIR}/scripts/lib/settings_json.py"
 CODEX_HOOKS_HELPER="${REPO_DIR}/scripts/lib/codex_hooks_json.py"
+CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
+MANIFEST_HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
 CLAUDE_MD_HELPER="${REPO_DIR}/scripts/lib/claude_md.py"
 SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
 

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -208,12 +208,7 @@ check_claude_home_installation() {
         green "[OK] Rule count in sync: ${actual_rule_count} rules"
       else
         yellow "[DRIFT] CLAUDE.md declares ${declared_count} rules, actual: ${actual_rule_count}"
-        if [[ "$(uname)" == "Darwin" ]]; then
-          sed -i '' "s/${declared_count} rules/${actual_rule_count} rules/" "${claude_md}"
-        else
-          sed -i "s/${declared_count} rules/${actual_rule_count} rules/" "${claude_md}"
-        fi
-        green "[FIXED] Updated CLAUDE.md rule count to ${actual_rule_count}"
+        yellow "[INFO] Re-run 'bash setup.sh' to repair the rule count banner in ~/.claude/CLAUDE.md"
       fi
     fi
   else

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -61,7 +61,7 @@ _enable_codex_hooks_feature() {
 
 _remove_legacy_codex_mcp_config() {
   local config="${CODEX_DIR}/config.toml"
-  python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${config}" 2>/dev/null || echo "ERROR"
+  python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${config}"
 }
 
 _has_legacy_codex_mcp_config() {
@@ -72,7 +72,10 @@ _has_legacy_codex_mcp_config() {
 configure_codex_home_runtime() {
   echo "Step 9.2: Remove legacy Codex MCP config"
   local cleanup_result
-  cleanup_result="$(_remove_legacy_codex_mcp_config)"
+  if ! cleanup_result="$(_remove_legacy_codex_mcp_config 2>/dev/null)"; then
+    red "  Failed to remove legacy Codex MCP config from ~/.codex/config.toml"
+    return 1
+  fi
   if [[ -f "${CODEX_DIR}/config.toml" ]]; then
     state_record_file "${CODEX_DIR}/config.toml" "generated/codex-config.toml" "copy"
   fi
@@ -170,7 +173,10 @@ clean_codex_home_installation() {
   # Keep codex_hooks flag untouched to avoid affecting other toolchains.
 
   local cleanup_result
-  cleanup_result="$(_remove_legacy_codex_mcp_config)"
+  if ! cleanup_result="$(_remove_legacy_codex_mcp_config 2>/dev/null)"; then
+    red "Failed to remove legacy Codex MCP config from ~/.codex/config.toml"
+    return 1
+  fi
   if [[ "${cleanup_result}" == "CHANGED" ]]; then
     yellow "Removed legacy VibeGuard MCP block from ~/.codex/config.toml"
   fi

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -45,7 +45,10 @@ install_codex_home_assets() {
 _enable_codex_hooks_feature() {
   local config="${CODEX_DIR}/config.toml"
   local result
-  result=$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${config}" 2>/dev/null || echo "ERROR")
+  if ! result=$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${config}" 2>/dev/null); then
+    red "  Failed to enable codex_hooks feature in config.toml"
+    return 1
+  fi
   case "${result}" in
     CHANGED)
       green "  codex_hooks feature enabled in config.toml"
@@ -55,6 +58,7 @@ _enable_codex_hooks_feature() {
       ;;
     *)
       red "  Failed to enable codex_hooks feature in config.toml"
+      return 1
       ;;
   esac
 }

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -32,6 +32,7 @@ install_codex_home_assets() {
   if [[ "${hooks_result}" == "CHANGED" || "${hooks_result}" == "SKIP" ]]; then
     state_record_file "${hooks_file}" "generated/codex-hooks.json" "copy"
     green "  ~/.codex/hooks.json merged (VibeGuard hooks upserted)"
+    yellow "  Codex capability profile: Bash approvals + Stop hooks are native; Edit/Write hooks stay unsupported here"
   else
     red "  Failed to update ~/.codex/hooks.json"
   fi
@@ -43,78 +44,24 @@ install_codex_home_assets() {
 
 _enable_codex_hooks_feature() {
   local config="${CODEX_DIR}/config.toml"
-  if [[ ! -f "$config" ]]; then
-    # config.toml doesn't exist yet, create minimal one
-    cat > "$config" <<'TOML'
-[features]
-codex_hooks = true
-TOML
-    green "  codex_hooks feature enabled (new config.toml)"
-    return
-  fi
-
-  # Check if already enabled
-  if grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "$config" 2>/dev/null; then
-    green "  codex_hooks feature already enabled"
-    return
-  fi
-
-  # Check if [features] section exists
-  if grep -q '^\[features\]' "$config" 2>/dev/null; then
-    # Add codex_hooks under existing [features] section
-    sed -i '' '/^\[features\]/a\
-codex_hooks = true' "$config"
-    green "  codex_hooks feature enabled (added to [features])"
-  else
-    # Append [features] section
-    printf '\n[features]\ncodex_hooks = true\n' >> "$config"
-    green "  codex_hooks feature enabled (new [features] section)"
-  fi
+  local result
+  result=$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${config}" 2>/dev/null || echo "ERROR")
+  case "${result}" in
+    CHANGED)
+      green "  codex_hooks feature enabled in config.toml"
+      ;;
+    SKIP)
+      green "  codex_hooks feature already enabled"
+      ;;
+    *)
+      red "  Failed to enable codex_hooks feature in config.toml"
+      ;;
+  esac
 }
 
 _remove_legacy_codex_mcp_config() {
   local config="${CODEX_DIR}/config.toml"
-  python3 - "$config" <<'PY'
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-if not path.exists():
-    print("SKIP")
-    raise SystemExit(0)
-
-old = path.read_text(encoding="utf-8")
-lines = old.splitlines()
-kept: list[str] = []
-in_legacy_section = False
-changed = False
-
-for line in lines:
-    if line.startswith("[") and line.endswith("]"):
-        if line == "[mcp_servers.vibeguard]":
-            in_legacy_section = True
-            changed = True
-            continue
-        in_legacy_section = False
-
-    if in_legacy_section:
-        changed = True
-        continue
-
-    kept.append(line)
-
-new = "\n".join(kept).strip()
-new = (new + "\n") if new else ""
-
-if not changed and new == old:
-    print("SKIP")
-elif new:
-    path.write_text(new, encoding="utf-8")
-    print("CHANGED")
-else:
-    path.unlink(missing_ok=True)
-    print("CHANGED")
-PY
+  python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${config}" 2>/dev/null || echo "ERROR"
 }
 
 _has_legacy_codex_mcp_config() {
@@ -179,6 +126,8 @@ print(total)
   else
     yellow "[MISSING] Codex hook wrapper not installed"
   fi
+
+  yellow "[INFO] Codex runtime scope: Bash approvals + Stop hooks only; Edit/Write/analysis-paralysis require Claude Code or the app-server wrapper"
 
   # Check feature flag
   if [[ -f "${CODEX_DIR}/config.toml" ]] && grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CODEX_DIR}/config.toml" 2>/dev/null; then

--- a/scripts/verify/doc-freshness-check.sh
+++ b/scripts/verify/doc-freshness-check.sh
@@ -51,7 +51,7 @@ common_doc_missing = sorted(documented_scope - documented_common)
 common_doc_extra = sorted(documented_common - documented_scope)
 mechanical_missing = sorted(canonical_all - mechanical)
 undocumented_mechanical = sorted(mechanical - canonical_all)
-installed_drift = sorted(canonical_all ^ installed_ids) if check_installed and installed_ids else []
+installed_drift = sorted(canonical_all ^ installed_ids) if check_installed else []
 
 mechanical_covered = sorted(canonical_all & mechanical)
 coverage_rate = (len(mechanical_covered) / len(canonical_all) * 100) if canonical_all else 0.0
@@ -88,10 +88,10 @@ if check_installed:
     print(f"Installed rule source: {installed_source}")
     if installed_ids:
         print(f"Installed rule ids: {len(installed_ids)}")
-        print_group("Installed-vs-repo rule drift", installed_drift)
     else:
         print("Installed rule ids: 0 (directory missing or empty)")
         print()
+    print_group("Installed-vs-repo rule drift", installed_drift)
 
 has_errors = bool(common_doc_missing or common_doc_extra or undocumented_mechanical)
 has_warnings = bool(mechanical_missing or installed_drift)

--- a/scripts/verify/doc-freshness-check.sh
+++ b/scripts/verify/doc-freshness-check.sh
@@ -1,198 +1,108 @@
 #!/usr/bin/env bash
-# VibeGuard document freshness detection
+# VibeGuard document/reference consistency check
 #
-# Cross-compare rule IDs defined in rules/claude-rules/ and IDs implemented by guards/hooks.
-# Output: Unimplemented rules (with rules and no guards) and undocumented guards (with guards and no rules).
+# Default mode is repo-local and deterministic:
+# - canonical rules: rules/claude-rules/**
+# - documented common rules: docs/rule-reference.md
+# - mechanical enforcement: guards/** + hooks/*.sh
 #
-# Usage:
-# bash doc-freshness-check.sh #Default check
-# bash doc-freshness-check.sh --strict # >10% inconsistency returns exit code 1
+# Optional --installed also checks ~/.claude/rules/vibeguard drift separately.
 
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 STRICT=false
+CHECK_INSTALLED=false
 
 for arg in "$@"; do
   case "$arg" in
     --strict) STRICT=true ;;
+    --installed) CHECK_INSTALLED=true ;;
   esac
 done
 
-RULES_DIR="${REPO_DIR}/rules/claude-rules"
-GUARDS_DIR="${REPO_DIR}/guards"
-NATIVE_RULES_DIR="${HOME}/.claude/rules/vibeguard"
+python3 - "$REPO_DIR" "$STRICT" "$CHECK_INSTALLED" <<'PY'
+from __future__ import annotations
 
-if [[ ! -d "$RULES_DIR" ]]; then
-  echo "The canonical rules directory does not exist: ${RULES_DIR}"
-  exit 1
-fi
+import json
+import sys
+from pathlib import Path
 
-if [[ ! -d "$GUARDS_DIR" ]]; then
-  echo "Guards directory does not exist: ${GUARDS_DIR}"
-  exit 1
-fi
+repo_dir = Path(sys.argv[1]).resolve()
+strict = sys.argv[2] == "true"
+check_installed = sys.argv[3] == "true"
 
-VG_RULES_DIR="$RULES_DIR" VG_GUARDS_DIR="$GUARDS_DIR" VG_NATIVE_RULES_DIR="$NATIVE_RULES_DIR" \
-  VG_STRICT="$STRICT" python3 -c '
-import os, re, sys, glob
+sys.path.insert(0, str(repo_dir / "scripts" / "lib"))
+import vibeguard_manifest as manifest  # type: ignore
 
-rules_dir = os.environ["VG_RULES_DIR"]
-guards_dir = os.environ["VG_GUARDS_DIR"]
-native_rules_dir = os.environ.get("VG_NATIVE_RULES_DIR", "")
-strict = os.environ.get("VG_STRICT", "false") == "true"
+canonical_all = set(manifest.canonical_rule_ids("all"))
+documented_scope = {rule_id for rule_id in canonical_all if rule_id.startswith(("U-", "W-", "SEC-"))}
+documented_common = set(manifest.reference_rule_ids())
+mechanical = set(manifest.guard_rule_ids())
 
-id_pattern = re.compile(r"\b(RS|GO|TS|PY|U|SEC)-(\d+)\b")
+installed_ids: set[str] = set()
+installed_source = "repo/rules/claude-rules (default)"
+installed_dir = Path.home() / ".claude" / "rules" / "vibeguard"
+if check_installed and installed_dir.is_dir():
+    installed_ids = set(manifest.rule_ids_from_tree(installed_dir))
+    installed_source = str(installed_dir)
 
-# Extract the rule ID and its description from the rules file
-rule_ids = {}  # id -> (file, description)
-for md_file in sorted(glob.glob(os.path.join(rules_dir, "**/*.md"), recursive=True)):
-    basename = os.path.relpath(md_file, rules_dir)
-    try:
-        with open(md_file, encoding="utf-8") as f:
-            for line in f:
-                for m in id_pattern.finditer(line):
-                    rule_id = m.group()
-                    if rule_id not in rule_ids:
-                        # Get a brief description of the row content
-                        desc = line.strip()[:80]
-                        rule_ids[rule_id] = (basename, desc)
-    except (UnicodeDecodeError, PermissionError):
-        continue
+common_doc_missing = sorted(documented_scope - documented_common)
+common_doc_extra = sorted(documented_common - documented_scope)
+mechanical_missing = sorted(canonical_all - mechanical)
+undocumented_mechanical = sorted(mechanical - canonical_all)
+installed_drift = sorted(canonical_all ^ installed_ids) if check_installed and installed_ids else []
 
-# Extract the implemented rule ID from the guard script
-guard_ids = {}  # id -> set(files)
-for guard_file in sorted(glob.glob(os.path.join(guards_dir, "**/*"), recursive=True)):
-    if not os.path.isfile(guard_file):
-        continue
-    try:
-        with open(guard_file, encoding="utf-8") as f:
-            content = f.read()
-    except (UnicodeDecodeError, PermissionError):
-        continue
-    rel_path = os.path.relpath(guard_file, guards_dir)
-    for m in id_pattern.finditer(content):
-        gid = m.group()
-        guard_ids.setdefault(gid, set()).add(rel_path)
+mechanical_covered = sorted(canonical_all & mechanical)
+coverage_rate = (len(mechanical_covered) / len(canonical_all) * 100) if canonical_all else 0.0
 
-# Also scan from the hooks directory (some rules are also implemented in hooks)
-hooks_dir = os.path.join(os.path.dirname(guards_dir), "hooks")
-if os.path.isdir(hooks_dir):
-    for hook_file in sorted(glob.glob(os.path.join(hooks_dir, "*.sh"))):
-        try:
-            with open(hook_file, encoding="utf-8") as f:
-                content = f.read()
-        except (UnicodeDecodeError, PermissionError):
-            continue
-        rel_path = "hooks/" + os.path.basename(hook_file)
-        for m in id_pattern.finditer(content):
-            gid = m.group()
-            guard_ids.setdefault(gid, set()).add(rel_path)
+print(
+    f"""
+VibeGuard Repo Consistency Report
+================================
+Canonical rule source: {repo_dir / 'rules' / 'claude-rules'}
+Canonical rules: {len(canonical_all)}
+Common documented rules: {len(documented_common)}
+Mechanical coverage: {len(mechanical_covered)} ({coverage_rate:.0f}%)
+Missing mechanical coverage: {len(mechanical_missing)}
+Undocumented mechanical ids: {len(undocumented_mechanical)}
+Common doc drift (missing): {len(common_doc_missing)}
+Common doc drift (extra): {len(common_doc_extra)}
+""".strip()
+)
+print()
 
-# AI visible rules: Prioritize ~/.claude/rules/vibeguard/, fall back to repo rules/ if missing (CI friendly)
-ai_visible_ids = {}  # id -> set(files)
-if native_rules_dir and os.path.isdir(native_rules_dir):
-    ai_rules_dir = native_rules_dir
-    ai_source_label = "~/.claude/rules/"
-    ai_fallback_used = False
-else:
-    ai_rules_dir = rules_dir
-    ai_source_label = "repo/rules (fallback)"
-    ai_fallback_used = True
-
-for nr_file in sorted(glob.glob(os.path.join(ai_rules_dir, "**/*.md"), recursive=True)):
-    try:
-        with open(nr_file, encoding="utf-8") as f:
-            content = f.read()
-    except (UnicodeDecodeError, PermissionError):
-        continue
-    rel_path = os.path.relpath(nr_file, ai_rules_dir)
-    for m in id_pattern.finditer(content):
-        aid = m.group()
-        ai_visible_ids.setdefault(aid, set()).add(rel_path)
-
-# Calculate the gap
-rule_set = set(rule_ids.keys())
-guard_set = set(guard_ids.keys())
-ai_set = set(ai_visible_ids.keys())
-
-implemented = sorted(rule_set & guard_set)
-ai_visible = sorted(rule_set & ai_set)
-dual_covered = sorted(rule_set & guard_set & ai_set)
-all_covered = sorted(rule_set & (guard_set | ai_set))
-unimplemented = sorted(rule_set - guard_set)
-not_ai_visible = sorted(rule_set - ai_set)
-fully_uncovered = sorted(rule_set - guard_set - ai_set)
-undocumented = sorted(guard_set - rule_set)
-
-total_rules = len(rule_ids)
-gap_count = len(fully_uncovered) + len(undocumented)
-gap_rate = (gap_count / total_rules * 100) if total_rules > 0 else 0
-
-# Output report
-print(f"""
-VibeGuard Document Freshness Report
-{"=" * 40}
-Rule source: {rules_dir}
-Total number of rules: {total_rules}
-Comprehensive coverage: {len(all_covered)} ({len(all_covered)/total_rules*100:.0f}%)
-  Mechanical enforcement: {len(implemented)} (guards/hooks)
-  AI visible: {len(ai_visible)} ({ai_source_label})
-  Double coverage: {len(dual_covered)}
-Fully uncovered: {len(fully_uncovered)}
-Undocumented guard: {len(undocumented)}
-Inconsistency rate: {gap_rate:.1f}%
-""")
-
-if ai_fallback_used:
-    print(f"NOTE: native rules dir does not exist and has fallen back to {rules_dir}")
-    print()
-
-def print_by_prefix(ids, label):
-    if not ids:
+def print_group(label: str, items: list[str]) -> None:
+    if not items:
         return
     print(f"{label}:")
-    by_prefix = {}
-    for rid in ids:
-        prefix = rid.split("-")[0]
-        by_prefix.setdefault(prefix, []).append(rid)
-    for prefix in sorted(by_prefix.keys()):
-        ids_str = ", ".join(by_prefix[prefix])
-        print(f"  {prefix}: {ids_str}")
+    print("  " + ", ".join(items))
     print()
 
-dual_set = set(dual_covered)
-print_by_prefix(dual_covered, "Double coverage (guard + AI visible)")
-print_by_prefix([r for r in implemented if r not in dual_set], "Only mechanical forcing (guards/hooks)")
-print_by_prefix([r for r in ai_visible if r not in dual_set], f"Only AI visible ({ai_source_label})")
+print_group("Missing from docs/rule-reference.md (common scope)", common_doc_missing)
+print_group("Extra in docs/rule-reference.md (not canonical)", common_doc_extra)
+print_group("Canonical rules without mechanical enforcement", mechanical_missing)
+print_group("Mechanical ids with no canonical rule definition", undocumented_mechanical)
 
-if fully_uncovered:
-    print("Completely uncovered rules:")
-    for rid in fully_uncovered:
-        if rid in rule_ids:
-            src_file, desc = rule_ids[rid]
-            print(f"  {rid} ({src_file})")
-    print()
+if check_installed:
+    print(f"Installed rule source: {installed_source}")
+    if installed_ids:
+        print(f"Installed rule ids: {len(installed_ids)}")
+        print_group("Installed-vs-repo rule drift", installed_drift)
+    else:
+        print("Installed rule ids: 0 (directory missing or empty)")
+        print()
 
-if undocumented:
-    print("Undocumented guard (referenced in guard, no rule definition):")
-    for gid in undocumented:
-        files = sorted(guard_ids[gid])
-        files_str = ", ".join(files)
-        print(f"  {gid} → {files_str}")
-    print()
+has_errors = bool(common_doc_missing or common_doc_extra or undocumented_mechanical)
+has_warnings = bool(mechanical_missing or installed_drift)
 
-# Judgment
-if gap_rate > 20:
-    print("FAIL: Inconsistency rate > 20%, it is recommended to complete it immediately")
-    status = 2
-elif gap_rate > 10:
-    print("WARN: Inconsistency rate > 10%, it is recommended to arrange for completion")
-    status = 1
+if has_errors:
+    print("FAIL: repo contract drift detected")
+elif has_warnings:
+    print("WARN: repo contract is document-consistent but still has uncovered rule ids")
 else:
-    print("PASS: Rule-Guard Consistency Good")
-    status = 0
+    print("PASS: repo contract is consistent")
 
-if strict and status > 0:
-    sys.exit(1)
-'
+if strict and has_errors:
+    raise SystemExit(1)
+PY

--- a/scripts/verify/doc-freshness-check.sh
+++ b/scripts/verify/doc-freshness-check.sh
@@ -37,7 +37,8 @@ import vibeguard_manifest as manifest  # type: ignore
 
 canonical_all = set(manifest.canonical_rule_ids("all"))
 documented_scope = {rule_id for rule_id in canonical_all if rule_id.startswith(("U-", "W-", "SEC-"))}
-documented_common = set(manifest.reference_rule_ids())
+reference_all = set(manifest.reference_rule_ids())
+documented_common = {rule_id for rule_id in reference_all if rule_id.startswith(("U-", "W-", "SEC-"))}
 mechanical = set(manifest.guard_rule_ids())
 
 installed_ids: set[str] = set()

--- a/skills/vibeguard/SKILL.md
+++ b/skills/vibeguard/SKILL.md
@@ -9,6 +9,13 @@ description: "AI-assisted development of anti-hallucination specifications. Chec
 
 VibeGuard is an anti-hallucination framework for AI-assisted development that systematically blocks common failure modes in LLM code generation through a seven-layer defense architecture.
 
+Canonical contract sources for this skill:
+- `README.md` — product entry and current Core vs Workflow boundary
+- `docs/rule-reference.md` — public rule/guard summary
+- `schemas/install-modules.json` — install/runtime contract
+
+`docs/spec.md` remains a historical design snapshot and should not be treated as the authoritative implementation contract.
+
 Calling `/vibeguard` can:
 - View the complete anti-hallucination specifications
 - Get task startup checklist
@@ -73,7 +80,9 @@ Refer to references/review-template.md, record:
 - `references/task-contract.yaml` — Task startup Checklist (machine verification format)
 - `references/review-template.md` — weekly review template
 - `references/scoring-matrix.md` — risk-impact scoring matrix
-- `docs/spec.md` (repository root directory) — complete specification document
+- `README.md` (repository root directory) — current product entrypoint
+- `docs/rule-reference.md` (repository root directory) — current rule/guard summary
+- `schemas/install-modules.json` (repository root directory) — current install/runtime contract
 
 ## Execution rules
 

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# VibeGuard Codex runtime regression tests
+#
+# Usage: bash tests/test_codex_runtime.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if ! echo "$output" | grep -qF "$unexpected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (unexpectedly contains: $unexpected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+header "run-hook-codex surfaces unsupported command rewrite"
+TMP_HOME="${TMP_DIR}/home"
+TMP_FAKE_REPO="${TMP_DIR}/fake-repo"
+mkdir -p "${TMP_HOME}/.vibeguard" "${TMP_FAKE_REPO}/hooks"
+printf '%s' "${TMP_FAKE_REPO}" > "${TMP_HOME}/.vibeguard/repo-path"
+
+cat > "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+python3 - <<'PY'
+import json
+print(json.dumps({"decision": "allow", "updatedInput": {"command": "pnpm install"}}))
+PY
+HOOK
+chmod +x "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh"
+
+rewrite_out="$(
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"npm install"}}' \
+    | HOME="${TMP_HOME}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${rewrite_out}" '"systemMessage"' "run-hook-codex emits an explicit note for unsupported rewrites"
+assert_contains "${rewrite_out}" 'pnpm install' "run-hook-codex includes the suggested rewritten command"
+
+header "app-server adapter propagates explicit session context and feedback"
+adapter_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-repo"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+
+(app_repo / "tracked.py").write_text("print('base')\n", encoding="utf-8")
+subprocess.run(["git", "init"], cwd=app_repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+subprocess.run(["git", "add", "tracked.py"], cwd=app_repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+subprocess.run(
+    ["git", "-c", "user.name=CI", "-c", "user.email=ci@vibeguard.test", "commit", "-m", "init"],
+    cwd=app_repo,
+    check=True,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+(app_repo / "tracked.py").write_text("print('changed')\n", encoding="utf-8")
+
+(hooks_dir / "pre-bash-guard.sh").write_text(
+    """#!/usr/bin/env bash
+cat >/dev/null
+python3 - <<'PY'
+import json
+import os
+msg = 'rewrite=' + '|'.join([
+    os.environ.get('VIBEGUARD_SESSION_ID', ''),
+    os.environ.get('VIBEGUARD_THREAD_ID', ''),
+    os.environ.get('VIBEGUARD_TURN_ID', ''),
+])
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': msg}}))
+PY
+""",
+    encoding="utf-8",
+)
+(hooks_dir / "stop-guard.sh").write_text(
+    "#!/usr/bin/env bash\ncat >/dev/null\n",
+    encoding="utf-8",
+)
+(hooks_dir / "learn-evaluator.sh").write_text(
+    """#!/usr/bin/env bash
+cat >/dev/null
+python3 - <<'PY'
+import json
+import os
+msg = 'learn=' + '|'.join([
+    os.environ.get('VIBEGUARD_SESSION_ID', ''),
+    os.environ.get('VIBEGUARD_THREAD_ID', ''),
+    os.environ.get('VIBEGUARD_TURN_ID', ''),
+])
+print(json.dumps({'stopReason': msg}))
+PY
+""",
+    encoding="utf-8",
+)
+(hooks_dir / "post-build-check.sh").write_text(
+    """#!/usr/bin/env bash
+cat >/dev/null
+python3 - <<'PY'
+import json
+import os
+msg = 'build=' + '|'.join([
+    os.environ.get('VIBEGUARD_SESSION_ID', ''),
+    os.environ.get('VIBEGUARD_THREAD_ID', ''),
+    os.environ.get('VIBEGUARD_TURN_ID', ''),
+])
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': msg}}))
+PY
+""",
+    encoding="utf-8",
+)
+
+for hook in hooks_dir.iterdir():
+    hook.chmod(0o755)
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/alpha", "cwd": str(app_repo)}},
+    state,
+)
+strategy.on_client_message(
+    {"method": "turn/start", "params": {"threadId": "thread/alpha", "cwd": str(app_repo), "turnId": "turn-42"}},
+    state,
+)
+
+captured = []
+approval_message = {
+    "id": "req-1",
+    "method": "item/commandExecution/requestApproval",
+    "params": {"threadId": "thread/alpha", "command": "npm install"},
+}
+intercepted = strategy.handle_server_request(approval_message, state, captured.append)
+
+completed = strategy.on_server_notification(
+    {"method": "turn/completed", "params": {"threadId": "thread/alpha", "turnId": "turn-42"}},
+    state,
+)
+
+print(
+    json.dumps(
+        {
+            "intercepted": intercepted,
+            "approval": captured[0],
+            "completed": completed,
+        },
+        ensure_ascii=False,
+    )
+)
+PYCODE
+)"
+
+assert_contains "${adapter_json}" '"intercepted": true' "app-server adapter intercepts approval requests with rewritten commands"
+assert_contains "${adapter_json}" 'rewrite=codex-thread-thread-alpha|thread/alpha|turn-42' "pre-bash hook receives explicit session/thread/turn context"
+assert_contains "${adapter_json}" '"vibeguard"' "turn/completed notification is enriched with vibeguard feedback"
+assert_contains "${adapter_json}" 'learn=codex-thread-thread-alpha|thread/alpha|turn-42' "learn-evaluator feedback is attached to turn/completed"
+assert_contains "${adapter_json}" 'build=codex-thread-thread-alpha|thread/alpha|turn-42' "post-build feedback is attached to turn/completed"
+assert_contains "${adapter_json}" '"pre_edit_guard": false' "capability matrix is exposed on app-server feedback"
+assert_not_contains "${adapter_json}" '"stop-guard.sh"' "empty stop-guard output does not create spurious feedback entries"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -189,6 +189,8 @@ print(
             "intercepted": intercepted,
             "approval": captured[0],
             "completed": completed,
+            "session_collision_free": module._session_id_for_thread("thread/alpha")
+            != module._session_id_for_thread("thread-alpha"),
         },
         ensure_ascii=False,
     )
@@ -197,10 +199,12 @@ PYCODE
 )"
 
 assert_contains "${adapter_json}" '"intercepted": true' "app-server adapter intercepts approval requests with rewritten commands"
-assert_contains "${adapter_json}" 'rewrite=codex-thread-thread-alpha|thread/alpha|turn-42' "pre-bash hook receives explicit session/thread/turn context"
+assert_contains "${adapter_json}" 'rewrite=codex-thread-thread-alpha-' "pre-bash hook receives a normalized hashed session id"
+assert_contains "${adapter_json}" '|thread/alpha|turn-42' "pre-bash hook receives explicit thread/turn context"
 assert_contains "${adapter_json}" '"vibeguard"' "turn/completed notification is enriched with vibeguard feedback"
-assert_contains "${adapter_json}" 'learn=codex-thread-thread-alpha|thread/alpha|turn-42' "learn-evaluator feedback is attached to turn/completed"
-assert_contains "${adapter_json}" 'build=codex-thread-thread-alpha|thread/alpha|turn-42' "post-build feedback is attached to turn/completed"
+assert_contains "${adapter_json}" 'learn=codex-thread-thread-alpha-' "learn-evaluator feedback is attached to turn/completed"
+assert_contains "${adapter_json}" 'build=codex-thread-thread-alpha-' "post-build feedback is attached to turn/completed"
+assert_contains "${adapter_json}" '"session_collision_free": true' "distinct thread ids do not collapse to the same session id"
 assert_contains "${adapter_json}" '"pre_edit_guard": false' "capability matrix is exposed on app-server feedback"
 assert_not_contains "${adapter_json}" '"stop-guard.sh"' "empty stop-guard output does not create spurious feedback entries"
 

--- a/tests/test_eval_contract.sh
+++ b/tests/test_eval_contract.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# VibeGuard eval contract regression tests
+#
+# Usage: bash tests/test_eval_contract.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_DIR_RESOLVED="$(python3 - <<'PY' "${REPO_DIR}"
+from pathlib import Path
+import sys
+print(Path(sys.argv[1]).resolve())
+PY
+)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+header "eval runner syntax"
+assert_cmd "eval/run_eval.py syntax is correct" python3 -m py_compile "${REPO_DIR}/eval/run_eval.py"
+
+header "dry-run uses repository snapshot by default"
+dry_run_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --dry-run)"
+assert_contains "${dry_run_out}" "Rules source: ${REPO_DIR_RESOLVED}/rules/claude-rules" "dry-run reports repository rule source"
+assert_contains "${dry_run_out}" "Core constraint source: ${REPO_DIR_RESOLVED}/claude-md/vibeguard-rules.md" "dry-run reports repository core rules source"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_eval_contract.sh
+++ b/tests/test_eval_contract.sh
@@ -9,7 +9,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_DIR_RESOLVED="$(python3 - <<'PY' "${REPO_DIR}"
 from pathlib import Path
 import sys
-print(Path(sys.argv[1]).resolve())
+print(Path(sys.argv[1]).resolve().as_posix())
 PY
 )"
 
@@ -51,8 +51,9 @@ assert_cmd "eval/run_eval.py syntax is correct" python3 -m py_compile "${REPO_DI
 
 header "dry-run uses repository snapshot by default"
 dry_run_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --dry-run)"
-assert_contains "${dry_run_out}" "Rules source: ${REPO_DIR_RESOLVED}/rules/claude-rules" "dry-run reports repository rule source"
-assert_contains "${dry_run_out}" "Core constraint source: ${REPO_DIR_RESOLVED}/claude-md/vibeguard-rules.md" "dry-run reports repository core rules source"
+normalized_out="$(printf '%s' "${dry_run_out}" | tr '\\' '/')"
+assert_contains "${normalized_out}" "Rules source: ${REPO_DIR_RESOLVED}/rules/claude-rules" "dry-run reports repository rule source"
+assert_contains "${normalized_out}" "Core constraint source: ${REPO_DIR_RESOLVED}/claude-md/vibeguard-rules.md" "dry-run reports repository core rules source"
 
 echo
 echo "=============================="

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# VibeGuard manifest contract regression tests
+#
+# Usage: bash tests/test_manifest_contract.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST_HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
+CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+header "helper syntax"
+assert_cmd "manifest helper syntax is correct" python3 -m py_compile "${MANIFEST_HELPER}"
+assert_cmd "codex config helper syntax is correct" python3 -m py_compile "${CODEX_CONFIG_HELPER}"
+
+header "manifest contract"
+assert_cmd "manifest contract validates" python3 "${MANIFEST_HELPER}" validate
+profiles_out="$(python3 "${MANIFEST_HELPER}" profile-names)"
+assert_contains "${profiles_out}" "core" "profile list contains core"
+assert_contains "${profiles_out}" "full" "profile list contains full"
+rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source canonical --scope common)"
+assert_contains "${rules_out}" "W-17" "canonical common rule ids include W-17"
+assert_contains "${rules_out}" "U-32" "canonical common rule ids include U-32"
+
+header "codex config helper"
+CONFIG_FILE="${TMP_DIR}/config.toml"
+enable_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
+assert_contains "${enable_out}" "CHANGED" "enable-codex-hooks creates config when missing"
+assert_cmd "enable-codex-hooks writes codex_hooks = true" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+
+cat > "${CONFIG_FILE}" <<'TOML'
+[features]
+foo = true
+
+[mcp_servers.vibeguard]
+command = "node"
+args = ["/legacy/mcp-server/dist/index.js"]
+TOML
+remove_out="$(python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${CONFIG_FILE}")"
+assert_contains "${remove_out}" "CHANGED" "remove-legacy-vibeguard-mcp reports change"
+assert_cmd "legacy vibeguard mcp section removed" bash -c "! grep -q '^\[mcp_servers\\.vibeguard\]' '${CONFIG_FILE}'"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -69,6 +69,16 @@ assert_cmd "enable-codex-hooks writes codex_hooks = true" grep -Eq '^codex_hooks
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
+codex_hooks_beta = false
+foo = true
+TOML
+enable_prefixed_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
+assert_contains "${enable_prefixed_out}" "CHANGED" "enable-codex-hooks adds canonical key when only prefixed keys exist"
+assert_cmd "enable-codex-hooks preserves prefixed feature keys" grep -Eq '^codex_hooks_beta[[:space:]]*=[[:space:]]*false$' "${CONFIG_FILE}"
+assert_cmd "enable-codex-hooks adds exact codex_hooks key" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+
+cat > "${CONFIG_FILE}" <<'TOML'
+[features]
 foo = true
 
 [mcp_servers.vibeguard]
@@ -78,6 +88,13 @@ TOML
 remove_out="$(python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${CONFIG_FILE}")"
 assert_contains "${remove_out}" "CHANGED" "remove-legacy-vibeguard-mcp reports change"
 assert_cmd "legacy vibeguard mcp section removed" bash -c "! grep -q '^\[mcp_servers\\.vibeguard\]' '${CONFIG_FILE}'"
+
+header "doc freshness installed drift"
+EMPTY_HOME="${TMP_DIR}/empty-home"
+mkdir -p "${EMPTY_HOME}/.claude/rules/vibeguard"
+installed_out="$(HOME="${EMPTY_HOME}" bash "${REPO_DIR}/scripts/verify/doc-freshness-check.sh" --installed)"
+assert_contains "${installed_out}" "Installed rule ids: 0" "installed drift reports empty installed rule set"
+assert_contains "${installed_out}" "Installed-vs-repo rule drift" "installed drift lists missing canonical rules even when installed set is empty"
 
 echo
 echo "=============================="

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -60,6 +60,8 @@ assert_contains "${profiles_out}" "full" "profile list contains full"
 rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source canonical --scope common)"
 assert_contains "${rules_out}" "W-17" "canonical common rule ids include W-17"
 assert_contains "${rules_out}" "U-32" "canonical common rule ids include U-32"
+reference_rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source reference)"
+assert_contains "${reference_rules_out}" "TASTE-ANSI" "reference rule ids include TASTE-prefixed rules"
 
 header "codex config helper"
 CONFIG_FILE="${TMP_DIR}/config.toml"
@@ -78,10 +80,19 @@ assert_cmd "enable-codex-hooks preserves prefixed feature keys" grep -Eq '^codex
 assert_cmd "enable-codex-hooks adds exact codex_hooks key" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
 
 cat > "${CONFIG_FILE}" <<'TOML'
+[features] # user comment
+codex_hooks_beta = false
+TOML
+enable_commented_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
+assert_contains "${enable_commented_out}" "CHANGED" "enable-codex-hooks recognizes commented features table"
+assert_cmd "enable-codex-hooks does not append duplicate commented features table" bash -c "test \$(grep -Ec '^\\[features\\]' '${CONFIG_FILE}') -eq 1"
+assert_cmd "enable-codex-hooks adds exact key under commented features table" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+
+cat > "${CONFIG_FILE}" <<'TOML'
 [features]
 foo = true
 
-[mcp_servers.vibeguard]
+[mcp_servers.vibeguard] # legacy comment
 command = "node"
 args = ["/legacy/mcp-server/dist/index.js"]
 TOML

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -178,6 +178,21 @@ assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'sessi
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 
+header "setup --check stays read-only"
+python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"
+from pathlib import Path
+import re
+path = Path(__import__('sys').argv[1])
+text = path.read_text(encoding='utf-8')
+updated = re.sub(r'\b\d+ rules\b', '999 rules', text, count=1)
+path.write_text(updated, encoding='utf-8')
+PY
+before_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
+check_again_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+after_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
+assert_contains "${check_again_out}" "CLAUDE.md declares 999 rules" "--check reports CLAUDE.md drift"
+assert_cmd "--check does not rewrite ~/.claude/CLAUDE.md" test "${before_sha}" = "${after_sha}"
+
 header "upsert idempotency with non-standard wrapper path"
 # Run upsert twice with a wrapper path that does not contain 'run-hook-codex.sh'.
 # Without the _has_entry dedup fix, the second upsert would append duplicates.

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -178,6 +178,19 @@ assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'sessi
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 
+header "codex config helper failure propagates"
+_ORIG_CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
+_BACKUP_CODEX_CONFIG_HELPER="${TMP_HOME}/codex_config_toml.py.backup"
+cp "${_ORIG_CODEX_CONFIG_HELPER}" "${_BACKUP_CODEX_CONFIG_HELPER}"
+cat > "${_ORIG_CODEX_CONFIG_HELPER}" <<'PY'
+#!/usr/bin/env python3
+raise SystemExit(42)
+PY
+fail_install_out="$(bash "${REPO_DIR}/setup.sh" 2>&1 || true)"
+cp "${_BACKUP_CODEX_CONFIG_HELPER}" "${_ORIG_CODEX_CONFIG_HELPER}"
+assert_contains "${fail_install_out}" "Failed to enable codex_hooks feature in config.toml" "setup reports codex_hooks helper failure"
+assert_cmd "setup exits before reporting success when codex_hooks helper fails" bash -c "! grep -q 'Setup complete! All components installed.' <<< '${fail_install_out}'"
+
 header "setup --check stays read-only"
 python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"
 from pathlib import Path


### PR DESCRIPTION
## Summary
- converge Codex/Claude install and runtime behavior onto an explicit manifest + helper layer
- surface Codex app-server post-turn hook feedback and explicit session/thread/turn context instead of silent fail-open behavior
- harden CI, eval, benchmark, and docs around repository-owned contract sources and clearer Core vs Workflow boundaries

## Testing
- python3 scripts/lib/vibeguard_manifest.py validate
- bash tests/test_manifest_contract.sh
- bash tests/test_eval_contract.sh
- bash tests/test_codex_runtime.sh
- bash tests/test_setup.sh
- bash tests/test_hook_health.sh
- VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh
- bash tests/test_precision_tracker.sh
- bash tests/unit/run_all.sh
- bash tests/test_rust_guards.sh
- bash scripts/verify/doc-freshness-check.sh --strict
- bash scripts/ci/validate-manifest-contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-precision-thresholds.sh
- bash scripts/benchmark.sh --mode=fast