### PR TITLE
fix(session_metrics): guard VIBEGUARD_LOG_FILE against KeyError (#103)

### DIFF
--- a/hooks/_lib/session_metrics.py
+++ b/hooks/_lib/session_metrics.py
@@ -32,7 +32,9 @@ from datetime import datetime, timezone, timedelta
 sys.path.insert(0, os.path.dirname(__file__))
 from event_log import load_events_from_file, parse_ts
 
-log_file = os.environ["VIBEGUARD_LOG_FILE"]
+log_file = os.environ.get("VIBEGUARD_LOG_FILE", "")
+if not log_file:
+    sys.exit(0)
 if not os.path.exists(log_file):
     sys.exit(0)
 

--- a/tests/unit/test_session_metrics_env_guard.sh
+++ b/tests/unit/test_session_metrics_env_guard.sh
@@ -114,20 +114,20 @@ else
 fi
 teardown
 
-# ── 5. Missing VIBEGUARD_LOG_FILE: exits 0 (no crash) ────────────────────────
+# ── 5. Missing VIBEGUARD_LOG_FILE: exits 0 with empty stdout ─────────────────
 printf '\n--- Missing VIBEGUARD_LOG_FILE (line 35 guard) ---\n'
 
 setup
 TOTAL=$((TOTAL + 1))
 exit_code=0
-env -u VIBEGUARD_LOG_FILE \
+output="$(env -u VIBEGUARD_LOG_FILE \
   VIBEGUARD_SESSION_ID="testsession01" \
   VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
-  python3 "${SCRIPT}" >/dev/null 2>&1 || exit_code=$?
-if [[ $exit_code -eq 0 ]]; then
-  green "Missing VIBEGUARD_LOG_FILE: exits 0 (early-exit guard works)"; PASS=$((PASS + 1))
+  python3 "${SCRIPT}" 2>/dev/null)" || exit_code=$?
+if [[ $exit_code -eq 0 && -z "$output" ]]; then
+  green "Missing VIBEGUARD_LOG_FILE: exits 0 with empty stdout (early-exit guard works)"; PASS=$((PASS + 1))
 else
-  red "Missing VIBEGUARD_LOG_FILE: expected exit 0, got $exit_code"; FAIL=$((FAIL + 1))
+  red "Missing VIBEGUARD_LOG_FILE: expected exit 0 with empty stdout, got exit=$exit_code output='$output'"; FAIL=$((FAIL + 1))
 fi
 teardown
 

--- a/tests/unit/test_session_metrics_env_guard.sh
+++ b/tests/unit/test_session_metrics_env_guard.sh
@@ -114,6 +114,38 @@ else
 fi
 teardown
 
+# ── 5. Missing VIBEGUARD_LOG_FILE: exits 0 (no crash) ────────────────────────
+printf '\n--- Missing VIBEGUARD_LOG_FILE (line 35 guard) ---\n'
+
+setup
+TOTAL=$((TOTAL + 1))
+exit_code=0
+env -u VIBEGUARD_LOG_FILE \
+  VIBEGUARD_SESSION_ID="testsession01" \
+  VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
+  python3 "${SCRIPT}" >/dev/null 2>&1 || exit_code=$?
+if [[ $exit_code -eq 0 ]]; then
+  green "Missing VIBEGUARD_LOG_FILE: exits 0 (early-exit guard works)"; PASS=$((PASS + 1))
+else
+  red "Missing VIBEGUARD_LOG_FILE: expected exit 0, got $exit_code"; FAIL=$((FAIL + 1))
+fi
+teardown
+
+# ── 6. Missing VIBEGUARD_LOG_FILE: no metrics file written ───────────────────
+# The early sys.exit(0) at line 36 fires before any event aggregation or write.
+setup
+TOTAL=$((TOTAL + 1))
+env -u VIBEGUARD_LOG_FILE \
+  VIBEGUARD_SESSION_ID="testsession01" \
+  VIBEGUARD_PROJECT_LOG_DIR="${TMPDIR_TEST}" \
+  python3 "${SCRIPT}" >/dev/null 2>&1 || true
+if [[ ! -f "${TMPDIR_TEST}/session-metrics.jsonl" ]]; then
+  green "Missing VIBEGUARD_LOG_FILE: no metrics file written (exited before write)"; PASS=$((PASS + 1))
+else
+  red "Missing VIBEGUARD_LOG_FILE: metrics file should not exist after early exit"; FAIL=$((FAIL + 1))
+fi
+teardown
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- Replace bare `os.environ["VIBEGUARD_LOG_FILE"]` at line 35 of `hooks/_lib/session_metrics.py` with `.get()` + `sys.exit(0)` guard, matching the pattern used for `VIBEGUARD_SESSION_ID` and `VIBEGUARD_PROJECT_LOG_DIR` added in PR #93
- Add two new test cases to `tests/unit/test_session_metrics_env_guard.sh` covering exit-0 and no-metrics-file-written behaviour when `VIBEGUARD_LOG_FILE` is unset (6/6 pass)

Closes #103

## Test plan

- [ ] `bash tests/unit/test_session_metrics_env_guard.sh` — all 6 tests pass (4 existing + 2 new)
- [ ] Manually invoke `python3 hooks/_lib/session_metrics.py` without `VIBEGUARD_LOG_FILE` set → exits 0 with no traceback

Signed-off-by: majiayu000 <1835304752@qq.com>