### PR TITLE
fix(session_metrics): guard env vars against silent KeyError crash

### DIFF
--- a/hooks/_lib/session_metrics.py
+++ b/hooks/_lib/session_metrics.py
@@ -37,6 +37,8 @@ if not os.path.exists(log_file):
     sys.exit(0)
 
 session_id = os.environ.get("VIBEGUARD_SESSION_ID", "")
+if not session_id:
+    sys.exit(0)
 cutoff = datetime.now(timezone.utc) - timedelta(minutes=30)
 skip_hooks = {"stop-guard", "learn-evaluator"}
 events = []

--- a/hooks/_lib/session_metrics.py
+++ b/hooks/_lib/session_metrics.py
@@ -158,7 +158,10 @@ if cb_trips > 0:
     correction_signals.append(f"Circuit breaker tripped {cb_trips} time(s)")
 
 # Signal 10: Warn trend regression (compare with project baseline)
-metrics_file = os.path.join(os.environ["VIBEGUARD_PROJECT_LOG_DIR"], "session-metrics.jsonl")
+project_log_dir = os.environ.get("VIBEGUARD_PROJECT_LOG_DIR", "")
+if not project_log_dir:
+    sys.exit(0)
+metrics_file = os.path.join(project_log_dir, "session-metrics.jsonl")
 if os.path.exists(metrics_file):
     try:
         recent_ratios = []
