### PR TITLE
fix(codex): clean nested vibeguard.* MCP subtables

### DIFF
--- a/plan/signal-report-legacy-vibeguard-mcp-cleanup.md
+++ b/plan/signal-report-legacy-vibeguard-mcp-cleanup.md
@@ -1,0 +1,54 @@
+# Signal Report: Legacy Vibeguard MCP Cleanup
+
+## Summary
+- Rule: `U-23`
+- Area: `scripts/lib/codex_config_toml.py`
+- Reproduced on: `2026-04-28`
+
+## Reproduction
+Input:
+
+```toml
+[features]
+foo = true
+
+[mcp_servers.vibeguard]
+command = "node"
+
+[mcp_servers.vibeguard.env]
+FOO = "bar"
+
+[other]
+value = 1
+```
+
+Observed output from `_remove_legacy_vibeguard_mcp()`:
+
+```toml
+[features]
+foo = true
+
+[mcp_servers.vibeguard.env]
+FOO = "bar"
+
+[other]
+value = 1
+```
+
+## Root Cause
+- The cleanup loop enters legacy-removal mode only for the exact table name `mcp_servers.vibeguard`.
+- At the next table header, it immediately clears `in_legacy`, even when that next table is a child table such as `mcp_servers.vibeguard.env`.
+- Result: nested legacy subtables survive cleanup and TOML parsing recreates the `mcp_servers.vibeguard` namespace.
+
+## Affected Files
+- `scripts/lib/codex_config_toml.py`: legacy MCP cleanup helper.
+- `tests/test_manifest_contract.sh`: closest existing regression coverage for the helper CLI.
+
+## Constraints
+- Must remove the exact legacy table and any nested table whose name starts with `mcp_servers.vibeguard.`.
+- Must not remove unrelated tables such as `[other]`.
+- Must keep the fix deterministic and local to the cleanup helper.
+
+## Verification Plan
+- Extend `tests/test_manifest_contract.sh` with a nested-subtable regression.
+- Run the targeted regression script after the patch.

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -71,10 +71,11 @@ def _remove_legacy_vibeguard_mcp(text: str) -> tuple[str, bool]:
     kept: list[str] = []
     in_legacy = False
     changed = False
+    legacy_table = "mcp_servers.vibeguard"
     for line in lines:
         table_name = _table_name(line)
         if table_name is not None:
-            if table_name == "mcp_servers.vibeguard":
+            if table_name == legacy_table or table_name.startswith(f"{legacy_table}."):
                 in_legacy = True
                 changed = True
                 continue

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -95,10 +95,20 @@ foo = true
 [mcp_servers.vibeguard] # legacy comment
 command = "node"
 args = ["/legacy/mcp-server/dist/index.js"]
+
+[mcp_servers.vibeguard.env]
+VIBEGUARD_MODE = "legacy"
+
+[mcp_servers.vibeguard.env.deep]
+NESTED = "true"
+
+[other]
+value = 1
 TOML
 remove_out="$(python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${CONFIG_FILE}")"
 assert_contains "${remove_out}" "CHANGED" "remove-legacy-vibeguard-mcp reports change"
-assert_cmd "legacy vibeguard mcp section removed" bash -c "! grep -q '^\[mcp_servers\\.vibeguard\]' '${CONFIG_FILE}'"
+assert_cmd "legacy vibeguard mcp tables removed recursively" bash -c "! grep -qE '^\[mcp_servers\\.vibeguard([.]|\\])' '${CONFIG_FILE}'"
+assert_cmd "non-legacy tables remain after recursive cleanup" grep -Eq '^\[other\]$' "${CONFIG_FILE}"
 
 header "doc freshness installed drift"
 EMPTY_HOME="${TMP_DIR}/empty-home"


### PR DESCRIPTION
Closes #122.

## Summary
- Cleanup logic now matches both `mcp_servers.vibeguard` and any nested table starting with `mcp_servers.vibeguard.` (e.g. `[mcp_servers.vibeguard.env]`), so a stale install no longer leaves child subtables active.
- Adds a regression test in `tests/test_manifest_contract.sh` covering parent + nested children + unrelated sections.
- Includes signal report in `plan/` documenting root cause (premature exit from legacy-removal mode).

## Test plan
- [x] `bash tests/test_manifest_contract.sh`
- [x] Manual: install with leftover `[mcp_servers.vibeguard.env]` → re-run setup → confirm subtable removed, unrelated MCP entries preserved.