### PR TITLE
fix(codex): fail closed on malformed app-server hook JSON

### DIFF
--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -109,19 +109,18 @@ class HookRunner:
             )
             return HookResult(decision="error", output=str(exc), failed=True)
         output = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
+        stripped_output = output.strip()
         if proc.returncode != 0:
-            return HookResult(decision="hook_error", output=output.strip() or f"hook failed with exit {proc.returncode}")
+            return HookResult(decision="hook_error", output=stripped_output or f"hook failed with exit {proc.returncode}")
         payloads = self._extract_payloads(output)
-        if proc.returncode != 0:
-            failed = True
-            decision = self._extract_decision(output, payloads) or "error"
-        else:
-            decision = self._extract_decision(output, payloads) or "pass"
+        if stripped_output and not payloads:
+            return HookResult(decision="hook_error", output=f"hook produced invalid JSON: {stripped_output}")
+        decision = self._extract_decision(payloads) or "pass"
         reason = self._extract_reason(payloads)
         updated_command = self._extract_updated_command(payloads) if decision == "allow" else None
         return HookResult(
             decision=decision,
-            output=output.strip(),
+            output=stripped_output,
             payloads=payloads,
             reason=reason,
             updated_command=updated_command,
@@ -152,14 +151,11 @@ class HookRunner:
         return payloads
 
     @staticmethod
-    def _extract_decision(output: str, payloads: list[dict[str, Any]]) -> str | None:
+    def _extract_decision(payloads: list[dict[str, Any]]) -> str | None:
         for payload in payloads:
             decision = payload.get("decision")
             if isinstance(decision, str):
                 return decision
-        match = re.search(r'"decision"\s*:\s*"([a-zA-Z_-]+)"', output)
-        if match:
-            return match.group(1)
         return None
 
     @staticmethod

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -393,6 +393,57 @@ PYCODE
 assert_contains "${app_server_failure_json}" '"intercepted": true' "app-server adapter intercepts approvals when pre-bash hook exits nonzero"
 assert_contains "${app_server_failure_json}" '"decision": "decline"' "app-server adapter declines approvals when pre-bash hook exits nonzero"
 
+header "app-server adapter fails closed on malformed non-empty pre-bash hook output"
+app_server_invalid_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper_invalid_json", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-invalid-json-repo"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+(hooks_dir / "pre-bash-guard.sh").write_text(
+    "#!/usr/bin/env bash\ncat >/dev/null\nprintf '{'\n",
+    encoding="utf-8",
+)
+(hooks_dir / "pre-bash-guard.sh").chmod(0o755)
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/alpha", "cwd": str(app_repo)}},
+    state,
+)
+
+captured = []
+intercepted = strategy.handle_server_request(
+    {
+        "id": "req-invalid-json-1",
+        "method": "item/commandExecution/requestApproval",
+        "params": {"threadId": "thread/alpha", "command": "git push --force"},
+    },
+    state,
+    captured.append,
+)
+
+print(json.dumps({"intercepted": intercepted, "approval": captured[0] if captured else None}, ensure_ascii=False))
+PYCODE
+)"
+assert_contains "${app_server_invalid_json}" '"intercepted": true' "app-server adapter intercepts approvals when pre-bash hook output is malformed"
+assert_contains "${app_server_invalid_json}" '"decision": "decline"' "app-server adapter declines approvals when pre-bash hook output is malformed"
+
 header "app-server adapter surfaces warn decisions before forwarding approval"
 warn_hook_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
 import json


### PR DESCRIPTION
Closes #114

## Summary
- fail closed in `scripts/codex/app_server_wrapper.py` when a hook exits 0 but emits non-empty malformed output
- derive approval decisions only from successfully parsed JSON payloads instead of raw regex matches
- add a runtime regression covering malformed `pre-bash-guard.sh` output on the app-server approval path

## Test plan
- [x] `bash tests/test_codex_runtime.sh`
- [x] `cargo check --manifest-path vg-helper/Cargo.toml`
- [x] `cargo test --manifest-path vg-helper/Cargo.toml`

## AI Role
- AI Role: implemented the minimal wrapper fix and regression test (risk level: medium)

## Review Focus
- Confirm the fail-closed classification in `HookRunner.run()` does not over-match best-effort hooks
- Confirm approval decisions now only come from parsed hook payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)