### PR TITLE
fix(pre-commit-guard): detect langs from staged files, not repo config

### DIFF
--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -33,7 +33,7 @@ if [[ "$_vg_repo_root" != "global" ]]; then
 fi
 
 # Source file extension list (shared constant)
-VG_SOURCE_EXTS="rs py ts js tsx jsx go java kt swift rb"
+VG_SOURCE_EXTS="rs py ts js mjs cjs tsx jsx go java kt swift rb"
 
 # Determine whether the file is a source code file
 # Usage: vg_is_source_file "path/to/file.rs" && echo "is source code"

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -231,6 +231,8 @@ PY
 }
 
 # --- Quality guards: call guards/ script (replaces inline grep) ---
+# Some guards are intentionally shared across multiple detected languages.
+# Run those shared suites once per commit to avoid duplicate failures/output.
 GUARD_OUTPUT=""
 GUARD_FAIL=0
 
@@ -251,34 +253,41 @@ run_guard() {
 if [[ -n "$GUARDS_DIR" ]]; then
   # Quote GUARDS_DIR for safe use inside bash -c strings (handles paths with spaces)
   GUARDS_DIR_Q=$(printf '%q' "${GUARDS_DIR}")
-  for lang in $DETECTED_LANGS; do
-    case "$lang" in
-      rust)
-        [[ -f "${GUARDS_DIR}/rust/check_unwrap_in_prod.sh" ]] && \
-          run_guard "rust/unwrap" "bash ${GUARDS_DIR_Q}/rust/check_unwrap_in_prod.sh --strict ."
-        ;;
-      typescript|javascript)
-        [[ -f "${GUARDS_DIR}/typescript/check_console_residual.sh" ]] && \
-          run_guard "ts/console" "bash ${GUARDS_DIR_Q}/typescript/check_console_residual.sh --strict ."
-        [[ -f "${GUARDS_DIR}/typescript/check_any_abuse.sh" ]] && \
-          run_guard "ts/any" "bash ${GUARDS_DIR_Q}/typescript/check_any_abuse.sh --strict ."
-        ;;
-      python)
-        [[ -f "${GUARDS_DIR}/python/check_naming_convention.py" ]] && \
-          run_guard "py/naming" "python3 ${GUARDS_DIR_Q}/python/check_naming_convention.py ."
-        [[ -f "${GUARDS_DIR}/python/check_dead_shims.py" ]] && \
-          run_guard "py/dead_shims" "python3 ${GUARDS_DIR_Q}/python/check_dead_shims.py --strict ."
-        ;;
-      go)
-        [[ -f "${GUARDS_DIR}/go/check_error_handling.sh" ]] && \
-          run_guard "go/error_handling" "bash ${GUARDS_DIR_Q}/go/check_error_handling.sh --strict ."
-        [[ -f "${GUARDS_DIR}/go/check_goroutine_leak.sh" ]] && \
-          run_guard "go/goroutine_leak" "bash ${GUARDS_DIR_Q}/go/check_goroutine_leak.sh --strict ."
-        [[ -f "${GUARDS_DIR}/go/check_defer_in_loop.sh" ]] && \
-          run_guard "go/defer_in_loop" "bash ${GUARDS_DIR_Q}/go/check_defer_in_loop.sh --strict ."
-        ;;
-    esac
-  done
+  case " $DETECTED_LANGS " in
+    *" rust "*)
+      [[ -f "${GUARDS_DIR}/rust/check_unwrap_in_prod.sh" ]] && \
+        run_guard "rust/unwrap" "bash ${GUARDS_DIR_Q}/rust/check_unwrap_in_prod.sh --strict ."
+      ;;
+  esac
+
+  case " $DETECTED_LANGS " in
+    *" typescript "*|*" javascript "*)
+      [[ -f "${GUARDS_DIR}/typescript/check_console_residual.sh" ]] && \
+        run_guard "ts/console" "bash ${GUARDS_DIR_Q}/typescript/check_console_residual.sh --strict ."
+      [[ -f "${GUARDS_DIR}/typescript/check_any_abuse.sh" ]] && \
+        run_guard "ts/any" "bash ${GUARDS_DIR_Q}/typescript/check_any_abuse.sh --strict ."
+      ;;
+  esac
+
+  case " $DETECTED_LANGS " in
+    *" python "*)
+      [[ -f "${GUARDS_DIR}/python/check_naming_convention.py" ]] && \
+        run_guard "py/naming" "python3 ${GUARDS_DIR_Q}/python/check_naming_convention.py ."
+      [[ -f "${GUARDS_DIR}/python/check_dead_shims.py" ]] && \
+        run_guard "py/dead_shims" "python3 ${GUARDS_DIR_Q}/python/check_dead_shims.py --strict ."
+      ;;
+  esac
+
+  case " $DETECTED_LANGS " in
+    *" go "*)
+      [[ -f "${GUARDS_DIR}/go/check_error_handling.sh" ]] && \
+        run_guard "go/error_handling" "bash ${GUARDS_DIR_Q}/go/check_error_handling.sh --strict ."
+      [[ -f "${GUARDS_DIR}/go/check_goroutine_leak.sh" ]] && \
+        run_guard "go/goroutine_leak" "bash ${GUARDS_DIR_Q}/go/check_goroutine_leak.sh --strict ."
+      [[ -f "${GUARDS_DIR}/go/check_defer_in_loop.sh" ]] && \
+        run_guard "go/defer_in_loop" "bash ${GUARDS_DIR_Q}/go/check_defer_in_loop.sh --strict ."
+      ;;
+  esac
 fi
 
 # --- Build check: all detected languages run (not elif) ---

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -97,13 +97,17 @@ git diff --cached -U0 2>/dev/null \
 export VIBEGUARD_DIFF_ADDED_LINES="$_DIFF_ADDED_TMPFILE"
 
 # --- Language automatic detection (Verifier mode core) ---
-# Use REPO_ROOT absolute path to avoid detection failure during subdirectory commit
+# Detect from *staged* files only — not repo-root config files — to avoid
+# false positives when a commit touches only files of a different language.
 DETECTED_LANGS=""
-[[ -f "${REPO_ROOT}/Cargo.toml" ]]                                                      && DETECTED_LANGS="${DETECTED_LANGS} rust"
-[[ -f "${REPO_ROOT}/tsconfig.json" ]]                                                   && DETECTED_LANGS="${DETECTED_LANGS} typescript"
-[[ -f "${REPO_ROOT}/package.json" && ! -f "${REPO_ROOT}/tsconfig.json" ]]               && DETECTED_LANGS="${DETECTED_LANGS} javascript"
-[[ -f "${REPO_ROOT}/pyproject.toml" || -f "${REPO_ROOT}/setup.py" || -f "${REPO_ROOT}/setup.cfg" ]]  && DETECTED_LANGS="${DETECTED_LANGS} python"
-[[ -f "${REPO_ROOT}/go.mod" ]]                                                          && DETECTED_LANGS="${DETECTED_LANGS} go"
+grep -qE '\.rs$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} rust"
+if grep -qE '\.(ts|tsx)$'   <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} typescript"
+elif grep -qE '\.(js|jsx)$' <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} javascript"
+fi
+grep -qE '\.py$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} python"
+grep -qE '\.go$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} go"
 DETECTED_LANGS=$(echo "$DETECTED_LANGS" | xargs)
 
 # --- Timeout executor ---

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -24,7 +24,7 @@ elif [[ -n "${VIBEGUARD_DIR:-}" ]] && [[ -f "${VIBEGUARD_DIR}/hooks/log.sh" ]]; 
 else
   vg_log() { :; }
   vg_start_timer() { :; }
-  VG_SOURCE_EXTS="rs py ts js tsx jsx go java kt swift rb"
+  VG_SOURCE_EXTS="rs py ts js mjs cjs tsx jsx go java kt swift rb"
 fi
 vg_start_timer
 
@@ -178,11 +178,10 @@ while IFS= read -r file; do
       if [[ -n "$ts_root" ]]; then
         add_unique_entry DETECTED_LANGS "typescript"
         add_unique_entry TYPESCRIPT_BUILD_ROOTS "$ts_root"
-      else
-        add_unique_entry DETECTED_LANGS "javascript"
-        if [[ "$ext" != "jsx" ]]; then
-          add_unique_entry JAVASCRIPT_BUILD_FILES "$file"
-        fi
+      fi
+      add_unique_entry DETECTED_LANGS "javascript"
+      if [[ "$ext" != "jsx" ]]; then
+        add_unique_entry JAVASCRIPT_BUILD_FILES "$file"
       fi
       ;;
     mjs|cjs)

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -97,15 +97,38 @@ git diff --cached -U0 2>/dev/null \
 export VIBEGUARD_DIFF_ADDED_LINES="$_DIFF_ADDED_TMPFILE"
 
 # --- Language automatic detection (Verifier mode core) ---
