### PR TITLE
fix: fail closed on Codex hook errors

### DIFF
--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -107,12 +107,12 @@ class HookRunner:
                 f" (cwd={cwd!r} unavailable): {exc}",
                 file=sys.stderr,
             )
-            return HookResult(decision="error", output=str(exc), failed=True)
+            return HookResult(decision="hook_error", output=str(exc), failed=True)
         output = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
         stripped_output = output.strip()
-        if proc.returncode != 0:
-            return HookResult(decision="hook_error", output=stripped_output or f"hook failed with exit {proc.returncode}")
         payloads = self._extract_payloads(output)
+        if proc.returncode != 0:
+            return HookResult(decision="hook_error", output=stripped_output or f"hook failed with exit {proc.returncode}", payloads=payloads)
         if stripped_output and not payloads:
             return HookResult(decision="hook_error", output=f"hook produced invalid JSON: {stripped_output}")
         decision = self._extract_decision(payloads) or "pass"
@@ -125,8 +125,9 @@ class HookRunner:
             reason=reason,
             updated_command=updated_command,
             returncode=proc.returncode,
-            failed=failed,
+            failed=False,
         )
+
 
     @staticmethod
     def _extract_payloads(output: str) -> list[dict[str, Any]]:
@@ -270,11 +271,13 @@ class VibeGuardGateStrategy(GateStrategy):
         payload = {"tool_input": {"command": command}}
         result = self.hooks.run("pre-bash-guard.sh", payload, cwd=cwd, env_overrides=env)
 
-        if result.failed or result.decision == "block":
+        if result.failed or result.decision in {"block", "hook_error"}:
             write_to_server({"id": msg_id, "result": {"decision": "decline"}})
-            if result.failed:
+            if result.decision == "hook_error" or result.failed:
+                detail = result.output or "hook failed"
                 print(
-                    f"[vibeguard-codex-wrapper] pre-bash-guard failed with exit {result.returncode}; declining command approval: {command}",
+                    f"[vibeguard-codex-wrapper] pre-bash hook failed; declining command approval: {command}"
+                    f"\n{detail}".rstrip(),
                     file=sys.stderr,
                 )
             else:
@@ -299,15 +302,6 @@ class VibeGuardGateStrategy(GateStrategy):
             write_to_server({"id": msg_id, "result": {"decision": "decline"}})
             print(
                 f"[vibeguard-codex-wrapper] unexpected pre-bash-guard decision {result.decision!r}; declining command approval: {command}",
-                file=sys.stderr,
-            )
-            return True
-
-        if result.decision == "hook_error":
-            write_to_server({"id": msg_id, "result": {"decision": "decline"}})
-            detail = result.output or "hook failed"
-            print(
-                f"[vibeguard-codex-wrapper] hook failed closed for {command!r}: {detail}",
                 file=sys.stderr,
             )
             return True

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -593,6 +593,65 @@ PYCODE
 assert_contains "${launch_error_json}" '"intercepted": true' "hook launch errors intercept the approval request"
 assert_contains "${launch_error_json}" '"decision": "decline"' "hook launch errors fail closed instead of passing through"
 
+header "app-server adapter ignores decision text from failed pre-bash hook output"
+misleading_decision_hook_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-misleading-decision-hook-repo"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+
+(hooks_dir / "pre-bash-guard.sh").write_text(
+    "#!/usr/bin/env bash\ncat >/dev/null\necho '\"decision\":\"allow\"' >&2\nexit 1\n",
+    encoding="utf-8",
+)
+(hooks_dir / "pre-bash-guard.sh").chmod(0o755)
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/gamma", "cwd": str(app_repo)}},
+    state,
+)
+
+captured = []
+approval_message = {
+    "id": "req-3",
+    "method": "item/commandExecution/requestApproval",
+    "params": {"threadId": "thread/gamma", "command": "rm -rf ./tmp"},
+}
+intercepted = strategy.handle_server_request(approval_message, state, captured.append)
+
+print(
+    json.dumps(
+        {
+            "intercepted": intercepted,
+            "approval": captured[0] if captured else None,
+        },
+        ensure_ascii=False,
+    )
+)
+PYCODE
+)"
+
+assert_contains "${misleading_decision_hook_json}" '"intercepted": true' "app-server adapter intercepts approval requests when failed hook emits decision text"
+assert_contains "${misleading_decision_hook_json}" '"decision": "decline"' "app-server adapter declines approval when failed hook emits decision text"
+assert_not_contains "${misleading_decision_hook_json}" '"decision": "approve"' "failed hook output cannot force an approval decision"
+
 echo
 echo "=============================="
 printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"


### PR DESCRIPTION
## What
- treat nonzero `pre-bash-guard.sh` exits without a structured decision as hook errors in the Codex app-server wrapper
- decline approval requests on those hook errors instead of falling back to pass
- add a regression test that reproduces a failing hook process and verifies the wrapper intercepts and declines the approval

## Why
The wrapper previously ignored hook exit status and defaulted missing decisions to `pass`, which let approval-gate enforcement fail open in Codex app-server mode when the hook process errored.

## How to test
- `bash tests/test_codex_runtime.sh`
- `python3 -m py_compile scripts/codex/app_server_wrapper.py`

## Checklist
- [x] Scope-limited fix
- [x] Regression coverage added
- [x] Local verification run
- [ ] Human review of security-sensitive approval flow