### PR TITLE
fix(codex): include untracked files in post-build checks

### DIFF
--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -396,6 +396,7 @@ class VibeGuardGateStrategy(GateStrategy):
 
         changed = set(run_git(["diff", "--name-only", "HEAD"]))
         changed.update(run_git(["diff", "--name-only", "--cached"]))
+        changed.update(run_git(["ls-files", "--others", "--exclude-standard"]))
         source_exts = {".rs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go"}
         return [p for p in sorted(changed) if Path(p).suffix in source_exts]
 

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -230,6 +230,7 @@ subprocess.run(
     stderr=subprocess.DEVNULL,
 )
 (app_repo / "tracked.py").write_text("print('changed')\n", encoding="utf-8")
+(app_repo / "new_file.py").write_text("print('new')\n", encoding="utf-8")
 
 (hooks_dir / "pre-bash-guard.sh").write_text(
     """#!/usr/bin/env bash
@@ -269,14 +270,17 @@ PY
 )
 (hooks_dir / "post-build-check.sh").write_text(
     """#!/usr/bin/env bash
-cat >/dev/null
-python3 - <<'PY'
+payload=$(cat)
+PAYLOAD="$payload" python3 - <<'PY'
 import json
 import os
+payload = json.loads(os.environ['PAYLOAD'])
+file_path = payload['tool_input']['file_path']
 msg = 'build=' + '|'.join([
     os.environ.get('VIBEGUARD_SESSION_ID', ''),
     os.environ.get('VIBEGUARD_THREAD_ID', ''),
     os.environ.get('VIBEGUARD_TURN_ID', ''),
+    os.path.basename(file_path),
 ])
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': msg}}))
 PY
@@ -332,6 +336,8 @@ assert_contains "${adapter_json}" '|thread/alpha|turn-42' "pre-bash hook receive
 assert_contains "${adapter_json}" '"vibeguard"' "turn/completed notification is enriched with vibeguard feedback"
 assert_contains "${adapter_json}" 'learn=codex-thread-thread-alpha-' "learn-evaluator feedback is attached to turn/completed"
 assert_contains "${adapter_json}" 'build=codex-thread-thread-alpha-' "post-build feedback is attached to turn/completed"
+assert_contains "${adapter_json}" 'tracked.py' "post-build check still covers modified tracked source files"
+assert_contains "${adapter_json}" 'new_file.py' "post-build check covers untracked source files"
 assert_contains "${adapter_json}" '"session_collision_free": true' "distinct thread ids do not collapse to the same session id"
 assert_contains "${adapter_json}" '"pre_edit_guard": false' "capability matrix is exposed on app-server feedback"
 assert_not_contains "${adapter_json}" '"stop-guard.sh"' "empty stop-guard output does not create spurious feedback entries"


### PR DESCRIPTION
Closes #107

## Summary
- include untracked source files when the Codex app-server wrapper collects changed paths for `post-build-check.sh`
- extend the Codex runtime regression to assert both modified tracked files and untracked source files are checked

## Test plan
- [x] bash tests/test_codex_runtime.sh
- [x] cargo check --manifest-path \"vg-helper/Cargo.toml\"
- [x] cargo test --manifest-path \"vg-helper/Cargo.toml\"
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_unwrap_in_prod.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_duplicate_types.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_nested_locks.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_workspace_consistency.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"  # reports no root Cargo workspace
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_single_source_of_truth.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_semantic_effect.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"
- [x] bash /Users/apple/Desktop/code/AI/tool/vibeguard/guards/rust/check_taste_invariants.sh \"/Users/apple/Library/Application Support/harness/workspaces/56d4992c-ead3-4b4f-aaad-7c18171252ba\"

## AI Role
- AI-generated: wrapper change and regression test update
- Risk level: low

## Review Focus
- confirm `_changed_files()` only broadens coverage to untracked source files and does not pull in non-source paths
- confirm the regression test proves the hook is invoked for both tracked and untracked source files