### PR TITLE
feat: persist OMX lifecycle and verification state

### DIFF
--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -103,3 +103,66 @@ JSON Schema definition for structured communication between commands. Each comma
   }
 }
 ```
+
+## OMX completion artifact
+
+Path: `.omx/state/<scope>/completion.json`
+
+```json
+{
+  "mode": "codex-app-server | plan-mode | exec-plan | ...",
+  "scope": "thread-foo-<hash>",
+  "status": "active | in_progress | incomplete | completed | failed | cancelled",
+  "started_at": "ISO8601",
+  "updated_at": "ISO8601",
+  "completed_at": "ISO8601 | null",
+  "cancelled_at": "ISO8601 | null",
+  "current_step": "step id or summary | null",
+  "verification_status": "missing | pass | fail | warn | stale | unknown",
+  "verification_entry_id": "jsonl row id | null",
+  "verification_commands": ["command string"],
+  "known_failures": ["signal or failure summary"],
+  "next_required_action": "human-readable next action | null",
+  "artifacts": {
+    "completion": ".omx/state/<scope>/completion.json",
+    "verification_log": ".omx/state/<scope>/verification-log.jsonl",
+    "current_plan": ".omx/state/current-plan.json"
+  }
+}
+```
+
+## OMX verification ledger row
+
+Path: `.omx/state/<scope>/verification-log.jsonl`
+
+Each line is one JSON object:
+
+```json
+{
+  "entry_id": "stable row id",
+  "ts": "ISO8601",
+  "scope": "thread-foo-<hash>",
+  "status": "missing | pass | fail | warn | stale | unknown",
+  "source": "learn-evaluator | manual | runtime-name",
+  "summary": "short explanation | null",
+  "turn_id": "turn id | null",
+  "session_id": "session id | null",
+  "commands": ["command string"],
+  "known_failures": ["signal or failure summary"]
+}
+```
+
+## OMX current-plan pointer
+
+Path: `.omx/state/current-plan.json`
+
+```json
+{
+  "scope": "thread-foo-<hash>",
+  "plan_path": "plan/2026-04-28_12-00-00-feature.md",
+  "mode": "plan-mode | exec-plan | null",
+  "current_step": "step id or summary | null",
+  "updated_at": "ISO8601",
+  "next_required_action": "resume hint | null"
+}
+```

--- a/docs/how/memory-files.md
+++ b/docs/how/memory-files.md
@@ -59,6 +59,30 @@ Common path patterns:
 
 Role: preserve decisions, open questions, completed remediation work, and reusable local knowledge.
 
+### OMX runtime state contract
+
+Repo-local continuation now uses one canonical state layout under `.omx/state/`:
+
+```text
+.omx/state/
+├── current-plan.json
+└── <scope>/
+    ├── completion.json
+    └── verification-log.jsonl
+```
+
+Scope rules:
+
+- Use the explicitly provided scope when the runtime already resolved one.
+- Otherwise prefer the canonical `current-plan.json` pointer when continuation is plan-driven.
+- Otherwise derive a stable scope from the active thread id, then session id, then repo root.
+
+Lifecycle rules:
+
+- `completion.json` is the durable source of truth for `active`, `in_progress`, `incomplete`, `completed`, `failed`, and `cancelled`.
+- `verification-log.jsonl` is append-only. Completion claims must reference a passing verification entry for the same scope.
+- `current-plan.json` maps the active plan file to the active scope so a new session can resume without trusting chat history alone.
+
 ## How the layers work together
 
 ```text

