### PR TITLE
feat: add compact chat contract prompts

### DIFF
--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -15,6 +15,14 @@
 | L6 | 1-2 file directly · 3-5 `/vibeguard:preflight` · 6+ `/vibeguard:interview` → spec |
 | L7 | AI tag does not exist / force push / key submission |
 
+## Chat Contract
+
+Compact Chat Contract: progress updates, concise answers, plain formatting.
+
+- Progress updates: for non-trivial or tool-heavy work, send a short update at start, after discovery, before edits, after verification, and when blocked.
+- Default verbosity: keep answers concise by default; use short paragraphs for simple tasks and expand only when the work is complex or the user asks for depth.
+- Formatting: use Markdown only when it helps; prefer prose first, flat bullets only for natural lists, and avoid decorative structure.
+
 ## Context · Validation
 
 - Corrected 2 times → `/clear`

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -5,6 +5,14 @@
 
 ---
 
+## Chat Contract
+
+Compact Chat Contract: progress updates, concise answers, plain formatting.
+
+- Progress updates: for non-trivial or tool-heavy work, send a short update at start, after discovery, before edits, after verification, and when blocked.
+- Default verbosity: keep answers concise by default; use short paragraphs for simple tasks and expand only when the work is complex or the user asks for depth.
+- Formatting: use Markdown only when it helps; prefer prose first, flat bullets only for natural lists, and avoid decorative structure.
+
 ## Workflow Orchestration
 
 ### 1. Complexity Router (Complexity Routing)

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -4,6 +4,14 @@
 > Copy to the project root directory and the Codex agent will automatically read it.
 > Scope = the entire subtree of the directory where this file is located, with increasing priority for deep AGENTS.md.
 
+## Chat Contract
+
+Compact Chat Contract: progress updates, concise answers, plain formatting.
+
+- Progress updates: for non-trivial or tool-heavy work, send a short update at start, after discovery, before edits, after verification, and when blocked.
+- Default verbosity: keep answers concise by default; use short paragraphs for simple tasks and expand only when the work is complex or the user asks for depth.
+- Formatting: use Markdown only when it helps; prefer prose first, flat bullets only for natural lists, and avoid decorative structure.
+
 ## Constraints
 
 | ID | Rule |
@@ -41,7 +49,7 @@ If `.vibeguard-architecture.yaml` exists, enforce dependency direction:
 
 security vulnerability > logic bug > data inconsistency > duplicate types > unwrap > naming
 
-## Style
+## Code Style
 
 - Single file ≤ 200 lines — split if exceeded
 - No hardcoded values (ports, URLs, configs)

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SETTINGS_HELPER="${REPO_DIR}/scripts/lib/settings_json.py"
 CODEX_HOOKS_HELPER="${REPO_DIR}/scripts/lib/codex_hooks_json.py"
+CHAT_CONTRACT_ANCHOR="Compact Chat Contract: progress updates, concise answers, plain formatting."
 
 PASS=0
 FAIL=0
@@ -40,6 +41,31 @@ assert_cmd() {
     red "$desc (exit code: $?)"
     FAIL=$((FAIL + 1))
   fi
+}
+
+assert_chat_contract_blocks_match() {
+  python3 - <<'PY' "${REPO_DIR}" "${HOME}/.claude/CLAUDE.md"
+from pathlib import Path
+import re
+import sys
+
+repo_dir = Path(sys.argv[1])
+installed_path = Path(sys.argv[2])
+pattern = re.compile(r"^## Chat Contract\n.*?(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+paths = [
+    repo_dir / "claude-md/vibeguard-rules.md",
+    repo_dir / "templates/AGENTS.md",
+    repo_dir / "docs/CLAUDE.md.example",
+    installed_path,
+]
+blocks = []
+for path in paths:
+    match = pattern.search(path.read_text(encoding="utf-8"))
+    if not match:
+        raise SystemExit(1)
+    blocks.append(match.group(0).strip())
+raise SystemExit(0 if len(set(blocks)) == 1 else 1)
+PY
 }
 
 ORIG_HOME="${HOME}"
@@ -185,6 +211,10 @@ assert_cmd "Codex hooks do not contain cognitive-reminder" bash -c "! grep -q 'c
 assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'session-tagger.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
+assert_cmd "~/.claude/CLAUDE.md includes the chat contract anchor after installation" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${HOME}/.claude/CLAUDE.md"
+assert_cmd "templates/AGENTS.md includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/templates/AGENTS.md"
+assert_cmd "docs/CLAUDE.md.example includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/docs/CLAUDE.md.example"
+assert_cmd "chat contract block matches across source, installed output, and templates" assert_chat_contract_blocks_match
 
 header "codex config helper failure propagates"
 _ORIG_CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
@@ -213,6 +243,10 @@ check_again_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 after_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
 assert_contains "${check_again_out}" "CLAUDE.md declares 999 rules" "--check reports CLAUDE.md drift"
 assert_cmd "--check does not rewrite ~/.claude/CLAUDE.md" test "${before_sha}" = "${after_sha}"
+assert_cmd "--check does not drop or duplicate the chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
+repair_out="$(bash "${REPO_DIR}/setup.sh")"
+assert_contains "${repair_out}" "Setup complete! All components installed." "re-running setup after drift still succeeds"
+assert_cmd "repeat setup keeps exactly one chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 
 header "upsert idempotency with non-standard wrapper path"
 # Run upsert twice with a wrapper path that does not contain 'run-hook-codex.sh'.


### PR DESCRIPTION
## Summary
- add a shared Chat Contract block to the Claude rules source and both manual-copy templates
- extend setup regression coverage for installed output consistency and no-duplication across repeated setup/check flows

## Testing
- bash scripts/ci/validate-rules.sh
- bash tests/test_setup.sh
- cargo check --manifest-path vg-helper/Cargo.toml
- cargo test --manifest-path vg-helper/Cargo.toml

Closes #97