### PR TITLE
[codex] avoid false drift reports in setup check with OMX coexistence

### DIFF
--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -108,6 +108,16 @@ files = state.get('files', {})
 drift_count = 0
 missing_count = 0
 
+# These files are merge/upsert targets that legitimately keep changing as
+# Codex/Claude/OMX update their own config.  Their semantic integrity is
+# checked elsewhere during setup.sh --check, so install-state should not flag
+# every benign coexistence edit as drift.
+SEMANTICALLY_VALIDATED_SOURCES = {
+    'generated/settings.json',
+    'generated/codex-hooks.json',
+    'generated/codex-config.toml',
+}
+
 for dest, info in files.items():
     expanded = os.path.expanduser(dest)
     if info['type'] == 'symlink':
@@ -122,6 +132,8 @@ for dest, info in files.items():
         if not os.path.exists(expanded):
             print(f'MISSING: {dest}')
             missing_count += 1
+        elif info.get('source') in SEMANTICALLY_VALIDATED_SOURCES:
+            continue
         elif 'checksum' in info:
             try:
                 result = subprocess.run(

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -218,13 +218,13 @@ check_claude_home_installation() {
   if settings_check "${SETTINGS_FILE}" "pre-hooks"; then
     green "[OK] PreToolUse hooks configured (Write block + Bash block + Edit guard)"
   else
-    yellow "[MISSING] PreToolUse hooks not fully configured"
+    yellow "[MISSING] Claude PreToolUse hooks not fully configured in ~/.claude/settings.json"
   fi
 
   if settings_check "${SETTINGS_FILE}" "post-hooks"; then
     green "[OK] PostToolUse hooks configured (Edit quality + Write dedup)"
   else
-    yellow "[MISSING] PostToolUse hooks not fully configured"
+    yellow "[MISSING] Claude PostToolUse hooks not fully configured in ~/.claude/settings.json"
   fi
 
   if settings_check "${SETTINGS_FILE}" "full-hooks"; then

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -178,6 +178,46 @@ assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'sessi
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 
+header "install state tolerates benign coexistence edits on shared mutable files"
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+home = Path.home()
+
+settings_path = home / ".claude" / "settings.json"
+settings = json.loads(settings_path.read_text(encoding="utf-8"))
+settings["alwaysThinkingEnabled"] = True
+settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+hooks_path = home / ".codex" / "hooks.json"
+hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+hooks.setdefault("hooks", {}).setdefault("SessionStart", []).append(
+    {
+        "hooks": [
+            {
+                "type": "command",
+                "command": "node /existing/coexistence-hook.js"
+            }
+        ]
+    }
+)
+hooks_path.write_text(json.dumps(hooks, indent=2) + "\n", encoding="utf-8")
+
+config_path = home / ".codex" / "config.toml"
+config_path.write_text(
+    config_path.read_text(encoding="utf-8")
+    + "\n[projects.\"/tmp/coexistence-test\"]\ntrust_level = \"trusted\"\n",
+    encoding="utf-8",
+)
+PY
+assert_cmd "Claude hooks still validate after coexistence edits" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target pre-hooks
+assert_cmd "Codex hooks still validate after coexistence edits" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${HOME}/.codex/hooks.json" --wrapper "${HOME}/.vibeguard/run-hook-codex.sh"
+drift_out="$(bash -lc 'source scripts/lib/install-state.sh; state_check_drift')"
+assert_cmd "state_check_drift stays clean after benign coexistence edits" bash -c "! grep -q 'checksum mismatch' <<< \"${drift_out}\" && grep -q 'STATUS: CLEAN' <<< \"${drift_out}\""
+check_coexist_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+assert_cmd "setup --check does not report checksum mismatch for shared mutable files" bash -c "! grep -q 'checksum mismatch' <<< \"${check_coexist_out}\""
+
 header "codex config helper failure propagates"
 _ORIG_CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
 _BACKUP_CODEX_CONFIG_HELPER="${TMP_HOME}/codex_config_toml.py.backup"


### PR DESCRIPTION
## Summary

This PR fixes a noisy `setup.sh --check` false positive when VibeGuard coexists with OMX/Codex-managed config files.

Specifically it:
- stops install-state drift detection from treating shared mutable config files as immutable checksum targets
- clarifies the Claude-side warning text so missing Claude hooks are reported as Claude config problems, not generic hook drift
- adds a regression test that simulates benign coexistence edits after installation

## Root Cause

VibeGuard was recording whole-file checksums for:
- `~/.claude/settings.json`
- `~/.codex/hooks.json`
- `~/.codex/config.toml`

Those files are merge/upsert targets that other toolchains continue to edit after setup. As long as the required VibeGuard entries were still present, the whole-file checksum check was too strict and turned normal coexistence into spurious drift.

## Impact

- `setup.sh --check` no longer reports checksum mismatch for benign OMX/Codex coexistence edits
- real semantic checks still validate that the required VibeGuard entries exist
- Claude warning output is more explicit when only Claude hooks are missing

## Validation

- `bash tests/test_setup.sh`

## Notes

This PR intentionally keeps the change narrow:
- it does not weaken symlink drift detection
- it does not remove semantic validation for managed hook/config content
- it does not change unrelated install behavior
