### PR TITLE
fix(guard): block git checkout/restore with quoted dot argument

### DIFF
--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -61,14 +61,52 @@ block() {
 # git reset --hard — Allow execution (users need to use it in scenarios such as rebase conflicts)
 
 # git checkout . / git restore . (discard all changes)
-# Only matches pure "." pathspec (bare, double-quoted ".", or single-quoted '.'), not quoted filenames.
-# Two-step: COMMAND_STRIPPED identifies git checkout/restore as top-level command (filters out content inside
-# -m strings); COMMAND_NO_HEREDOC verifies pathspec is exactly "." while avoiding false positives from
-# heredoc blocks that contain inert "git checkout ." examples.
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+'; then
-  if echo "$COMMAND_NO_HEREDOC" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?("\."|'"'"'\.'"'"'|\.)\s*(;|&&|\|\||$)'; then
-    block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
-  fi
+# Shell-aware per-subcommand check: splits on &&/||/; outside of quotes so that
+# "." appearing inside a commit message or other quoted arg in a later subcommand
+# (e.g. git commit -m 'docs: mention git checkout ".";') does not cause a false positive.
+if _CMD_DATA="$COMMAND_NO_HEREDOC" python3 - <<'PYEOF'
+import re, sys, os
+
+def split_shell(cmd):
+    parts, cur, in_s, in_d = [], '', False, False
+    i = 0
+    while i < len(cmd):
+        c = cmd[i]
+        if c == "'" and not in_d:
+            in_s = not in_s; cur += c
+        elif c == '"' and not in_s:
+            in_d = not in_d; cur += c
+        elif not in_s and not in_d:
+            if cmd[i:i+2] in ('&&', '||'):
+                parts.append(cur); cur = ''; i += 2; continue
+            elif c == ';':
+                parts.append(cur); cur = ''
+            else:
+                cur += c
+        else:
+            cur += c
+        i += 1
+    if cur.strip():
+        parts.append(cur)
+    return parts
+
+cmd = os.environ.get('_CMD_DATA', '')
+for sub in split_shell(cmd):
+    s = re.sub(r'"[^"]*"', '""', sub)
+    s = re.sub(r"'[^']*'", "''", s)
+    if not re.search(r'git\s+(checkout|restore)\s+', s):
+        continue
+    # quoted dot: "." or '.' with matching quotes
+    m = re.search(r'git\s+(checkout|restore)\s+(?:--\s+)?(["\'])\.(["\'])', sub)
+    if m and m.group(2) == m.group(3):
+        sys.exit(0)
+    # bare dot: must be followed by whitespace or end-of-subcommand
+    if re.search(r'git\s+(checkout|restore)\s+(?:--\s+)?\.(?:\s|$)', sub.rstrip()):
+        sys.exit(0)
+sys.exit(1)
+PYEOF
+then
+  block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 
 # git clean -f (delete untracked files)

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -63,9 +63,10 @@ block() {
 # git checkout . / git restore . (discard all changes)
 # Only matches pure "." pathspec (bare, double-quoted ".", or single-quoted '.'), not quoted filenames.
 # Two-step: COMMAND_STRIPPED identifies git checkout/restore as top-level command (filters out content inside
-# -m strings); COMMAND verifies pathspec is exactly "." since COMMAND_STRIPPED collapses all quoted args to "".
+# -m strings); COMMAND_NO_HEREDOC verifies pathspec is exactly "." while avoiding false positives from
+# heredoc blocks that contain inert "git checkout ." examples.
 if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+'; then
-  if echo "$COMMAND" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?("\."|'"'"'\.'"'"'|\.)\s*(;|&&|\|\||$)'; then
+  if echo "$COMMAND_NO_HEREDOC" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?("\."|'"'"'\.'"'"'|\.)\s*(;|&&|\|\||$)'; then
     block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
   fi
 fi

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -62,7 +62,7 @@ block() {
 
 # git checkout . / git restore . (discard all changes)
 # Only matches pure "." endings, excluding legal path operations such as git checkout ./src/file
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
+if echo "$COMMAND_STRIPPED"$'\n'"$COMMAND_PATH_SCAN" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -64,8 +64,11 @@ block() {
 # Shell-aware per-subcommand check: splits on &&/||/; outside of quotes so that
 # "." appearing inside a commit message or other quoted arg in a later subcommand
 # (e.g. git commit -m 'docs: mention git checkout ".";') does not cause a false positive.
-if _CMD_DATA="$COMMAND_NO_HEREDOC" python3 - <<'PYEOF'
-import re, sys, os
+# Command is passed on stdin (not env var) to avoid exec-env size limits.
+# Fail-closed: any scanner exit code other than 1 (safe) triggers block.
+_SCANNER_EC=2
+if printf '%s' "$COMMAND_NO_HEREDOC" | python3 <(cat <<'PYEOF'
+import re, sys
 
 def split_shell(cmd):
     parts, cur, in_s, in_d = [], '', False, False
@@ -90,22 +93,27 @@ def split_shell(cmd):
         parts.append(cur)
     return parts
 
-cmd = os.environ.get('_CMD_DATA', '')
+cmd = sys.stdin.read()
 for sub in split_shell(cmd):
     s = re.sub(r'"[^"]*"', '""', sub)
     s = re.sub(r"'[^']*'", "''", s)
     if not re.search(r'git\s+(checkout|restore)\s+', s):
         continue
-    # quoted dot: "." or '.' with matching quotes
-    m = re.search(r'git\s+(checkout|restore)\s+(?:--\s+)?(["\'])\.(["\'])', sub)
+    # quoted dot: "." or '.' as a standalone argument (not part of a larger path)
+    m = re.search(r'git\s+(checkout|restore)\s+(?:--\s+)?(["\'])\.(["\'])(?=\s|$)', sub)
     if m and m.group(2) == m.group(3):
-        sys.exit(0)
+        sys.exit(0)  # dangerous
     # bare dot: must be followed by whitespace or end-of-subcommand
     if re.search(r'git\s+(checkout|restore)\s+(?:--\s+)?\.(?:\s|$)', sub.rstrip()):
-        sys.exit(0)
-sys.exit(1)
+        sys.exit(0)  # dangerous
+sys.exit(1)  # safe
 PYEOF
-then
+) 2>/dev/null; then
+  _SCANNER_EC=0
+else
+  _SCANNER_EC=$?
+fi
+if [[ "$_SCANNER_EC" -ne 1 ]]; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -61,8 +61,9 @@ block() {
 # git reset --hard — Allow execution (users need to use it in scenarios such as rebase conflicts)
 
 # git checkout . / git restore . (discard all changes)
-# Only matches pure "." endings, excluding legal path operations such as git checkout ./src/file
-if echo "$COMMAND_STRIPPED"$'\n'"$COMMAND_PATH_SCAN" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
+# Only matches pure "." pathspec (bare, quoted, or with -- separator), excluding legal paths like git checkout ./src/file
+# Uses COMMAND_STRIPPED only (quoted content replaced with "" or '') to avoid false positives from commit messages or echo strings.
+if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?(\.|""|'"''"')\s*(;|&&|\|\||$)'; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -61,10 +61,13 @@ block() {
 # git reset --hard — Allow execution (users need to use it in scenarios such as rebase conflicts)
 
 # git checkout . / git restore . (discard all changes)
-# Only matches pure "." pathspec (bare, quoted, or with -- separator), excluding legal paths like git checkout ./src/file
-# Uses COMMAND_STRIPPED only (quoted content replaced with "" or '') to avoid false positives from commit messages or echo strings.
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?(\.|""|'"''"')\s*(;|&&|\|\||$)'; then
-  block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
+# Only matches pure "." pathspec (bare, double-quoted ".", or single-quoted '.'), not quoted filenames.
+# Two-step: COMMAND_STRIPPED identifies git checkout/restore as top-level command (filters out content inside
+# -m strings); COMMAND verifies pathspec is exactly "." since COMMAND_STRIPPED collapses all quoted args to "".
+if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+(checkout|restore)\s+'; then
+  if echo "$COMMAND" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?("\."|'"'"'\.'"'"'|\.)\s*(;|&&|\|\||$)'; then
+    block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
+  fi
 fi
 
 # git clean -f (delete untracked files)

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -177,6 +177,22 @@ assert_contains "$result" '"decision": "block"' "Intercept git checkout with quo
 result=$(echo $'{"tool_input":{"command":"git restore \x27.\x27"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Intercept git restore with single-quoted dot"
 
+# git checkout -- "." should be intercepted (-- separator is treated identically by Git)
+result=$(echo '{"tool_input":{"command":"git checkout -- \".\""}}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git checkout -- with quoted dot"
+
+# git restore -- "." should be intercepted
+result=$(echo '{"tool_input":{"command":"git restore -- \".\""}}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git restore -- with quoted dot"
+
+# echo "git checkout ." should NOT be intercepted (dot is inside a string argument, not a git pathspec)
+result=$(echo '{"tool_input":{"command":"echo \"git checkout .\""}}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "Allow echo with git checkout . in string"
+
+# git commit -m "document git checkout ." should NOT be intercepted (dot is inside commit message)
+result=$(echo '{"tool_input":{"command":"git commit -m \"document git checkout .\""}}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "Allow git commit with git checkout . in message"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -169,6 +169,14 @@ assert_not_contains "$result" '"decision": "block"' "Release git reset --hard (p
 result=$(echo '{"tool_input":{"command":"git checkout ."}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Intercept git checkout ."
 
+# git checkout "." (quoted dot) should be intercepted — #88
+result=$(echo '{"tool_input":{"command":"git checkout \".\""}}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git checkout with quoted dot"
+
+# git restore '.' (single-quoted dot) should be intercepted — #88
+result=$(echo $'{"tool_input":{"command":"git restore \x27.\x27"}}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git restore with single-quoted dot"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -193,6 +193,14 @@ assert_not_contains "$result" '"decision": "block"' "Allow echo with git checkou
 result=$(echo '{"tool_input":{"command":"git commit -m \"document git checkout .\""}}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "Allow git commit with git checkout . in message"
 
+# git restore "README.md" should NOT be intercepted — quoted filename, not a dot
+result=$(echo '{"tool_input":{"command":"git restore \"README.md\""}}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "Allow git restore with quoted filename"
+
+# git checkout -- 'src/file.txt' should NOT be intercepted — single-quoted specific path
+result=$(echo $'{"tool_input":{"command":"git checkout -- \x27src/file.txt\x27"}}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "Allow git checkout -- with single-quoted specific path"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -201,6 +201,11 @@ assert_not_contains "$result" '"decision": "block"' "Allow git restore with quot
 result=$(echo $'{"tool_input":{"command":"git checkout -- \x27src/file.txt\x27"}}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "Allow git checkout -- with single-quoted specific path"
 
+# chained: safe checkout followed by commit whose message mentions git checkout "." — must NOT be blocked
+# (the "." is inside a commit message string, not a pathspec; this was a false positive in the two-step check)
+result=$(echo '{"tool_input":{"command":"git checkout -- README.md && git commit -m '"'"'docs: mention git checkout \".\";'"'"'"}}' | bash hooks/pre-bash-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "Allow chained checkout+commit where quoted dot is only inside commit message"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"


### PR DESCRIPTION
## Summary

- `git checkout "."` bypassed the guard because `COMMAND_STRIPPED` replaces quoted content with `""`, so the literal `.` check never matched
- Fix: check both `COMMAND_STRIPPED` and `COMMAND_PATH_SCAN` (which strips quotes but keeps content) in a single `grep` call
- Adds regression tests for `git checkout "."` and `git restore '.'`

## Root cause

`COMMAND_PATH_SCAN` already existed for the `rm -rf` path scanner (strips quotes, retains content). The checkout/restore check only used `COMMAND_STRIPPED`. Feeding both into grep closes the bypass.

## Test plan

- [x] `bash tests/test_hooks.sh` — 96/96 pass
- [x] New: "Intercept git checkout with quoted dot"
- [x] New: "Intercept git restore with single-quoted dot"

Closes #88