### PR TITLE
fix(guards): block git checkout/restore with quoted dot argument

### DIFF
--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -65,8 +65,10 @@ block() {
 # Check both COMMAND_STRIPPED and COMMAND_PATH_SCAN: COMMAND_STRIPPED erases quoted content
 # (e.g. "." → ""), so `git checkout "."` would bypass the pattern; COMMAND_PATH_SCAN strips
 # the quotes but keeps the content, catching the quoted-dot variant.
+# COMMAND_PATH_SCAN regex must be anchored to start-of-command (^|;|&&||) so that commands
+# like `echo "git checkout ."` or commit messages mentioning the pattern are not falsely blocked.
 if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)' || \
-   echo "$COMMAND_PATH_SCAN" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
+   echo "$COMMAND_PATH_SCAN" | grep -qE '(^|;|&&|\|\|)\s*(sudo\s+)?git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -51,6 +51,23 @@ print(cmd)
 # Use path scanning: remove quotation marks but retain the content to prevent rm -rf \"/Users/...\" from being bypassed
 COMMAND_PATH_SCAN=$(printf '%s' "$COMMAND_NO_HEREDOC" | tr -d "\"'")
 
+# Variant of COMMAND_STRIPPED that converts "." / '.' (standalone quoted dot) into a bare dot
+# before stripping other quoted content. This lets the same no-anchor regex detect both
+# `git checkout .` and `git checkout "."` (including wrappers like `GIT_TRACE=1 git checkout "."`
+# or `echo y | git checkout "."`) without exposing separators that were inside larger quoted
+# strings (which would cause false positives when stripping all quotes via COMMAND_PATH_SCAN).
+COMMAND_STRIPPED_WITH_DOT=$(printf '%s' "$COMMAND_NO_HEREDOC" | python3 -c "
+import re, sys
+cmd = sys.stdin.read()
+# Replace standalone quoted dot (\".\"/'.') with bare dot before stripping other quoted content
+cmd = re.sub(r'\"\.\"', '.', cmd)
+cmd = re.sub(r\"'\\.'\", '.', cmd)
+# Strip remaining quoted content so separators inside strings stay invisible
+cmd = re.sub(r'\"[^\"]*\"', '\"\"', cmd)
+cmd = re.sub(r\"'[^']*'\", \"''\", cmd)
+print(cmd)
+" 2>/dev/null || echo "$COMMAND_NO_HEREDOC")
+
 block() {
   local reason="$1"
   vg_log "pre-bash-guard" "Bash" "block" "$reason" "$COMMAND"
@@ -62,13 +79,10 @@ block() {
 
 # git checkout . / git restore . (discard all changes)
 # Only matches pure "." endings, excluding legal path operations such as git checkout ./src/file
-# Check both COMMAND_STRIPPED and COMMAND_PATH_SCAN: COMMAND_STRIPPED erases quoted content
-# (e.g. "." → ""), so `git checkout "."` would bypass the pattern; COMMAND_PATH_SCAN strips
-# the quotes but keeps the content, catching the quoted-dot variant.
-# COMMAND_PATH_SCAN regex must be anchored to start-of-command (^|;|&&||) so that commands
-# like `echo "git checkout ."` or commit messages mentioning the pattern are not falsely blocked.
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)' || \
-   echo "$COMMAND_PATH_SCAN" | grep -qE '(^|;|&&|\|\|)\s*(sudo\s+)?git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
+# COMMAND_STRIPPED_WITH_DOT converts "." / '.' to a bare dot then strips other quoted content,
+# so a no-anchor regex safely detects all wrapper forms (env vars, pipes, `command`, `env`)
+# without false-positives from separators inside commit messages or string arguments.
+if echo "$COMMAND_STRIPPED_WITH_DOT" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -62,7 +62,11 @@ block() {
 
 # git checkout . / git restore . (discard all changes)
 # Only matches pure "." endings, excluding legal path operations such as git checkout ./src/file
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
+# Check both COMMAND_STRIPPED and COMMAND_PATH_SCAN: COMMAND_STRIPPED erases quoted content
+# (e.g. "." → ""), so `git checkout "."` would bypass the pattern; COMMAND_PATH_SCAN strips
+# the quotes but keeps the content, catching the quoted-dot variant.
+if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)' || \
+   echo "$COMMAND_PATH_SCAN" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/tests/fixtures/pre-bash-guard/fp/commit-checkout-dot-mention.txt
+++ b/tests/fixtures/pre-bash-guard/fp/commit-checkout-dot-mention.txt
@@ -1,0 +1,1 @@
+git commit -m "repro: git checkout ."

--- a/tests/fixtures/pre-bash-guard/fp/commit-msg-separator-checkout.txt
+++ b/tests/fixtures/pre-bash-guard/fp/commit-msg-separator-checkout.txt
@@ -1,0 +1,1 @@
+git commit -m "docs; git checkout ."

--- a/tests/fixtures/pre-bash-guard/fp/echo-and-restore-mention.txt
+++ b/tests/fixtures/pre-bash-guard/fp/echo-and-restore-mention.txt
@@ -1,0 +1,1 @@
+echo "note && git restore ."

--- a/tests/fixtures/pre-bash-guard/fp/echo-checkout-dot.txt
+++ b/tests/fixtures/pre-bash-guard/fp/echo-checkout-dot.txt
@@ -1,0 +1,1 @@
+echo "git checkout ."

--- a/tests/fixtures/pre-bash-guard/fp/printf-restore-dot.txt
+++ b/tests/fixtures/pre-bash-guard/fp/printf-restore-dot.txt
@@ -1,0 +1,1 @@
+printf "%s\n" "git restore ."

--- a/tests/fixtures/pre-bash-guard/meta.json
+++ b/tests/fixtures/pre-bash-guard/meta.json
@@ -10,6 +10,18 @@
       "keyword": "\"decision\": \"block\"",
       "description": "git checkout . should be intercepted"
     },
+    "tp/checkout-dot-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "git checkout \".\" (quoted dot) should be intercepted"
+    },
+    "tp/restore-dot-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "git restore \".\" (quoted dot) should be intercepted"
+    },
     "tp/clean-fd.txt": {
       "rule": "BLOCK",
       "expect": "block",
@@ -87,6 +99,24 @@
       "expect": "pass",
       "keyword": "\"decision\": \"block\"",
       "description": "heredoc contains force push and no false positives"
+    },
+    "fp/echo-checkout-dot.txt": {
+      "rule": "BLOCK",
+      "expect": "pass",
+      "keyword": "\"decision\": \"block\"",
+      "description": "echo containing git checkout . should not be blocked"
+    },
+    "fp/printf-restore-dot.txt": {
+      "rule": "BLOCK",
+      "expect": "pass",
+      "keyword": "\"decision\": \"block\"",
+      "description": "printf containing git restore . should not be blocked"
+    },
+    "fp/commit-checkout-dot-mention.txt": {
+      "rule": "BLOCK",
+      "expect": "pass",
+      "keyword": "\"decision\": \"block\"",
+      "description": "commit message mentioning git checkout . should not be blocked"
     }
   }
 }

