### PR TITLE
feat: shift stable contract checks left into local pre-commit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,11 @@ jobs:
         shell: bash
         run: bash tests/test_quality_grader.sh
 
+      - name: Local contract gate regression tests
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash tests/test_local_contract_gate.sh
+
       - name: Guard unit tests
         if: runner.os != 'Windows'
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,40 @@ bash scripts/verify/doc-freshness-check.sh --strict
 
 If your change touches installation, Codex hook wiring, or repo docs, prefer running the full set above. The authoritative source for CI coverage is [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
+### Local Contract Gate
+
+A dedicated wrapper runs the stable, fast subset of contract checks in one command — the same checks available in CI but scoped to what is deterministic, repository-local, and cheap enough for a commit loop.
+
+```bash
+# Run the full local gate manually
+bash scripts/local-contract-check.sh
+
+# Skip the doc-freshness check for a faster pass
+bash scripts/local-contract-check.sh --quick
+
+# Wire the gate as a git pre-commit hook (one-time setup)
+bash scripts/install-pre-commit-hook.sh
+```
+
+**Local-vs-CI split**
+
+| Check | Local gate | CI only |
+|-------|-----------|---------|
+| `validate-guards.sh` | Yes | Yes |
+| `validate-hooks.sh` | Yes | Yes |
+| `validate-rules.sh` | Yes | Yes |
+| `validate-doc-paths.sh` | Yes | Yes |
+| `validate-doc-command-paths.sh` | Yes | Yes |
+| `doc-freshness-check.sh --strict` | Yes (skippable with `--quick`) | Yes |
+| `test_manifest_contract.sh` | Yes (once PR #80 merges) | Yes |
+| `test_eval_contract.sh` | Yes (once PR #80 merges) | Yes |
+| Benchmark suite (`bench_hook_latency.sh`) | No — too slow | Yes |
+| Full precision suite (`run_precision.sh --all`) | No — requires full dataset | Yes |
+| Hook regression matrix (`test_hooks.sh`) | No — run manually | Yes |
+| Static perf analysis | No | Yes |
+
+> **Note:** The local gate is Unix-first (Linux and macOS). Windows contributors should run the full CI matrix for contract coverage, as several checks depend on Bash 5+ features not available in Git Bash or WSL by default.
+
 ---
 
 ## Contribution Workflow

--- a/README.md
+++ b/README.md
@@ -290,6 +290,17 @@ Bootstrap another repository with project-specific guidance and the pre-commit w
 bash ~/vibeguard/scripts/project-init.sh /path/to/project
 ```
 
+### Local Contract Gate (contributors)
+
+Run stable contract checks locally before pushing, or wire them as a pre-commit hook:
+
+```bash
+bash scripts/local-contract-check.sh          # run the full local gate
+bash scripts/install-pre-commit-hook.sh       # install as git pre-commit hook
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the local-vs-CI split and the `--quick` flag.
+
 ### Custom Rules
 
 Add your own rules to `~/.vibeguard/user-rules/`. Any `.md` files placed there are automatically installed to `~/.claude/rules/vibeguard/custom/` on the next setup run. Format: standard Claude Code rule files with YAML frontmatter.

--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -8,38 +8,37 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-HOOK_DIR="$REPO_ROOT/.git/hooks"
+# Works for regular repos, worktrees, and submodules
+HOOK_DIR="$(git rev-parse --git-path hooks)"
 HOOK_FILE="$HOOK_DIR/pre-commit"
 
 if [[ ! -d "$HOOK_DIR" ]]; then
-  echo "Error: .git/hooks directory not found. Are you inside a git repository?" >&2
+  echo "Error: hooks directory not found at $HOOK_DIR. Are you inside a git repository?" >&2
   exit 1
 fi
 
-# Back up any existing hook
 if [[ -f "$HOOK_FILE" ]]; then
+  if grep -qF "local-contract-check.sh" "$HOOK_FILE"; then
+    echo "Contract gate already present in $HOOK_FILE — nothing to do."
+    exit 0
+  fi
+
   BACKUP="$HOOK_FILE.bak.$(date +%s)"
   cp "$HOOK_FILE" "$BACKUP"
   echo "Existing hook backed up to: $BACKUP"
-fi
 
-cat > "$HOOK_FILE" <<EOF
-#!/usr/bin/env bash
-exec bash "\${REPO_ROOT}/scripts/local-contract-check.sh"
-EOF
-
-# Inject REPO_ROOT resolution into the hook so it works from any working dir
-cat > "$HOOK_FILE" <<'EOF'
+  # Chain: append the contract gate so the existing hook's guards are preserved
+  printf '\n# Contract gate (chained by install-pre-commit-hook.sh)\n__vg_root="$(git rev-parse --show-toplevel)"\nbash "${__vg_root}/scripts/local-contract-check.sh"\n' >> "$HOOK_FILE"
+  echo "Contract gate appended to existing hook at: $HOOK_FILE"
+else
+  cat > "$HOOK_FILE" <<'EOF'
 #!/usr/bin/env bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 exec bash "${REPO_ROOT}/scripts/local-contract-check.sh"
 EOF
+  chmod +x "$HOOK_FILE"
+  echo "Installed pre-commit hook at: $HOOK_FILE"
+fi
 
-chmod +x "$HOOK_FILE"
-
-echo "Installed pre-commit hook at: $HOOK_FILE"
-echo "Runs on every 'git commit'. Use --quick to skip the freshness check:"
-echo "  QUICK=1 git commit   # not supported via env — edit hook to pass --quick if needed"
-echo ""
-echo "To use --quick mode, edit $HOOK_FILE and change the exec line to:"
-echo "  exec bash \"\${REPO_ROOT}/scripts/local-contract-check.sh\" --quick"
+echo "Runs on every 'git commit'."
+echo "To use --quick mode, edit $HOOK_FILE and change the exec line (or appended call) to pass --quick."

--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install the local contract gate as a git pre-commit hook.
+# Backs up any existing hook before overwriting.
+#
+# Usage:
+#   bash scripts/install-pre-commit-hook.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_DIR="$REPO_ROOT/.git/hooks"
+HOOK_FILE="$HOOK_DIR/pre-commit"
+
+if [[ ! -d "$HOOK_DIR" ]]; then
+  echo "Error: .git/hooks directory not found. Are you inside a git repository?" >&2
+  exit 1
+fi
+
+# Back up any existing hook
+if [[ -f "$HOOK_FILE" ]]; then
+  BACKUP="$HOOK_FILE.bak.$(date +%s)"
+  cp "$HOOK_FILE" "$BACKUP"
+  echo "Existing hook backed up to: $BACKUP"
+fi
+
+cat > "$HOOK_FILE" <<EOF
+#!/usr/bin/env bash
+exec bash "\${REPO_ROOT}/scripts/local-contract-check.sh"
+EOF
+
+# Inject REPO_ROOT resolution into the hook so it works from any working dir
+cat > "$HOOK_FILE" <<'EOF'
+#!/usr/bin/env bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec bash "${REPO_ROOT}/scripts/local-contract-check.sh"
+EOF
+
+chmod +x "$HOOK_FILE"
+
+echo "Installed pre-commit hook at: $HOOK_FILE"
+echo "Runs on every 'git commit'. Use --quick to skip the freshness check:"
+echo "  QUICK=1 git commit   # not supported via env — edit hook to pass --quick if needed"
+echo ""
+echo "To use --quick mode, edit $HOOK_FILE and change the exec line to:"
+echo "  exec bash \"\${REPO_ROOT}/scripts/local-contract-check.sh\" --quick"

--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -49,9 +49,12 @@ if [[ -L "$HOOK_FILE" ]] || [[ -f "$HOOK_FILE" ]]; then
 #!/usr/bin/env bash
 # Chain: previous hook runs as subprocess so exec-terminated hooks don't skip the gate
 bash "${PREV_HOOK}" "\$@"
+_prev_exit=\$?
 # Contract gate (chained by install-pre-commit-hook.sh)
 __vg_root="\$(git rev-parse --show-toplevel)"
 bash "\${__vg_root}/scripts/local-contract-check.sh"
+_gate_exit=\$?
+exit \$(( _prev_exit != 0 ? _prev_exit : _gate_exit ))
 HOOKEOF
   chmod +x "$HOOK_FILE"
   echo "Contract gate chained to existing hook at: $HOOK_FILE"

--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -11,25 +11,50 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Works for regular repos, worktrees, and submodules
 HOOK_DIR="$(git rev-parse --git-path hooks)"
 HOOK_FILE="$HOOK_DIR/pre-commit"
+# Stable path for the original hook so the wrapper can call it
+PREV_HOOK="$HOOK_DIR/pre-commit.vibeguard-prev"
 
 if [[ ! -d "$HOOK_DIR" ]]; then
   echo "Error: hooks directory not found at $HOOK_DIR. Are you inside a git repository?" >&2
   exit 1
 fi
 
-if [[ -f "$HOOK_FILE" ]]; then
+# -L covers symlinks that exist without a backing regular file entry
+if [[ -L "$HOOK_FILE" ]] || [[ -f "$HOOK_FILE" ]]; then
   if grep -qF "local-contract-check.sh" "$HOOK_FILE"; then
     echo "Contract gate already present in $HOOK_FILE — nothing to do."
     exit 0
   fi
 
   BACKUP="$HOOK_FILE.bak.$(date +%s)"
-  cp "$HOOK_FILE" "$BACKUP"
+  cp "$HOOK_FILE" "$BACKUP"   # cp follows symlinks; backup always gets real content
   echo "Existing hook backed up to: $BACKUP"
 
-  # Chain: append the contract gate so the existing hook's guards are preserved
-  printf '\n# Contract gate (chained by install-pre-commit-hook.sh)\n__vg_root="$(git rev-parse --show-toplevel)"\nbash "${__vg_root}/scripts/local-contract-check.sh"\n' >> "$HOOK_FILE"
-  echo "Contract gate appended to existing hook at: $HOOK_FILE"
+  # Save the original content to a stable path the wrapper can call.
+  # cp follows the symlink here, so PREV_HOOK is always a regular file.
+  cp "$HOOK_FILE" "$PREV_HOOK"
+  chmod +x "$PREV_HOOK"
+
+  # Break any symlink so the next write creates a new regular file scoped to this
+  # repo only.  Without this, writing to $HOOK_FILE would follow the symlink and
+  # mutate the shared target (e.g. ~/.vibeguard/hooks/pre-commit-guard.sh) used by
+  # every other repository on the machine.
+  [[ -L "$HOOK_FILE" ]] && rm "$HOOK_FILE"
+
+  # Write a wrapper that calls the original hook as a subprocess (bash, not exec).
+  # Calling with exec would make everything after the exec line unreachable, so the
+  # contract gate would silently never run on repos whose existing hook ends with
+  # `exec bash <vibeguard-guard>`.
+  cat > "$HOOK_FILE" <<HOOKEOF
+#!/usr/bin/env bash
+# Chain: previous hook runs as subprocess so exec-terminated hooks don't skip the gate
+bash "${PREV_HOOK}" "\$@"
+# Contract gate (chained by install-pre-commit-hook.sh)
+__vg_root="\$(git rev-parse --show-toplevel)"
+bash "\${__vg_root}/scripts/local-contract-check.sh"
+HOOKEOF
+  chmod +x "$HOOK_FILE"
+  echo "Contract gate chained to existing hook at: $HOOK_FILE"
 else
   cat > "$HOOK_FILE" <<'EOF'
 #!/usr/bin/env bash

--- a/scripts/local-contract-check.sh
+++ b/scripts/local-contract-check.sh
@@ -32,6 +32,8 @@ run_check() {
   local label="$1"
   local script="$2"
   local unix_only="${3:-false}"
+  shift 3
+  # remaining positional args are forwarded to the script
 
   if [[ "$unix_only" == "true" ]] && ! is_unix; then
     echo "  SKIP (non-Unix): $label"
@@ -44,7 +46,7 @@ run_check() {
   fi
 
   echo "  RUN: $label"
-  if bash "$script"; then
+  if bash "$script" "$@"; then
     echo "  PASS: $label"
   else
     echo "  FAIL: $label"
@@ -65,7 +67,7 @@ run_check "validate-doc-paths"       "$REPO_DIR/scripts/ci/validate-doc-paths.sh
 run_check "validate-doc-command-paths" "$REPO_DIR/scripts/ci/validate-doc-command-paths.sh" "false"
 
 if [[ "$QUICK" -eq 0 ]]; then
-  run_check "doc-freshness (--strict)" "$REPO_DIR/scripts/verify/doc-freshness-check.sh --strict" "true"
+  run_check "doc-freshness (--strict)" "$REPO_DIR/scripts/verify/doc-freshness-check.sh" "true" --strict
 else
   echo "  SKIP (--quick): doc-freshness"
 fi

--- a/scripts/local-contract-check.sh
+++ b/scripts/local-contract-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Run the stable, fast subset of contract checks locally.
+# Mirrors the CI gate but excludes slow/environment-sensitive checks.
+#
+# Usage:
+#   bash scripts/local-contract-check.sh           # full local gate
+#   bash scripts/local-contract-check.sh --quick   # skip doc-freshness check
+
+set -euo pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+QUICK=0
+FAIL=0
+declare -a FAILED_LABELS=()
+
+# ---- flag parsing ----------------------------------------------------------
+for arg in "$@"; do
+  case "$arg" in
+    --quick) QUICK=1 ;;
+    *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# ---- helpers ---------------------------------------------------------------
+is_unix() {
+  local os
+  os="$(uname -s 2>/dev/null || true)"
+  [[ "$os" == "Linux" || "$os" == "Darwin" ]]
+}
+
+run_check() {
+  local label="$1"
+  local script="$2"
+  local unix_only="${3:-false}"
+
+  if [[ "$unix_only" == "true" ]] && ! is_unix; then
+    echo "  SKIP (non-Unix): $label"
+    return
+  fi
+
+  if [[ ! -f "$script" ]]; then
+    echo "  SKIP (not found): $label"
+    return
+  fi
+
+  echo "  RUN: $label"
+  if bash "$script"; then
+    echo "  PASS: $label"
+  else
+    echo "  FAIL: $label"
+    FAIL=$((FAIL + 1))
+    FAILED_LABELS+=("$label")
+  fi
+}
+
+# ---- checks ----------------------------------------------------------------
+echo ""
+echo "=== Local Contract Gate ==="
+echo ""
+
+run_check "validate-guards"          "$REPO_DIR/scripts/ci/validate-guards.sh"          "true"
+run_check "validate-hooks"           "$REPO_DIR/scripts/ci/validate-hooks.sh"           "true"
+run_check "validate-rules"           "$REPO_DIR/scripts/ci/validate-rules.sh"           "true"
+run_check "validate-doc-paths"       "$REPO_DIR/scripts/ci/validate-doc-paths.sh"       "false"
+run_check "validate-doc-command-paths" "$REPO_DIR/scripts/ci/validate-doc-command-paths.sh" "false"
+
+if [[ "$QUICK" -eq 0 ]]; then
+  run_check "doc-freshness (--strict)" "$REPO_DIR/scripts/verify/doc-freshness-check.sh --strict" "true"
+else
+  echo "  SKIP (--quick): doc-freshness"
+fi
+
+# PR #80 contract tests — activate automatically once those files exist
+if [[ -f "$REPO_DIR/tests/test_manifest_contract.sh" ]]; then
+  run_check "test_manifest_contract" "$REPO_DIR/tests/test_manifest_contract.sh" "true"
+fi
+
+if [[ -f "$REPO_DIR/tests/test_eval_contract.sh" ]]; then
+  run_check "test_eval_contract"     "$REPO_DIR/tests/test_eval_contract.sh"     "true"
+fi
+
+# ---- summary ---------------------------------------------------------------
+echo ""
+echo "==========================="
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "All checks passed."
+else
+  echo "FAILED checks (${FAIL}):"
+  for lbl in "${FAILED_LABELS[@]}"; do
+    echo "  - $lbl"
+  done
+  echo ""
+  echo "To reproduce: bash scripts/local-contract-check.sh"
+fi
+echo "==========================="
+echo ""
+
+exit $((FAIL > 0 ? 1 : 0))

--- a/tests/test_local_contract_gate.sh
+++ b/tests/test_local_contract_gate.sh
@@ -230,5 +230,44 @@ assert_contains "$INSTALLED4" "local-contract-check.sh" \
   "exec-chain: contract gate present after original hook call"
 
 # ---------------------------------------------------------------------------
+header "install-pre-commit-hook.sh: original hook failure propagated"
+
+FAKE_REPO5="$TMPDIR_TEST/repo5"
+mkdir -p "$FAKE_REPO5"
+git -C "$FAKE_REPO5" init -q
+FAKE_HOOKS5="$FAKE_REPO5/.git/hooks"
+
+# Existing hook that always fails
+cat > "$FAKE_HOOKS5/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+exit 42
+HOOK
+chmod +x "$FAKE_HOOKS5/pre-commit"
+
+cd "$FAKE_REPO5"
+bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" > /dev/null 2>&1 || true
+cd "$REPO_DIR"
+
+# The generated wrapper must preserve the original hook's non-zero exit
+INSTALLED5="$(cat "$FAKE_HOOKS5/pre-commit")"
+TOTAL=$((TOTAL + 1))
+if echo "$INSTALLED5" | grep -qE '_prev_exit'; then
+  green "exit-propagation: wrapper captures original hook exit code"
+  PASS=$((PASS + 1))
+else
+  red "exit-propagation: wrapper does not capture original hook exit code"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if echo "$INSTALLED5" | grep -qE 'exit.*_prev_exit.*_gate_exit|_prev_exit.*_gate_exit'; then
+  green "exit-propagation: wrapper exits with combined failure result"
+  PASS=$((PASS + 1))
+else
+  red "exit-propagation: wrapper does not propagate exit codes correctly"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
 printf '\n=== Results: %d/%d passed ===\n' "$PASS" "$TOTAL"
 [[ "$FAIL" -eq 0 ]] || { echo "FAILED: $FAIL test(s)"; exit 1; }

--- a/tests/test_local_contract_gate.sh
+++ b/tests/test_local_contract_gate.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Tests for scripts/local-contract-check.sh and scripts/install-pre-commit-hook.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$unexpected"; then
+    red "$desc (expected NOT to contain: $unexpected)"
+    FAIL=$((FAIL + 1))
+  else
+    green "$desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_exit() {
+  local expected="$1" actual="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$actual" -eq "$expected" ]]; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected exit $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+header "local-contract-check.sh: --quick flag skips doc-freshness"
+
+OUT=$(bash scripts/local-contract-check.sh --quick 2>&1 || true)
+assert_contains "$OUT" "SKIP (--quick): doc-freshness" "--quick skips freshness label"
+assert_not_contains "$OUT" "SKIP (not found): doc-freshness" "--quick does not emit 'not found' for freshness"
+
+# ---------------------------------------------------------------------------
+header "local-contract-check.sh: doc-freshness run_check uses file path only (not path+args)"
+
+# The script at scripts/verify/doc-freshness-check.sh should be checked with -f
+# against just the script path, not the path+' --strict' string.
+# We verify by ensuring the output is either RUN/PASS/FAIL/SKIP(not found) — never
+# a false SKIP that contains '--strict' as part of the filename message.
+OUT=$(bash scripts/local-contract-check.sh 2>&1 || true)
+assert_not_contains "$OUT" "SKIP (not found): doc-freshness (--strict)" \
+  "doc-freshness is not skipped due to path+args being treated as filename"
+
+# ---------------------------------------------------------------------------
+header "local-contract-check.sh: unknown flag exits 2"
+
+set +e
+bash scripts/local-contract-check.sh --bogus-flag > /dev/null 2>&1
+RC=$?
+set -e
+assert_exit 2 "$RC" "unknown flag exits with code 2"
+
+# ---------------------------------------------------------------------------
+header "install-pre-commit-hook.sh: uses git rev-parse --git-path hooks (not hardcoded .git/hooks)"
+
+# Verify the script text does not hardcode .git/hooks
+SCRIPT_CONTENT="$(cat scripts/install-pre-commit-hook.sh)"
+TOTAL=$((TOTAL + 1))
+if echo "$SCRIPT_CONTENT" | grep -qF 'git rev-parse --git-path hooks'; then
+  green "installer uses git rev-parse --git-path hooks"
+  PASS=$((PASS + 1))
+else
+  red "installer does NOT use git rev-parse --git-path hooks"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if echo "$SCRIPT_CONTENT" | grep -qF '\.git/hooks'; then
+  red "installer still hardcodes .git/hooks path"
+  FAIL=$((FAIL + 1))
+else
+  green "installer does not hardcode .git/hooks"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+header "install-pre-commit-hook.sh: chains to existing hook rather than overwriting"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Set up a minimal fake git repo so install script has a valid git context
+FAKE_REPO="$TMPDIR_TEST/repo"
+mkdir -p "$FAKE_REPO"
+git -C "$FAKE_REPO" init -q
+# git init always creates .git/hooks; compute absolute path directly
+FAKE_HOOKS="$FAKE_REPO/.git/hooks"
+
+# Install an existing hook that simulates pre-commit-guard.sh
+EXISTING_HOOK="$FAKE_HOOKS/pre-commit"
+cat > "$EXISTING_HOOK" <<'HOOK'
+#!/usr/bin/env bash
+echo "existing-guard-ran"
+HOOK
+chmod +x "$EXISTING_HOOK"
+
+# Run the installer from inside the fake repo
+OUT=$(cd "$FAKE_REPO" && bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" 2>&1 || true)
+
+# The original hook should NOT have been replaced — check content still has existing-guard-ran
+HOOK_CONTENT="$(cat "$EXISTING_HOOK")"
+assert_contains "$HOOK_CONTENT" "existing-guard-ran" "existing hook content preserved after install"
+assert_contains "$HOOK_CONTENT" "local-contract-check.sh" "contract gate appended to existing hook"
+
+# Re-run installer: should detect gate already present and skip
+OUT2=$(cd "$FAKE_REPO" && bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" 2>&1 || true)
+assert_contains "$OUT2" "already present" "idempotent: re-run detects gate already installed"
+
+# ---------------------------------------------------------------------------
+header "install-pre-commit-hook.sh: fresh install (no existing hook)"
+
+FAKE_REPO2="$TMPDIR_TEST/repo2"
+mkdir -p "$FAKE_REPO2"
+git -C "$FAKE_REPO2" init -q
+FAKE_HOOKS2="$FAKE_REPO2/.git/hooks"
+
+cd "$FAKE_REPO2"
+bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" > /dev/null 2>&1
+cd "$REPO_DIR"
+
+HOOK2_CONTENT="$(cat "$FAKE_HOOKS2/pre-commit")"
+assert_contains "$HOOK2_CONTENT" "local-contract-check.sh" "fresh install writes contract gate hook"
+assert_contains "$HOOK2_CONTENT" "#!/usr/bin/env bash" "fresh install writes shebang"
+
+# ---------------------------------------------------------------------------
+printf '\n=== Results: %d/%d passed ===\n' "$PASS" "$TOTAL"
+[[ "$FAIL" -eq 0 ]] || { echo "FAILED: $FAIL test(s)"; exit 1; }

--- a/tests/test_local_contract_gate.sh
+++ b/tests/test_local_contract_gate.sh
@@ -124,10 +124,11 @@ chmod +x "$EXISTING_HOOK"
 # Run the installer from inside the fake repo
 OUT=$(cd "$FAKE_REPO" && bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" 2>&1 || true)
 
-# The original hook should NOT have been replaced — check content still has existing-guard-ran
+# New wrapper is at $EXISTING_HOOK; original content saved to pre-commit.vibeguard-prev
 HOOK_CONTENT="$(cat "$EXISTING_HOOK")"
-assert_contains "$HOOK_CONTENT" "existing-guard-ran" "existing hook content preserved after install"
-assert_contains "$HOOK_CONTENT" "local-contract-check.sh" "contract gate appended to existing hook"
+PREV_CONTENT="$(cat "$FAKE_HOOKS/pre-commit.vibeguard-prev" 2>/dev/null || echo "")"
+assert_contains "$HOOK_CONTENT" "local-contract-check.sh" "contract gate present in wrapper hook"
+assert_contains "$PREV_CONTENT" "existing-guard-ran" "original hook saved to pre-commit.vibeguard-prev"
 
 # Re-run installer: should detect gate already present and skip
 OUT2=$(cd "$FAKE_REPO" && bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" 2>&1 || true)
@@ -148,6 +149,85 @@ cd "$REPO_DIR"
 HOOK2_CONTENT="$(cat "$FAKE_HOOKS2/pre-commit")"
 assert_contains "$HOOK2_CONTENT" "local-contract-check.sh" "fresh install writes contract gate hook"
 assert_contains "$HOOK2_CONTENT" "#!/usr/bin/env bash" "fresh install writes shebang"
+
+# ---------------------------------------------------------------------------
+header "install-pre-commit-hook.sh: symlink safety — shared target not mutated"
+
+FAKE_REPO3="$TMPDIR_TEST/repo3"
+mkdir -p "$FAKE_REPO3"
+git -C "$FAKE_REPO3" init -q
+FAKE_HOOKS3="$FAKE_REPO3/.git/hooks"
+
+# Simulate a shared VibeGuard wrapper (e.g. ~/.vibeguard/hooks/pre-commit-guard.sh)
+SHARED_TARGET="$TMPDIR_TEST/shared-pre-commit-guard.sh"
+cat > "$SHARED_TARGET" <<'HOOK'
+#!/usr/bin/env bash
+exec bash "$(dirname "$0")/vibeguard-guard.sh" "$@"
+HOOK
+chmod +x "$SHARED_TARGET"
+SHARED_BEFORE="$(cat "$SHARED_TARGET")"
+
+# Point this repo's pre-commit hook at the shared target via a symlink
+ln -s "$SHARED_TARGET" "$FAKE_HOOKS3/pre-commit"
+
+cd "$FAKE_REPO3"
+bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" > /dev/null 2>&1 || true
+cd "$REPO_DIR"
+
+SHARED_AFTER="$(cat "$SHARED_TARGET")"
+TOTAL=$((TOTAL + 1))
+if [[ "$SHARED_BEFORE" == "$SHARED_AFTER" ]]; then
+  green "symlink: shared target not mutated"
+  PASS=$((PASS + 1))
+else
+  red "symlink: shared target was mutated!"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if [[ ! -L "$FAKE_HOOKS3/pre-commit" ]]; then
+  green "symlink: symlink replaced with regular file"
+  PASS=$((PASS + 1))
+else
+  red "symlink: hook is still a symlink after install"
+  FAIL=$((FAIL + 1))
+fi
+
+assert_contains "$(cat "$FAKE_HOOKS3/pre-commit")" "local-contract-check.sh" \
+  "symlink: contract gate wired into new regular-file hook"
+
+# ---------------------------------------------------------------------------
+header "install-pre-commit-hook.sh: exec-terminated hook — contract gate reachable"
+
+FAKE_REPO4="$TMPDIR_TEST/repo4"
+mkdir -p "$FAKE_REPO4"
+git -C "$FAKE_REPO4" init -q
+FAKE_HOOKS4="$FAKE_REPO4/.git/hooks"
+
+# Simulate the VibeGuard wrapper pattern: hook body ends with exec
+cat > "$FAKE_HOOKS4/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+exec bash "$(git rev-parse --show-toplevel)/hooks/pre-commit-guard.sh" "$@"
+HOOK
+chmod +x "$FAKE_HOOKS4/pre-commit"
+
+cd "$FAKE_REPO4"
+bash "$REPO_DIR/scripts/install-pre-commit-hook.sh" > /dev/null 2>&1 || true
+cd "$REPO_DIR"
+
+INSTALLED4="$(cat "$FAKE_HOOKS4/pre-commit")"
+# The call to the original hook must use bash (subprocess), not exec.
+# exec would make the contract gate line unreachable.
+TOTAL=$((TOTAL + 1))
+if echo "$INSTALLED4" | grep -qE '^exec[[:space:]].*vibeguard-prev'; then
+  red "exec-chain: original hook called via exec (gate is unreachable)"
+  FAIL=$((FAIL + 1))
+else
+  green "exec-chain: original hook called as subprocess (gate reachable)"
+  PASS=$((PASS + 1))
+fi
+assert_contains "$INSTALLED4" "local-contract-check.sh" \
+  "exec-chain: contract gate present after original hook call"
 
 # ---------------------------------------------------------------------------
 printf '\n=== Results: %d/%d passed ===\n' "$PASS" "$TOTAL"


### PR DESCRIPTION
## Summary

- Add `scripts/local-contract-check.sh`: wrapper that runs the deterministic, repository-local subset of CI contract checks (validate-guards, validate-hooks, validate-rules, validate-doc-paths, validate-doc-command-paths, doc-freshness). Supports `--quick` to skip freshness. PR #80 contract tests activate automatically once those files exist.
- Add `scripts/install-pre-commit-hook.sh`: one-command hook installer with timestamped backup of any existing hook.
- Update `CONTRIBUTING.md`: new "Local Contract Gate" subsection with local-vs-CI split table, usage examples, and Windows note.
- Update `README.md`: brief entrypoint note under Project Bootstrap.

## Test plan

- [ ] `bash scripts/local-contract-check.sh --quick` exits 0 on clean repo
- [ ] `bash scripts/local-contract-check.sh` exits 0 on clean repo (all checks pass)
- [ ] `bash scripts/install-pre-commit-hook.sh` creates `.git/hooks/pre-commit` (executable)
- [ ] Re-running installer with existing hook creates timestamped `.bak` and installs new hook
- [ ] `bash scripts/ci/validate-doc-paths.sh` passes (new script paths referenced in docs exist)
- [ ] `bash scripts/ci/validate-doc-command-paths.sh` passes

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)