### PR TITLE
Fix Codex config health validation

### DIFF
--- a/plan/2026-04-28-codex-config-validation-signal-report.md
+++ b/plan/2026-04-28-codex-config-validation-signal-report.md
@@ -1,0 +1,33 @@
+# Signal Report: Codex Config Validation False Negative
+
+Date: 2026-04-28
+Rule context: U-23
+
+## Signal
+
+`setup.sh --check` reported the Codex config as healthy when `~/.codex/config.toml`
+contained the literal line `codex_hooks = true`, even if the file was malformed TOML.
+
+## Root Cause
+
+`scripts/setup/targets/codex-home.sh` used a regex-only grep check for
+`codex_hooks = true`. That logic was not structurally validating TOML and could
+therefore produce a false-negative health signal for malformed or partially
+corrupted config files.
+
+## Deterministic Fix
+
+Move the health check onto a parser-backed helper in
+`scripts/lib/codex_config_toml.py` using Python `tomllib`, and have the setup
+status path distinguish three states:
+
+- `OK`: valid TOML with `[features].codex_hooks = true`
+- `MISSING`: valid TOML but feature not enabled
+- `INVALID`: malformed TOML
+
+## Verification
+
+Regression coverage added in:
+
+- `tests/test_manifest_contract.sh`
+- `tests/test_setup.sh`

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 import tempfile
+import tomllib
 from pathlib import Path
 
 
@@ -87,6 +88,18 @@ def _remove_legacy_vibeguard_mcp(text: str) -> tuple[str, bool]:
     return ((new_text + "\n") if new_text else ""), changed
 
 
+def _check_codex_hooks_enabled(text: str) -> tuple[str, int]:
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return "INVALID", 1
+
+    features = data.get("features")
+    if isinstance(features, dict) and features.get("codex_hooks") is True:
+        return "OK", 0
+    return "MISSING", 1
+
+
 def cmd_enable_codex_hooks(args: argparse.Namespace) -> int:
     path = Path(args.config_file)
     old = path.read_text(encoding="utf-8") if path.exists() else ""
@@ -117,12 +130,26 @@ def cmd_remove_legacy_vibeguard_mcp(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_check_codex_hooks(args: argparse.Namespace) -> int:
+    path = Path(args.config_file)
+    if not path.exists():
+        print("MISSING")
+        return 1
+
+    status, code = _check_codex_hooks_enabled(path.read_text(encoding="utf-8"))
+    print(status)
+    return code
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Structured Codex config.toml helper")
     sub = parser.add_subparsers(dest="command", required=True)
 
     enable = sub.add_parser("enable-codex-hooks", help="Ensure [features].codex_hooks = true")
     enable.add_argument("--config-file", required=True)
+
+    check = sub.add_parser("check-codex-hooks", help="Validate [features].codex_hooks = true")
+    check.add_argument("--config-file", required=True)
 
     remove = sub.add_parser("remove-legacy-vibeguard-mcp", help="Remove [mcp_servers.vibeguard] block")
     remove.add_argument("--config-file", required=True)
@@ -134,6 +161,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.command == "enable-codex-hooks":
         return cmd_enable_codex_hooks(args)
+    if args.command == "check-codex-hooks":
+        return cmd_check_codex_hooks(args)
     if args.command == "remove-legacy-vibeguard-mcp":
         return cmd_remove_legacy_vibeguard_mcp(args)
     parser.error("unknown command")

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -137,8 +137,15 @@ print(total)
   yellow "[INFO] Codex runtime scope: Bash approvals + Stop hooks only; Edit/Write/analysis-paralysis require Claude Code or the app-server wrapper"
 
   # Check feature flag
-  if [[ -f "${CODEX_DIR}/config.toml" ]] && grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CODEX_DIR}/config.toml" 2>/dev/null; then
+  local config="${CODEX_DIR}/config.toml"
+  local codex_hooks_status="MISSING"
+  if [[ -f "${config}" ]]; then
+    codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${config}" 2>/dev/null || true)"
+  fi
+  if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] codex_hooks feature enabled in config.toml"
+  elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
+    red "[BROKEN] ~/.codex/config.toml is malformed TOML"
   else
     yellow "[MISSING] codex_hooks feature not enabled in ~/.codex/config.toml"
   fi

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -87,6 +87,16 @@ enable_commented_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --co
 assert_contains "${enable_commented_out}" "CHANGED" "enable-codex-hooks recognizes commented features table"
 assert_cmd "enable-codex-hooks does not append duplicate commented features table" bash -c "test \$(grep -Ec '^\\[features\\]' '${CONFIG_FILE}') -eq 1"
 assert_cmd "enable-codex-hooks adds exact key under commented features table" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+check_ok_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}")"
+assert_contains "${check_ok_out}" "OK" "check-codex-hooks accepts valid TOML with feature enabled"
+
+cat > "${CONFIG_FILE}" <<'TOML'
+[features]
+codex_hooks = true
+broken = [
+TOML
+check_invalid_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
+assert_contains "${check_invalid_out}" "INVALID" "check-codex-hooks rejects malformed TOML"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -186,6 +186,16 @@ assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'sessi
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 
+header "setup --check detects malformed codex config"
+cat > "${HOME}/.codex/config.toml" <<'TOML'
+[features]
+codex_hooks = true
+broken = [
+TOML
+malformed_config_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+assert_contains "${malformed_config_out}" "[BROKEN] ~/.codex/config.toml is malformed TOML" "--check reports malformed codex config"
+assert_cmd "--check does not report malformed config as healthy" bash -c "! grep -q '\\[OK\\] codex_hooks feature enabled in config.toml' <<< '${malformed_config_out}'"
+
 header "codex config helper failure propagates"
 _ORIG_CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
 _BACKUP_CODEX_CONFIG_HELPER="${TMP_HOME}/codex_config_toml.py.backup"


### PR DESCRIPTION
## Summary
- replace the regex-only Codex config health check with a parser-backed `check-codex-hooks` command
- report malformed `~/.codex/config.toml` as `[BROKEN]` instead of healthy during `setup.sh --check`
- add regression coverage plus a signal report artifact documenting the root cause

## Root cause
`setup.sh --check` previously treated any file containing a matching `codex_hooks = true` line as healthy, even when the surrounding TOML was malformed.

## Verification
- `bash tests/test_manifest_contract.sh`
- `bash tests/test_setup.sh`
- `bash scripts/local-contract-check.sh`
