### PR TITLE
Version session metrics records

### DIFF
--- a/hooks/_lib/session_metrics.py
+++ b/hooks/_lib/session_metrics.py
@@ -192,6 +192,7 @@ if os.path.exists(metrics_file):
         pass
 
 metrics = {
+    "schema_version": 1,
     "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     "session": session_id,
     "event_count": len(events),

--- a/vg-helper/src/event_schema.rs
+++ b/vg-helper/src/event_schema.rs
@@ -4,6 +4,7 @@
 //! instead of retyping event field strings.
 
 pub const UNKNOWN: &str = "unknown";
+pub const SESSION_METRICS_SCHEMA_VERSION: u64 = 1;
 
 pub mod field {
     pub const TS: &str = "ts";
@@ -50,6 +51,7 @@ pub mod tool {
 }
 
 pub mod metric_field {
+    pub const SCHEMA_VERSION: &str = "schema_version";
     pub const TS: &str = super::field::TS;
     pub const SESSION: &str = super::field::SESSION;
     pub const EVENT_COUNT: &str = "event_count";

--- a/vg-helper/src/session_metrics/engine.rs
+++ b/vg-helper/src/session_metrics/engine.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{self, BufRead, Write};
 
-use crate::event_schema::{UNKNOWN, decision, field, hook, metric_field, tool};
+use crate::event_schema::{
+    SESSION_METRICS_SCHEMA_VERSION, UNKNOWN, decision, field, hook, metric_field, tool,
+};
 
 use super::signals::build_signals;
 use super::time::{
@@ -137,6 +139,10 @@ pub(super) fn run_inner(
     // Write metrics
     let metrics_path = format!("{project_dir}/session-metrics.jsonl");
     let mut metrics_map = serde_json::Map::new();
+    metrics_map.insert(
+        metric_field::SCHEMA_VERSION.into(),
+        json!(SESSION_METRICS_SCHEMA_VERSION),
+    );
     metrics_map.insert(metric_field::TS.into(), json!(chrono_now()));
     metrics_map.insert(metric_field::SESSION.into(), json!(session));
     metrics_map.insert(metric_field::EVENT_COUNT.into(), json!(events.len()));

--- a/vg-helper/src/session_metrics/tests/run.rs
+++ b/vg-helper/src/session_metrics/tests/run.rs
@@ -144,6 +144,7 @@ fn test_run_produces_learn_suggested_and_appends_metrics() {
     // metrics_path is JSONL; parse the last line to get the entry from this run.
     let last_line = file_content.lines().last().unwrap_or("{}").trim();
     let parsed: serde_json::Value = serde_json::from_str(last_line).unwrap();
+    assert_eq!(parsed["schema_version"], 1);
     assert_eq!(parsed["session"], "sess-A");
     assert_eq!(parsed["event_count"], 6);
 }


### PR DESCRIPTION
## Summary
- add schema_version to session-metrics JSONL records
- define the version and field name in the Rust event schema constants
- keep the deprecated Python fallback output aligned with Rust

## Tests
- cd vg-helper && cargo fmt
- cd vg-helper && cargo test
- python3 -m py_compile hooks/_lib/session_metrics.py
- bash tests/unit/test_session_metrics_env_guard.sh
- bash scripts/ci/check-event-schema-literals.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check