--- a/hooks/_lib/omx_state.py
+++ b/hooks/_lib/omx_state.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Shared repo-local OMX state helpers.
+
+This module is the single source of truth for:
+- resolving the active OMX scope
+- validating lifecycle + verification payloads
+- atomically writing `.omx/state/<scope>/completion.json`
+- appending `.omx/state/<scope>/verification-log.jsonl`
+- reading the canonical current-plan pointer
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+VALID_COMPLETION_STATUSES = {
+    "active",
+    "in_progress",
+    "incomplete",
+    "completed",
+    "failed",
+    "cancelled",
+}
+VALID_VERIFICATION_STATUSES = {"missing", "pass", "fail", "warn", "stale", "unknown"}
+
+
+class StateError(RuntimeError):
+    """Raised when OMX state is malformed or invalid."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _ensure_str(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise StateError(f"{field} must be a non-empty string")
+    return value
+
+
+def _ensure_optional_str(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise StateError(f"{field} must be a string or null")
+    return value
+
+
+def _ensure_string_list(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise StateError(f"{field} must be a list of strings")
+    return value
+
+
+def _slugify(raw: str) -> str:
+    cleaned = []
+    for char in raw:
+        if char.isalnum():
+            cleaned.append(char.lower())
+        else:
+            cleaned.append("-")
+    slug = "".join(cleaned).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "scope"
+
+
+def _scoped_name(prefix: str, raw: str) -> str:
+    slug = _slugify(raw)
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}-{slug}-{digest}"
+
+
+def _repo_root_from_env() -> Path | None:
+    raw = os.environ.get("VIBEGUARD_REPO_ROOT")
+    if raw:
+        path = Path(raw).expanduser().resolve()
+        return path
+    return None
+
+
+def repo_root_from_cwd(cwd: str | os.PathLike[str] | None = None) -> Path:
+    repo_from_env = _repo_root_from_env()
+    if repo_from_env is not None:
+        return repo_from_env
+
+    cwd_path = Path(cwd).resolve() if cwd else Path.cwd()
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(cwd_path),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise StateError(f"unable to resolve git repo root from {cwd_path}: {exc}") from exc
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _read_json_file(path: Path, *, allow_missing: bool = True) -> dict[str, Any] | None:
+    if not path.exists():
+        if allow_missing:
+            return None
+        raise StateError(f"{path} does not exist")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise StateError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise StateError(f"{path} must contain a JSON object")
+    return data
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        prefix=f".{path.name}.tmp.",
+        delete=False,
+    ) as handle:
+        handle.write(serialized)
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+@dataclass(frozen=True)
+class ScopeInfo:
+    repo_root: Path
+    scope: str
+    scope_source: str
+    mode: str
+    current_step: str | None
+    current_plan_path: str | None
+    pointer_error: str | None
+
+    @property
+    def state_root(self) -> Path:
+        return self.repo_root / ".omx" / "state"
+
+    @property
+    def scope_dir(self) -> Path:
+        return self.state_root / self.scope
+
+    @property
+    def completion_path(self) -> Path:
+        return self.scope_dir / "completion.json"
+
+    @property
+    def verification_log_path(self) -> Path:
+        return self.scope_dir / "verification-log.jsonl"
+
+    @property
+    def current_plan_pointer_path(self) -> Path:
+        return self.state_root / "current-plan.json"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repo_root": str(self.repo_root),
+            "scope": self.scope,
+            "scope_source": self.scope_source,
+            "mode": self.mode,
+            "current_step": self.current_step,
+            "current_plan_path": self.current_plan_path,
+            "pointer_error": self.pointer_error,
+            "state_dir": _relative_to_repo(self.scope_dir, self.repo_root),
+            "completion_path": _relative_to_repo(self.completion_path, self.repo_root),
+            "verification_log_path": _relative_to_repo(self.verification_log_path, self.repo_root),
+            "current_plan_pointer_path": _relative_to_repo(self.current_plan_pointer_path, self.repo_root),
+        }
+
+
+def _relative_to_repo(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+def _validate_current_plan_pointer(data: dict[str, Any]) -> dict[str, Any]:
+    scope = _ensure_str(data.get("scope"), "scope")
+    plan_path = _ensure_str(data.get("plan_path"), "plan_path")
+    updated_at = _ensure_str(data.get("updated_at"), "updated_at")
+    mode = data.get("mode")
+    if mode is not None and not isinstance(mode, str):
+        raise StateError("mode must be a string or null")
+    current_step = data.get("current_step")
+    if current_step is not None and not isinstance(current_step, str):
+        raise StateError("current_step must be a string or null")
+    next_required_action = data.get("next_required_action")
+    if next_required_action is not None and not isinstance(next_required_action, str):
+        raise StateError("next_required_action must be a string or null")
+    return {
+        "scope": scope,
+        "plan_path": plan_path,
+        "updated_at": updated_at,
+        "mode": mode,
+        "current_step": current_step,
+        "next_required_action": next_required_action,
+    }
+
+
+def load_current_plan_pointer(repo_root: Path) -> tuple[dict[str, Any] | None, str | None]:
+    path = repo_root / ".omx" / "state" / "current-plan.json"
+    if not path.exists():
+        return None, None
+    try:
+        data = _read_json_file(path, allow_missing=False)
+        assert data is not None
+        return _validate_current_plan_pointer(data), None
+    except StateError as exc:
+        return None, str(exc)
+
+
+def write_current_plan_pointer(repo_root: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    pointer = _validate_current_plan_pointer(payload)
+    path = repo_root / ".omx" / "state" / "current-plan.json"
+    _atomic_write_json(path, pointer)
+    return pointer
+
+
+def resolve_scope(
+    repo_root: Path,
+    *,
+    explicit_scope: str | None = None,
+    thread_id: str | None = None,
+    session_id: str | None = None,
+    mode: str | None = None,
+) -> ScopeInfo:
+    pointer, pointer_error = load_current_plan_pointer(repo_root)
+    resolved_mode = mode or os.environ.get("VIBEGUARD_MODE") or (pointer or {}).get("mode") or os.environ.get("VIBEGUARD_CLI") or "unknown"
+    if explicit_scope:
+        scope = _slugify(explicit_scope)
+        source = "explicit"
+    elif pointer and isinstance(pointer.get("scope"), str) and pointer["scope"]:
+        scope = _slugify(pointer["scope"])
+        source = "current-plan"
+    elif thread_id:
+        scope = _scoped_name("thread", thread_id)
+        source = "thread"
+    elif session_id:
+        scope = _scoped_name("session", session_id)
+        source = "session"
+    else:
+        scope = _scoped_name("repo", str(repo_root))
+        source = "repo"
+    return ScopeInfo(
+        repo_root=repo_root,
+        scope=scope,
+        scope_source=source,
+        mode=resolved_mode,
+        current_step=(pointer or {}).get("current_step"),
+        current_plan_path=(pointer or {}).get("plan_path"),
+        pointer_error=pointer_error,
+    )
+
+
+def _artifacts_for(scope_info: ScopeInfo) -> dict[str, str]:
+    return {
+        "completion": _relative_to_repo(scope_info.completion_path, scope_info.repo_root),
+        "verification_log": _relative_to_repo(scope_info.verification_log_path, scope_info.repo_root),
+        "current_plan": _relative_to_repo(scope_info.current_plan_pointer_path, scope_info.repo_root),
+    }
+
+
+def _validate_completion(scope_info: ScopeInfo, data: dict[str, Any]) -> dict[str, Any]:
+    status = _ensure_str(data.get("status"), "status")
+    if status not in VALID_COMPLETION_STATUSES:
+        raise StateError(f"status must be one of {sorted(VALID_COMPLETION_STATUSES)}")
+
+    verification_status = _ensure_str(data.get("verification_status"), "verification_status")
+    if verification_status not in VALID_VERIFICATION_STATUSES:
+        raise StateError(f"verification_status must be one of {sorted(VALID_VERIFICATION_STATUSES)}")
+
+    scope = _ensure_str(data.get("scope"), "scope")
+    if scope != scope_info.scope:
+        raise StateError(f"scope mismatch: expected {scope_info.scope}, got {scope}")
+
+    mode = _ensure_str(data.get("mode"), "mode")
+    started_at = _ensure_str(data.get("started_at"), "started_at")
+    updated_at = _ensure_str(data.get("updated_at"), "updated_at")
+
+    completed_at = _ensure_optional_str(data.get("completed_at"), "completed_at")
+    cancelled_at = _ensure_optional_str(data.get("cancelled_at"), "cancelled_at")
+    current_step = _ensure_optional_str(data.get("current_step"), "current_step")
+    next_required_action = _ensure_optional_str(data.get("next_required_action"), "next_required_action")
+    verification_entry_id = _ensure_optional_str(data.get("verification_entry_id"), "verification_entry_id")
+    verification_commands = _ensure_string_list(data.get("verification_commands"), "verification_commands")
+    known_failures = _ensure_string_list(data.get("known_failures"), "known_failures")
+    artifacts = data.get("artifacts")
+    if artifacts is not None:
+        if not isinstance(artifacts, dict):
+            raise StateError("artifacts must be an object")
+        for key, expected in _artifacts_for(scope_info).items():
+            if artifacts.get(key) != expected:
+                raise StateError(f"artifacts.{key} must equal {expected}")
+
+    return {
+        "mode": mode,
+        "scope": scope,
+        "status": status,
+        "started_at": started_at,
+        "updated_at": updated_at,
+        "completed_at": completed_at,
+        "cancelled_at": cancelled_at,
+        "current_step": current_step,
+        "verification_status": verification_status,
+        "verification_entry_id": verification_entry_id,
+        "verification_commands": verification_commands,
+        "known_failures": known_failures,
+        "next_required_action": next_required_action,
+        "artifacts": _artifacts_for(scope_info),
+    }
+
+
+def read_completion(scope_info: ScopeInfo) -> dict[str, Any] | None:
+    data = _read_json_file(scope_info.completion_path, allow_missing=True)
+    if data is None:
+        return None
+    return _validate_completion(scope_info, data)
+
+
+def write_completion(scope_info: ScopeInfo, payload: dict[str, Any]) -> dict[str, Any]:
+    existing: dict[str, Any] | None = None
+    existing_error: str | None = None
+    try:
+        existing = read_completion(scope_info)
+    except StateError as exc:
+        existing_error = str(exc)
+
+    now = _utc_now()
+    status = _ensure_str(payload.get("status"), "status")
+    if status not in VALID_COMPLETION_STATUSES:
+        raise StateError(f"status must be one of {sorted(VALID_COMPLETION_STATUSES)}")
+
+    verification_status = payload.get("verification_status", "unknown")
+    if verification_status not in VALID_VERIFICATION_STATUSES:
+        raise StateError(f"verification_status must be one of {sorted(VALID_VERIFICATION_STATUSES)}")
+
+    if status == "completed" and verification_status != "pass":
+        raise StateError("completed status requires verification_status=pass")
+
+    completion = {
+        "mode": _ensure_str(payload.get("mode") or scope_info.mode, "mode"),
+        "scope": scope_info.scope,
+        "status": status,
+        "started_at": (existing or {}).get("started_at") or payload.get("started_at") or now,
+        "updated_at": now,
+        "completed_at": now if status == "completed" else None,
+        "cancelled_at": now if status == "cancelled" else None,
+        "current_step": payload.get("current_step", scope_info.current_step),
+        "verification_status": verification_status,
+        "verification_entry_id": payload.get("verification_entry_id"),
+        "verification_commands": _ensure_string_list(payload.get("verification_commands"), "verification_commands"),
+        "known_failures": _ensure_string_list(payload.get("known_failures"), "known_failures"),
+        "next_required_action": payload.get("next_required_action"),
+        "artifacts": _artifacts_for(scope_info),
+    }
+    if existing_error is not None:
+        completion["known_failures"] = completion["known_failures"] + [f"prior-state-error: {existing_error}"]
+        completion["next_required_action"] = (
+            "Repair malformed OMX state and rerun verification before claiming completion."
+        )
+        if status == "completed":
+            raise StateError("cannot mark completion completed while prior completion state is malformed")
+
+    validated = _validate_completion(scope_info, completion)
+    _atomic_write_json(scope_info.completion_path, validated)
+    return validated
+
+
+def _validate_verification_row(scope_info: ScopeInfo, data: dict[str, Any]) -> dict[str, Any]:
+    status = _ensure_str(data.get("status"), "status")
+    if status not in VALID_VERIFICATION_STATUSES:
+        raise StateError(f"status must be one of {sorted(VALID_VERIFICATION_STATUSES)}")
+    scope = _ensure_str(data.get("scope"), "scope")
+    if scope != scope_info.scope:
+        raise StateError(f"scope mismatch: expected {scope_info.scope}, got {scope}")
+    source = _ensure_str(data.get("source"), "source")
+    ts = _ensure_str(data.get("ts"), "ts")
+    entry_id = _ensure_str(data.get("entry_id"), "entry_id")
+    summary = _ensure_optional_str(data.get("summary"), "summary")
+    turn_id = _ensure_optional_str(data.get("turn_id"), "turn_id")
+    session_id = _ensure_optional_str(data.get("session_id"), "session_id")
+    commands = _ensure_string_list(data.get("commands"), "commands")
+    known_failures = _ensure_string_list(data.get("known_failures"), "known_failures")
+    return {
+        "entry_id": entry_id,
+        "ts": ts,
+        "scope": scope,
+        "status": status,
+        "source": source,
+        "summary": summary,
+        "turn_id": turn_id,
+        "session_id": session_id,
+        "commands": commands,
+        "known_failures": known_failures,
+    }
+
+
+def _verification_entry_id(scope: str, turn_id: str | None, commands: list[str], source: str, status: str) -> str:
+    seed = json.dumps(
+        {"scope": scope, "turn_id": turn_id or "", "commands": commands, "source": source, "status": status},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def append_verification(scope_info: ScopeInfo, payload: dict[str, Any]) -> dict[str, Any]:
+    commands = _ensure_string_list(payload.get("commands"), "commands")
+    status = _ensure_str(payload.get("status"), "status")
+    if status not in VALID_VERIFICATION_STATUSES:
+        raise StateError(f"status must be one of {sorted(VALID_VERIFICATION_STATUSES)}")
+    source = _ensure_str(payload.get("source"), "source")
+    turn_id = _ensure_optional_str(payload.get("turn_id"), "turn_id")
+    session_id = _ensure_optional_str(payload.get("session_id"), "session_id")
+    summary = _ensure_optional_str(payload.get("summary"), "summary")
+    known_failures = _ensure_string_list(payload.get("known_failures"), "known_failures")
+    row = {
+        "entry_id": payload.get("entry_id") or _verification_entry_id(scope_info.scope, turn_id, commands, source, status),
+        "ts": payload.get("ts") or _utc_now(),
+        "scope": scope_info.scope,
+        "status": status,
+        "source": source,
+        "summary": summary,
+        "turn_id": turn_id,
+        "session_id": session_id,
+        "commands": commands,
+        "known_failures": known_failures,
+    }
+    validated = _validate_verification_row(scope_info, row)
+    _append_jsonl(scope_info.verification_log_path, validated)
+    return validated
+
+
+def latest_verification(scope_info: ScopeInfo) -> dict[str, Any] | None:
+    path = scope_info.verification_log_path
+    if not path.exists():
+        return None
+    latest: dict[str, Any] | None = None
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            try:
+                validated = _validate_verification_row(scope_info, data)
+            except StateError:
+                continue
+            latest = validated
+    return latest
+
+
+def scope_info_from_env(cwd: str | None = None) -> ScopeInfo:
+    repo_root = repo_root_from_cwd(cwd)
+    return resolve_scope(
+        repo_root,
+        explicit_scope=os.environ.get("VIBEGUARD_SCOPE"),
+        thread_id=os.environ.get("VIBEGUARD_THREAD_ID"),
+        session_id=os.environ.get("VIBEGUARD_SESSION_ID"),
+        mode=os.environ.get("VIBEGUARD_MODE"),
+    )
+
+
+def _load_stdin_json() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise StateError(f"stdin payload must be JSON object: {exc}") from exc
+    if not isinstance(data, dict):
+        raise StateError("stdin payload must be a JSON object")
+    return data
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="OMX repo-local state helpers")
+    parser.add_argument(
+        "--cwd",
+        default=None,
+        help="Working directory used to resolve the git repository root",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("scope-meta")
+    subparsers.add_parser("read-completion")
+    subparsers.add_parser("write-completion")
+    subparsers.add_parser("latest-verification")
+    subparsers.add_parser("append-verification")
+    subparsers.add_parser("read-current-plan")
+    subparsers.add_parser("write-current-plan")
+    return parser
+
+
+def _emit(obj: dict[str, Any]) -> int:
+    print(json.dumps(obj, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        if args.command in {"read-current-plan", "write-current-plan"}:
+            repo_root = repo_root_from_cwd(args.cwd)
+            if args.command == "read-current-plan":
+                pointer, error = load_current_plan_pointer(repo_root)
+                return _emit({"pointer": pointer, "error": error})
+            pointer = write_current_plan_pointer(repo_root, _load_stdin_json())
+            return _emit({"pointer": pointer})
+
+        scope_info = scope_info_from_env(args.cwd)
+        if args.command == "scope-meta":
+            return _emit(scope_info.to_dict())
+        if args.command == "read-completion":
+            return _emit({"completion": read_completion(scope_info), "scope": scope_info.to_dict()})
+        if args.command == "write-completion":
+            completion = write_completion(scope_info, _load_stdin_json())
+            return _emit({"completion": completion, "scope": scope_info.to_dict()})
+        if args.command == "latest-verification":
+            return _emit({"verification": latest_verification(scope_info), "scope": scope_info.to_dict()})
+        if args.command == "append-verification":
+            row = append_verification(scope_info, _load_stdin_json())
+            return _emit({"verification": row, "scope": scope_info.to_dict()})
+    except StateError as exc:
+        return _emit({"error": str(exc)})
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/learn-evaluator.sh
+++ b/hooks/learn-evaluator.sh
@@ -40,10 +40,37 @@ else
     python3 "$_SESSION_METRICS_SCRIPT" 2>/dev/null || true)
 fi
 
+SIGNALS=""
+
 # If a correction signal is detected, output suggestions (not blocking)
 if [[ "$LEARN_SUGGESTION" == LEARN_SUGGESTED* ]]; then
   SIGNALS=$(echo "$LEARN_SUGGESTION" | tail -n +2)
   SIGNAL_COUNT=$(echo "$SIGNALS" | wc -l | tr -d ' ')
+
+  verification_payload=$(
+    VG_SIGNALS="$SIGNALS" \
+    python3 - <<'PY'
+import json
+import os
+
+signals = [line for line in os.environ.get("VG_SIGNALS", "").splitlines() if line.strip()]
+print(
+    json.dumps(
+        {
+            "source": "learn-evaluator",
+            "status": "warn",
+            "commands": [],
+            "known_failures": signals,
+            "summary": "Correction signals detected during stop-hook evaluation.",
+            "turn_id": os.environ.get("VIBEGUARD_TURN_ID"),
+            "session_id": os.environ.get("VIBEGUARD_SESSION_ID"),
+        },
+        ensure_ascii=False,
+    )
+)
+PY
+  )
+  vg_omx_append_verification "$verification_payload" >/dev/null 2>&1 || true
 
   # Stop hook only supports top-level fields, hookSpecificOutput is not supported
   VG_SIGNALS="$SIGNALS" VG_COUNT="$SIGNAL_COUNT" python3 -c '
@@ -55,6 +82,41 @@ msg = f"[VibeGuard correction detection] {count} signals: {signal_list}. It is r
 result = {"stopReason": msg}
 print(json.dumps(result, ensure_ascii=False))
 '
+fi
+
+if [[ -n "${VIBEGUARD_VERIFICATION_STATUS:-}" ]]; then
+  explicit_verification_payload=$(
+    VG_STATUS="${VIBEGUARD_VERIFICATION_STATUS}" \
+    VG_COMMANDS_JSON="${VIBEGUARD_VERIFICATION_COMMANDS_JSON:-[]}" \
+    VG_KNOWN_FAILURES_JSON="${VIBEGUARD_KNOWN_FAILURES_JSON:-[]}" \
+    VG_SUMMARY="${VIBEGUARD_VERIFICATION_SUMMARY:-}" \
+    python3 - <<'PY'
+import json
+import os
+
+commands = json.loads(os.environ.get("VG_COMMANDS_JSON", "[]"))
+known_failures = json.loads(os.environ.get("VG_KNOWN_FAILURES_JSON", "[]"))
+if not isinstance(commands, list):
+    commands = []
+if not isinstance(known_failures, list):
+    known_failures = []
+print(
+    json.dumps(
+        {
+            "source": "learn-evaluator",
+            "status": os.environ["VG_STATUS"],
+            "commands": [item for item in commands if isinstance(item, str)],
+            "known_failures": [item for item in known_failures if isinstance(item, str)],
+            "summary": os.environ.get("VG_SUMMARY") or None,
+            "turn_id": os.environ.get("VIBEGUARD_TURN_ID"),
+            "session_id": os.environ.get("VIBEGUARD_SESSION_ID"),
+        },
+        ensure_ascii=False,
+    )
+)
+PY
+  )
+  vg_omx_append_verification "$explicit_verification_payload" >/dev/null 2>&1 || true
 fi
 
 # Clean up the churn flag file of this session

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -62,6 +62,8 @@ for _candidate in \
   fi
 done
 
+VG_OMX_STATE_SCRIPT="${VG_OMX_STATE_SCRIPT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/_lib" && pwd)/omx_state.py}"
+
 #Extract specified fields from stdin JSON
 # Usage: value=$(echo "$INPUT" | vg_json_field "tool_input.file_path")
 vg_json_field() {
@@ -334,4 +336,31 @@ vg_json_output_kv() {
   done
   json="${json} }"
   printf '%s\n' "$json"
+}
+
+vg_omx_scope_meta() {
+  [[ -f "$VG_OMX_STATE_SCRIPT" ]] || return 1
+  VIBEGUARD_REPO_ROOT="${_vg_repo_root}" python3 "$VG_OMX_STATE_SCRIPT" scope-meta
+}
+
+vg_omx_read_completion() {
+  [[ -f "$VG_OMX_STATE_SCRIPT" ]] || return 1
+  VIBEGUARD_REPO_ROOT="${_vg_repo_root}" python3 "$VG_OMX_STATE_SCRIPT" read-completion
+}
+
+vg_omx_write_completion() {
+  local payload="${1:-}"
+  [[ -f "$VG_OMX_STATE_SCRIPT" ]] || return 1
+  printf '%s' "$payload" | VIBEGUARD_REPO_ROOT="${_vg_repo_root}" python3 "$VG_OMX_STATE_SCRIPT" write-completion
+}
+
+vg_omx_latest_verification() {
+  [[ -f "$VG_OMX_STATE_SCRIPT" ]] || return 1
+  VIBEGUARD_REPO_ROOT="${_vg_repo_root}" python3 "$VG_OMX_STATE_SCRIPT" latest-verification
+}
+
+vg_omx_append_verification() {
+  local payload="${1:-}"
+  [[ -f "$VG_OMX_STATE_SCRIPT" ]] || return 1
+  printf '%s' "$payload" | VIBEGUARD_REPO_ROOT="${_vg_repo_root}" python3 "$VG_OMX_STATE_SCRIPT" append-verification
 }

--- a/hooks/stop-guard.sh
+++ b/hooks/stop-guard.sh
@@ -26,26 +26,182 @@ if ! git rev-parse --is-inside-work-tree &>/dev/null; then
   exit 0
 fi
 
-# Check if there are any uncommitted source code changes (staged + unstaged)
+# Check if there are any uncommitted or untracked source code changes.
 changed_source_files=""
 while IFS= read -r file; do
   if [[ -n "$file" ]] && vg_is_source_file "$file"; then
     changed_source_files="${changed_source_files}${file}"$'\n'
   fi
-done < <(git diff --name-only HEAD 2>/dev/null || git diff --name-only --cached 2>/dev/null)
+done < <(
+  {
+    git diff --name-only HEAD 2>/dev/null || true
+    git diff --name-only --cached 2>/dev/null || true
+    git ls-files --others --exclude-standard 2>/dev/null || true
+  } | sed '/^$/d'
+)
 
 # Remove duplicates
 if [[ -n "$changed_source_files" ]]; then
   changed_source_files=$(echo "$changed_source_files" | sort -u)
-  count=$(echo "$changed_source_files" | grep -c . || true)
-
-  vg_log "stop-guard" "Stop" "gate" "uncommitted source changes: ${count} files" "$(echo "$changed_source_files" | head -5 | tr '\n' ' ')"
-
-  # exit 0: log only, do not block — Claude cannot commit in Stop context,
-  # so exit 2 here causes an infinite loop (feedback → response → stop hooks → repeat).
-  # See GitHub issues #3573, #10205.
-  exit 0
 fi
 
-vg_log "stop-guard" "Stop" "pass" "" ""
+scope_meta_json=$(vg_omx_scope_meta 2>/dev/null || echo '{"error":"omx scope resolution failed"}')
+latest_verification_json=$(vg_omx_latest_verification 2>/dev/null || echo '{"error":"verification lookup failed"}')
+
+decision_json=$(
+  VG_SCOPE_META="$scope_meta_json" \
+  VG_LATEST_VERIFICATION="$latest_verification_json" \
+  VG_CHANGED_SOURCE_FILES="$changed_source_files" \
+  VG_EXPLICIT_STATUS="${VIBEGUARD_LIFECYCLE_STATUS:-}" \
+  VG_NEXT_REQUIRED_ACTION="${VIBEGUARD_NEXT_REQUIRED_ACTION:-}" \
+  python3 - <<'PY'
+import json
+import os
+
+scope_meta = json.loads(os.environ.get("VG_SCOPE_META", "{}"))
+latest_raw = json.loads(os.environ.get("VG_LATEST_VERIFICATION", "{}"))
+latest = latest_raw.get("verification") if isinstance(latest_raw, dict) else None
+explicit_status = os.environ.get("VG_EXPLICIT_STATUS", "")
+changed_files = [line for line in os.environ.get("VG_CHANGED_SOURCE_FILES", "").splitlines() if line.strip()]
+known_failures = []
+verification_status = "missing"
+verification_commands = []
+verification_entry_id = None
+latest_status = None
+if isinstance(latest, dict):
+    latest_status = latest.get("status")
+    verification_status = latest_status or "unknown"
+    verification_commands = latest.get("commands") or []
+    verification_entry_id = latest.get("entry_id")
+    known_failures.extend(latest.get("known_failures") or [])
+
+pointer_error = scope_meta.get("pointer_error")
+if isinstance(pointer_error, str) and pointer_error:
+    known_failures.append(f"current-plan-pointer-error: {pointer_error}")
+
+mode = scope_meta.get("mode") or os.environ.get("VIBEGUARD_MODE") or os.environ.get("VIBEGUARD_CLI") or "unknown"
+current_step = scope_meta.get("current_step")
+scope = scope_meta.get("scope", "unknown")
+response = None
+log_decision = "pass"
+log_reason = ""
+log_detail = ""
+
+if explicit_status in {"failed", "cancelled"}:
+    status = explicit_status
+    verification_status = verification_status if verification_status != "missing" else "unknown"
+    next_required_action = os.environ.get("VG_NEXT_REQUIRED_ACTION") or (
+        "Investigate the failure before resuming work." if explicit_status == "failed" else "Resume only after selecting a new active scope."
+    )
+    response = f"VIBEGUARD lifecycle marked {explicit_status} for scope {scope}."
+    log_decision = "warn"
+    log_reason = f"lifecycle marked {explicit_status}"
+elif changed_files:
+    status = "incomplete"
+    verification_status = "stale" if latest_status == "pass" else verification_status
+    next_required_action = "Commit or revert changed source files, then rerun verification for the active scope."
+    preview = " ".join(changed_files[:5])
+    count = len(changed_files)
+    known_failures.append(f"changed_source_files:{count}")
+    response = f"VIBEGUARD lifecycle incomplete: {count} source file(s) still changed for scope {scope}."
+    log_decision = "gate"
+    log_reason = f"unverified source changes: {count} files"
+    log_detail = preview
+elif latest_status != "pass":
+    status = "incomplete"
+    verification_status = latest_status or "missing"
+    next_required_action = "Run verification commands and append a passing verification entry for the active scope."
+    if verification_status == "missing":
+        response = f"VIBEGUARD lifecycle incomplete: no passing verification artifact exists for scope {scope}."
+        log_reason = "missing verification artifact"
+    else:
+        response = f"VIBEGUARD lifecycle incomplete: latest verification status for scope {scope} is {verification_status}."
+        log_reason = f"verification status {verification_status}"
+    log_decision = "gate"
+else:
+    status = "completed"
+    verification_status = "pass"
+    next_required_action = None
+    log_decision = "complete"
+    log_reason = "verification artifact confirmed"
+
+completion = {
+    "mode": mode,
+    "status": status,
+    "current_step": current_step,
+    "verification_status": verification_status,
+    "verification_entry_id": verification_entry_id,
+    "verification_commands": verification_commands,
+    "known_failures": known_failures,
+    "next_required_action": next_required_action,
+}
+
+print(json.dumps({
+    "completion": completion,
+    "response": response,
+    "log_decision": log_decision,
+    "log_reason": log_reason,
+    "log_detail": log_detail,
+}, ensure_ascii=False))
+PY
+)
+
+completion_payload=$(printf '%s' "$decision_json" | python3 -c 'import json,sys; print(json.dumps(json.loads(sys.stdin.read())["completion"], ensure_ascii=False))' 2>/dev/null || echo "{}")
+write_result=$(vg_omx_write_completion "$completion_payload" 2>/dev/null || echo '{"error":"completion write failed"}')
+write_error=$(printf '%s' "$write_result" | python3 -c 'import json,sys; data=json.loads(sys.stdin.read()); print(data.get("error",""))' 2>/dev/null || echo "")
+
+if [[ -n "$write_error" ]]; then
+  fallback_payload=$(
+    VG_WRITE_ERROR="$write_error" \
+    VG_COMPLETION_PAYLOAD="$completion_payload" \
+    python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["VG_COMPLETION_PAYLOAD"])
+known_failures = list(payload.get("known_failures") or [])
+known_failures.append(f"completion-write-error: {os.environ['VG_WRITE_ERROR']}")
+payload.update(
+    {
+        "status": "incomplete",
+        "verification_status": "unknown",
+        "known_failures": known_failures,
+        "next_required_action": "Repair malformed OMX state and rerun verification before claiming completion.",
+    }
+)
+print(json.dumps(payload, ensure_ascii=False))
+PY
+  )
+  write_result=$(vg_omx_write_completion "$fallback_payload" 2>/dev/null || echo '{"error":"fallback completion write failed"}')
+  decision_json=$(
+    VG_DECISION_JSON="$decision_json" \
+    VG_WRITE_ERROR="$write_error" \
+    python3 - <<'PY'
+import json
+import os
+
+decision = json.loads(os.environ["VG_DECISION_JSON"])
+decision["response"] = "VIBEGUARD lifecycle incomplete: prior OMX state was malformed and was reset to an incomplete state."
+decision["log_decision"] = "gate"
+decision["log_reason"] = f"malformed lifecycle state: {os.environ['VG_WRITE_ERROR']}"
+print(json.dumps(decision, ensure_ascii=False))
+PY
+  )
+fi
+
+log_decision=$(printf '%s' "$decision_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("log_decision","pass"))' 2>/dev/null || echo "pass")
+log_reason=$(printf '%s' "$decision_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("log_reason",""))' 2>/dev/null || echo "")
+log_detail=$(printf '%s' "$decision_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("log_detail",""))' 2>/dev/null || echo "")
+vg_log "stop-guard" "Stop" "$log_decision" "$log_reason" "$log_detail"
+
+response_message=$(printf '%s' "$decision_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("response") or "")' 2>/dev/null || echo "")
+if [[ -n "$response_message" ]]; then
+  VG_STOP_REASON="$response_message" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({"stopReason": os.environ["VG_STOP_REASON"]}, ensure_ascii=False))
+PY
+fi
+
 exit 0

--- a/scripts/codex/app_server_wrapper.py
+++ b/scripts/codex/app_server_wrapper.py
@@ -26,6 +26,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+OMX_STATE_LIB = Path(__file__).resolve().parents[2] / "hooks" / "_lib"
+if str(OMX_STATE_LIB) not in sys.path:
+    sys.path.insert(0, str(OMX_STATE_LIB))
+
+import omx_state
+
 
 CODEX_APP_SERVER_CAPABILITIES: dict[str, bool] = {
     "pre_bash_guard": True,
@@ -44,6 +50,7 @@ class ThreadState:
     cwd: str | None = None
     session_id: str | None = None
     turn_id: str | None = None
+    scope: str | None = None
 
 
 @dataclass
@@ -233,6 +240,7 @@ class VibeGuardGateStrategy(GateStrategy):
                 thread = state.ensure_thread(thread_id)
                 if isinstance(cwd, str) and cwd:
                     thread.cwd = cwd
+                    self._ensure_thread_scope(thread_id, thread)
         elif method == "turn/start":
             thread_id = params.get("threadId")
             cwd = params.get("cwd")
@@ -240,6 +248,7 @@ class VibeGuardGateStrategy(GateStrategy):
                 thread = state.ensure_thread(thread_id)
                 if isinstance(cwd, str) and cwd:
                     thread.cwd = cwd
+                    self._ensure_thread_scope(thread_id, thread)
                 turn_id = params.get("turnId")
                 if isinstance(turn_id, str) and turn_id:
                     thread.turn_id = turn_id
@@ -353,6 +362,7 @@ class VibeGuardGateStrategy(GateStrategy):
         env = {
             "VIBEGUARD_CLI": "codex",
             "VIBEGUARD_AGENT_TYPE": "codex",
+            "VIBEGUARD_MODE": "codex-app-server",
         }
         if thread is not None and thread.session_id:
             env["VIBEGUARD_SESSION_ID"] = thread.session_id
@@ -360,13 +370,33 @@ class VibeGuardGateStrategy(GateStrategy):
             env["VIBEGUARD_THREAD_ID"] = thread_id
         if thread is not None and thread.turn_id:
             env["VIBEGUARD_TURN_ID"] = thread.turn_id
+        if thread is not None and thread.scope:
+            env["VIBEGUARD_SCOPE"] = thread.scope
         return env
 
+    def _ensure_thread_scope(self, thread_id: str, thread: ThreadState) -> omx_state.ScopeInfo | None:
+        if not thread.cwd:
+            return None
+        try:
+            scope_info = omx_state.resolve_scope(
+                omx_state.repo_root_from_cwd(thread.cwd),
+                explicit_scope=thread.scope,
+                thread_id=thread_id,
+                session_id=thread.session_id,
+                mode="codex-app-server",
+            )
+        except omx_state.StateError:
+            return None
+        thread.scope = scope_info.scope
+        return scope_info
+
     def _collect_turn_feedback(self, cwd: str, thread_id: str, thread: ThreadState) -> dict[str, Any] | None:
+        scope_info = self._ensure_thread_scope(thread_id, thread)
         env = self._hook_env(thread_id, thread)
         messages = self._run_stop_gates(cwd, env)
         messages.extend(self._run_post_build_checks(cwd, env))
-        if not messages:
+        lifecycle, verification = self._load_omx_feedback(scope_info)
+        if not messages and lifecycle is None and verification is None:
             return None
 
         feedback: dict[str, Any] = {
@@ -374,6 +404,10 @@ class VibeGuardGateStrategy(GateStrategy):
             "capabilities": CODEX_APP_SERVER_CAPABILITIES,
             "messages": messages,
         }
+        if lifecycle is not None:
+            feedback["lifecycle"] = lifecycle
+        if verification is not None:
+            feedback["verification"] = verification
         if thread.session_id:
             feedback["sessionId"] = thread.session_id
         if thread_id:
@@ -381,6 +415,59 @@ class VibeGuardGateStrategy(GateStrategy):
         if thread.turn_id:
             feedback["turnId"] = thread.turn_id
         return feedback
+
+    @staticmethod
+    def _artifact_path(scope_info: omx_state.ScopeInfo, path: Path) -> str:
+        return omx_state._relative_to_repo(path, scope_info.repo_root)
+
+    def _load_omx_feedback(
+        self,
+        scope_info: omx_state.ScopeInfo | None,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        if scope_info is None:
+            return None, None
+
+        lifecycle: dict[str, Any] = {
+            "scope": scope_info.scope,
+            "scopeSource": scope_info.scope_source,
+            "mode": scope_info.mode,
+            "completionPath": self._artifact_path(scope_info, scope_info.completion_path),
+            "currentPlanPath": self._artifact_path(scope_info, scope_info.current_plan_pointer_path),
+            "currentStep": scope_info.current_step,
+        }
+        verification: dict[str, Any] = {
+            "scope": scope_info.scope,
+            "verificationLogPath": self._artifact_path(scope_info, scope_info.verification_log_path),
+        }
+
+        try:
+            completion = omx_state.read_completion(scope_info)
+        except omx_state.StateError as exc:
+            lifecycle["status"] = "incomplete"
+            lifecycle["error"] = str(exc)
+        else:
+            if completion is not None:
+                lifecycle["status"] = completion.get("status")
+                lifecycle["verificationStatus"] = completion.get("verification_status")
+                lifecycle["nextRequiredAction"] = completion.get("next_required_action")
+                lifecycle["currentStep"] = completion.get("current_step")
+                verification["status"] = completion.get("verification_status")
+                verification["entryId"] = completion.get("verification_entry_id")
+                verification["commands"] = completion.get("verification_commands")
+
+        try:
+            latest = omx_state.latest_verification(scope_info)
+        except omx_state.StateError as exc:
+            verification["error"] = str(exc)
+        else:
+            if latest is not None:
+                verification["status"] = latest.get("status")
+                verification["entryId"] = latest.get("entry_id")
+                verification["commands"] = latest.get("commands")
+                verification["knownFailures"] = latest.get("known_failures")
+                verification["source"] = latest.get("source")
+
+        return lifecycle, verification
 
     def _run_stop_gates(self, cwd: str, env: dict[str, str]) -> list[dict[str, str]]:
         messages: list[dict[str, str]] = []

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -201,6 +201,7 @@ adapter_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
 import json
 import importlib.util
 import pathlib
+import shutil
 import subprocess
 import sys
 
@@ -218,6 +219,9 @@ VibeGuardGateStrategy = module.VibeGuardGateStrategy
 app_repo = tmp_root / "app-server-repo"
 hooks_dir = app_repo / "hooks"
 hooks_dir.mkdir(parents=True, exist_ok=True)
+shutil.copytree(repo_dir / "hooks" / "_lib", hooks_dir / "_lib")
+for name in ("log.sh", "circuit-breaker.sh", "stop-guard.sh", "learn-evaluator.sh"):
+    shutil.copy2(repo_dir / "hooks" / name, hooks_dir / name)
 
 (app_repo / "tracked.py").write_text("print('base')\n", encoding="utf-8")
 subprocess.run(["git", "init"], cwd=app_repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -244,26 +248,6 @@ msg = 'rewrite=' + '|'.join([
     os.environ.get('VIBEGUARD_TURN_ID', ''),
 ])
 print(json.dumps({'decision': 'allow', 'updatedInput': {'command': msg}}))
-PY
-""",
-    encoding="utf-8",
-)
-(hooks_dir / "stop-guard.sh").write_text(
-    "#!/usr/bin/env bash\ncat >/dev/null\n",
-    encoding="utf-8",
-)
-(hooks_dir / "learn-evaluator.sh").write_text(
-    """#!/usr/bin/env bash
-cat >/dev/null
-python3 - <<'PY'
-import json
-import os
-msg = 'learn=' + '|'.join([
-    os.environ.get('VIBEGUARD_SESSION_ID', ''),
-    os.environ.get('VIBEGUARD_THREAD_ID', ''),
-    os.environ.get('VIBEGUARD_TURN_ID', ''),
-])
-print(json.dumps({'stopReason': msg}))
 PY
 """,
     encoding="utf-8",
@@ -314,6 +298,13 @@ completed = strategy.on_server_notification(
     {"method": "turn/completed", "params": {"threadId": "thread/alpha", "turnId": "turn-42"}},
     state,
 )
+feedback = completed["params"]["vibeguard"]
+lifecycle = feedback["lifecycle"]
+verification = feedback["verification"]
+scope_dir_from_completion = pathlib.PurePosixPath(lifecycle["completionPath"]).parts[2]
+scope_dir_from_verification = pathlib.PurePosixPath(verification["verificationLogPath"]).parts[2]
+completion_exists = (app_repo / lifecycle["completionPath"]).exists()
+verification_path_stable = scope_dir_from_completion == scope_dir_from_verification
 
 print(
     json.dumps(
@@ -321,6 +312,8 @@ print(
             "intercepted": intercepted,
             "approval": captured[0],
             "completed": completed,
+            "completion_exists": completion_exists,
+            "verification_path_stable": verification_path_stable,
             "session_collision_free": module._session_id_for_thread("thread/alpha")
             != module._session_id_for_thread("thread-alpha"),
         },
@@ -334,13 +327,16 @@ assert_contains "${adapter_json}" '"intercepted": true' "app-server adapter inte
 assert_contains "${adapter_json}" 'rewrite=codex-thread-thread-alpha-' "pre-bash hook receives a normalized hashed session id"
 assert_contains "${adapter_json}" '|thread/alpha|turn-42' "pre-bash hook receives explicit thread/turn context"
 assert_contains "${adapter_json}" '"vibeguard"' "turn/completed notification is enriched with vibeguard feedback"
-assert_contains "${adapter_json}" 'learn=codex-thread-thread-alpha-' "learn-evaluator feedback is attached to turn/completed"
 assert_contains "${adapter_json}" 'build=codex-thread-thread-alpha-' "post-build feedback is attached to turn/completed"
 assert_contains "${adapter_json}" 'tracked.py' "post-build check still covers modified tracked source files"
 assert_contains "${adapter_json}" 'new_file.py' "post-build check covers untracked source files"
+assert_contains "${adapter_json}" '".omx/state/thread-thread-alpha-' "turn/completed includes stable OMX artifact paths"
+assert_contains "${adapter_json}" '"status": "incomplete"' "Missing verification fails closed to incomplete lifecycle status"
+assert_contains "${adapter_json}" '"completion_exists": true' "turn/completed lifecycle reference points at a written completion artifact"
+assert_contains "${adapter_json}" '"verification_path_stable": true' "lifecycle and verification references share a stable scope path"
 assert_contains "${adapter_json}" '"session_collision_free": true' "distinct thread ids do not collapse to the same session id"
 assert_contains "${adapter_json}" '"pre_edit_guard": false' "capability matrix is exposed on app-server feedback"
-assert_not_contains "${adapter_json}" '"stop-guard.sh"' "empty stop-guard output does not create spurious feedback entries"
+assert_contains "${adapter_json}" '"stop-guard.sh"' "stop-guard feedback is surfaced when lifecycle state is incomplete"
 
 header "app-server adapter fails closed when pre-bash hook exits nonzero"
 app_server_failure_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
@@ -392,6 +388,87 @@ PYCODE
 )"
 assert_contains "${app_server_failure_json}" '"intercepted": true' "app-server adapter intercepts approvals when pre-bash hook exits nonzero"
 assert_contains "${app_server_failure_json}" '"decision": "decline"' "app-server adapter declines approvals when pre-bash hook exits nonzero"
+
+header "app-server adapter fails closed on malformed prior OMX state"
+app_server_malformed_state_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'
+import json
+import importlib.util
+import pathlib
+import shutil
+import subprocess
+import sys
+
+repo_dir = pathlib.Path(sys.argv[1])
+tmp_root = pathlib.Path(sys.argv[2])
+module_path = repo_dir / "scripts" / "codex" / "app_server_wrapper.py"
+spec = importlib.util.spec_from_file_location("vibeguard_app_server_wrapper_malformed_state", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+SessionState = module.SessionState
+VibeGuardGateStrategy = module.VibeGuardGateStrategy
+
+app_repo = tmp_root / "app-server-malformed-state-repo"
+hooks_dir = app_repo / "hooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+shutil.copytree(repo_dir / "hooks" / "_lib", hooks_dir / "_lib")
+for name in ("log.sh", "circuit-breaker.sh", "stop-guard.sh", "learn-evaluator.sh"):
+    shutil.copy2(repo_dir / "hooks" / name, hooks_dir / name)
+
+(app_repo / "tracked.py").write_text("print('base')\n", encoding="utf-8")
+subprocess.run(["git", "init"], cwd=app_repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+subprocess.run(["git", "add", "tracked.py"], cwd=app_repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+subprocess.run(
+    ["git", "-c", "user.name=CI", "-c", "user.email=ci@vibeguard.test", "commit", "-m", "init"],
+    cwd=app_repo,
+    check=True,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+
+scope = module.omx_state.resolve_scope(
+    module.omx_state.repo_root_from_cwd(app_repo),
+    thread_id="thread/malformed",
+    session_id=module._session_id_for_thread("thread/malformed"),
+    mode="codex-app-server",
+)
+scope.scope_dir.mkdir(parents=True, exist_ok=True)
+scope.completion_path.write_text("{\n", encoding="utf-8")
+
+strategy = VibeGuardGateStrategy(app_repo)
+state = SessionState()
+strategy.on_client_message(
+    {"method": "thread/start", "params": {"threadId": "thread/malformed", "cwd": str(app_repo)}},
+    state,
+)
+strategy.on_client_message(
+    {"method": "turn/start", "params": {"threadId": "thread/malformed", "cwd": str(app_repo), "turnId": "turn-99"}},
+    state,
+)
+
+completed = strategy.on_server_notification(
+    {"method": "turn/completed", "params": {"threadId": "thread/malformed", "turnId": "turn-99"}},
+    state,
+)
+feedback = completed["params"]["vibeguard"]
+completion = module.omx_state.read_completion(scope)
+print(
+    json.dumps(
+        {
+            "completed": completed,
+            "completion": completion,
+            "status": feedback["lifecycle"].get("status"),
+            "next_required_action": feedback["lifecycle"].get("nextRequiredAction"),
+        },
+        ensure_ascii=False,
+    )
+)
+PYCODE
+)"
+assert_contains "${app_server_malformed_state_json}" '"status": "incomplete"' "Malformed prior OMX state is reset to incomplete instead of completed"
+assert_contains "${app_server_malformed_state_json}" 'Repair malformed OMX state' "Malformed prior OMX state records a concrete recovery action"
+assert_not_contains "${app_server_malformed_state_json}" '"status": "completed"' "Malformed prior OMX state never silently claims completion"
 
 header "app-server adapter fails closed on malformed non-empty pre-bash hook output"
 app_server_invalid_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -61,6 +61,18 @@ print(haystack.count(needle))
   fi
 }
 
+assert_equals() {
+  local actual="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$actual" == "$expected" ]]; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected: $expected, got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 assert_exit_zero() {
   local desc="$1"
   shift
@@ -1531,6 +1543,128 @@ else
 fi
 
 # =========================================================
+header "OMX lifecycle state"
+# =========================================================
+
+_omx_repo="$(mktemp -d)"
+git -C "$_omx_repo" init -q
+cat >"$_omx_repo/main.py" <<'EOF'
+print("base")
+EOF
+git -C "$_omx_repo" add main.py
+git -C "$_omx_repo" -c user.name=CI -c user.email=ci@vibeguard.test commit -q -m "init"
+
+_omx_read_completion() {
+  local repo="$1" session="$2"
+  (
+    cd "$repo" && \
+    VIBEGUARD_SESSION_ID="$session" \
+    VIBEGUARD_CLI="codex" \
+    VIBEGUARD_MODE="test-hooks" \
+    python3 "$REPO_DIR/hooks/_lib/omx_state.py" read-completion
+  )
+}
+
+_omx_latest_verification() {
+  local repo="$1" session="$2"
+  (
+    cd "$repo" && \
+    VIBEGUARD_SESSION_ID="$session" \
+    VIBEGUARD_CLI="codex" \
+    VIBEGUARD_MODE="test-hooks" \
+    python3 "$REPO_DIR/hooks/_lib/omx_state.py" latest-verification
+  )
+}
+
+# Dirty tree => incomplete
+printf 'print("changed")\n' >"$_omx_repo/main.py"
+dirty_output="$(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_SESSION_ID="session-dirty" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" bash "$REPO_DIR/hooks/stop-guard.sh"
+)"
+dirty_completion="$(_omx_read_completion "$_omx_repo" "session-dirty")"
+assert_contains "$dirty_output" "lifecycle incomplete" "stop-guard emits a stop reason when source files remain changed"
+assert_contains "$dirty_completion" '"status": "incomplete"' "Dirty source tree writes incomplete completion state"
+assert_contains "$dirty_completion" '"verification_status": "missing"' "Dirty source tree does not claim verification success"
+git -C "$_omx_repo" checkout -- main.py
+
+# Clean tree without verification => incomplete
+clean_no_verification_output="$(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_SESSION_ID="session-clean" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" bash "$REPO_DIR/hooks/stop-guard.sh"
+)"
+clean_no_verification_completion="$(_omx_read_completion "$_omx_repo" "session-clean")"
+assert_contains "$clean_no_verification_output" "no passing verification artifact exists" "stop-guard demands durable verification artifacts on a clean tree"
+assert_contains "$clean_no_verification_completion" '"status": "incomplete"' "Clean tree without verification remains incomplete"
+assert_contains "$clean_no_verification_completion" '"verification_status": "missing"' "Missing verification is recorded in completion.json"
+
+# Clean tree with passing verification => completed
+(
+  cd "$_omx_repo" && \
+  printf '%s' '{"source":"test","status":"pass","commands":["bash tests/test_hooks.sh"],"summary":"passing regression","session_id":"session-pass"}' \
+    | VIBEGUARD_SESSION_ID="session-pass" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" python3 "$REPO_DIR/hooks/_lib/omx_state.py" append-verification >/dev/null
+)
+completed_output="$(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_SESSION_ID="session-pass" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" bash "$REPO_DIR/hooks/stop-guard.sh"
+)"
+completed_completion="$(_omx_read_completion "$_omx_repo" "session-pass")"
+assert_equals "$completed_output" "" "Completed lifecycle stays silent when verification is current"
+assert_contains "$completed_completion" '"status": "completed"' "Passing verification promotes lifecycle state to completed"
+assert_contains "$completed_completion" 'bash tests/test_hooks.sh' "completion.json retains verification command evidence"
+
+# Explicit failed / cancelled updates remain durable and explicit
+failed_output="$(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_SESSION_ID="session-failed" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" VIBEGUARD_LIFECYCLE_STATUS="failed" bash "$REPO_DIR/hooks/stop-guard.sh"
+)"
+failed_completion="$(_omx_read_completion "$_omx_repo" "session-failed")"
+assert_contains "$failed_output" "marked failed" "Explicit failed lifecycle update produces a stop reason"
+assert_contains "$failed_completion" '"status": "failed"' "Explicit failed lifecycle update writes failed status"
+
+cancelled_output="$(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_SESSION_ID="session-cancelled" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" VIBEGUARD_LIFECYCLE_STATUS="cancelled" bash "$REPO_DIR/hooks/stop-guard.sh"
+)"
+cancelled_completion="$(_omx_read_completion "$_omx_repo" "session-cancelled")"
+assert_contains "$cancelled_output" "marked cancelled" "Explicit cancelled lifecycle update produces a stop reason"
+assert_contains "$cancelled_completion" '"status": "cancelled"' "Explicit cancelled lifecycle update writes cancelled status"
+
+# learn-evaluator appends structured verification rows
+(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_SESSION_ID="session-explicit-verification" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" \
+    VIBEGUARD_VERIFICATION_STATUS="pass" \
+    VIBEGUARD_VERIFICATION_COMMANDS_JSON='["cargo test"]' \
+    VIBEGUARD_VERIFICATION_SUMMARY="explicit verification" \
+    bash "$REPO_DIR/hooks/learn-evaluator.sh" >/dev/null
+)
+explicit_verification="$(_omx_latest_verification "$_omx_repo" "session-explicit-verification")"
+assert_contains "$explicit_verification" '"status": "pass"' "learn-evaluator appends explicit verification rows"
+assert_contains "$explicit_verification" 'cargo test' "verification ledger preserves command evidence"
+
+# learn-evaluator persists known-failure signals into the verification ledger
+_omx_repo_root=$(git -C "$_omx_repo" rev-parse --show-toplevel)
+_omx_project_hash=$(printf '%s' "$_omx_repo_root" | shasum -a 256 2>/dev/null | cut -c1-8)
+_omx_project_log_dir="$VIBEGUARD_LOG_DIR/projects/${_omx_project_hash}"
+mkdir -p "$_omx_project_log_dir"
+cat >"$_omx_project_log_dir/events.jsonl" <<EOF
+{"ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","session":"session-signal-ledger","hook":"post-edit-guard","tool":"Edit","decision":"warn","reason":"warn one","detail":"main.py"}
+{"ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","session":"session-signal-ledger","hook":"post-edit-guard","tool":"Edit","decision":"warn","reason":"warn two","detail":"main.py"}
+{"ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","session":"session-signal-ledger","hook":"post-edit-guard","tool":"Edit","decision":"warn","reason":"warn three","detail":"main.py"}
+EOF
+signal_output="$(
+  cd "$_omx_repo" && \
+  printf '{}' | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_SESSION_ID="session-signal-ledger" VIBEGUARD_CLI="codex" VIBEGUARD_MODE="test-hooks" bash "$REPO_DIR/hooks/learn-evaluator.sh"
+)"
+signal_verification="$(_omx_latest_verification "$_omx_repo" "session-signal-ledger")"
+assert_contains "$signal_output" "correction detection" "learn-evaluator still emits the correction-detection stop reason"
+assert_contains "$signal_verification" '"status": "warn"' "Correction signals append warning verification rows"
+assert_contains "$signal_verification" 'High friction session' "Known-failure signals are preserved in the verification ledger"
+
+rm -rf "$_omx_repo"
+
+# =========================================================
 header "post-edit-guard.sh — W-14 path normalization"
 # =========================================================
 
