### PR TITLE
Generate Claude rule count banner

### DIFF
--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -1,7 +1,7 @@
 <!-- vibeguard-start -->
 #VibeGuard — AI anti-hallucination rules
 
-> 88 rules loaded natively via `~/.claude/rules/vibeguard/`. There is no ORM, no front-end framework, and no microservices in this project.
+> __VIBEGUARD_RULE_COUNT__ rules loaded natively via `~/.claude/rules/vibeguard/`. There is no ORM, no front-end framework, and no microservices in this project.
 
 ## Constraints (L1-L7 are enforced by Hooks)
 

--- a/scripts/lib/claude_md.py
+++ b/scripts/lib/claude_md.py
@@ -1,17 +1,45 @@
 #!/usr/bin/env python3
 """CLAUDE.md VibeGuard rules inject/remove."""
 import difflib
+import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 START = "<!-- vibeguard-start -->"
 END = "<!-- vibeguard-end -->"
+RULE_COUNT_PLACEHOLDER = "__VIBEGUARD_RULE_COUNT__"
+RULE_HEADING_RE = re.compile(r"^## [A-Z]+-[0-9]+", re.MULTILINE)
 
 
-def render_injected(claude_md_path: str, rules_path: str, vibeguard_dir: str) -> tuple[str, str, str]:
+def count_rule_headings(root: Path) -> int:
+    if not root.exists():
+        return 0
+    total = 0
+    for rule_file in root.rglob("*.md"):
+        if not rule_file.is_file():
+            continue
+        text = rule_file.read_text(encoding="utf-8", errors="replace")
+        total += len(RULE_HEADING_RE.findall(text))
+    return total
+
+
+def resolve_rule_count(vibeguard_dir: str, rule_count: Optional[int]) -> int:
+    if rule_count is not None:
+        return rule_count
+    return count_rule_headings(Path(vibeguard_dir) / "rules" / "claude-rules")
+
+
+def render_injected(
+    claude_md_path: str,
+    rules_path: str,
+    vibeguard_dir: str,
+    rule_count: Optional[int] = None,
+) -> tuple[str, str, str]:
     claude_md = Path(claude_md_path)
     rules = Path(rules_path).read_text()
     rules = rules.replace("__VIBEGUARD_DIR__", vibeguard_dir)
+    rules = rules.replace(RULE_COUNT_PLACEHOLDER, str(resolve_rule_count(vibeguard_dir, rule_count)))
 
     original = claude_md.read_text() if claude_md.exists() else ""
     content = original
@@ -37,15 +65,15 @@ def render_injected(claude_md_path: str, rules_path: str, vibeguard_dir: str) ->
     return action, original, content
 
 
-def inject(claude_md_path: str, rules_path: str, vibeguard_dir: str) -> str:
-    action, _original, content = render_injected(claude_md_path, rules_path, vibeguard_dir)
+def inject(claude_md_path: str, rules_path: str, vibeguard_dir: str, rule_count: Optional[int] = None) -> str:
+    action, _original, content = render_injected(claude_md_path, rules_path, vibeguard_dir, rule_count)
     claude_md = Path(claude_md_path)
     claude_md.write_text(content)
     return action
 
 