-# Detect from *staged* files only — not repo-root config files — to avoid
-# false positives when a commit touches only files of a different language.
+# Quality guards run for languages present in the staged diff.
+# Build checks additionally require a runnable repo-root config when the command
+# assumes project state from "." (for example cargo check or tsc --noEmit).
 DETECTED_LANGS=""
-grep -qE '\.rs$'          <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} rust"
-grep -qE '\.(ts|tsx)$'   <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} typescript"
-grep -qE '\.(js|jsx)$'   <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} javascript"
-grep -qE '\.py$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} python"
-grep -qE '\.go$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} go"
+BUILD_LANGS=""
+
+if grep -qE '\.rs$' <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} rust"
+  [[ -f "${REPO_ROOT}/Cargo.toml" ]] && BUILD_LANGS="${BUILD_LANGS} rust"
+fi
+
+if grep -qE '\.(ts|tsx)$' <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} typescript"
+  [[ -f "${REPO_ROOT}/tsconfig.json" ]] && BUILD_LANGS="${BUILD_LANGS} typescript"
+fi
+
+if grep -qE '\.(js|jsx)$' <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} javascript"
+  BUILD_LANGS="${BUILD_LANGS} javascript"
+fi
+
+if grep -qE '\.py$' <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} python"
+fi
+
+if grep -qE '\.go$' <<< "$_ALL_STAGED"; then
+  DETECTED_LANGS="${DETECTED_LANGS} go"
+  [[ -f "${REPO_ROOT}/go.mod" ]] && BUILD_LANGS="${BUILD_LANGS} go"
+fi
+
 DETECTED_LANGS=$(echo "$DETECTED_LANGS" | xargs)
+BUILD_LANGS=$(echo "$BUILD_LANGS" | xargs)
 
 # --- Timeout executor ---
 run_with_timeout() {
@@ -188,7 +211,7 @@ if [[ -n "$GUARDS_DIR" ]]; then
   done
 fi
 
-# --- Build check: all detected languages run (not elif) ---
+# --- Build check: only run commands that are supported from the repo root ---
 BUILD_FAILS=""
 
 run_build_check() {
@@ -202,7 +225,7 @@ run_build_check() {
   fi
 }
 
-for lang in $DETECTED_LANGS; do
+for lang in $BUILD_LANGS; do
   case "$lang" in
     rust)
       run_build_check "cargo check --quiet" "cargo check failed"

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -96,39 +96,110 @@ git diff --cached -U0 2>/dev/null \
   > "$_DIFF_ADDED_TMPFILE" || true
 export VIBEGUARD_DIFF_ADDED_LINES="$_DIFF_ADDED_TMPFILE"
 
-# --- Language automatic detection (Verifier mode core) ---
-# Quality guards run for languages present in the staged diff.
-# Build checks additionally require a runnable repo-root config when the command
-# assumes project state from "." (for example cargo check or tsc --noEmit).
+# --- Language and project-root detection (driven by the staged tree, not the working tree) ---
+index_has_path() {
+  local path="$1"
+  git cat-file -e ":${path}" 2>/dev/null
+}
+
+find_project_root() {
+  local path="$1"
+  local marker="$2"
+  local dir="$(dirname "$path")"
+  local candidate=""
+
+  while true; do
+    if [[ "$dir" == "." ]]; then
+      candidate="$marker"
+    else
+      candidate="${dir}/${marker}"
+    fi
+
+    if index_has_path "$candidate"; then
+      if [[ "$dir" == "." ]]; then
+        echo "$REPO_ROOT"
+      else
+        echo "${REPO_ROOT}/${dir}"
+      fi
+      return 0
+    fi
+
+    if [[ "$dir" == "." ]]; then
+      break
+    fi
+
+    dir=$(dirname "$dir")
+  done
+
+  return 1
+}
+
+add_unique_entry() {
+  local var_name="$1"
+  local value="$2"
+  local current=""
+
+  [[ -z "$value" ]] && return 0
+  eval "current=\${$var_name-}"
+
+  case $'\n'"$current"$'\n' in
+    *$'\n'"$value"$'\n'*) return 0 ;;
+  esac
+
+  if [[ -n "$current" ]]; then
+    printf -v "$var_name" '%s\n%s' "$current" "$value"
+  else
+    printf -v "$var_name" '%s' "$value"
+  fi
+}
+
 DETECTED_LANGS=""
-BUILD_LANGS=""
+RUST_BUILD_ROOTS=""
+TYPESCRIPT_BUILD_ROOTS=""
+GO_BUILD_ROOTS=""
+JAVASCRIPT_BUILD_FILES=""
 
-if grep -qE '\.rs$' <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} rust"
-  [[ -f "${REPO_ROOT}/Cargo.toml" ]] && BUILD_LANGS="${BUILD_LANGS} rust"
-fi
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
 
-if grep -qE '\.(ts|tsx)$' <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} typescript"
-  [[ -f "${REPO_ROOT}/tsconfig.json" ]] && BUILD_LANGS="${BUILD_LANGS} typescript"
-fi
+  ext="${file##*.}"
 
-if grep -qE '\.(js|jsx)$' <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} javascript"
-  BUILD_LANGS="${BUILD_LANGS} javascript"
-fi
-
-if grep -qE '\.py$' <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} python"
-fi
-
-if grep -qE '\.go$' <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} go"
-  [[ -f "${REPO_ROOT}/go.mod" ]] && BUILD_LANGS="${BUILD_LANGS} go"
-fi
+  case "$ext" in
+    rs)
+      add_unique_entry DETECTED_LANGS "rust"
+      add_unique_entry RUST_BUILD_ROOTS "$(find_project_root "$file" "Cargo.toml" || true)"
+      ;;
+    ts|tsx)
+      add_unique_entry DETECTED_LANGS "typescript"
+      add_unique_entry TYPESCRIPT_BUILD_ROOTS "$(find_project_root "$file" "tsconfig.json" || true)"
+      ;;
+    js|jsx)
+      ts_root="$(find_project_root "$file" "tsconfig.json" || true)"
+      if [[ -n "$ts_root" ]]; then
+        add_unique_entry DETECTED_LANGS "typescript"
+        add_unique_entry TYPESCRIPT_BUILD_ROOTS "$ts_root"
+      else
+        add_unique_entry DETECTED_LANGS "javascript"
+        if [[ "$ext" != "jsx" ]]; then
+          add_unique_entry JAVASCRIPT_BUILD_FILES "$file"
+        fi
+      fi
+      ;;
+    mjs|cjs)
+      add_unique_entry DETECTED_LANGS "javascript"
+      add_unique_entry JAVASCRIPT_BUILD_FILES "$file"
+      ;;
+    py)
+      add_unique_entry DETECTED_LANGS "python"
+      ;;
+    go)
+      add_unique_entry DETECTED_LANGS "go"
+      add_unique_entry GO_BUILD_ROOTS "$(find_project_root "$file" "go.mod" || true)"
+      ;;
+  esac
+done <<< "$STAGED_FILES"
 
 DETECTED_LANGS=$(echo "$DETECTED_LANGS" | xargs)
