### PR TITLE
fix(guards): move || true outside $() to prevent pipefail propagation

### DIFF
--- a/guards/rust/check_nested_locks.sh
+++ b/guards/rust/check_nested_locks.sh
@@ -18,13 +18,9 @@ TMPFILE=$(create_tmpfile)
 
 # Pre-commit mode: only scan new lines in staged diff
 if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-  if ! grep -q '\.rs$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null; then
-    STAGED_RS=""
-  else
-    STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" \
-      | { grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" || true; } \
-      | { grep -vE "${VIBEGUARD_TEST_FILE_PATTERN}" || true; })
-  fi
+  STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" \
+    | grep -vE "${VIBEGUARD_EXCLUDE_PATHS}" \
+    | grep -vE "${VIBEGUARD_TEST_FILE_PATTERN}") || STAGED_RS=""
 
   if [[ -n "${STAGED_RS}" ]]; then
     while IFS= read -r f; do

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -110,7 +110,7 @@ echo "Check legacy debugging code..."
 DEBUG_CODE=$(grep -rn "${EXCLUDE_ARGS[@]}" \
   -E '^\s*(console\.(log|debug|info)\(|print\(|println!\(|dbg!\(|puts |p |pp )' \
   "$TARGET_DIR" --include='*.py' --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' --include='*.rs' --include='*.rb' --include='*.go' \
-  2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || DEBUG_CODE=""
+  2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || true
 if [[ -n "$DEBUG_CODE" ]]; then
   COUNT=$(echo "$DEBUG_CODE" | wc -l | tr -d ' ')
   yellow "Legacy debug code: ${COUNT}"

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -110,7 +110,7 @@ echo "Check legacy debugging code..."
 DEBUG_CODE=$(grep -rn "${EXCLUDE_ARGS[@]}" \
   -E '^\s*(console\.(log|debug|info)\(|print\(|println!\(|dbg!\(|puts |p |pp )' \
   "$TARGET_DIR" --include='*.py' --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' --include='*.rs' --include='*.rb' --include='*.go' \
-  2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.' || true)
+  2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || DEBUG_CODE=""
 if [[ -n "$DEBUG_CODE" ]]; then
   COUNT=$(echo "$DEBUG_CODE" | wc -l | tr -d ' ')
   yellow "Legacy debug code: ${COUNT}"

--- a/tests/unit/run_all.sh
+++ b/tests/unit/run_all.sh
@@ -63,9 +63,9 @@ for test_file in "${TESTS[@]}"; do
   if [[ $exit_code -eq 0 ]]; then
     # Parse pass/fail counts from test output (last line: "Total: N  Pass: N  Fail: N")
     clean_output="$(printf '%s\n' "$output" | strip_ansi)"
-    pass_count=$(echo "$clean_output" | grep -oE 'Pass:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' || true)
-    fail_count=$(echo "$clean_output" | grep -oE 'Fail:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' || true)
-    skip_count=$(echo "$clean_output" | grep -oE 'Skip:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' || true)
+    pass_count=$(echo "$clean_output" | grep -oE 'Pass:[[:space:]]*[0-9]+' | grep -oE '[0-9]+') || pass_count=""
+    fail_count=$(echo "$clean_output" | grep -oE 'Fail:[[:space:]]*[0-9]+' | grep -oE '[0-9]+') || fail_count=""
+    skip_count=$(echo "$clean_output" | grep -oE 'Skip:[[:space:]]*[0-9]+' | grep -oE '[0-9]+') || skip_count=""
     [[ -z "$pass_count" ]] && pass_count="N/A"
     [[ -z "$fail_count" ]] && fail_count="N/A"
     [[ -z "$skip_count" ]] && skip_count="0"

--- a/tests/unit/test_rust_check_nested_locks.sh
+++ b/tests/unit/test_rust_check_nested_locks.sh
@@ -127,6 +127,20 @@ impl S {
 EOF
 assert_ok "locks split across separate functions passes" bash "$GUARD" --strict "$proj6"
 
+# --- Pre-commit mode: VIBEGUARD_STAGED_FILES with no .rs files (pipefail regression) ---
+staged_no_rs=$(mktemp)
+printf 'main.go\nApp.tsx\nstyles.css\n' > "$staged_no_rs"
+trap 'rm -f "$staged_no_rs"; rm -rf "$tmpdir"' EXIT
+assert_ok "pre-commit: no .rs files staged exits 0" \
+  env VIBEGUARD_STAGED_FILES="$staged_no_rs" bash "$GUARD"
+
+# --- Pre-commit mode: all staged .rs files match VIBEGUARD_EXCLUDE_PATHS ---
+staged_excluded=$(mktemp)
+printf '/project/target/debug/foo.rs\n/project/.git/foo.rs\n' > "$staged_excluded"
+trap 'rm -f "$staged_no_rs" "$staged_excluded"; rm -rf "$tmpdir"' EXIT
+assert_ok "pre-commit: all staged .rs files excluded exits 0" \
+  env VIBEGUARD_STAGED_FILES="$staged_excluded" bash "$GUARD"
+
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
 [[ $FAIL -gt 0 ]] && exit 1 || exit 0

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -114,6 +114,16 @@ proj_empty="${tmpdir}/pass_empty"
 mkdir -p "${proj_empty}"
 assert_ok "empty directory passes" bash "$GUARD" "$proj_empty"
 
+# --- PASS: console.log present but all occurrences have // keep marker ---
+proj_kept="${tmpdir}/pass_kept_debug"
+mkdir -p "${proj_kept}"
+cat > "${proj_kept}/logger.ts" <<'EOF'
+export function log(msg: string): void {
+  console.log(msg); // keep
+}
+EOF
+assert_ok "console.log with // keep is not flagged" bash "$GUARD" "$proj_kept"
+
 # --- PASS/FAIL: fixtures excluded by default, but includable via flag ---
 proj_fixtures="${tmpdir}/fixtures_scope"
 mkdir -p "${proj_fixtures}/tests/fixtures"


### PR DESCRIPTION
## Summary

- `guards/rust/check_nested_locks.sh`: replace three-segment pipe with `{ grep || true; }` intermediate guards with a clean linear pipe guarded by `|| STAGED_RS=""` outside the command substitution
- `guards/universal/check_code_slop.sh`: move `|| true` from inside `$(…)` to `|| DEBUG_CODE=""` outside, making the guard placement consistent and unambiguous under `set -o pipefail`
- `tests/unit/run_all.sh`: same pattern fix for `pass_count`/`fail_count`/`skip_count` parsing pipelines
- Adds two pre-commit mode regression tests to `test_rust_check_nested_locks.sh` (no `.rs` files staged; all `.rs` files match `VIBEGUARD_EXCLUDE_PATHS`) and one `// keep` filter test to `test_universal_check_code_slop.sh`

Closes #79

## Root cause

With `set -euo pipefail`, a failed `grep` in segment N of a pipeline propagates its non-zero exit through the entire pipe even when a later `{ grep || true; }` segment exits 0. The `pipefail` option picks the *rightmost non-zero* exit, so the outer assignment `VAR=$(…)` inherits the failure and `set -e` aborts the script — causing false-positive guard firings on non-Rust commits.

The fix: remove intermediate `{ … || true; }` guards and instead append `|| VAR=""` after the closing `)` of the command substitution. This pattern is safe in all POSIX shells and bash 3.2+.

## Test plan

- [x] `bash tests/unit/test_rust_check_nested_locks.sh` — 9/9 pass (includes 2 new pre-commit regression tests)
- [x] `bash tests/unit/test_universal_check_code_slop.sh` — 13/13 pass (includes new `// keep` filter test)
- [x] `bash tests/unit/run_all.sh` — 18/19 pass (pre-existing failure in `test_ts_check_console_residual.sh` unrelated to this PR)