@@ -1538,7 +1672,8 @@ _w14_dir=$(mktemp -d "$REPO_DIR/.tmp-w14.XXXXXX")
 _w14_file="$_w14_dir/overlap.py"
 printf 'value = 1\n' > "$_w14_file"
 _w14_rel="${_w14_file#$REPO_DIR/}"
-_w14_project_hash=$(printf '%s' "$REPO_DIR" | shasum -a 256 2>/dev/null | cut -c1-8)
+_w14_repo_root=$(git -C "$REPO_DIR" rev-parse --show-toplevel)
+_w14_project_hash=$(printf '%s' "$_w14_repo_root" | shasum -a 256 2>/dev/null | cut -c1-8)
 _w14_log_file="$VIBEGUARD_LOG_DIR/projects/${_w14_project_hash}/events.jsonl"
 mkdir -p "$(dirname "$_w14_log_file")"
 

--- a/workflows/plan-flow/references/execplan-template.md
+++ b/workflows/plan-flow/references/execplan-template.md
@@ -35,6 +35,8 @@ Minimal context required to resume execution:
 - **Key entry**: <e.g. src/main.rs, src/lib.rs>
 - **Related Constraint Set**: <preflight output path | None>
 - **Existing decision**: <reference Decision Log entry number>
+- **Active Scope**: <OMX scope id persisted at `.omx/state/<scope>/...`>
+- **Current Plan Pointer**: `.omx/state/current-plan.json`
 
 ## 4. Plan of Work
 