@@ -182,7 +185,7 @@ if os.path.exists(metrics_file):
 
 metrics = {
     "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "session": os.environ["VIBEGUARD_SESSION_ID"],
+    "session": session_id,
     "event_count": len(events),
     "decisions": dict(decisions),
     "hooks": dict(hooks),

--- a/tests/unit/test_session_metrics_env_guard.sh
+++ b/tests/unit/test_session_metrics_env_guard.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Unit tests for hooks/_lib/session_metrics.py — missing env var fallback paths
+#
+# Covers two guard paths added in PR #93:
+#   line  39: VIBEGUARD_SESSION_ID missing  → os.environ.get("...", "") → permissive filter
+#   line 161: VIBEGUARD_PROJECT_LOG_DIR missing → os.environ.get("...", "") + early sys.exit(0)
+#
+# bench_hook_latency.sh always supplies both vars, so these paths were untested.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="${REPO_DIR}/hooks/_lib/session_metrics.py"
+
+PASS=0; FAIL=0; TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+
+# ── Fixture helpers ────────────────────────────────────────────────────────────
+TMPDIR_TEST=""
+
+setup() {
+  TMPDIR_TEST="$(mktemp -d)"
+  # Write events with timestamps in the last 30 minutes (5 events, same session)
+  python3 - <<'PYEOF' > "${TMPDIR_TEST}/events.jsonl"
+import json, datetime
+now = datetime.datetime.now(datetime.timezone.utc)
+for i in range(5):
+    ts = (now - datetime.timedelta(seconds=i * 10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(json.dumps({"ts": ts, "session": "testsession01", "hook": "post-edit-guard",
+                      "tool": "Edit", "decision": "pass", "reason": "", "detail": f"src/file{i}.rs"}))
+PYEOF
+}
+
+teardown() {
+  [[ -n "${TMPDIR_TEST:-}" ]] && rm -rf "$TMPDIR_TEST"
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+printf '\n=== session_metrics.py env var guard paths ===\n'
+
+# ── 1. Missing VIBEGUARD_PROJECT_LOG_DIR: exits 0 (no crash) ─────────────────
+printf '\n--- Missing VIBEGUARD_PROJECT_LOG_DIR (line 161 guard) ---\n'
+
+setup
+TOTAL=$((TOTAL + 1))
+exit_code=0
+env -u VIBEGUARD_PROJECT_LOG_DIR \
+  VIBEGUARD_LOG_FILE="${TMPDIR_TEST}/events.jsonl" \
+  VIBEGUARD_SESSION_ID="testsession01" \
+  python3 "${SCRIPT}" >/dev/null 2>&1 || exit_code=$?
+if [[ $exit_code -eq 0 ]]; then
+  green "Missing VIBEGUARD_PROJECT_LOG_DIR: exits 0 (early-exit guard works)"; PASS=$((PASS + 1))
+else
+  red "Missing VIBEGUARD_PROJECT_LOG_DIR: expected exit 0, got $exit_code"; FAIL=$((FAIL + 1))
+fi
+teardown
+
+# ── 2. Missing VIBEGUARD_PROJECT_LOG_DIR: no metrics file written ─────────────
+# The early sys.exit(0) at line 163 fires before the write at line 201.
+setup
+TOTAL=$((TOTAL + 1))
+env -u VIBEGUARD_PROJECT_LOG_DIR \
+  VIBEGUARD_LOG_FILE="${TMPDIR_TEST}/events.jsonl" \
+  VIBEGUARD_SESSION_ID="testsession01" \
+  python3 "${SCRIPT}" >/dev/null 2>&1 || true
+if [[ ! -f "${TMPDIR_TEST}/session-metrics.jsonl" ]]; then
+  green "Missing VIBEGUARD_PROJECT_LOG_DIR: no metrics file written (exited before write)"; PASS=$((PASS + 1))
+else
+  red "Missing VIBEGUARD_PROJECT_LOG_DIR: metrics file should not exist after early exit"; FAIL=$((FAIL + 1))
+fi
+teardown
+
+# ── 3. Missing VIBEGUARD_SESSION_ID: exits 0, no crash ───────────────────────
+printf '\n--- Missing VIBEGUARD_SESSION_ID (line 39 guard) ---\n'
+
+setup
+TOTAL=$((TOTAL + 1))
+exit_code=0
+env -u VIBEGUARD_SESSION_ID \
+  VIBEGUARD_LOG_FILE="${TMPDIR_TEST}/events.jsonl" \
+  VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
+  python3 "${SCRIPT}" >/dev/null 2>&1 || exit_code=$?
+if [[ $exit_code -eq 0 ]]; then
+  green "Missing VIBEGUARD_SESSION_ID: exits 0 (permissive event filter)"; PASS=$((PASS + 1))
+else
+  red "Missing VIBEGUARD_SESSION_ID: expected exit 0, got $exit_code"; FAIL=$((FAIL + 1))
+fi
+teardown
+
+# ── 4. Missing VIBEGUARD_SESSION_ID: cross-session events accepted ────────────
+# When session_id == "" the filter `if evt_session and session_id and ...` is
+# short-circuited — all events pass through regardless of their session field.
+# 6 events (≥ threshold of 3) → metrics file is written.
+setup
+python3 - <<'PYEOF' > "${TMPDIR_TEST}/events_multi.jsonl"
+import json, datetime
+now = datetime.datetime.now(datetime.timezone.utc)
+for sess in ("sessionA", "sessionB"):
+    for i in range(3):
+        ts = (now - datetime.timedelta(seconds=i * 10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        print(json.dumps({"ts": ts, "session": sess, "hook": "post-edit-guard",
+                          "tool": "Edit", "decision": "pass", "reason": "", "detail": f"src/file{i}.rs"}))
+PYEOF
+TOTAL=$((TOTAL + 1))
+env -u VIBEGUARD_SESSION_ID \
+  VIBEGUARD_LOG_FILE="${TMPDIR_TEST}/events_multi.jsonl" \
+  VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
+  python3 "${SCRIPT}" >/dev/null 2>&1 || true
+if [[ -f "${TMPDIR_TEST}/session-metrics.jsonl" ]]; then
+  green "Missing VIBEGUARD_SESSION_ID: cross-session events accepted (metrics written)"; PASS=$((PASS + 1))
+else
+  red "Missing VIBEGUARD_SESSION_ID: expected metrics file (6 events, no session filter applied)"; FAIL=$((FAIL + 1))
+fi
+teardown
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo
+printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
+[[ $FAIL -gt 0 ]] && exit 1 || exit 0

--- a/tests/unit/test_session_metrics_env_guard.sh
+++ b/tests/unit/test_session_metrics_env_guard.sh
@@ -2,7 +2,7 @@
 # Unit tests for hooks/_lib/session_metrics.py — missing env var fallback paths
 #
 # Covers two guard paths added in PR #93:
-#   line  39: VIBEGUARD_SESSION_ID missing  → os.environ.get("...", "") → permissive filter
+#   line  39: VIBEGUARD_SESSION_ID missing  → os.environ.get("...", "") + early sys.exit(0)
 #   line 161: VIBEGUARD_PROJECT_LOG_DIR missing → os.environ.get("...", "") + early sys.exit(0)
 #
 # bench_hook_latency.sh always supplies both vars, so these paths were untested.
@@ -83,16 +83,15 @@ env -u VIBEGUARD_SESSION_ID \
   VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
   python3 "${SCRIPT}" >/dev/null 2>&1 || exit_code=$?
 if [[ $exit_code -eq 0 ]]; then
-  green "Missing VIBEGUARD_SESSION_ID: exits 0 (permissive event filter)"; PASS=$((PASS + 1))
+  green "Missing VIBEGUARD_SESSION_ID: exits 0 (early-exit guard works)"; PASS=$((PASS + 1))
 else
   red "Missing VIBEGUARD_SESSION_ID: expected exit 0, got $exit_code"; FAIL=$((FAIL + 1))
 fi
 teardown
 
-# ── 4. Missing VIBEGUARD_SESSION_ID: cross-session events accepted ────────────
-# When session_id == "" the filter `if evt_session and session_id and ...` is
-# short-circuited — all events pass through regardless of their session field.
-# 6 events (≥ threshold of 3) → metrics file is written.
+# ── 4. Missing VIBEGUARD_SESSION_ID: no metrics file written ─────────────────
+# The early sys.exit(0) at line 41 fires before any event aggregation or write.
+# Cross-session data must not be included under an empty session value.
 setup
 python3 - <<'PYEOF' > "${TMPDIR_TEST}/events_multi.jsonl"
 import json, datetime
@@ -108,10 +107,10 @@ env -u VIBEGUARD_SESSION_ID \
   VIBEGUARD_LOG_FILE="${TMPDIR_TEST}/events_multi.jsonl" \
   VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
   python3 "${SCRIPT}" >/dev/null 2>&1 || true
-if [[ -f "${TMPDIR_TEST}/session-metrics.jsonl" ]]; then
-  green "Missing VIBEGUARD_SESSION_ID: cross-session events accepted (metrics written)"; PASS=$((PASS + 1))
+if [[ ! -f "${TMPDIR_TEST}/session-metrics.jsonl" ]]; then
+  green "Missing VIBEGUARD_SESSION_ID: no metrics file written (early-exit before aggregation)"; PASS=$((PASS + 1))
 else
-  red "Missing VIBEGUARD_SESSION_ID: expected metrics file (6 events, no session filter applied)"; FAIL=$((FAIL + 1))
+  red "Missing VIBEGUARD_SESSION_ID: metrics file must not exist when session ID is missing"; FAIL=$((FAIL + 1))
 fi
 teardown
 


### PR DESCRIPTION
## Summary
- Replace `os.environ["VIBEGUARD_PROJECT_LOG_DIR"]` (line 161) with `os.environ.get()` + early `sys.exit(0)` guard so missing env var exits cleanly instead of crashing silently after all work is done
- Replace `os.environ["VIBEGUARD_SESSION_ID"]` (line 185) with the already-computed `session_id` variable (set safely with `.get()` at line 39) to eliminate the redundant unguarded access

## Test plan
- [ ] Run `VIBEGUARD_LOG_FILE=/dev/null python3 hooks/_lib/session_metrics.py` — should exit 0 immediately (log file missing path)
- [ ] Run with only `VIBEGUARD_LOG_FILE` set and no `VIBEGUARD_PROJECT_LOG_DIR` — should exit 0 cleanly after computing signals 1-9
- [ ] Run with all env vars set — behavior unchanged, metrics written as before

Closes #89