--- a/tests/fixtures/pre-bash-guard/meta.json
+++ b/tests/fixtures/pre-bash-guard/meta.json
@@ -117,6 +117,42 @@
       "expect": "pass",
       "keyword": "\"decision\": \"block\"",
       "description": "commit message mentioning git checkout . should not be blocked"
+    },
+    "tp/git-trace-checkout-dot-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "GIT_TRACE=1 git checkout \".\" (env-var wrapper) should be intercepted"
+    },
+    "tp/env-trace-restore-dot-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "env GIT_TRACE=1 git restore \".\" (env command wrapper) should be intercepted"
+    },
+    "tp/command-checkout-dot-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "command git checkout \".\" (command builtin wrapper) should be intercepted"
+    },
+    "tp/pipe-checkout-dot-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "echo y | git checkout \".\" (pipe wrapper) should be intercepted"
+    },
+    "fp/commit-msg-separator-checkout.txt": {
+      "rule": "BLOCK",
+      "expect": "pass",
+      "keyword": "\"decision\": \"block\"",
+      "description": "commit message with semicolon before git checkout . mention should not be blocked"
+    },
+    "fp/echo-and-restore-mention.txt": {
+      "rule": "BLOCK",
+      "expect": "pass",
+      "keyword": "\"decision\": \"block\"",
+      "description": "echo string with && before git restore . mention should not be blocked"
     }
   }
 }

--- a/tests/fixtures/pre-bash-guard/tp/checkout-dot-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/checkout-dot-quoted.txt
@@ -1,0 +1,1 @@
+git checkout "."

