### PR TITLE
fix: fail closed on Codex hook errors

### DIFF
--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -66,6 +66,8 @@ class HookResult:
     output: str
     payloads: list[dict[str, Any]] = field(default_factory=list)
     updated_command: str | None = None
+    returncode: int = 0
+    failed: bool = False
 
 
 class HookRunner:
@@ -83,6 +85,8 @@ class HookRunner:
         hook_path = self.hooks_dir / hook_name
         if not hook_path.exists():
             return HookResult(decision="pass", output="")
+
+        failed = False
 
         env = os.environ.copy()
         if env_overrides:
@@ -103,13 +107,19 @@ class HookRunner:
         if proc.returncode != 0:
             return HookResult(decision="hook_error", output=output.strip() or f"hook failed with exit {proc.returncode}")
         payloads = self._extract_payloads(output)
-        decision = self._extract_decision(output, payloads) or "pass"
+        if proc.returncode != 0:
+            failed = True
+            decision = self._extract_decision(output, payloads) or "error"
+        else:
+            decision = self._extract_decision(output, payloads) or "pass"
         updated_command = self._extract_updated_command(payloads) if decision == "allow" else None
         return HookResult(
             decision=decision,
             output=output.strip(),
             payloads=payloads,
             updated_command=updated_command,
+            returncode=proc.returncode,
+            failed=failed,
         )
 
     @staticmethod
@@ -249,10 +259,24 @@ class VibeGuardGateStrategy(GateStrategy):
         payload = {"tool_input": {"command": command}}
         result = self.hooks.run("pre-bash-guard.sh", payload, cwd=cwd, env_overrides=env)
 
-        if result.decision == "block":
+        if result.failed or result.decision == "block":
+            write_to_server({"id": msg_id, "result": {"decision": "decline"}})
+            if result.failed:
+                print(
+                    f"[vibeguard-codex-wrapper] pre-bash-guard failed with exit {result.returncode}; declining command approval: {command}",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"[vibeguard-codex-wrapper] blocked command approval: {command}",
+                    file=sys.stderr,
+                )
+            return True
+
+        if result.decision not in {"pass", "allow"}:
             write_to_server({"id": msg_id, "result": {"decision": "decline"}})
             print(
-                f"[vibeguard-codex-wrapper] blocked command approval: {command}",
+                f"[vibeguard-codex-wrapper] unexpected pre-bash-guard decision {result.decision!r}; declining command approval: {command}",
                 file=sys.stderr,
             )
             return True

--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -65,6 +65,7 @@ class HookResult:
     decision: str
     output: str
     payloads: list[dict[str, Any]] = field(default_factory=list)
+    reason: str | None = None
     updated_command: str | None = None
     returncode: int = 0
     failed: bool = False
@@ -116,11 +117,13 @@ class HookRunner:
             decision = self._extract_decision(output, payloads) or "error"
         else:
             decision = self._extract_decision(output, payloads) or "pass"
+        reason = self._extract_reason(payloads)
         updated_command = self._extract_updated_command(payloads) if decision == "allow" else None
         return HookResult(
             decision=decision,
             output=output.strip(),
             payloads=payloads,
+            reason=reason,
             updated_command=updated_command,
             returncode=proc.returncode,
             failed=failed,
@@ -157,6 +160,14 @@ class HookRunner:
         match = re.search(r'"decision"\s*:\s*"([a-zA-Z_-]+)"', output)
         if match:
             return match.group(1)
+        return None
+
+    @staticmethod
+    def _extract_reason(payloads: list[dict[str, Any]]) -> str | None:
+        for payload in payloads:
+            reason = payload.get("reason")
+            if isinstance(reason, str) and reason:
+                return reason
         return None
 
     @staticmethod
@@ -278,6 +289,14 @@ class VibeGuardGateStrategy(GateStrategy):
             return True
 
         if result.decision == "warn":
+            if result.reason:
+                warning_message: dict[str, Any] = {
+                    "method": "warning",
+                    "params": {"message": result.reason},
+                }
+                if isinstance(thread_id, str):
+                    warning_message["params"]["threadId"] = thread_id
+                write_to_server(warning_message)
             return False
 
         if result.decision not in {"pass", "allow"}:

--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -101,8 +101,12 @@ class HookRunner:
                 env=env,
             )
         except OSError as exc:
-            output = f"hook failed to launch: {exc}"
-            return HookResult(decision="hook_error", output=output)
+            print(
+                f"[vibeguard-codex-wrapper] hook {hook_name} failed to launch"
+                f" (cwd={cwd!r} unavailable): {exc}",
+                file=sys.stderr,
+            )
+            return HookResult(decision="error", output=str(exc), failed=True)
         output = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
         if proc.returncode != 0:
             return HookResult(decision="hook_error", output=output.strip() or f"hook failed with exit {proc.returncode}")
@@ -272,6 +276,9 @@ class VibeGuardGateStrategy(GateStrategy):
                     file=sys.stderr,
                 )
             return True
+
+        if result.decision == "warn":
+            return False
 
         if result.decision not in {"pass", "allow"}:
             write_to_server({"id": msg_id, "result": {"decision": "decline"}})

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -387,6 +387,104 @@ PYCODE
 assert_contains "${app_server_failure_json}" '"intercepted": true' "app-server adapter intercepts approvals when pre-bash hook exits nonzero"
 assert_contains "${app_server_failure_json}" '"decision": "decline"' "app-server adapter declines approvals when pre-bash hook exits nonzero"
 