-BUILD_LANGS=$(echo "$BUILD_LANGS" | xargs)
 
 # --- Timeout executor ---
 run_with_timeout() {
@@ -211,7 +282,7 @@ if [[ -n "$GUARDS_DIR" ]]; then
   done
 fi
 
-# --- Build check: only run commands that are supported from the repo root ---
+# --- Build check: all detected languages run (not elif) ---
 BUILD_FAILS=""
 
 run_build_check() {
@@ -225,14 +296,37 @@ run_build_check() {
   fi
 }
 
-for lang in $BUILD_LANGS; do
+for lang in $DETECTED_LANGS; do
   case "$lang" in
     rust)
-      run_build_check "cargo check --quiet" "cargo check failed"
+      while IFS= read -r build_root; do
+        [[ -z "$build_root" ]] && continue
+        build_root_q=$(printf '%q' "$build_root")
+        run_build_check "cd ${build_root_q} && cargo check --quiet" "cargo check failed (${build_root})"
+      done <<< "$RUST_BUILD_ROOTS"
       ;;
-    typescript) run_build_check "if ! command -v tsc >/dev/null 2>&1 && ! [ -f node_modules/.bin/tsc ]; then exit 0; fi; npx tsc --noEmit" "tsc --noEmit failed" ;;
-    javascript) run_build_check 'if ! command -v node >/dev/null 2>&1; then exit 0; fi; FILES=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E "\.(js|mjs|cjs)$" || true); [[ -z "$FILES" ]] && exit 0; while IFS= read -r f; do [[ -z "$f" || ! -f "$f" ]] && continue; node --check "$f" >/dev/null 2>&1 || exit 1; done <<< "$FILES"' "JavaScript syntax check failed (node --check)" ;;
-    go) run_build_check "go build ./..." "go build failed" ;;
+    typescript)
+      while IFS= read -r build_root; do
+        [[ -z "$build_root" ]] && continue
+        build_root_q=$(printf '%q' "$build_root")
+        run_build_check "cd ${build_root_q} && if ! command -v tsc >/dev/null 2>&1 && ! [ -f node_modules/.bin/tsc ]; then exit 0; fi; npx tsc --noEmit" "tsc --noEmit failed (${build_root})"
+      done <<< "$TYPESCRIPT_BUILD_ROOTS"
+      ;;
+    javascript)
+      if [[ -n "$JAVASCRIPT_BUILD_FILES" ]]; then
+        javascript_files_q="$(printf '%s\n' "$JAVASCRIPT_BUILD_FILES" | sed '/^$/d' | while IFS= read -r file; do printf '%q\n' "$file"; done)"
+        run_build_check "if ! command -v node >/dev/null 2>&1; then exit 0; fi; while IFS= read -r f; do [[ -z \"\$f\" || ! -f \"\$f\" ]] && continue; node --check \"\$f\" >/dev/null 2>&1 || exit 1; done <<'EOF'
+${javascript_files_q}
+EOF" "JavaScript syntax check failed (node --check)"
+      fi
+      ;;
+    go)
+      while IFS= read -r build_root; do
+        [[ -z "$build_root" ]] && continue
+        build_root_q=$(printf '%q' "$build_root")
+        run_build_check "cd ${build_root_q} && go build ./..." "go build failed (${build_root})"
+      done <<< "$GO_BUILD_ROOTS"
+      ;;
   esac
 done
 

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -309,14 +309,15 @@ for lang in $DETECTED_LANGS; do
       while IFS= read -r build_root; do
         [[ -z "$build_root" ]] && continue
         build_root_q=$(printf '%q' "$build_root")
-        run_build_check "cd ${build_root_q} && if ! command -v tsc >/dev/null 2>&1 && ! [ -f node_modules/.bin/tsc ]; then exit 0; fi; npx tsc --noEmit" "tsc --noEmit failed (${build_root})"
+        repo_root_q=$(printf '%q' "$REPO_ROOT")
+        run_build_check "cd ${build_root_q} && tsc_cmd=''; search_dir=\"\$PWD\"; while true; do if [[ -x \"\$search_dir/node_modules/.bin/tsc\" ]]; then tsc_cmd=\"\$search_dir/node_modules/.bin/tsc\"; break; fi; [[ \"\$search_dir\" == ${repo_root_q} ]] && break; parent_dir=\$(dirname \"\$search_dir\"); [[ \"\$parent_dir\" == \"\$search_dir\" ]] && break; search_dir=\"\$parent_dir\"; done; [[ -z \"\$tsc_cmd\" ]] && command -v tsc >/dev/null 2>&1 && tsc_cmd=\$(command -v tsc); [[ -z \"\$tsc_cmd\" ]] && exit 0; \"\$tsc_cmd\" --noEmit" "tsc --noEmit failed (${build_root})"
       done <<< "$TYPESCRIPT_BUILD_ROOTS"
       ;;
     javascript)
       if [[ -n "$JAVASCRIPT_BUILD_FILES" ]]; then
-        javascript_files_q="$(printf '%s\n' "$JAVASCRIPT_BUILD_FILES" | sed '/^$/d' | while IFS= read -r file; do printf '%q\n' "$file"; done)"
+        javascript_files="$(printf '%s\n' "$JAVASCRIPT_BUILD_FILES" | sed '/^$/d')"
         run_build_check "if ! command -v node >/dev/null 2>&1; then exit 0; fi; while IFS= read -r f; do [[ -z \"\$f\" || ! -f \"\$f\" ]] && continue; node --check \"\$f\" >/dev/null 2>&1 || exit 1; done <<'EOF'
-${javascript_files_q}
+${javascript_files}
 EOF" "JavaScript syntax check failed (node --check)"
       fi
       ;;

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -100,12 +100,9 @@ export VIBEGUARD_DIFF_ADDED_LINES="$_DIFF_ADDED_TMPFILE"
 # Detect from *staged* files only — not repo-root config files — to avoid
 # false positives when a commit touches only files of a different language.
 DETECTED_LANGS=""
-grep -qE '\.rs$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} rust"
-if grep -qE '\.(ts|tsx)$'   <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} typescript"
-elif grep -qE '\.(js|jsx)$' <<< "$_ALL_STAGED"; then
-  DETECTED_LANGS="${DETECTED_LANGS} javascript"
-fi
+grep -qE '\.rs$'          <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} rust"
+grep -qE '\.(ts|tsx)$'   <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} typescript"
+grep -qE '\.(js|jsx)$'   <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} javascript"
 grep -qE '\.py$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} python"
 grep -qE '\.go$'            <<< "$_ALL_STAGED" && DETECTED_LANGS="${DETECTED_LANGS} go"
 DETECTED_LANGS=$(echo "$DETECTED_LANGS" | xargs)

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -801,14 +801,6 @@ cat >"$tmp_repo_precommit_ts_js/src/bad.js" <<'EOF'
 const value = missingSymbol;
 EOF
 
-cat >"$tmp_repo_precommit_ts_js/bin/npx" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$1" == "tsc" && "$2" == "--noEmit" ]]; then
-  exit 1
-fi
-exit 0
-EOF
-
 cat >"$tmp_repo_precommit_ts_js/bin/node" <<'EOF'
 #!/usr/bin/env bash
 exit 0
@@ -816,10 +808,10 @@ EOF
 
 cat >"$tmp_repo_precommit_ts_js/bin/tsc" <<'EOF'
 #!/usr/bin/env bash
-exit 0
+exit 1
 EOF
 
-chmod +x "$tmp_repo_precommit_ts_js/bin/npx" "$tmp_repo_precommit_ts_js/bin/node" "$tmp_repo_precommit_ts_js/bin/tsc"
+chmod +x "$tmp_repo_precommit_ts_js/bin/node" "$tmp_repo_precommit_ts_js/bin/tsc"
 git -C "$tmp_repo_precommit_ts_js" add tsconfig.json src/bad.js
 _stub_guards="$(_make_stub_guard_dir)"
 assert_exit_nonzero "JS-only staged changes in a TS repo still run tsc --noEmit" bash -c "cd '$tmp_repo_precommit_ts_js' && PATH='$tmp_repo_precommit_ts_js/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
@@ -858,9 +850,11 @@ assert_exit_nonzero "Nested Cargo.toml projects still run cargo check in pre-com
 rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_rust"
 
 # Nested TS apps must run tsc from the staged file's nearest tsconfig.json.
+# The compiler may be installed only at the repo root, so the hook must search
+# ancestor node_modules/.bin entries instead of skipping the build check.
 tmp_repo_precommit_nested_ts="$(mktemp -d)"
 git -C "$tmp_repo_precommit_nested_ts" init -q
