### PR TITLE
fix: validate malformed Codex config health checks

### DIFF
--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -8,6 +8,14 @@ import re
 import tempfile
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:  # pragma: no cover - pip vendor fallback
+        from pip._vendor import tomli as tomllib
+
 
 def _write_atomic(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -88,6 +96,18 @@ def _remove_legacy_vibeguard_mcp(text: str) -> tuple[str, bool]:
     return ((new_text + "\n") if new_text else ""), changed
 
 
+def _check_codex_hooks_enabled(text: str) -> tuple[str, int]:
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return "INVALID", 1
+
+    features = data.get("features")
+    if isinstance(features, dict) and features.get("codex_hooks") is True:
+        return "OK", 0
+    return "MISSING", 1
+
+
 def cmd_enable_codex_hooks(args: argparse.Namespace) -> int:
     path = Path(args.config_file)
     old = path.read_text(encoding="utf-8") if path.exists() else ""
@@ -118,12 +138,26 @@ def cmd_remove_legacy_vibeguard_mcp(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_check_codex_hooks(args: argparse.Namespace) -> int:
+    path = Path(args.config_file)
+    if not path.exists():
+        print("MISSING")
+        return 1
+
+    status, code = _check_codex_hooks_enabled(path.read_text(encoding="utf-8"))
+    print(status)
+    return code
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Structured Codex config.toml helper")
     sub = parser.add_subparsers(dest="command", required=True)
 
     enable = sub.add_parser("enable-codex-hooks", help="Ensure [features].codex_hooks = true")
     enable.add_argument("--config-file", required=True)
+
+    check = sub.add_parser("check-codex-hooks", help="Validate [features].codex_hooks = true")
+    check.add_argument("--config-file", required=True)
 
     remove = sub.add_parser("remove-legacy-vibeguard-mcp", help="Remove [mcp_servers.vibeguard] block")
     remove.add_argument("--config-file", required=True)
@@ -135,6 +169,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.command == "enable-codex-hooks":
         return cmd_enable_codex_hooks(args)
+    if args.command == "check-codex-hooks":
+        return cmd_check_codex_hooks(args)
     if args.command == "remove-legacy-vibeguard-mcp":
         return cmd_remove_legacy_vibeguard_mcp(args)
     parser.error("unknown command")

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -144,7 +144,13 @@ def cmd_check_codex_hooks(args: argparse.Namespace) -> int:
         print("MISSING")
         return 1
 
-    status, code = _check_codex_hooks_enabled(path.read_text(encoding="utf-8"))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        print("INVALID")
+        return 1
+
+    status, code = _check_codex_hooks_enabled(text)
     print(status)
     return code
 

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -137,8 +137,15 @@ print(total)
   yellow "[INFO] Codex runtime scope: Bash approvals + Stop hooks only; Edit/Write/analysis-paralysis require Claude Code or the app-server wrapper"
 
   # Check feature flag
-  if [[ -f "${CODEX_DIR}/config.toml" ]] && grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CODEX_DIR}/config.toml" 2>/dev/null; then
+  local config="${CODEX_DIR}/config.toml"
+  local codex_hooks_status="MISSING"
+  if [[ -f "${config}" ]]; then
+    codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${config}" 2>/dev/null || true)"
+  fi
+  if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] codex_hooks feature enabled in config.toml"
+  elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
+    red "[BROKEN] ~/.codex/config.toml is malformed TOML"
   else
     yellow "[MISSING] codex_hooks feature not enabled in ~/.codex/config.toml"
   fi

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -119,6 +119,21 @@ assert_contains "${remove_out}" "CHANGED" "remove-legacy-vibeguard-mcp reports c
 assert_cmd "legacy vibeguard mcp tables removed recursively" bash -c "! grep -qE '^\[mcp_servers\\.vibeguard([.]|\\])' '${CONFIG_FILE}'"
 assert_cmd "non-legacy tables remain after recursive cleanup" grep -Eq '^\[other\]$' "${CONFIG_FILE}"
 