@@ -59,6 +61,7 @@ High-level work plan grouped by milestones, without implementation details (deta
 - Status: `pending`
 - Milestone: M1
 - Goal: <What to deliver in this step>
+- Runtime resume fields: `scope`, `current_step`, `next_required_action`
 - Expected changes to files:
   - `<file1>`
   - `<file2>`
@@ -88,6 +91,10 @@ Verification of observable behavior, specific to input/output:
 
 Regression testing:
 - `<Full test command>`
+
+Persisted verification metadata:
+- Verification commands to record in `.omx/state/<scope>/verification-log.jsonl`
+- Expected lifecycle transition in `.omx/state/<scope>/completion.json`
 
 ## 7. Idempotence
 

--- a/workflows/plan-mode/SKILL.md
+++ b/workflows/plan-mode/SKILL.md
@@ -147,6 +147,9 @@ Require:
 - After successful writing, clearly inform the user in the conversation:
   - actual file path;
   - Whether to include PLAN_META block and full plan content.
+- After writing or updating the plan file, also update the canonical OMX pointer at `.omx/state/current-plan.json` so continuation can recover the active plan and scope without relying on prior chat text alone.
+  - Required fields: `scope`, `plan_path`, `updated_at`
+  - Recommended fields: `mode`, `current_step`, `next_required_action`
 - If the file cannot be created/written due to approval/policy restrictions or other errors:
   - Give reasons in your answer;
   - Still output the complete plan text, ensuring that the user can manually copy it to a file.
@@ -165,7 +168,7 @@ You need to determine whether to "continue the same Plan" or "create a new Plan"
    - If there is already a current Plan in this session (you have output the `Plan file: path: plan/....md` in the previous answer):
      - When the user uses expressions such as "previously", "just now", "previous plan", "previous plan", "adjusted on the original basis", etc., it is deemed to continue the same Plan:
        - No new files are created;
-       - Use the previously recorded Plan file path as the "current Plan";
+       - Use the plan path from `.omx/state/current-plan.json` as the canonical "current Plan" when it exists; otherwise fall back to the previously recorded Plan file path in the conversation;
        - First read the original plan through `cat plan/XXXX.md`, and modify or incrementally update it based on this.
      - When the user clearly states "new plan", "another task", "change a requirement", "redesign a plan for YYY", it is regarded as a new plan:
        - Create new Plan files for new tasks;
@@ -174,12 +177,13 @@ You need to determine whether to "continue the same Plan" or "create a new Plan"
      - First ask for clarification in one sentence (for example: "Is this adjusting the previous Plan, or creating a new Plan for a completely new task?"), and then execute according to the user's choice.
 
 2. Behavior when continuing the same Plan
-   - Prioritize reading the contents of the current Plan file through the shell (for example, `cat plan/2025-12-01_17-05-30-plan.md`) to quickly review the summary of existing plans;
+   - Prioritize reading `.omx/state/current-plan.json`, then read the pointed-to plan file through the shell (for example, `cat plan/2025-12-01_17-05-30-plan.md`) to quickly review the summary of existing plans;
    - If the user wishes to adjust the plan:
      - In your answer, first give a "Summary of Changes" to explain the main modifications compared to the original Plan;
      - Then provide the updated complete plan fragment (it can replace certain phases or add new phases);
      - Update the same Plan file using append or rewrite, and explain in your answer:
        - Updated Plan file path;
+       - Updated `.omx/state/current-plan.json` pointer;
        - If you use a "Change History" or "Revisions" section in your document, briefly describe your structure.
 
 3. Behavior when creating a new Plan


### PR DESCRIPTION
## Summary
- add a shared repo-local `.omx/state` helper and wire stop/learn hooks to durable lifecycle + verification artifacts
- propagate stable lifecycle and verification references through the Codex app-server wrapper
- document the OMX artifact contracts and add regression coverage for lifecycle transitions and malformed-state fail-closed behavior

Closes #100