+header "app-server adapter passes through warn decisions without declining"
+warn_hook_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper_warn_hook", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-repo-warn-hook"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+
+(hooks_dir / "pre-bash-guard.sh").write_text(
+    "#!/usr/bin/env bash\ncat >/dev/null\npython3 - <<'PY'\nimport json\nprint(json.dumps({'decision': 'warn', 'reason': 'warn only'}))\nPY\n",
+    encoding="utf-8",
+)
+(hooks_dir / "pre-bash-guard.sh").chmod(0o755)
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/warn", "cwd": str(app_repo)}},
+    state,
+)
+
+captured = []
+approval_message = {
+    "id": "req-warn",
+    "method": "item/commandExecution/requestApproval",
+    "params": {"threadId": "thread/warn", "command": "printf test > notes.md"},
+}
+intercepted = strategy.handle_server_request(approval_message, state, captured.append)
+
+print(json.dumps({"intercepted": intercepted, "captured": captured}, ensure_ascii=False))
+PYCODE
+)"
+assert_contains "${warn_hook_json}" '"intercepted": false' "warn pre-bash hook leaves approval request untouched"
+assert_contains "${warn_hook_json}" '"captured": []' "warn pre-bash hook does not synthesize a decline"
+
+header "app-server adapter fails closed when pre-bash hook cannot launch"
+launch_error_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper_launch_error", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-repo-launch-error"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+
+(hooks_dir / "pre-bash-guard.sh").write_text(
+    "#!/usr/bin/env bash\ncat >/dev/null\nprintf '{\"decision\":\"pass\"}'\n",
+    encoding="utf-8",
+)
+(hooks_dir / "pre-bash-guard.sh").chmod(0o755)
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/launch-error", "cwd": str(app_repo / 'missing-cwd')}},
+    state,
+)
+
+captured = []
+approval_message = {
+    "id": "req-launch-error",
+    "method": "item/commandExecution/requestApproval",
+    "params": {"threadId": "thread/launch-error", "command": "echo hi"},
+}
+intercepted = strategy.handle_server_request(approval_message, state, captured.append)
+
+print(json.dumps({"intercepted": intercepted, "approval": captured[0]}, ensure_ascii=False))
+PYCODE
+)"
+assert_contains "${launch_error_json}" '"intercepted": true' "hook launch errors intercept the approval request"
+assert_contains "${launch_error_json}" '"decision": "decline"' "hook launch errors fail closed instead of passing through"
+
 echo
 echo "=============================="
 printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -387,7 +387,7 @@ PYCODE
 assert_contains "${app_server_failure_json}" '"intercepted": true' "app-server adapter intercepts approvals when pre-bash hook exits nonzero"
 assert_contains "${app_server_failure_json}" '"decision": "decline"' "app-server adapter declines approvals when pre-bash hook exits nonzero"
 
-header "app-server adapter passes through warn decisions without declining"
+header "app-server adapter surfaces warn decisions before forwarding approval"
 warn_hook_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
 import json
 import importlib.util
@@ -434,7 +434,58 @@ print(json.dumps({"intercepted": intercepted, "captured": captured}, ensure_asci
 PYCODE
 )"
 assert_contains "${warn_hook_json}" '"intercepted": false' "warn pre-bash hook leaves approval request untouched"
-assert_contains "${warn_hook_json}" '"captured": []' "warn pre-bash hook does not synthesize a decline"
+assert_contains "${warn_hook_json}" '"method": "warning"' "warn pre-bash hook emits a visible warning notification"
+assert_contains "${warn_hook_json}" '"message": "warn only"' "warn pre-bash hook preserves the warning reason"
+assert_contains "${warn_hook_json}" '"threadId": "thread/warn"' "warn notification targets the active thread"
+
+header "app-server adapter fails closed on unexpected hook decisions"
+unknown_decision_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper_unknown_decision", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-repo-unknown-decision"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+
+(hooks_dir / "pre-bash-guard.sh").write_text(
+    "#!/usr/bin/env bash\ncat >/dev/null\npython3 - <<'PY'\nimport json\nprint(json.dumps({'decision': 'banana', 'reason': 'bad protocol'}))\nPY\n",
+    encoding="utf-8",
+)
+(hooks_dir / "pre-bash-guard.sh").chmod(0o755)
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/unknown", "cwd": str(app_repo)}},
+    state,
+)
+
+captured = []
+approval_message = {
+    "id": "req-unknown",
+    "method": "item/commandExecution/requestApproval",
+    "params": {"threadId": "thread/unknown", "command": "echo hi"},
+}
+intercepted = strategy.handle_server_request(approval_message, state, captured.append)
+
+print(json.dumps({"intercepted": intercepted, "approval": captured[0]}, ensure_ascii=False))
+PYCODE
+)"
+assert_contains "${unknown_decision_json}" '"intercepted": true' "unexpected decisions intercept the approval request"
+assert_contains "${unknown_decision_json}" '"decision": "decline"' "unexpected decisions fail closed instead of approving"
 
 header "app-server adapter fails closed when pre-bash hook cannot launch"
 launch_error_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'


### PR DESCRIPTION
Closes #108

## Summary
- fail closed when `pre-bash-guard.sh` exits nonzero in the Codex app-server wrapper
- decline approval requests for unexpected pre-bash hook decisions instead of forwarding them upstream
- add a regression test covering a crashing pre-bash hook during approval handling

## Test plan
- [x] `cargo check --manifest-path "vg-helper/Cargo.toml"`
- [x] `cargo test --manifest-path "vg-helper/Cargo.toml"`
- [x] `bash tests/test_codex_runtime.sh`