### PR TITLE
fix(scripts): correct guard_paths.sh source path after subdir reorganization

### DIFF
--- a/scripts/metrics/metrics_collector.sh
+++ b/scripts/metrics/metrics_collector.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 PROJECT_DIR="${1:-.}"
 VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
-source "$(dirname "$0")/lib/guard_paths.sh"
+source "$(dirname "$0")/../lib/guard_paths.sh"
 TODAY=$(date '+%Y-%m-%d')
 
 echo "======================================"

--- a/scripts/verify/compliance_check.sh
+++ b/scripts/verify/compliance_check.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 PROJECT_DIR="${1:-.}"
 VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
-source "$(dirname "$0")/lib/guard_paths.sh"
+source "$(dirname "$0")/../lib/guard_paths.sh"
 PASS=0
 FAIL=0
 WARN=0


### PR DESCRIPTION
## Summary

`compliance_check.sh` and `metrics_collector.sh` source `lib/guard_paths.sh` from a relative path that no longer exists after the scripts moved into `scripts/verify/` and `scripts/metrics/`. Both fail at startup with `No such file or directory`.

## What

Two-line path fix: change `"$(dirname "$0")/lib/guard_paths.sh"` → `"$(dirname "$0")/../lib/guard_paths.sh"` in both files. The actual `guard_paths.sh` lives at `scripts/lib/guard_paths.sh`.

## Why

The wrong relative path makes both scripts unusable. `compliance_check.sh` is invoked by the `/vibeguard:check` skill; the breakage was discovered while running that skill against an external project.

## How to test

```bash
bash scripts/verify/compliance_check.sh /path/to/some-project
# Before: "No such file or directory" — exits immediately
# After: full compliance report runs

bash scripts/metrics/metrics_collector.sh /path/to/some-project
# Before: same error
# After: M1/M3/M5 metrics output
```

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests pass — `bash scripts/local-contract-check.sh --quick` (20 + 3 PASS, 0 FAIL)
- [x] Verified — `compliance_check.sh` on a real project: 16 PASS / 0 WARN / 0 FAIL
- [x] Verified — `metrics_collector.sh` on a real project: produces metrics output
- [x] No hardcoded paths
- [x] Conventional commit message used (`fix(scripts):`)
- [x] Lore protocol trailers in commit body
- [x] No AI markers / Co-Authored-By

## Related issues

None.