+cat > "${CONFIG_FILE}" <<'TOML'
+[features]
+codex_hooks = true
+TOML
+check_ok_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}")"
+assert_contains "${check_ok_out}" "OK" "check-codex-hooks accepts valid TOML with feature enabled"
+
+cat > "${CONFIG_FILE}" <<'TOML'
+[features]
+codex_hooks = true
+broken = [
+TOML
+check_invalid_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
+assert_contains "${check_invalid_out}" "INVALID" "check-codex-hooks rejects malformed TOML"
+
 header "doc freshness installed drift"
 EMPTY_HOME="${TMP_DIR}/empty-home"
 mkdir -p "${EMPTY_HOME}/.claude/rules/vibeguard"

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -134,6 +134,14 @@ TOML
 check_invalid_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
 assert_contains "${check_invalid_out}" "INVALID" "check-codex-hooks rejects malformed TOML"
 
+python3 - <<'PY' "${CONFIG_FILE}"
+from pathlib import Path
+import sys
+Path(sys.argv[1]).write_bytes(b'[features]\ncodex_hooks = true\n\xff')
+PY
+check_invalid_utf8_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
+assert_contains "${check_invalid_utf8_out}" "INVALID" "check-codex-hooks rejects invalid UTF-8"
+
 header "doc freshness installed drift"
 EMPTY_HOME="${TMP_DIR}/empty-home"
 mkdir -p "${EMPTY_HOME}/.claude/rules/vibeguard"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -9,6 +9,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SETTINGS_HELPER="${REPO_DIR}/scripts/lib/settings_json.py"
 CODEX_HOOKS_HELPER="${REPO_DIR}/scripts/lib/codex_hooks_json.py"
 CHAT_CONTRACT_ANCHOR="Compact Chat Contract: progress updates, concise answers, plain formatting."
+CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
 
 PASS=0
 FAIL=0
@@ -87,6 +88,7 @@ assert_cmd "scripts/setup/clean.sh syntax is correct" bash -n "${REPO_DIR}/scrip
 assert_cmd "scripts/install-systemd.sh syntax is correct" bash -n "${REPO_DIR}/scripts/install-systemd.sh"
 assert_cmd "scripts/lib/settings_json.py syntax is correct" python3 -m py_compile "${SETTINGS_HELPER}"
 assert_cmd "scripts/lib/codex_hooks_json.py syntax is correct" python3 -m py_compile "${CODEX_HOOKS_HELPER}"
+assert_cmd "scripts/lib/codex_config_toml.py syntax is correct" python3 -m py_compile "${CODEX_CONFIG_HELPER}"
 
 header "scheduled GC templates"
 assert_cmd "scheduled GC script exists at canonical path" test -x "${REPO_DIR}/scripts/gc/gc-scheduled.sh"
@@ -228,6 +230,19 @@ fail_install_out="$(bash "${REPO_DIR}/setup.sh" 2>&1 || true)"
 cp "${_BACKUP_CODEX_CONFIG_HELPER}" "${_ORIG_CODEX_CONFIG_HELPER}"
 assert_contains "${fail_install_out}" "Failed to enable codex_hooks feature in config.toml" "setup reports codex_hooks helper failure"
 assert_cmd "setup exits before reporting success when codex_hooks helper fails" bash -c "! grep -q 'Setup complete! All components installed.' <<< '${fail_install_out}'"
+
+header "setup --check rejects invalid codex config"
+_VALID_CODEX_CONFIG="${TMP_HOME}/config.toml.valid.backup"
+cp "${HOME}/.codex/config.toml" "${_VALID_CODEX_CONFIG}"
+cat > "${HOME}/.codex/config.toml" <<'TOML'
+not valid toml =
+[features]
+codex_hooks = true
+TOML
+invalid_codex_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_CONFIG}" "${HOME}/.codex/config.toml"
+assert_contains "${invalid_codex_check_out}" "[BROKEN] ~/.codex/config.toml is malformed TOML" "--check reports invalid ~/.codex/config.toml"
+assert_cmd "invalid config does not report codex_hooks enabled" bash -c "! grep -qF '[OK] codex_hooks feature enabled in config.toml' <<< '${invalid_codex_check_out}'"
 
 header "setup --check stays read-only"
 python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -244,6 +244,17 @@ cp "${_VALID_CODEX_CONFIG}" "${HOME}/.codex/config.toml"
 assert_contains "${invalid_codex_check_out}" "[BROKEN] ~/.codex/config.toml is malformed TOML" "--check reports invalid ~/.codex/config.toml"
 assert_cmd "invalid config does not report codex_hooks enabled" bash -c "! grep -qF '[OK] codex_hooks feature enabled in config.toml' <<< '${invalid_codex_check_out}'"
 
+header "setup --check rejects invalid UTF-8 codex config"
+python3 - <<'PY' "${HOME}/.codex/config.toml"
+from pathlib import Path
+import sys
+Path(sys.argv[1]).write_bytes(b'[features]\ncodex_hooks = true\n\xff')
+PY
+invalid_utf8_codex_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_CONFIG}" "${HOME}/.codex/config.toml"
+assert_contains "${invalid_utf8_codex_check_out}" "[BROKEN] ~/.codex/config.toml is malformed TOML" "--check reports invalid UTF-8 ~/.codex/config.toml"
+assert_cmd "invalid UTF-8 config does not report codex_hooks enabled" bash -c "! grep -qF '[OK] codex_hooks feature enabled in config.toml' <<< '${invalid_utf8_codex_check_out}'"
+
 header "setup --check stays read-only"
 python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"
 from pathlib import Path


### PR DESCRIPTION
## Summary
- parse ~/.codex/config.toml before reporting codex_hooks as healthy
- surface malformed TOML as a broken Codex setup signal in setup.sh --check
- add regression coverage for valid and malformed Codex config states

Closes #120