--- a/tests/fixtures/pre-bash-guard/tp/command-checkout-dot-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/command-checkout-dot-quoted.txt
@@ -1,0 +1,1 @@
+command git checkout "."

--- a/tests/fixtures/pre-bash-guard/tp/env-trace-restore-dot-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/env-trace-restore-dot-quoted.txt
@@ -1,0 +1,1 @@
+env GIT_TRACE=1 git restore "."

--- a/tests/fixtures/pre-bash-guard/tp/git-trace-checkout-dot-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/git-trace-checkout-dot-quoted.txt
@@ -1,0 +1,1 @@
+GIT_TRACE=1 git checkout "."

--- a/tests/fixtures/pre-bash-guard/tp/pipe-checkout-dot-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/pipe-checkout-dot-quoted.txt
@@ -1,0 +1,1 @@
+echo y | git checkout "."

--- a/tests/fixtures/pre-bash-guard/tp/restore-dot-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/restore-dot-quoted.txt
@@ -1,0 +1,1 @@
+git restore "."

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -189,6 +189,26 @@ assert_not_contains "$result" '"decision": "block"' "printf containing git resto
 result=$(echo '{"tool_input":{"command":"git commit -m \"repro: git checkout .\"" }}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "commit message mentioning git checkout . not blocked"
 
+# shell wrapper bypasses: env-var prefix, env command, command builtin, pipe — all should block
+result=$(echo '{"tool_input":{"command":"GIT_TRACE=1 git checkout \".\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "GIT_TRACE=1 git checkout \".\" (env-var wrapper) intercepted"
+
+result=$(echo '{"tool_input":{"command":"env GIT_TRACE=1 git restore \".\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "env GIT_TRACE=1 git restore \".\" (env command wrapper) intercepted"
+
+result=$(echo '{"tool_input":{"command":"command git checkout \".\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "command git checkout \".\" (command builtin wrapper) intercepted"
+
+result=$(echo '{"tool_input":{"command":"echo y | git checkout \".\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "echo y | git checkout \".\" (pipe wrapper) intercepted"
+
+# separator false-positives from quoted strings — must NOT block
+result=$(echo '{"tool_input":{"command":"git commit -m \"docs; git checkout .\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "commit message with semicolon before checkout mention not blocked"
+
+result=$(echo '{"tool_input":{"command":"echo \"note && git restore .\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "echo string with && before restore mention not blocked"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -169,6 +169,26 @@ assert_not_contains "$result" '"decision": "block"' "Release git reset --hard (p
 result=$(echo '{"tool_input":{"command":"git checkout ."}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Intercept git checkout ."
 
+# git checkout "." (quoted dot) should be intercepted
+result=$(echo '{"tool_input":{"command":"git checkout \".\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git checkout \".\" (quoted dot)"
+
+# git restore "." (quoted dot) should be intercepted
+result=$(echo '{"tool_input":{"command":"git restore \".\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git restore \".\" (quoted dot)"
+
+# echo "git checkout ." should NOT be intercepted (false-positive guard)
+result=$(echo '{"tool_input":{"command":"echo \"git checkout .\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "echo containing git checkout . not blocked"
+
+# printf mentioning git restore . should NOT be intercepted (false-positive guard)
+result=$(printf '{"tool_input":{"command":"printf \"%s\\n\" \"git restore .\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "printf containing git restore . not blocked"
+
+# commit message mentioning git checkout . should NOT be intercepted (false-positive guard)
+result=$(echo '{"tool_input":{"command":"git commit -m \"repro: git checkout .\"" }}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "commit message mentioning git checkout . not blocked"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"


### PR DESCRIPTION
## Summary

- `COMMAND_STRIPPED` replaces quoted strings with empty strings, so `git checkout "."` becomes `git checkout ""` and bypasses the guard pattern `git\s+(checkout|restore)\s+\.`
- Fix: also check `COMMAND_PATH_SCAN` (which strips quote characters but retains content) for the git checkout/restore pattern, so the quoted-dot variant is caught

## Test plan

- [ ] `git checkout .` is still blocked
- [ ] `git checkout "."` is now blocked (was bypassed before)
- [ ] `git restore "."` is now blocked (was bypassed before)
- [ ] `git checkout ./src/file` is still allowed (path prefix, not pure dot)
- [ ] `git checkout -- specific-file` is still allowed