-mkdir -p "$tmp_repo_precommit_nested_ts/bin" "$tmp_repo_precommit_nested_ts/apps/web/src"
+mkdir -p "$tmp_repo_precommit_nested_ts/bin" "$tmp_repo_precommit_nested_ts/apps/web/src" "$tmp_repo_precommit_nested_ts/node_modules/.bin"
 
 cat >"$tmp_repo_precommit_nested_ts/apps/web/tsconfig.json" <<'EOF'
 {
@@ -875,24 +869,102 @@ cat >"$tmp_repo_precommit_nested_ts/apps/web/src/index.ts" <<'EOF'
 export const value = 1;
 EOF
 
-cat >"$tmp_repo_precommit_nested_ts/bin/npx" <<'EOF'
+cat >"$tmp_repo_precommit_nested_ts/node_modules/.bin/tsc" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$1" == "tsc" && "$2" == "--noEmit" ]]; then
+exit 1
+EOF
+
+chmod +x "$tmp_repo_precommit_nested_ts/node_modules/.bin/tsc"
+git -C "$tmp_repo_precommit_nested_ts" add apps/web/tsconfig.json apps/web/src/index.ts
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "Nested tsconfig.json projects still run tsc --noEmit in pre-commit" bash -c "cd '$tmp_repo_precommit_nested_ts' && PATH='$tmp_repo_precommit_nested_ts/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_ts"
+
+# JS syntax checks must not skip staged files whose names contain spaces.
+tmp_repo_precommit_js_space="$(mktemp -d)"
+git -C "$tmp_repo_precommit_js_space" init -q
+mkdir -p "$tmp_repo_precommit_js_space/bin" "$tmp_repo_precommit_js_space/src"
+
+cat >"$tmp_repo_precommit_js_space/src/bad file.js" <<'EOF'
+function () {}
+EOF
+
+cat >"$tmp_repo_precommit_js_space/bin/node" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--check" ]]; then
   exit 1
 fi
 exit 0
 EOF
 
-cat >"$tmp_repo_precommit_nested_ts/bin/tsc" <<'EOF'
+chmod +x "$tmp_repo_precommit_js_space/bin/node"
+git -C "$tmp_repo_precommit_js_space" add "src/bad file.js"
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "JavaScript syntax check still runs for staged files with spaces in the path" bash -c "cd '$tmp_repo_precommit_js_space' && PATH='$tmp_repo_precommit_js_space/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_js_space"
+
+# Nested TS apps should keep working when only the repo root provides tsc.
+tmp_repo_precommit_nested_ts_root_tsc="$(mktemp -d)"
+git -C "$tmp_repo_precommit_nested_ts_root_tsc" init -q
+mkdir -p "$tmp_repo_precommit_nested_ts_root_tsc/apps/web/src" "$tmp_repo_precommit_nested_ts_root_tsc/node_modules/.bin"
+
+cat >"$tmp_repo_precommit_nested_ts_root_tsc/apps/web/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts_root_tsc/apps/web/src/index.ts" <<'EOF'
+export const value = missingSymbol;
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts_root_tsc/node_modules/.bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+chmod +x "$tmp_repo_precommit_nested_ts_root_tsc/node_modules/.bin/tsc"
+git -C "$tmp_repo_precommit_nested_ts_root_tsc" add apps/web/tsconfig.json apps/web/src/index.ts
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "Nested tsconfig.json projects use repo-root tsc when no nested compiler exists" bash -c "cd '$tmp_repo_precommit_nested_ts_root_tsc' && PATH='/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_ts_root_tsc"
+
+# Repo-local tsc must win over a globally available compiler for nested TS projects.
+tmp_repo_precommit_nested_ts_prefer_local="$(mktemp -d)"
+git -C "$tmp_repo_precommit_nested_ts_prefer_local" init -q
+mkdir -p "$tmp_repo_precommit_nested_ts_prefer_local/bin" "$tmp_repo_precommit_nested_ts_prefer_local/apps/web/src" "$tmp_repo_precommit_nested_ts_prefer_local/node_modules/.bin"
+
+cat >"$tmp_repo_precommit_nested_ts_prefer_local/apps/web/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts_prefer_local/apps/web/src/index.ts" <<'EOF'
+export const value = missingSymbol;
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts_prefer_local/node_modules/.bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts_prefer_local/bin/tsc" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
 
-chmod +x "$tmp_repo_precommit_nested_ts/bin/npx" "$tmp_repo_precommit_nested_ts/bin/tsc"
-git -C "$tmp_repo_precommit_nested_ts" add apps/web/tsconfig.json apps/web/src/index.ts
+chmod +x "$tmp_repo_precommit_nested_ts_prefer_local/node_modules/.bin/tsc" "$tmp_repo_precommit_nested_ts_prefer_local/bin/tsc"
+git -C "$tmp_repo_precommit_nested_ts_prefer_local" add apps/web/tsconfig.json apps/web/src/index.ts
 _stub_guards="$(_make_stub_guard_dir)"
-assert_exit_nonzero "Nested tsconfig.json projects still run tsc --noEmit in pre-commit" bash -c "cd '$tmp_repo_precommit_nested_ts' && PATH='$tmp_repo_precommit_nested_ts/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
-rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_ts"
+assert_exit_nonzero "Nested tsconfig.json projects prefer repo-local tsc over a global compiler" bash -c "cd '$tmp_repo_precommit_nested_ts_prefer_local' && PATH='$tmp_repo_precommit_nested_ts_prefer_local/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_ts_prefer_local"
 
 # Nested Go modules must run go build from the staged file's nearest go.mod.
 tmp_repo_precommit_nested_go="$(mktemp -d)"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -41,6 +41,26 @@ assert_not_contains() {
   fi
 }
 
+assert_occurrences() {
+  local output="$1" needle="$2" expected_count="$3" desc="$4"
+  local actual_count
+  TOTAL=$((TOTAL + 1))
+  actual_count=$(python3 -c '
+import sys
+
+haystack = sys.argv[1]
+needle = sys.argv[2]
+print(haystack.count(needle))
+' "$output" "$needle")
+  if [[ "$actual_count" == "$expected_count" ]]; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected $expected_count occurrences of: $needle, got $actual_count)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 assert_exit_zero() {
   local desc="$1"
   shift
@@ -816,6 +836,98 @@ git -C "$tmp_repo_precommit_ts_js" add tsconfig.json src/bad.js
 _stub_guards="$(_make_stub_guard_dir)"
 assert_exit_nonzero "JS-only staged changes in a TS repo still run tsc --noEmit" bash -c "cd '$tmp_repo_precommit_ts_js' && PATH='$tmp_repo_precommit_ts_js/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
 rm -rf "$_stub_guards" "$tmp_repo_precommit_ts_js"
+
+# Mixed TS + JS staged changes should only run the shared TS quality guards once.
+tmp_repo_precommit_ts_js_quality_once="$(mktemp -d)"
+git -C "$tmp_repo_precommit_ts_js_quality_once" init -q
+mkdir -p "$tmp_repo_precommit_ts_js_quality_once/bin" "$tmp_repo_precommit_ts_js_quality_once/src"
+
+cat >"$tmp_repo_precommit_ts_js_quality_once/src/app.ts" <<'EOF'
+export const value: number = 1;
+EOF
+
+cat >"$tmp_repo_precommit_ts_js_quality_once/src/util.js" <<'EOF'
+export const util = 1;
+EOF
+
+cat >"$tmp_repo_precommit_ts_js_quality_once/bin/node" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_ts_js_quality_once/bin/node"
+git -C "$tmp_repo_precommit_ts_js_quality_once" add src/app.ts src/util.js
+_stub_guards="$(_make_stub_guard_dir)"
+cat >"$_stub_guards/guards/typescript/check_console_residual.sh" <<'EOF'
+#!/usr/bin/env bash
+echo ts-console-ran
+exit 1
+EOF
+cat >"$_stub_guards/guards/typescript/check_any_abuse.sh" <<'EOF'
+#!/usr/bin/env bash
+echo ts-any-ran
+exit 1
+EOF
+chmod +x \
+  "$_stub_guards/guards/typescript/check_console_residual.sh" \
+  "$_stub_guards/guards/typescript/check_any_abuse.sh"
+mixed_ts_js_quality_out=$(cd "$tmp_repo_precommit_ts_js_quality_once" && PATH="$tmp_repo_precommit_ts_js_quality_once/bin:/usr/bin:/bin:$PATH" VIBEGUARD_DIR="$_stub_guards" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
+assert_occurrences "$mixed_ts_js_quality_out" "[ts/console]" 1 "Mixed TS+JS staged changes run the shared TS console guard once"
+assert_occurrences "$mixed_ts_js_quality_out" "[ts/any]" 1 "Mixed TS+JS staged changes run the shared TS any guard once"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_ts_js_quality_once"
+
+# JS files inside a TS project should still run the shared TS quality guards once.
+tmp_repo_precommit_js_in_ts_quality_once="$(mktemp -d)"
+git -C "$tmp_repo_precommit_js_in_ts_quality_once" init -q
+mkdir -p "$tmp_repo_precommit_js_in_ts_quality_once/bin" "$tmp_repo_precommit_js_in_ts_quality_once/src"
+
+cat >"$tmp_repo_precommit_js_in_ts_quality_once/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}
+EOF
+
+cat >"$tmp_repo_precommit_js_in_ts_quality_once/src/util.js" <<'EOF'
+export const util = 1;
+EOF
+
+cat >"$tmp_repo_precommit_js_in_ts_quality_once/bin/node" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat >"$tmp_repo_precommit_js_in_ts_quality_once/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x \
+  "$tmp_repo_precommit_js_in_ts_quality_once/bin/node" \
+  "$tmp_repo_precommit_js_in_ts_quality_once/bin/tsc"
+git -C "$tmp_repo_precommit_js_in_ts_quality_once" add tsconfig.json src/util.js
+_stub_guards="$(_make_stub_guard_dir)"
+cat >"$_stub_guards/guards/typescript/check_console_residual.sh" <<'EOF'
+#!/usr/bin/env bash
+echo ts-console-ran
+exit 1
+EOF
+cat >"$_stub_guards/guards/typescript/check_any_abuse.sh" <<'EOF'
+#!/usr/bin/env bash
+echo ts-any-ran
+exit 1
+EOF
+chmod +x \
+  "$_stub_guards/guards/typescript/check_console_residual.sh" \
+  "$_stub_guards/guards/typescript/check_any_abuse.sh"
+js_in_ts_quality_out=$(cd "$tmp_repo_precommit_js_in_ts_quality_once" && PATH="$tmp_repo_precommit_js_in_ts_quality_once/bin:/usr/bin:/bin:$PATH" VIBEGUARD_DIR="$_stub_guards" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
+assert_occurrences "$js_in_ts_quality_out" "[ts/console]" 1 "JS-in-TS staged changes run the shared TS console guard once"
+assert_occurrences "$js_in_ts_quality_out" "[ts/any]" 1 "JS-in-TS staged changes run the shared TS any guard once"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_js_in_ts_quality_once"
 
 # Nested Rust crates must run cargo check from the staged file's nearest Cargo.toml.
 tmp_repo_precommit_nested_rust="$(mktemp -d)"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -789,16 +789,28 @@ cat >"$tmp_repo_ts_in_rust/bin/cargo" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$tmp_repo_ts_in_rust/bin/cargo"
-# Stage only the .ts file; Cargo.toml remains untracked — must not trigger rust detection
+cat >"$tmp_repo_ts_in_rust/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$tmp_repo_ts_in_rust/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$tmp_repo_ts_in_rust/bin/cargo" "$tmp_repo_ts_in_rust/bin/tsc" "$tmp_repo_ts_in_rust/bin/npx"
+# Stage only the .ts file; Cargo.toml remains untracked — rust build must not run.
+# Point VIBEGUARD_DIR at an empty guards dir so this test exercises only build gating.
 git -C "$tmp_repo_ts_in_rust" add src/index.ts
+tmp_vg_empty_ts_in_rust="$(mktemp -d)"
+mkdir -p "$tmp_vg_empty_ts_in_rust/guards"
 
-assert_exit_zero "TS-only staged in Rust repo: rust not detected from untracked Cargo.toml" bash -c "cd '$tmp_repo_ts_in_rust' && PATH='$tmp_repo_ts_in_rust/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+assert_exit_zero "TS-only staged in Rust repo: rust build not triggered from untracked Cargo.toml" bash -c "cd '$tmp_repo_ts_in_rust' && PATH='$tmp_repo_ts_in_rust/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$tmp_vg_empty_ts_in_rust' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$tmp_vg_empty_ts_in_rust"
 rm -rf "$tmp_repo_ts_in_rust"
 
 # RS-only staged in a TS repo: only .rs file staged — package.json is untracked.
-# TypeScript must NOT be detected based on untracked config files.
-# Fake tsc + npx exit 1 so any incorrect TS detection causes the test to fail.
+# TypeScript build must NOT run based on untracked repo files.
+# Fake tsc + npx exit 1 so any incorrect TS build detection causes the test to fail.
 tmp_repo_rs_in_ts="$(mktemp -d)"
 git -C "$tmp_repo_rs_in_ts" init -q
 mkdir -p "$tmp_repo_rs_in_ts/src" "$tmp_repo_rs_in_ts/bin"
@@ -816,7 +828,7 @@ cat >"$tmp_repo_rs_in_ts/bin/cargo" <<'EOF'
 exit 0
 EOF
 # Fake tsc in PATH so the guard's `command -v tsc` check succeeds and would run `npx tsc --noEmit`
-# if typescript were incorrectly detected — then fake npx fails, proving TS was triggered.
+# if typescript build were incorrectly enabled from the repo root.
 cat >"$tmp_repo_rs_in_ts/bin/tsc" <<'EOF'
 #!/usr/bin/env bash
 exit 1
@@ -826,11 +838,76 @@ cat >"$tmp_repo_rs_in_ts/bin/npx" <<'EOF'
 exit 1
 EOF
 chmod +x "$tmp_repo_rs_in_ts/bin/cargo" "$tmp_repo_rs_in_ts/bin/tsc" "$tmp_repo_rs_in_ts/bin/npx"
-# Stage only the .rs file; package.json remains untracked — must not trigger typescript detection
+# Stage only the .rs file; package.json remains untracked — TS build must not trigger.
 git -C "$tmp_repo_rs_in_ts" add src/lib.rs
 
-assert_exit_zero "RS-only staged in TS repo: typescript not detected from untracked package.json" bash -c "cd '$tmp_repo_rs_in_ts' && PATH='$tmp_repo_rs_in_ts/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+assert_exit_zero "RS-only staged in TS repo: typescript build not triggered from untracked package.json" bash -c "cd '$tmp_repo_rs_in_ts' && PATH='$tmp_repo_rs_in_ts/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
 rm -rf "$tmp_repo_rs_in_ts"
+
+# Nested Rust crate without root Cargo.toml: rust guard should still run on staged .rs files,
+# but the root-level cargo check must stay disabled.
+tmp_repo_nested_rust="$(mktemp -d)"
+git -C "$tmp_repo_nested_rust" init -q
+mkdir -p "$tmp_repo_nested_rust/crate/src" "$tmp_repo_nested_rust/bin"
+
+cat >"$tmp_repo_nested_rust/crate/Cargo.toml" <<'EOF'
+[package]
+name = "nested-vg-test"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat >"$tmp_repo_nested_rust/crate/src/lib.rs" <<'EOF'
+pub fn nested() {
+    let _value = Some(1).unwrap();
+}
+EOF
+
+cat >"$tmp_repo_nested_rust/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$tmp_repo_nested_rust/bin/cargo"
+git -C "$tmp_repo_nested_rust" add crate/src/lib.rs
+
+nested_rust_out=$(cd "$tmp_repo_nested_rust" && PATH="$tmp_repo_nested_rust/bin:/usr/bin:/bin:$PATH" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
+assert_contains "$nested_rust_out" "[rust/unwrap]" "Nested Rust crate: staged rust guard still runs without root Cargo.toml"
+assert_not_contains "$nested_rust_out" "cargo check failed" "Nested Rust crate: root cargo check stays disabled without root Cargo.toml"
+rm -rf "$tmp_repo_nested_rust"
+
+# Nested TS project without root tsconfig.json: TS guards should still run on staged .ts files,
+# but the root-level tsc build must stay disabled.
+tmp_repo_nested_ts="$(mktemp -d)"
+git -C "$tmp_repo_nested_ts" init -q
+mkdir -p "$tmp_repo_nested_ts/app/src" "$tmp_repo_nested_ts/bin"
+
+cat >"$tmp_repo_nested_ts/app/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "target": "ES2020"
+  }
+}
+EOF
+
+cat >"$tmp_repo_nested_ts/app/src/index.ts" <<'EOF'
+console.log('nested');
+EOF
+
+cat >"$tmp_repo_nested_ts/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$tmp_repo_nested_ts/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$tmp_repo_nested_ts/bin/tsc" "$tmp_repo_nested_ts/bin/npx"
+git -C "$tmp_repo_nested_ts" add app/src/index.ts
+
+nested_ts_out=$(cd "$tmp_repo_nested_ts" && PATH="$tmp_repo_nested_ts/bin:/usr/bin:/bin:$PATH" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
+assert_contains "$nested_ts_out" "[ts/console]" "Nested TS project: staged TS guard still runs without root tsconfig.json"
+assert_not_contains "$nested_ts_out" "tsc --noEmit failed" "Nested TS project: root tsc stays disabled without root tsconfig.json"
+rm -rf "$tmp_repo_nested_ts"
 
 # =========================================================
 header "log.sh — session_id: start-time anchor + 30-min TTL"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -735,179 +735,261 @@ git -C "$tmp_repo_precommit_go" add go.mod cmd/main.go
 assert_exit_nonzero "Go guards prevent _= discarding commits with error" bash -c "cd '$tmp_repo_precommit_go' && PATH='$tmp_repo_precommit_go/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
 rm -rf "$tmp_repo_precommit_go"
 
-# =========================================================
-header "pre-commit-guard.sh — staged language detection (mixed)"
-# =========================================================
+_make_stub_guard_dir() {
+  local stub_root
+  stub_root=$(mktemp -d)
+  mkdir -p "$stub_root/guards/rust" "$stub_root/guards/typescript" "$stub_root/guards/go"
 
-# Regression: mixed TS + JS commit must detect both typescript AND javascript.
-# Before the fix, the elif branch suppressed javascript whenever .ts files were staged,
-# so a mixed .ts + .js commit would skip JS syntax validation entirely.
-tmp_repo_ts_js="$(mktemp -d)"
-git -C "$tmp_repo_ts_js" init -q
-mkdir -p "$tmp_repo_ts_js/src" "$tmp_repo_ts_js/bin"
-
-cat >"$tmp_repo_ts_js/src/app.ts" <<'EOF'
-const x: number = 1;
-EOF
-
-cat >"$tmp_repo_ts_js/src/util.js" <<'EOF'
-const y = 1;
-EOF
-
-# Fake node that fails --check — proves the JS build check actually ran
-cat >"$tmp_repo_ts_js/bin/node" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--check" ]] && exit 1
-exit 0
-EOF
-chmod +x "$tmp_repo_ts_js/bin/node"
-git -C "$tmp_repo_ts_js" add src/app.ts src/util.js
-
-mixed_ts_js_out=$(cd "$tmp_repo_ts_js" && PATH="$tmp_repo_ts_js/bin:/usr/bin:/bin:$PATH" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
-assert_contains "$mixed_ts_js_out" "javascript" "Mixed TS+JS staged: javascript is detected even when TS files are present"
-rm -rf "$tmp_repo_ts_js"
-
-# TS-only staged in a Rust repo: only .ts file staged — Cargo.toml is untracked.
-# Rust must NOT be detected based on untracked config files.
-# Fake cargo exits 1 so any incorrect rust detection causes the test to fail.
-tmp_repo_ts_in_rust="$(mktemp -d)"
-git -C "$tmp_repo_ts_in_rust" init -q
-mkdir -p "$tmp_repo_ts_in_rust/src" "$tmp_repo_ts_in_rust/bin"
-
-cat >"$tmp_repo_ts_in_rust/Cargo.toml" <<'EOF'
-[package]
-name = "vg-test"
-version = "0.1.0"
-edition = "2021"
-EOF
-
-cat >"$tmp_repo_ts_in_rust/src/index.ts" <<'EOF'
-const x: number = 1;
-EOF
-
-cat >"$tmp_repo_ts_in_rust/bin/cargo" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
-cat >"$tmp_repo_ts_in_rust/bin/tsc" <<'EOF'
+  cat >"$stub_root/guards/rust/check_unwrap_in_prod.sh" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-cat >"$tmp_repo_ts_in_rust/bin/npx" <<'EOF'
+
+  cat >"$stub_root/guards/typescript/check_console_residual.sh" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-chmod +x "$tmp_repo_ts_in_rust/bin/cargo" "$tmp_repo_ts_in_rust/bin/tsc" "$tmp_repo_ts_in_rust/bin/npx"
-# Stage only the .ts file; Cargo.toml remains untracked — rust build must not run.
-# Point VIBEGUARD_DIR at an empty guards dir so this test exercises only build gating.
-git -C "$tmp_repo_ts_in_rust" add src/index.ts
-tmp_vg_empty_ts_in_rust="$(mktemp -d)"
-mkdir -p "$tmp_vg_empty_ts_in_rust/guards"
 
-assert_exit_zero "TS-only staged in Rust repo: rust build not triggered from untracked Cargo.toml" bash -c "cd '$tmp_repo_ts_in_rust' && PATH='$tmp_repo_ts_in_rust/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$tmp_vg_empty_ts_in_rust' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
-rm -rf "$tmp_vg_empty_ts_in_rust"
-rm -rf "$tmp_repo_ts_in_rust"
-
-# RS-only staged in a TS repo: only .rs file staged — package.json is untracked.
-# TypeScript build must NOT run based on untracked repo files.
-# Fake tsc + npx exit 1 so any incorrect TS build detection causes the test to fail.
-tmp_repo_rs_in_ts="$(mktemp -d)"
-git -C "$tmp_repo_rs_in_ts" init -q
-mkdir -p "$tmp_repo_rs_in_ts/src" "$tmp_repo_rs_in_ts/bin"
-
-cat >"$tmp_repo_rs_in_ts/package.json" <<'EOF'
-{"name":"vg-test","version":"1.0.0"}
-EOF
-
-cat >"$tmp_repo_rs_in_ts/src/lib.rs" <<'EOF'
-pub fn add(a: i32, b: i32) -> i32 { a + b }
-EOF
-
-cat >"$tmp_repo_rs_in_ts/bin/cargo" <<'EOF'
+  cat >"$stub_root/guards/typescript/check_any_abuse.sh" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-# Fake tsc in PATH so the guard's `command -v tsc` check succeeds and would run `npx tsc --noEmit`
-# if typescript build were incorrectly enabled from the repo root.
-cat >"$tmp_repo_rs_in_ts/bin/tsc" <<'EOF'
+
+  cat >"$stub_root/guards/go/check_error_handling.sh" <<'EOF'
 #!/usr/bin/env bash
-exit 1
+exit 0
 EOF
-cat >"$tmp_repo_rs_in_ts/bin/npx" <<'EOF'
+
+  cat >"$stub_root/guards/go/check_goroutine_leak.sh" <<'EOF'
 #!/usr/bin/env bash
-exit 1
-EOF
-chmod +x "$tmp_repo_rs_in_ts/bin/cargo" "$tmp_repo_rs_in_ts/bin/tsc" "$tmp_repo_rs_in_ts/bin/npx"
-# Stage only the .rs file; package.json remains untracked — TS build must not trigger.
-git -C "$tmp_repo_rs_in_ts" add src/lib.rs
-
-assert_exit_zero "RS-only staged in TS repo: typescript build not triggered from untracked package.json" bash -c "cd '$tmp_repo_rs_in_ts' && PATH='$tmp_repo_rs_in_ts/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
-rm -rf "$tmp_repo_rs_in_ts"
-
-# Nested Rust crate without root Cargo.toml: rust guard should still run on staged .rs files,
-# but the root-level cargo check must stay disabled.
-tmp_repo_nested_rust="$(mktemp -d)"
-git -C "$tmp_repo_nested_rust" init -q
-mkdir -p "$tmp_repo_nested_rust/crate/src" "$tmp_repo_nested_rust/bin"
-
-cat >"$tmp_repo_nested_rust/crate/Cargo.toml" <<'EOF'
-[package]
-name = "nested-vg-test"
-version = "0.1.0"
-edition = "2021"
+exit 0
 EOF
 
-cat >"$tmp_repo_nested_rust/crate/src/lib.rs" <<'EOF'
-pub fn nested() {
-    let _value = Some(1).unwrap();
+  cat >"$stub_root/guards/go/check_defer_in_loop.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  chmod +x \
+    "$stub_root/guards/rust/check_unwrap_in_prod.sh" \
+    "$stub_root/guards/typescript/check_console_residual.sh" \
+    "$stub_root/guards/typescript/check_any_abuse.sh" \
+    "$stub_root/guards/go/check_error_handling.sh" \
+    "$stub_root/guards/go/check_goroutine_leak.sh" \
+    "$stub_root/guards/go/check_defer_in_loop.sh"
+
+  echo "$stub_root"
 }
-EOF
 
-cat >"$tmp_repo_nested_rust/bin/cargo" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
-chmod +x "$tmp_repo_nested_rust/bin/cargo"
-git -C "$tmp_repo_nested_rust" add crate/src/lib.rs
+# JS-only changes inside a TS repo must still run tsc when tsconfig.json is present.
+tmp_repo_precommit_ts_js="$(mktemp -d)"
+git -C "$tmp_repo_precommit_ts_js" init -q
+mkdir -p "$tmp_repo_precommit_ts_js/bin" "$tmp_repo_precommit_ts_js/src"
 
-nested_rust_out=$(cd "$tmp_repo_nested_rust" && PATH="$tmp_repo_nested_rust/bin:/usr/bin:/bin:$PATH" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
-assert_contains "$nested_rust_out" "[rust/unwrap]" "Nested Rust crate: staged rust guard still runs without root Cargo.toml"
-assert_not_contains "$nested_rust_out" "cargo check failed" "Nested Rust crate: root cargo check stays disabled without root Cargo.toml"
-rm -rf "$tmp_repo_nested_rust"
-
-# Nested TS project without root tsconfig.json: TS guards should still run on staged .ts files,
-# but the root-level tsc build must stay disabled.
-tmp_repo_nested_ts="$(mktemp -d)"
-git -C "$tmp_repo_nested_ts" init -q
-mkdir -p "$tmp_repo_nested_ts/app/src" "$tmp_repo_nested_ts/bin"
-
-cat >"$tmp_repo_nested_ts/app/tsconfig.json" <<'EOF'
+cat >"$tmp_repo_precommit_ts_js/tsconfig.json" <<'EOF'
 {
   "compilerOptions": {
-    "target": "ES2020"
-  }
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
 }
 EOF
 
-cat >"$tmp_repo_nested_ts/app/src/index.ts" <<'EOF'
-console.log('nested');
+cat >"$tmp_repo_precommit_ts_js/src/bad.js" <<'EOF'
+const value = missingSymbol;
 EOF
 
-cat >"$tmp_repo_nested_ts/bin/tsc" <<'EOF'
+cat >"$tmp_repo_precommit_ts_js/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "tsc" && "$2" == "--noEmit" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$tmp_repo_precommit_ts_js/bin/node" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-cat >"$tmp_repo_nested_ts/bin/npx" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
-chmod +x "$tmp_repo_nested_ts/bin/tsc" "$tmp_repo_nested_ts/bin/npx"
-git -C "$tmp_repo_nested_ts" add app/src/index.ts
 
-nested_ts_out=$(cd "$tmp_repo_nested_ts" && PATH="$tmp_repo_nested_ts/bin:/usr/bin:/bin:$PATH" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
-assert_contains "$nested_ts_out" "[ts/console]" "Nested TS project: staged TS guard still runs without root tsconfig.json"
-assert_not_contains "$nested_ts_out" "tsc --noEmit failed" "Nested TS project: root tsc stays disabled without root tsconfig.json"
-rm -rf "$tmp_repo_nested_ts"
+cat >"$tmp_repo_precommit_ts_js/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_ts_js/bin/npx" "$tmp_repo_precommit_ts_js/bin/node" "$tmp_repo_precommit_ts_js/bin/tsc"
+git -C "$tmp_repo_precommit_ts_js" add tsconfig.json src/bad.js
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "JS-only staged changes in a TS repo still run tsc --noEmit" bash -c "cd '$tmp_repo_precommit_ts_js' && PATH='$tmp_repo_precommit_ts_js/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_ts_js"
+
+# Nested Rust crates must run cargo check from the staged file's nearest Cargo.toml.
+tmp_repo_precommit_nested_rust="$(mktemp -d)"
+git -C "$tmp_repo_precommit_nested_rust" init -q
+mkdir -p "$tmp_repo_precommit_nested_rust/bin" "$tmp_repo_precommit_nested_rust/crates/demo/src"
+
+cat >"$tmp_repo_precommit_nested_rust/crates/demo/Cargo.toml" <<'EOF'
+[package]
+name = "nested-demo"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat >"$tmp_repo_precommit_nested_rust/crates/demo/src/lib.rs" <<'EOF'
+pub fn demo() -> i32 {
+    1
+}
+EOF
+
+cat >"$tmp_repo_precommit_nested_rust/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "check" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_nested_rust/bin/cargo"
+git -C "$tmp_repo_precommit_nested_rust" add crates/demo/Cargo.toml crates/demo/src/lib.rs
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "Nested Cargo.toml projects still run cargo check in pre-commit" bash -c "cd '$tmp_repo_precommit_nested_rust' && PATH='$tmp_repo_precommit_nested_rust/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_rust"
+
+# Nested TS apps must run tsc from the staged file's nearest tsconfig.json.
+tmp_repo_precommit_nested_ts="$(mktemp -d)"
+git -C "$tmp_repo_precommit_nested_ts" init -q
+mkdir -p "$tmp_repo_precommit_nested_ts/bin" "$tmp_repo_precommit_nested_ts/apps/web/src"
+
+cat >"$tmp_repo_precommit_nested_ts/apps/web/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts/apps/web/src/index.ts" <<'EOF'
+export const value = 1;
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "tsc" && "$2" == "--noEmit" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$tmp_repo_precommit_nested_ts/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_nested_ts/bin/npx" "$tmp_repo_precommit_nested_ts/bin/tsc"
+git -C "$tmp_repo_precommit_nested_ts" add apps/web/tsconfig.json apps/web/src/index.ts
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "Nested tsconfig.json projects still run tsc --noEmit in pre-commit" bash -c "cd '$tmp_repo_precommit_nested_ts' && PATH='$tmp_repo_precommit_nested_ts/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_ts"
+
+# Nested Go modules must run go build from the staged file's nearest go.mod.
+tmp_repo_precommit_nested_go="$(mktemp -d)"
+git -C "$tmp_repo_precommit_nested_go" init -q
+mkdir -p "$tmp_repo_precommit_nested_go/bin" "$tmp_repo_precommit_nested_go/services/api/cmd"
+
+cat >"$tmp_repo_precommit_nested_go/services/api/go.mod" <<'EOF'
+module nested-go-demo
+
+go 1.22
+EOF
+
+cat >"$tmp_repo_precommit_nested_go/services/api/cmd/main.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+
+cat >"$tmp_repo_precommit_nested_go/bin/go" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "build" && "$2" == "./..." ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_nested_go/bin/go"
+git -C "$tmp_repo_precommit_nested_go" add services/api/go.mod services/api/cmd/main.go
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "Nested go.mod projects still run go build ./... in pre-commit" bash -c "cd '$tmp_repo_precommit_nested_go' && PATH='$tmp_repo_precommit_nested_go/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_nested_go"
+
+# Build-root discovery must stay inside the repo instead of walking into parent workspaces.
+_tmp_precommit_parent_workspace_root="$(mktemp -d)"
+_tmp_precommit_parent_workspace_repo="${_tmp_precommit_parent_workspace_root}/repo"
+mkdir -p "${_tmp_precommit_parent_workspace_repo}/src" "${_tmp_precommit_parent_workspace_root}/bin"
+git -C "${_tmp_precommit_parent_workspace_repo}" init -q
+
+cat >"${_tmp_precommit_parent_workspace_root}/Cargo.toml" <<'EOF'
+[package]
+name = "outer-workspace"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat >"${_tmp_precommit_parent_workspace_repo}/src/lib.rs" <<'EOF'
+pub fn demo() -> i32 {
+    1
+}
+EOF
+
+cat >"${_tmp_precommit_parent_workspace_root}/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "check" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+chmod +x "${_tmp_precommit_parent_workspace_root}/bin/cargo"
+git -C "${_tmp_precommit_parent_workspace_repo}" add src/lib.rs
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_zero "Parent-workspace Cargo.toml outside the repo does not affect pre-commit root discovery" bash -c "cd '${_tmp_precommit_parent_workspace_repo}' && PATH='${_tmp_precommit_parent_workspace_root}/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$_tmp_precommit_parent_workspace_root"
+
+# Same-language unstaged manifests/configs must not change staged build-root detection.
+_tmp_precommit_unstaged_manifest_repo="$(mktemp -d)"
+git -C "$_tmp_precommit_unstaged_manifest_repo" init -q
+mkdir -p "$_tmp_precommit_unstaged_manifest_repo/bin" "$_tmp_precommit_unstaged_manifest_repo/src"
+
+cat >"$_tmp_precommit_unstaged_manifest_repo/src/lib.rs" <<'EOF'
+pub fn demo() -> i32 {
+    1
+}
+EOF
+
+git -C "$_tmp_precommit_unstaged_manifest_repo" add src/lib.rs
+
+cat >"$_tmp_precommit_unstaged_manifest_repo/Cargo.toml" <<'EOF'
+[package]
+name = "unstaged-manifest"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat >"$_tmp_precommit_unstaged_manifest_repo/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "check" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+chmod +x "$_tmp_precommit_unstaged_manifest_repo/bin/cargo"
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_zero "Unstaged Cargo.toml does not trigger cargo check for a staged Rust file" bash -c "cd '$_tmp_precommit_unstaged_manifest_repo' && PATH='$_tmp_precommit_unstaged_manifest_repo/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$_tmp_precommit_unstaged_manifest_repo"
 
 # =========================================================
 header "log.sh — session_id: start-time anchor + 30-min TTL"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -903,6 +903,66 @@ _stub_guards="$(_make_stub_guard_dir)"
 assert_exit_nonzero "JavaScript syntax check still runs for staged files with spaces in the path" bash -c "cd '$tmp_repo_precommit_js_space' && PATH='$tmp_repo_precommit_js_space/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
 rm -rf "$_stub_guards" "$tmp_repo_precommit_js_space"
 
+# JS files under a TS config still need node --check when the tsconfig excludes them.
+tmp_repo_precommit_js_outside_tsconfig="$(mktemp -d)"
+git -C "$tmp_repo_precommit_js_outside_tsconfig" init -q
+mkdir -p "$tmp_repo_precommit_js_outside_tsconfig/bin" "$tmp_repo_precommit_js_outside_tsconfig/src" "$tmp_repo_precommit_js_outside_tsconfig/scripts"
+
+cat >"$tmp_repo_precommit_js_outside_tsconfig/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}
+EOF
+
+cat >"$tmp_repo_precommit_js_outside_tsconfig/scripts/bad.js" <<'EOF'
+function () {}
+EOF
+
+cat >"$tmp_repo_precommit_js_outside_tsconfig/bin/node" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--check" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$tmp_repo_precommit_js_outside_tsconfig/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_js_outside_tsconfig/bin/node" "$tmp_repo_precommit_js_outside_tsconfig/bin/tsc"
+git -C "$tmp_repo_precommit_js_outside_tsconfig" add tsconfig.json scripts/bad.js
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero "JavaScript syntax check still runs when a staged JS file sits outside tsconfig include globs" bash -c "cd '$tmp_repo_precommit_js_outside_tsconfig' && PATH='$tmp_repo_precommit_js_outside_tsconfig/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_js_outside_tsconfig"
+
+# .mjs files must be treated as staged source files so node --check can validate them.
+tmp_repo_precommit_mjs="$(mktemp -d)"
+git -C "$tmp_repo_precommit_mjs" init -q
+mkdir -p "$tmp_repo_precommit_mjs/bin"
+
+cat >"$tmp_repo_precommit_mjs/bad.mjs" <<'EOF'
+function () {}
+EOF
+
+cat >"$tmp_repo_precommit_mjs/bin/node" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--check" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+chmod +x "$tmp_repo_precommit_mjs/bin/node"
+git -C "$tmp_repo_precommit_mjs" add bad.mjs
+_stub_guards="$(_make_stub_guard_dir)"
+assert_exit_nonzero ".mjs files still run JavaScript syntax checks in pre-commit" bash -c "cd '$tmp_repo_precommit_mjs' && PATH='$tmp_repo_precommit_mjs/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$_stub_guards" "$tmp_repo_precommit_mjs"
+
 # Nested TS apps should keep working when only the repo root provides tsc.
 tmp_repo_precommit_nested_ts_root_tsc="$(mktemp -d)"
 git -C "$tmp_repo_precommit_nested_ts_root_tsc" init -q

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -736,6 +736,103 @@ assert_exit_nonzero "Go guards prevent _= discarding commits with error" bash -c
 rm -rf "$tmp_repo_precommit_go"
 
 # =========================================================
+header "pre-commit-guard.sh — staged language detection (mixed)"
+# =========================================================
+
+# Regression: mixed TS + JS commit must detect both typescript AND javascript.
+# Before the fix, the elif branch suppressed javascript whenever .ts files were staged,
+# so a mixed .ts + .js commit would skip JS syntax validation entirely.
+tmp_repo_ts_js="$(mktemp -d)"
+git -C "$tmp_repo_ts_js" init -q
+mkdir -p "$tmp_repo_ts_js/src" "$tmp_repo_ts_js/bin"
+
+cat >"$tmp_repo_ts_js/src/app.ts" <<'EOF'
+const x: number = 1;
+EOF
+
+cat >"$tmp_repo_ts_js/src/util.js" <<'EOF'
+const y = 1;
+EOF
+
+# Fake node that fails --check — proves the JS build check actually ran
+cat >"$tmp_repo_ts_js/bin/node" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--check" ]] && exit 1
+exit 0
+EOF
+chmod +x "$tmp_repo_ts_js/bin/node"
+git -C "$tmp_repo_ts_js" add src/app.ts src/util.js
+
+mixed_ts_js_out=$(cd "$tmp_repo_ts_js" && PATH="$tmp_repo_ts_js/bin:/usr/bin:/bin:$PATH" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
+assert_contains "$mixed_ts_js_out" "javascript" "Mixed TS+JS staged: javascript is detected even when TS files are present"
+rm -rf "$tmp_repo_ts_js"
+
+# TS-only staged in a Rust repo: only .ts file staged — Cargo.toml is untracked.
+# Rust must NOT be detected based on untracked config files.
+# Fake cargo exits 1 so any incorrect rust detection causes the test to fail.
+tmp_repo_ts_in_rust="$(mktemp -d)"
+git -C "$tmp_repo_ts_in_rust" init -q
+mkdir -p "$tmp_repo_ts_in_rust/src" "$tmp_repo_ts_in_rust/bin"
+
+cat >"$tmp_repo_ts_in_rust/Cargo.toml" <<'EOF'
+[package]
+name = "vg-test"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat >"$tmp_repo_ts_in_rust/src/index.ts" <<'EOF'
+const x: number = 1;
+EOF
+
+cat >"$tmp_repo_ts_in_rust/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$tmp_repo_ts_in_rust/bin/cargo"
+# Stage only the .ts file; Cargo.toml remains untracked — must not trigger rust detection
+git -C "$tmp_repo_ts_in_rust" add src/index.ts
+
+assert_exit_zero "TS-only staged in Rust repo: rust not detected from untracked Cargo.toml" bash -c "cd '$tmp_repo_ts_in_rust' && PATH='$tmp_repo_ts_in_rust/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$tmp_repo_ts_in_rust"
+
+# RS-only staged in a TS repo: only .rs file staged — package.json is untracked.
+# TypeScript must NOT be detected based on untracked config files.
+# Fake tsc + npx exit 1 so any incorrect TS detection causes the test to fail.
+tmp_repo_rs_in_ts="$(mktemp -d)"
+git -C "$tmp_repo_rs_in_ts" init -q
+mkdir -p "$tmp_repo_rs_in_ts/src" "$tmp_repo_rs_in_ts/bin"
+
+cat >"$tmp_repo_rs_in_ts/package.json" <<'EOF'
+{"name":"vg-test","version":"1.0.0"}
+EOF
+
+cat >"$tmp_repo_rs_in_ts/src/lib.rs" <<'EOF'
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+EOF
+
+cat >"$tmp_repo_rs_in_ts/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+# Fake tsc in PATH so the guard's `command -v tsc` check succeeds and would run `npx tsc --noEmit`
+# if typescript were incorrectly detected — then fake npx fails, proving TS was triggered.
+cat >"$tmp_repo_rs_in_ts/bin/tsc" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cat >"$tmp_repo_rs_in_ts/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$tmp_repo_rs_in_ts/bin/cargo" "$tmp_repo_rs_in_ts/bin/tsc" "$tmp_repo_rs_in_ts/bin/npx"
+# Stage only the .rs file; package.json remains untracked — must not trigger typescript detection
+git -C "$tmp_repo_rs_in_ts" add src/lib.rs
+
+assert_exit_zero "RS-only staged in TS repo: typescript not detected from untracked package.json" bash -c "cd '$tmp_repo_rs_in_ts' && PATH='$tmp_repo_rs_in_ts/bin:/usr/bin:/bin:$PATH' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+rm -rf "$tmp_repo_rs_in_ts"
+
+# =========================================================
 header "log.sh — session_id: start-time anchor + 30-min TTL"
 # =========================================================
 


### PR DESCRIPTION
## Summary

- `DETECTED_LANGS` was built from repo-root config files (`Cargo.toml`, `tsconfig.json`, …), not from the staged diff, causing every guard for every project language to fire on every commit.
- A TypeScript-only commit in a mixed Rust/TS repo would block on pre-existing `unwrap()` calls in unrelated `.rs` files.
- Replace the file-existence checks with `grep` over `$_ALL_STAGED` so each language guard only runs when at least one file of that language is staged.

## Test plan

- [ ] Stage only `.ts` files in a repo with `Cargo.toml` → `rust/unwrap` guard does NOT run
- [ ] Stage only `.rs` files in a repo with `tsconfig.json` → `ts/console` / `ts/any` guards do NOT run
- [ ] Stage `.rs` + `.ts` files → both guard sets run
- [ ] Stage no source files (e.g. only `.md`) → early exit at the existing STAGED_FILES check, no guards run

Closes #87