### PR TITLE
test(hooks): cover single-quoted quoted-dot guard

### DIFF
--- a/tests/fixtures/pre-bash-guard/meta.json
+++ b/tests/fixtures/pre-bash-guard/meta.json
@@ -22,6 +22,18 @@
       "keyword": "\"decision\": \"block\"",
       "description": "git restore \".\" (quoted dot) should be intercepted"
     },
+    "tp/checkout-dot-single-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "git checkout '.' (single-quoted dot) should be intercepted"
+    },
+    "tp/restore-dot-single-quoted.txt": {
+      "rule": "BLOCK",
+      "expect": "block",
+      "keyword": "\"decision\": \"block\"",
+      "description": "git restore '.' (single-quoted dot) should be intercepted"
+    },
     "tp/clean-fd.txt": {
       "rule": "BLOCK",
       "expect": "block",

--- a/tests/fixtures/pre-bash-guard/tp/checkout-dot-single-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/checkout-dot-single-quoted.txt
@@ -1,0 +1,1 @@
+git checkout '.'

--- a/tests/fixtures/pre-bash-guard/tp/restore-dot-single-quoted.txt
+++ b/tests/fixtures/pre-bash-guard/tp/restore-dot-single-quoted.txt
@@ -1,0 +1,1 @@
+git restore '.'

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -197,6 +197,14 @@ assert_contains "$result" '"decision": "block"' "Intercept git checkout \".\" (q
 result=$(echo '{"tool_input":{"command":"git restore \".\"" }}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Intercept git restore \".\" (quoted dot)"
 
+# git checkout '.' (single-quoted dot) should be intercepted
+result=$(echo "{\"tool_input\":{\"command\":\"git checkout '.'\" }}" | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git checkout '.' (single-quoted dot)"
+
+# git restore '.' (single-quoted dot) should be intercepted
+result=$(echo "{\"tool_input\":{\"command\":\"git restore '.'\" }}" | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"decision": "block"' "Intercept git restore '.' (single-quoted dot)"
+
 # echo "git checkout ." should NOT be intercepted (false-positive guard)
 result=$(echo '{"tool_input":{"command":"echo \"git checkout .\"" }}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "echo containing git checkout . not blocked"


### PR DESCRIPTION
## Summary
- add regression coverage for single-quoted quoted-dot checkout and restore commands
- keep the existing quoted-dot guard behavior covered across fixture metadata and hook tests

## Testing
- bash tests/test_hooks.sh
- cargo check --manifest-path vg-helper/Cargo.toml
- cargo test --manifest-path vg-helper/Cargo.toml

Closes #88