-def diff_inject(claude_md_path: str, rules_path: str, vibeguard_dir: str) -> str:
-    action, original, content = render_injected(claude_md_path, rules_path, vibeguard_dir)
+def diff_inject(claude_md_path: str, rules_path: str, vibeguard_dir: str, rule_count: Optional[int] = None) -> str:
+    action, original, content = render_injected(claude_md_path, rules_path, vibeguard_dir, rule_count)
     if original == content:
         return "SKIP"
     diff = "".join(
@@ -88,12 +116,28 @@ def remove(claude_md_path: str) -> str:
     return "NOT_FOUND"
 
 
+def parse_rule_count(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        count = int(value)
+    except ValueError:
+        print(f"Invalid rule count: {value}", file=sys.stderr)
+        sys.exit(2)
+    if count < 0:
+        print(f"Invalid rule count: {value}", file=sys.stderr)
+        sys.exit(2)
+    return count
+
+
 if __name__ == "__main__":
     action = sys.argv[1]
     if action == "inject":
-        print(inject(sys.argv[2], sys.argv[3], sys.argv[4]))
+        rule_count = parse_rule_count(sys.argv[5] if len(sys.argv) > 5 else None)
+        print(inject(sys.argv[2], sys.argv[3], sys.argv[4], rule_count))
     elif action == "diff-inject":
-        print(diff_inject(sys.argv[2], sys.argv[3], sys.argv[4]))
+        rule_count = parse_rule_count(sys.argv[5] if len(sys.argv) > 5 else None)
+        print(diff_inject(sys.argv[2], sys.argv[3], sys.argv[4], rule_count))
     elif action == "remove":
         print(remove(sys.argv[2]))
     else:

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -175,6 +175,49 @@ install_claude_home_assets() {
   echo
 }
 
+claude_rule_id_count() {
+  local root="$1"
+  local total=0 file_count rule_file
+  if [[ ! -d "${root}" ]]; then
+    printf '0\n'
+    return 0
+  fi
+  while IFS= read -r rule_file; do
+    file_count=$(grep -cE '^## [A-Z]+-[0-9]+' "${rule_file}" 2>/dev/null || true)
+    total=$((total + file_count))
+  done < <(find "${root}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
+  printf '%s\n' "${total}"
+}
+
+claude_rule_count_for_banner() {
+  local rules_dest="${HOME}/.claude/rules/vibeguard"
+  local rules_src="${REPO_DIR}/rules/claude-rules"
+  local total=0 dir_count subdir
+
+  if [[ "${VIBEGUARD_SETUP_DRY_RUN}" != "1" && -d "${rules_dest}" ]]; then
+    claude_rule_id_count "${rules_dest}"
+    return 0
+  fi
+
+  if [[ -d "${rules_src}/common" ]]; then
+    dir_count=$(claude_rule_id_count "${rules_src}/common")
+    total=$((total + dir_count))
+  fi
+  for subdir in rust golang typescript python; do
+    if [[ -d "${rules_src}/${subdir}" ]]; then
+      if ! declare -F lang_selected >/dev/null || lang_selected "${subdir}"; then
+        dir_count=$(claude_rule_id_count "${rules_src}/${subdir}")
+        total=$((total + dir_count))
+      fi
+    fi
+  done
+  if [[ -d "${HOME}/.vibeguard/user-rules" ]]; then
+    dir_count=$(claude_rule_id_count "${HOME}/.vibeguard/user-rules")
+    total=$((total + dir_count))
+  fi
+  printf '%s\n' "${total}"
+}
+
 configure_claude_home_runtime() {
   echo "Step 9: Configure Claude hooks (${PROFILE} profile)"
   local settings_diff
@@ -201,8 +244,9 @@ configure_claude_home_runtime() {
 inject_claude_home_rules() {
   echo "Step 10: Update VibeGuard rules in CLAUDE.md"
   local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
-  local rules_diff
-  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${CLAUDE_DIR}/CLAUDE.md" "${rules_file}" "${REPO_DIR}" 2>&1); then
+  local rules_diff rule_count
+  rule_count=$(claude_rule_count_for_banner)
+  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${CLAUDE_DIR}/CLAUDE.md" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
     red "  Failed to compute CLAUDE.md diff"
     return 1
   fi
@@ -213,7 +257,7 @@ inject_claude_home_rules() {
     fi
     return 1
   fi
-  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${CLAUDE_DIR}/CLAUDE.md" "${rules_file}" "${REPO_DIR}" 2>&1); then
+  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${CLAUDE_DIR}/CLAUDE.md" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
     if [[ -f "${CLAUDE_DIR}/CLAUDE.md" ]]; then
       state_record_file "${CLAUDE_DIR}/CLAUDE.md" "generated/CLAUDE.md" "copy"
     fi
@@ -266,7 +310,7 @@ check_claude_home_installation() {
   fi
 
   local rules_dest="${HOME}/.claude/rules/vibeguard"
-  local rule_file_count actual_rule_count file_count claude_md declared_count
+  local rule_file_count actual_rule_count claude_md declared_count
   local symlink_count copy_count
   if [[ -d "${rules_dest}" ]]; then
     rule_file_count=$(find "${rules_dest}" -name "*.md" \( -type f -o -type l \) 2>/dev/null | wc -l | tr -d ' ')
@@ -281,11 +325,7 @@ check_claude_home_installation() {
       yellow "[DRIFT] ${copy_count} rule files are copies instead of symlinks — re-run setup.sh to fix"
     fi
 
-    actual_rule_count=0
-    while IFS= read -r rule_file; do
-      file_count=$(grep -cE '^## [A-Z]+-[0-9]+' "${rule_file}" 2>/dev/null || true)
-      actual_rule_count=$((actual_rule_count + file_count))
-    done < <(find "${rules_dest}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
+    actual_rule_count=$(claude_rule_id_count "${rules_dest}")
     claude_md="${CLAUDE_DIR}/CLAUDE.md"
     if [[ -f "${claude_md}" ]]; then
       declared_count=$(grep -o '[0-9]* rules' "${claude_md}" 2>/dev/null | grep -o '[0-9]*' | head -1)

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -70,6 +70,17 @@ raise SystemExit(0 if len(set(blocks)) == 1 else 1)
 PY
 }
 
+assert_claude_rule_banner_matches_installed_rules() {
+  local rules_dest="${HOME}/.claude/rules/vibeguard"
+  local actual=0 declared file_count rule_file
+  while IFS= read -r rule_file; do
+    file_count=$(grep -cE '^## [A-Z]+-[0-9]+' "${rule_file}" 2>/dev/null || true)
+    actual=$((actual + file_count))
+  done < <(find "${rules_dest}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
+  declared=$(grep -o '[0-9]* rules' "${HOME}/.claude/CLAUDE.md" 2>/dev/null | grep -o '[0-9]*' | head -1 || true)
+  [[ "${declared}" == "${actual}" ]]
+}
+
 ORIG_HOME="${HOME}"
 TMP_HOME="$(mktemp -d)"
 
@@ -94,6 +105,7 @@ assert_cmd "scripts/lib/codex_hooks_json.py syntax is correct" python3 -m py_com
 assert_cmd "scripts/lib/codex_config_toml.py syntax is correct" python3 -m py_compile "${CODEX_CONFIG_HELPER}"
 assert_cmd "scripts/setup/regenerate-hooks-from-manifest.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/regenerate-hooks-from-manifest.sh"
 assert_cmd "scripts/ci/validate-hooks-manifest.sh syntax is correct" bash -n "${REPO_DIR}/scripts/ci/validate-hooks-manifest.sh"
+assert_cmd "CLAUDE.md template uses generated rule count placeholder" grep -q "__VIBEGUARD_RULE_COUNT__" "${REPO_DIR}/claude-md/vibeguard-rules.md"
 
 header "hooks manifest"
 assert_cmd "hooks manifest validates" bash "${REPO_DIR}/scripts/ci/validate-hooks-manifest.sh"
@@ -246,6 +258,7 @@ assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'sessi
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 assert_cmd "~/.claude/CLAUDE.md includes the chat contract anchor after installation" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${HOME}/.claude/CLAUDE.md"
+assert_cmd "~/.claude/CLAUDE.md rule banner matches installed rules" assert_claude_rule_banner_matches_installed_rules
 assert_cmd "templates/AGENTS.md includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/templates/AGENTS.md"
 assert_cmd "docs/CLAUDE.md.example includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/docs/CLAUDE.md.example"
 assert_cmd "chat contract block matches across source, installed output, and templates" assert_chat_contract_blocks_match
@@ -335,6 +348,7 @@ assert_cmd "--check does not rewrite ~/.claude/CLAUDE.md" test "${before_sha}" =
 assert_cmd "--check does not drop or duplicate the chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 repair_out="$(bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${repair_out}" "Setup complete! All components installed." "re-running setup after drift still succeeds"
+assert_cmd "repair restores CLAUDE.md rule banner count" assert_claude_rule_banner_matches_installed_rules
 assert_cmd "repeat setup keeps exactly one chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 
 header "upsert idempotency with non-standard wrapper path"


### PR DESCRIPTION
## Summary
- replace the hardcoded CLAUDE.md rule count with a generated placeholder
- pass the install-time rule count into the CLAUDE.md helper, including language-filtered installs
- add setup regression checks that the installed banner matches actual rule files

## Tests
- python3 -m py_compile scripts/lib/claude_md.py
- bash -n scripts/setup/targets/claude-home.sh
- bash tests/test_setup.sh
- bash setup.sh --dry-run
- bash setup.sh --yes
- bash setup.sh --check
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/self-application/run-all.sh