### PR TITLE
Split scheduled GC helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,14 @@ jobs:
         shell: bash
         run: bash tests/test_setup.sh
 
+      - name: GC regression tests
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          bash tests/test_gc_config.sh
+          bash tests/test_gc_logs_concurrent.sh
+          bash tests/test_gc_scheduled.sh
+
       - name: Hook health regression tests
         shell: bash
         run: bash tests/test_hook_health.sh

--- a/scripts/gc/gc-scheduled.sh
+++ b/scripts/gc/gc-scheduled.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # VibeGuard periodic GC — scheduled by launchd
 #
-# Execute log archiving + worktree cleaning, and write the results to gc-cron.log.
-# Triggered by com.vibeguard.gc plist every Sunday at 3am.
+# Execute log archiving + worktree cleaning, metrics pruning, learning digest,
+# and reflection reporting. Triggered by com.vibeguard.gc every Sunday at 3am.
 #
 # Manually run: bash gc-scheduled.sh
 
@@ -23,451 +23,73 @@ GC_LOG_MAX_KB="$(vg_config_positive_int VIBEGUARD_GC_LOG_MAX_KB gc.gc_log_max_kb
 
 mkdir -p "${LOG_DIR}"
 
+run_gc_log_archive() {
+  echo "--- Log archive ---"
+  bash "${SCRIPT_DIR}/gc-logs.sh" 2>&1 || echo "[ERROR] gc-logs failed"
+  echo
+}
+
+run_worktree_cleanup() {
+  echo "--- Worktree Cleanup ---"
+  bash "${SCRIPT_DIR}/gc-worktrees.sh" 2>&1 || echo "[ERROR] gc-worktrees failed"
+  echo
+}
+
+run_session_metrics_cleanup() {
+  echo "--- Session Metrics Cleanup ---"
+  local cutoff
+  cutoff=$(date -v-"${SESSION_METRICS_RETAIN_DAYS}"d '+%Y-%m-%dT' 2>/dev/null \
+    || date -d "${SESSION_METRICS_RETAIN_DAYS} days ago" '+%Y-%m-%dT' 2>/dev/null \
+    || echo "")
+  if [[ -n "${cutoff}" ]]; then
+    _GC_LOG_DIR="${LOG_DIR}" _GC_CUTOFF="${cutoff}" \
+      python3 "${SCRIPT_DIR}/session_metrics_cleanup.py" 2>/dev/null || true
+  else
+    echo "Skip (cannot calculate date)"
+  fi
+  echo
+}
+
+run_learning_digest() {
+  echo "--- Regular learning (event log + code scanning unified signal source) ---"
+  _GC_LOG_DIR="${LOG_DIR}" \
+    _GC_VIBEGUARD_DIR="${REPO_ROOT}" \
+    _GC_LEARNING_WINDOW_DAYS="${LEARNING_WINDOW_DAYS}" \
+    python3 "${SCRIPT_DIR}/learn_digest.py" 2>&1 || echo "[ERROR] learn-digest failed"
+  echo
+}
+
+run_reflection_digest() {
+  echo "---Session Quality Reflection (Reflection Automation) ---"
+  local reflection_file="${LOG_DIR}/reflection-digest.md"
+  _GC_LOG_DIR="${LOG_DIR}" _GC_REFLECTION_FILE="${reflection_file}" \
+    python3 "${SCRIPT_DIR}/reflection_digest.py" 2>&1 || echo "[ERROR] reflection failed"
+  echo
+}
+
+trim_gc_log() {
+  [[ -f "${GC_LOG}" ]] || return 0
+  local size
+  size=$(du -k "${GC_LOG}" | cut -f1)
+  if [[ ${size} -gt "${GC_LOG_MAX_KB}" ]]; then
+    tail -500 "${GC_LOG}" > "${GC_LOG}.tmp"
+    mv "${GC_LOG}.tmp" "${GC_LOG}"
+  fi
+}
+
 {
   echo "=========================================="
   echo "VibeGuard GC — $(date '+%Y-%m-%d %H:%M:%S')"
   echo "=========================================="
   echo
 
-  echo "--- Log archive ---"
-  bash "${SCRIPT_DIR}/gc-logs.sh" 2>&1 || echo "[ERROR] gc-logs failed"
-  echo
-
-  echo "--- Worktree Cleanup ---"
-  bash "${SCRIPT_DIR}/gc-worktrees.sh" 2>&1 || echo "[ERROR] gc-worktrees failed"
-  echo
-
-  echo "--- Session Metrics Cleanup ---"
-  # Delete session-metrics entries older than the configured retention window.
-  CUTOFF=$(date -v-"${SESSION_METRICS_RETAIN_DAYS}"d '+%Y-%m-%dT' 2>/dev/null || date -d "${SESSION_METRICS_RETAIN_DAYS} days ago" '+%Y-%m-%dT' 2>/dev/null || echo "")
-  if [[ -n "${CUTOFF}" ]]; then
-    CLEANED=0
-    for mf in "${LOG_DIR}"/projects/*/session-metrics.jsonl; do
-      [[ -f "${mf}" ]] || continue
-      BEFORE=$(wc -l < "${mf}" | tr -d ' ')
-      _GC_CUTOFF="${CUTOFF}" _GC_MF="${mf}" _GC_BEFORE="${BEFORE}" \
-      python3 <<'PYEOF' 2>/dev/null || true
-import sys, os
-cutoff = os.environ['_GC_CUTOFF']
-mf = os.environ['_GC_MF']
-before = os.environ['_GC_BEFORE']
-kept = []
-with open(mf) as f:
-    for line in f:
-        if line.strip():
-            if '"ts"' in line:
-                idx = line.find('"ts"')
-                ts_start = line.find('"', idx + 4) + 1
-                ts_val = line[ts_start:ts_start+10]
-                if ts_val >= cutoff[:10]:
-                    kept.append(line)
-            else:
-                kept.append(line)
-with open(mf, 'w') as f:
-    f.writelines(kept)
-print(f' {len(kept)} reserved items (original {before} items)')
-PYEOF
-      AFTER=$(wc -l < "${mf}" | tr -d ' ')
-      DIFF=$((BEFORE - AFTER))
-      [[ ${DIFF} -gt 0 ]] && CLEANED=$((CLEANED + DIFF))
-    done
-    echo "Clean ${CLEANED} expired metrics"
-  else
-    echo "Skip (cannot calculate date)"
-  fi
-  echo
-
-  echo "--- Regular learning (event log + code scanning unified signal source) ---"
-  VIBEGUARD_DIR="${SCRIPT_DIR}/.."
-  _GC_LOG_DIR="${LOG_DIR}" _GC_VIBEGUARD_DIR="${VIBEGUARD_DIR}" _GC_LEARNING_WINDOW_DAYS="${LEARNING_WINDOW_DAYS}" \
-  python3 <<'PYEOF' 2>&1 || echo "[ERROR] learn-digest failed"
-import json, os, sys, subprocess
-from collections import Counter
-from datetime import datetime, timezone, timedelta
-
-log_dir = os.environ['_GC_LOG_DIR']
-vibeguard_dir = os.environ['_GC_VIBEGUARD_DIR']
-projects_dir = os.path.join(log_dir, 'projects')
-digest_file = os.path.join(log_dir, 'learn-digest.jsonl')
-
-if not os.path.isdir(projects_dir):
-    print('No project data, skip')
-    sys.exit(0)
-
-now = datetime.now(timezone.utc)
-learning_window_days = int(os.environ.get('_GC_LEARNING_WINDOW_DAYS', '7'))
-cutoff_7d = (now - timedelta(days=learning_window_days)).strftime('%Y-%m-%dT')
-signals_found = 0
-
-# Language detection → corresponds to guards script
-def detect_guards(project_root):
-    '''Return [(guard_script, rule_id_prefix)] list'''
-    guards = []
-    guards_dir = os.path.join(vibeguard_dir, 'guards')
-    # Universal guard (all projects)
-    slop = os.path.join(guards_dir, 'universal', 'check_code_slop.sh')
-    if os.path.exists(slop):
-        guards.append((slop, 'SLOP'))
-    # Language detection
-    if os.path.exists(os.path.join(project_root, 'Cargo.toml')):
-        for f in os.listdir(os.path.join(guards_dir, 'rust')):
-            if f.startswith('check_') and f.endswith('.sh'):
-                guards.append((os.path.join(guards_dir, 'rust', f), 'RS'))
-    if os.path.exists(os.path.join(project_root, 'tsconfig.json')) or \
-       os.path.exists(os.path.join(project_root, 'package.json')):
-        for f in os.listdir(os.path.join(guards_dir, 'typescript')):
-            if f.startswith('check_') and f.endswith('.sh'):
-                guards.append((os.path.join(guards_dir, 'typescript', f), 'TS'))
-    if os.path.exists(os.path.join(project_root, 'go.mod')):
-        for f in os.listdir(os.path.join(guards_dir, 'go')):
-            if f.startswith('check_') and f.endswith('.sh'):
-                guards.append((os.path.join(guards_dir, 'go', f), 'GO'))
-    return guards
-
-def run_guard(script, project_root):
-    '''Run the guard script and return the number of violating lines'''
-    try:
-        result = subprocess.run(
-            ['bash', script, project_root],
-            capture_output=True, text=True, timeout=30
-        )
-        output = result.stdout.strip()
-        if not output:
-            return 0, []
-        # Count the offending lines marked by [XX-NN]
-        violations = [l for l in output.split('\\n') if l.startswith('[')]
-        return len(violations), violations[:3] # Keep up to 3 examples
-    except (subprocess.TimeoutExpired, OSError):
-        return 0, []
-
-for proj in os.listdir(projects_dir):
-    proj_dir = os.path.join(projects_dir, proj)
-    if not os.path.isdir(proj_dir):
-        continue
-
-    events_file = os.path.join(proj_dir, 'events.jsonl')
-    project_root_file = os.path.join(proj_dir, '.project-root')
-
-    signals = []
-    session_set = set()
-
-    # ── Signal source A: event log analysis ──
-    if os.path.exists(events_file):
-        warn_reasons = Counter()
-        block_reasons = Counter()
-        edit_files = Counter()
-        slow_count = 0
-
-        with open(events_file) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    evt = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                ts = evt.get('ts', '')
-                if ts[:10] < cutoff_7d[:10]:
-                    continue
-                session_set.add(evt.get('session', ''))
-                decision = evt.get('decision', '')
-                reason = evt.get('reason', '')
-                if decision == 'warn' and reason:
-                    warn_reasons[reason] += 1
-                elif decision == 'block' and reason:
-                    block_reasons[reason] += 1
-                if evt.get('tool') == 'Edit' and evt.get('detail'):
-                    edit_files[evt['detail'].split()[-1]] += 1
-                if evt.get('duration_ms', 0) > 5000:
-                    slow_count += 1
-
-        for reason, count in warn_reasons.most_common(5):
-            if count >= 10:
-                signals.append({
-                    'type': 'repeated_warn', 'source': 'events',
-                    'reason': reason, 'count': count,
-                    'sessions': len(session_set)
-                })
-        for reason, count in block_reasons.most_common(5):
-            if count >= 5:
-                signals.append({
-                    'type': 'chronic_block', 'source': 'events',
-                    'reason': reason, 'count': count,
-                    'sessions': len(session_set)
-                })
-        for filepath, count in edit_files.most_common(5):
-            if count >= 20:
-                signals.append({
-                    'type': 'hot_files', 'source': 'events',
-                    'file': filepath, 'edits': count,
-                    'sessions': len(session_set)
-                })
-        if slow_count >= 10:
-            signals.append({
-                'type': 'slow_sessions', 'source': 'events',
-                'count': slow_count, 'sessions': len(session_set)
-            })
-
-        # warn Trending
-        metrics_file = os.path.join(proj_dir, 'session-metrics.jsonl')
-        if os.path.exists(metrics_file):
-            mid = (now - timedelta(days=3.5)).strftime('%Y-%m-%dT')
-            early_warns, late_warns = 0, 0
-            with open(metrics_file) as mf:
-                for ml in mf:
-                    ml = ml.strip()
-                    if not ml:
-                        continue
-                    try:
-                        m = json.loads(ml)
-                    except json.JSONDecodeError:
-                        continue
-                    mts = m.get('ts', '')
-                    if mts[:10] < cutoff_7d[:10]:
-                        continue
-                    w = m.get('decisions', {}).get('warn', 0)
-                    if mts < mid:
-                        early_warns += w
-                    else:
-                        late_warns += w
-            if early_warns > 0 and late_warns > early_warns * 1.5:
-                signals.append({
-                    'type': 'warn_escalation', 'source': 'events',
-                    'early': early_warns, 'late': late_warns,
-                    'ratio': round(late_warns / max(early_warns, 1), 2)
-                })
-
-    # ── Signal source B: code scan (linter violation) ──
-    if os.path.exists(project_root_file):
-        project_root = open(project_root_file).read().strip()
-        if os.path.isdir(project_root):
-            guards = detect_guards(project_root)
-            for guard_script, prefix in guards:
-                vcount, examples = run_guard(guard_script, project_root)
-                if vcount >= 5:
-                    guard_name = os.path.basename(guard_script).replace('check_', '').replace('.sh', '')
-                    signals.append({
-                        'type': 'linter_violations', 'source': 'code_scan',
-                        'guard': guard_name, 'count': vcount,
-                        'examples': examples
-                    })
-
-    if signals:
-        signals_found += len(signals)
-        entry = {
-            'ts': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
-            'project': proj,
-            'signals': signals,
-            'recommendation': f'consider /vibeguard:learn for project {proj}'
-        }
-        # Read project-root to supplement the readable path
-        if os.path.exists(project_root_file):
-            entry['project_root'] = open(project_root_file).read().strip()
-        with open(digest_file, 'a') as df:
-            df.write(json.dumps(entry, ensure_ascii=False) + '\n')
-        print(f' project {proj}: {len(signals)} learning signals')
-        for s in signals:
-            src = s.get('source', '')
-            if s['type'] == 'linter_violations':
-                print(f' - [code scan] {s["guard"]}: {s["count"]} violations')
-            else:
-                detail = s.get('reason', s.get('file', ''))
-                count = s.get('count', s.get('edits', ''))
-                print(f' - [Event Log] {s["type"]}: {detail} ({count})')
-
-if signals_found == 0:
-    print('No need to learn signals')
-else:
-    print(f' A total of {signals_found} signals have been written to learn-digest.jsonl')
-PYEOF
-  echo
-
-  echo "---Session Quality Reflection (Reflection Automation) ---"
-  REFLECTION_FILE="${LOG_DIR}/reflection-digest.md"
-  _GC_LOG_DIR="${LOG_DIR}" _GC_REFLECTION_FILE="${REFLECTION_FILE}" \
-  python3 <<'PYEOF' 2>&1 || echo "[ERROR] reflection failed"
-import json, os, sys
-from collections import Counter
-from datetime import datetime, timezone, timedelta
-
-log_dir = os.environ['_GC_LOG_DIR']
-projects_dir = os.path.join(log_dir, 'projects')
-output_file = os.environ['_GC_REFLECTION_FILE']
-
-if not os.path.isdir(projects_dir):
-    print('No project data, skip')
-    sys.exit(0)
-
-now = datetime.now(timezone.utc)
-cutoff_7d = (now - timedelta(days=7)).strftime('%Y-%m-%dT')
-
-# Collect session-metrics of all projects
-all_sessions = []
-project_names = {}
-for proj in os.listdir(projects_dir):
-    proj_dir = os.path.join(projects_dir, proj)
-    if not os.path.isdir(proj_dir):
-        continue
-    # Read project name
-    root_file = os.path.join(proj_dir, '.project-root')
-    if os.path.exists(root_file):
-        project_names[proj] = open(root_file).read().strip().split('/')[-1]
-    else:
-        project_names[proj] = proj
-
-    metrics_file = os.path.join(proj_dir, 'session-metrics.jsonl')
-    if not os.path.exists(metrics_file):
-        continue
-    with open(metrics_file) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                m = json.loads(line)
-                if m.get('ts', '')[:10] >= cutoff_7d[:10]:
-                    m['_project'] = proj
-                    all_sessions.append(m)
-            except json.JSONDecodeError:
-                continue
-
-if not all_sessions:
-    print('No session data in the past 7 days, skip')
-    sys.exit(0)
-
-# Aggregation analysis
-total_sessions = len(all_sessions)
-total_events = sum(s.get('event_count', 0) for s in all_sessions)
-
-# Decision distribution
-decision_totals = Counter()
-for s in all_sessions:
-    for d, c in s.get('decisions', {}).items():
-        decision_totals[d] += c
-
-# Correct signal statistics
-sessions_with_corrections = 0
-all_correction_signals = Counter()
-for s in all_sessions:
-    sigs = s.get('correction_signals', [])
-    if sigs:
-        sessions_with_corrections += 1
-        for sig in sigs:
-            # Classify signals
-            if 'repeated revision' in sig:
-                all_correction_signals['File repeatedly corrected'] += 1
-            elif 'high friction' in sig:
-                all_correction_signals['High Friction Session'] += 1
-            elif 'correction detection' in sig:
-                all_correction_signals['Real-time correction trigger'] += 1
-            elif 'upgrade warning' in sig:
-                all_correction_signals['Upgrade warning'] += 1
-
-# Hook trigger frequency
-hook_totals = Counter()
-for s in all_sessions:
-    for h, c in s.get('hooks', {}).items():
-        hook_totals[h] += c
-
-# High warn rate sessions
-high_friction = [s for s in all_sessions if s.get('warn_ratio', 0) > 0.4]
-
-# Most frequently edited files
-file_edits = Counter()
-for s in all_sessions:
-    for f, c in s.get('top_edited_files', {}).items():
-        if f:
-            file_edits[f] += c
-
-# Generate reflection report
-report = []
-report.append(f'# VibeGuard Weekly Reflection Report')
-report.append(f'')
-report.append(f'> Generation time: {now.strftime("%Y-%m-%d %H:%M UTC")}')
-report.append(f'>Coverage: Last 7 days')
-report.append(f'')
-report.append(f'## overview')
-report.append(f'')
-report.append(f'- Number of sessions: {total_sessions}')
-report.append(f'-Total number of events: {total_events}')
-report.append(f'- pass: {decision_totals.get("pass", 0)} | warn: {decision_totals.get("warn", 0)} | block: {decision_totals.get("block", 0)} | escalate: {decision_totals.get("escalate", 0)}')
-total_decisions = sum(decision_totals.values())
-overall_warn_rate = (decision_totals.get('warn', 0) + decision_totals.get('block', 0) + decision_totals.get('escalate', 0)) / max(total_decisions, 1)
-report.append(f'- overall friction rate: {overall_warn_rate:.0%}')
-report.append(f'')
-
-if sessions_with_corrections > 0 or high_friction:
-    report.append(f'##Correction signal')
-    report.append(f'')
-    report.append(f'- Sessions with correction signals: {sessions_with_corrections}/{total_sessions}')
-    report.append(f'- High friction session (>40% warn): {len(high_friction)}')
-    if all_correction_signals:
-        report.append(f'- signal type:')
-        for sig, count in all_correction_signals.most_common():
-            report.append(f' - {sig}: {count} times')
-    report.append(f'')
-
-report.append(f'## Top trigger Hook')
-report.append(f'')
-for hook, count in hook_totals.most_common(5):
-    report.append(f'- {hook}: {count} times')
-report.append(f'')
-
-if file_edits:
-    report.append(f'## Hotspot files (high-frequency editing across sessions)')
-    report.append(f'')
-    for f, c in file_edits.most_common(5):
-        basename = os.path.basename(f)
-        report.append(f'- {basename}: {c} edits')
-    report.append(f'')
-
-# Improvement suggestions
-suggestions = []
-if overall_warn_rate > 0.3:
-    suggestions.append('The overall friction rate is high → Check the reason for top warn and consider adding new rules or enhancing Hook prompts')
-if sessions_with_corrections > total_sessions * 0.3:
-    suggestions.append('More than 30% of sessions have correction signals → run /vibeguard:learn batch extraction mode')
-top_hook = hook_totals.most_common(1)
-if top_hook and top_hook[0][1] > total_events * 0.3:
-    suggestions.append(f'{top_hook[0][0]} is triggered too frequently → check whether there are false positives or the rules are too strict')
-if file_edits:
-    top_file = file_edits.most_common(1)[0]
-    if top_file[1] > 30:
-        suggestions.append(f'{os.path.basename(top_file[0])} Edited {top_file[1]} times → Consider splitting components or reviewing the architecture')
-
-if suggestions:
-    report.append(f'## Improvement suggestions')
-    report.append(f'')
-    for i, s in enumerate(suggestions, 1):
-        report.append(f'{i}. {s}')
-    report.append(f'')
-else:
-    report.append(f'## Improvement suggestions')
-    report.append(f'')
-    report.append(f'There is no significant improvement signal this week, the system is running normally.')
-    report.append(f'')
-
-#Write to file
-with open(output_file, 'w') as f:
-    f.write('\n'.join(report))
-
-print(f' Generate reflection report: {output_file}')
-print(f' Sessions: {total_sessions}, Events: {total_events}, Friction rate: {overall_warn_rate:.0%}')
-if suggestions:
-    for s in suggestions:
-        print(f'    - {s}')
-PYEOF
-  echo
+  run_gc_log_archive
+  run_worktree_cleanup
+  run_session_metrics_cleanup
+  run_learning_digest
+  run_reflection_digest
 
   echo "GC completed"
 } >> "${GC_LOG}" 2>&1
 
-# Keep gc-cron.log no larger than 1MB
-if [[ -f "${GC_LOG}" ]]; then
-  SIZE=$(du -k "${GC_LOG}" | cut -f1)
-  if [[ ${SIZE} -gt "${GC_LOG_MAX_KB}" ]]; then
-    tail -500 "${GC_LOG}" > "${GC_LOG}.tmp"
-    mv "${GC_LOG}.tmp" "${GC_LOG}"
-  fi
-fi
+trim_gc_log

--- a/scripts/gc/gc-worktrees.sh
+++ b/scripts/gc/gc-worktrees.sh
@@ -47,19 +47,35 @@ NOW=$(date +%s)
 CLEANED=0
 WARNED=0
 
+mtime_or_now() {
+  local target="$1"
+  local value
+  value=$(stat -f %m "$target" 2>/dev/null || true)
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+    return 0
+  fi
+  value=$(stat -c %Y "$target" 2>/dev/null || true)
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+    return 0
+  fi
+  echo "$NOW"
+}
+
 for wt_dir in "${WORKTREE_BASE}"/*/; do
   [[ -d "$wt_dir" ]] || continue
   NAME=$(basename "$wt_dir")
 
   # Get the latest modification time (get the latest file in the .git file or directory)
   if [[ -f "${wt_dir}.git" ]]; then
-    LAST_MOD=$(stat -f %m "${wt_dir}.git" 2>/dev/null || stat -c %Y "${wt_dir}.git" 2>/dev/null || echo "$NOW")
+    LAST_MOD=$(mtime_or_now "${wt_dir}.git")
   else
     LAST_MOD=$(find "$wt_dir" -maxdepth 2 -type f -newer "$wt_dir" -print -quit 2>/dev/null | head -1)
     if [[ -z "$LAST_MOD" ]]; then
-      LAST_MOD=$(stat -f %m "$wt_dir" 2>/dev/null || stat -c %Y "$wt_dir" 2>/dev/null || echo "$NOW")
+      LAST_MOD=$(mtime_or_now "$wt_dir")
     else
-      LAST_MOD=$(stat -f %m "$LAST_MOD" 2>/dev/null || stat -c %Y "$LAST_MOD" 2>/dev/null || echo "$NOW")
+      LAST_MOD=$(mtime_or_now "$LAST_MOD")
     fi
   fi
 

--- a/scripts/gc/learn_digest.py
+++ b/scripts/gc/learn_digest.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Generate weekly learning signals for gc-scheduled.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+
+log_dir = os.environ["_GC_LOG_DIR"]
+vibeguard_dir = os.environ["_GC_VIBEGUARD_DIR"]
+projects_dir = os.path.join(log_dir, "projects")
+digest_file = os.path.join(log_dir, "learn-digest.jsonl")
+
+if not os.path.isdir(projects_dir):
+    print("No project data, skip")
+    sys.exit(0)
+
+now = datetime.now(timezone.utc)
+learning_window_days = int(os.environ.get("_GC_LEARNING_WINDOW_DAYS", "7"))
+cutoff_7d = (now - timedelta(days=learning_window_days)).strftime("%Y-%m-%dT")
+signals_found = 0
+
+
+def detect_guards(project_root):
+    """Return [(guard_script, rule_id_prefix)] list."""
+    guards = []
+    guards_dir = os.path.join(vibeguard_dir, "guards")
+    if not os.path.isdir(guards_dir):
+        return guards
+    slop = os.path.join(guards_dir, "universal", "check_code_slop.sh")
+    if os.path.exists(slop):
+        guards.append((slop, "SLOP"))
+    if os.path.exists(os.path.join(project_root, "Cargo.toml")):
+        rust_dir = os.path.join(guards_dir, "rust")
+        for f in os.listdir(rust_dir) if os.path.isdir(rust_dir) else []:
+            if f.startswith("check_") and f.endswith(".sh"):
+                guards.append((os.path.join(rust_dir, f), "RS"))
+    if os.path.exists(os.path.join(project_root, "tsconfig.json")) or os.path.exists(
+        os.path.join(project_root, "package.json")
+    ):
+        ts_dir = os.path.join(guards_dir, "typescript")
+        for f in os.listdir(ts_dir) if os.path.isdir(ts_dir) else []:
+            if f.startswith("check_") and f.endswith(".sh"):
+                guards.append((os.path.join(ts_dir, f), "TS"))
+    if os.path.exists(os.path.join(project_root, "go.mod")):
+        go_dir = os.path.join(guards_dir, "go")
+        for f in os.listdir(go_dir) if os.path.isdir(go_dir) else []:
+            if f.startswith("check_") and f.endswith(".sh"):
+                guards.append((os.path.join(go_dir, f), "GO"))
+    return guards
+
+
+def run_guard(script, project_root):
+    """Run the guard script and return the number of violating lines."""
+    try:
+        result = subprocess.run(
+            ["bash", script, project_root],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        output = result.stdout.strip()
+        if not output:
+            return 0, []
+        violations = [line for line in output.split("\n") if line.startswith("[")]
+        return len(violations), violations[:3]
+    except (subprocess.TimeoutExpired, OSError):
+        return 0, []
+
+
+for proj in os.listdir(projects_dir):
+    proj_dir = os.path.join(projects_dir, proj)
+    if not os.path.isdir(proj_dir):
+        continue
+
+    events_file = os.path.join(proj_dir, "events.jsonl")
+    project_root_file = os.path.join(proj_dir, ".project-root")
+
+    signals = []
+    session_set = set()
+
+    if os.path.exists(events_file):
+        warn_reasons = Counter()
+        block_reasons = Counter()
+        edit_files = Counter()
+        slow_count = 0
+
+        with open(events_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = evt.get("ts", "")
+                if ts[:10] < cutoff_7d[:10]:
+                    continue
+                session_set.add(evt.get("session", ""))
+                decision = evt.get("decision", "")
+                reason = evt.get("reason", "")
+                if decision == "warn" and reason:
+                    warn_reasons[reason] += 1
+                elif decision == "block" and reason:
+                    block_reasons[reason] += 1
+                if evt.get("tool") == "Edit" and evt.get("detail"):
+                    edit_files[evt["detail"].split()[-1]] += 1
+                if evt.get("duration_ms", 0) > 5000:
+                    slow_count += 1
+
+        for reason, count in warn_reasons.most_common(5):
+            if count >= 10:
+                signals.append(
+                    {
+                        "type": "repeated_warn",
+                        "source": "events",
+                        "reason": reason,
+                        "count": count,
+                        "sessions": len(session_set),
+                    }
+                )
+        for reason, count in block_reasons.most_common(5):
+            if count >= 5:
+                signals.append(
+                    {
+                        "type": "chronic_block",
+                        "source": "events",
+                        "reason": reason,
+                        "count": count,
+                        "sessions": len(session_set),
+                    }
+                )
+        for filepath, count in edit_files.most_common(5):
+            if count >= 20:
+                signals.append(
+                    {
+                        "type": "hot_files",
+                        "source": "events",
+                        "file": filepath,
+                        "edits": count,
+                        "sessions": len(session_set),
+                    }
+                )
+        if slow_count >= 10:
+            signals.append(
+                {
+                    "type": "slow_sessions",
+                    "source": "events",
+                    "count": slow_count,
+                    "sessions": len(session_set),
+                }
+            )
+
+        metrics_file = os.path.join(proj_dir, "session-metrics.jsonl")
+        if os.path.exists(metrics_file):
+            mid = (now - timedelta(days=3.5)).strftime("%Y-%m-%dT")
+            early_warns, late_warns = 0, 0
+            with open(metrics_file, encoding="utf-8") as mf:
+                for ml in mf:
+                    ml = ml.strip()
+                    if not ml:
+                        continue
+                    try:
+                        m = json.loads(ml)
+                    except json.JSONDecodeError:
+                        continue
+                    mts = m.get("ts", "")
+                    if mts[:10] < cutoff_7d[:10]:
+                        continue
+                    w = m.get("decisions", {}).get("warn", 0)
+                    if mts < mid:
+                        early_warns += w
+                    else:
+                        late_warns += w
+            if early_warns > 0 and late_warns > early_warns * 1.5:
+                signals.append(
+                    {
+                        "type": "warn_escalation",
+                        "source": "events",
+                        "early": early_warns,
+                        "late": late_warns,
+                        "ratio": round(late_warns / max(early_warns, 1), 2),
+                    }
+                )
+
+    if os.path.exists(project_root_file):
+        project_root = open(project_root_file, encoding="utf-8").read().strip()
+        if os.path.isdir(project_root):
+            guards = detect_guards(project_root)
+            for guard_script, prefix in guards:
+                vcount, examples = run_guard(guard_script, project_root)
+                if vcount >= 5:
+                    guard_name = os.path.basename(guard_script).replace("check_", "").replace(".sh", "")
+                    signals.append(
+                        {
+                            "type": "linter_violations",
+                            "source": "code_scan",
+                            "guard": guard_name,
+                            "count": vcount,
+                            "examples": examples,
+                        }
+                    )
+
+    if signals:
+        signals_found += len(signals)
+        entry = {
+            "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "project": proj,
+            "signals": signals,
+            "recommendation": f"consider /vibeguard:learn for project {proj}",
+        }
+        if os.path.exists(project_root_file):
+            entry["project_root"] = open(project_root_file, encoding="utf-8").read().strip()
+        with open(digest_file, "a", encoding="utf-8") as df:
+            df.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        print(f" project {proj}: {len(signals)} learning signals")
+        for signal in signals:
+            if signal["type"] == "linter_violations":
+                print(f' - [code scan] {signal["guard"]}: {signal["count"]} violations')
+            else:
+                detail = signal.get("reason", signal.get("file", ""))
+                count = signal.get("count", signal.get("edits", ""))
+                print(f' - [Event Log] {signal["type"]}: {detail} ({count})')
+
+if signals_found == 0:
+    print("No need to learn signals")
+else:
+    print(f" A total of {signals_found} signals have been written to learn-digest.jsonl")

--- a/scripts/gc/reflection_digest.py
+++ b/scripts/gc/reflection_digest.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Generate weekly session reflection report for gc-scheduled.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+
+log_dir = os.environ["_GC_LOG_DIR"]
+projects_dir = os.path.join(log_dir, "projects")
+output_file = os.environ["_GC_REFLECTION_FILE"]
+
+if not os.path.isdir(projects_dir):
+    print("No project data, skip")
+    sys.exit(0)
+
+now = datetime.now(timezone.utc)
+cutoff_7d = (now - timedelta(days=7)).strftime("%Y-%m-%dT")
+
+all_sessions = []
+project_names = {}
+for proj in os.listdir(projects_dir):
+    proj_dir = os.path.join(projects_dir, proj)
+    if not os.path.isdir(proj_dir):
+        continue
+    root_file = os.path.join(proj_dir, ".project-root")
+    if os.path.exists(root_file):
+        project_names[proj] = open(root_file, encoding="utf-8").read().strip().split("/")[-1]
+    else:
+        project_names[proj] = proj
+
+    metrics_file = os.path.join(proj_dir, "session-metrics.jsonl")
+    if not os.path.exists(metrics_file):
+        continue
+    with open(metrics_file, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                metric = json.loads(line)
+                if metric.get("ts", "")[:10] >= cutoff_7d[:10]:
+                    metric["_project"] = proj
+                    all_sessions.append(metric)
+            except json.JSONDecodeError:
+                continue
+
+if not all_sessions:
+    print("No session data in the past 7 days, skip")
+    sys.exit(0)
+
+total_sessions = len(all_sessions)
+total_events = sum(session.get("event_count", 0) for session in all_sessions)
+
+decision_totals = Counter()
+for session in all_sessions:
+    for decision, count in session.get("decisions", {}).items():
+        decision_totals[decision] += count
+
+sessions_with_corrections = 0
+all_correction_signals = Counter()
+for session in all_sessions:
+    signals = session.get("correction_signals", [])
+    if signals:
+        sessions_with_corrections += 1
+        for signal in signals:
+            if "repeated revision" in signal:
+                all_correction_signals["File repeatedly corrected"] += 1
+            elif "high friction" in signal:
+                all_correction_signals["High Friction Session"] += 1
+            elif "correction detection" in signal:
+                all_correction_signals["Real-time correction trigger"] += 1
+            elif "upgrade warning" in signal:
+                all_correction_signals["Upgrade warning"] += 1
+
+hook_totals = Counter()
+for session in all_sessions:
+    for hook, count in session.get("hooks", {}).items():
+        hook_totals[hook] += count
+
+high_friction = [session for session in all_sessions if session.get("warn_ratio", 0) > 0.4]
+
+file_edits = Counter()
+for session in all_sessions:
+    for file_path, count in session.get("top_edited_files", {}).items():
+        if file_path:
+            file_edits[file_path] += count
+
+report = []
+report.append("# VibeGuard Weekly Reflection Report")
+report.append("")
+report.append(f'> Generation time: {now.strftime("%Y-%m-%d %H:%M UTC")}')
+report.append(">Coverage: Last 7 days")
+report.append("")
+report.append("## overview")
+report.append("")
+report.append(f"- Number of sessions: {total_sessions}")
+report.append(f"-Total number of events: {total_events}")
+report.append(
+    f'- pass: {decision_totals.get("pass", 0)} | warn: {decision_totals.get("warn", 0)} | '
+    f'block: {decision_totals.get("block", 0)} | escalate: {decision_totals.get("escalate", 0)}'
+)
+total_decisions = sum(decision_totals.values())
+overall_warn_rate = (
+    decision_totals.get("warn", 0)
+    + decision_totals.get("block", 0)
+    + decision_totals.get("escalate", 0)
+) / max(total_decisions, 1)
+report.append(f"- overall friction rate: {overall_warn_rate:.0%}")
+report.append("")
+
+if sessions_with_corrections > 0 or high_friction:
+    report.append("##Correction signal")
+    report.append("")
+    report.append(f"- Sessions with correction signals: {sessions_with_corrections}/{total_sessions}")
+    report.append(f"- High friction session (>40% warn): {len(high_friction)}")
+    if all_correction_signals:
+        report.append("- signal type:")
+        for signal, count in all_correction_signals.most_common():
+            report.append(f" - {signal}: {count} times")
+    report.append("")
+
+report.append("## Top trigger Hook")
+report.append("")
+for hook, count in hook_totals.most_common(5):
+    report.append(f"- {hook}: {count} times")
+report.append("")
+
+if file_edits:
+    report.append("## Hotspot files (high-frequency editing across sessions)")
+    report.append("")
+    for file_path, count in file_edits.most_common(5):
+        basename = os.path.basename(file_path)
+        report.append(f"- {basename}: {count} edits")
+    report.append("")
+
+suggestions = []
+if overall_warn_rate > 0.3:
+    suggestions.append(
+        "The overall friction rate is high → Check the reason for top warn and consider adding new rules or enhancing Hook prompts"
+    )
+if sessions_with_corrections > total_sessions * 0.3:
+    suggestions.append("More than 30% of sessions have correction signals → run /vibeguard:learn batch extraction mode")
+top_hook = hook_totals.most_common(1)
+if top_hook and top_hook[0][1] > total_events * 0.3:
+    suggestions.append(f"{top_hook[0][0]} is triggered too frequently → check whether there are false positives or the rules are too strict")
+if file_edits:
+    top_file = file_edits.most_common(1)[0]
+    if top_file[1] > 30:
+        suggestions.append(f"{os.path.basename(top_file[0])} Edited {top_file[1]} times → Consider splitting components or reviewing the architecture")
+
+report.append("## Improvement suggestions")
+report.append("")
+if suggestions:
+    for i, suggestion in enumerate(suggestions, 1):
+        report.append(f"{i}. {suggestion}")
+else:
+    report.append("There is no significant improvement signal this week, the system is running normally.")
+report.append("")
+
+with open(output_file, "w", encoding="utf-8") as f:
+    f.write("\n".join(report))
+
+print(f" Generate reflection report: {output_file}")
+print(f" Sessions: {total_sessions}, Events: {total_events}, Friction rate: {overall_warn_rate:.0%}")
+if suggestions:
+    for suggestion in suggestions:
+        print(f"    - {suggestion}")

--- a/scripts/gc/session_metrics_cleanup.py
+++ b/scripts/gc/session_metrics_cleanup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Prune per-project session-metrics.jsonl files for gc-scheduled.sh."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def keep_line(line: str, cutoff: str) -> bool:
+    if not line.strip():
+        return False
+    if '"ts"' not in line:
+        return True
+    idx = line.find('"ts"')
+    ts_start = line.find('"', idx + 4) + 1
+    ts_val = line[ts_start : ts_start + 10]
+    return ts_val >= cutoff[:10]
+
+
+def main() -> int:
+    log_dir = Path(os.environ["_GC_LOG_DIR"])
+    cutoff = os.environ["_GC_CUTOFF"]
+    cleaned = 0
+
+    for metrics_file in sorted(log_dir.glob("projects/*/session-metrics.jsonl")):
+        before_lines = metrics_file.read_text(encoding="utf-8").splitlines(keepends=True)
+        kept = [line for line in before_lines if keep_line(line, cutoff)]
+        metrics_file.write_text("".join(kept), encoding="utf-8")
+        print(f" {len(kept)} reserved items (original {len(before_lines)} items)")
+        cleaned += len(before_lines) - len(kept)
+
+    print(f"Clean {cleaned} expired metrics")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gc_config.sh
+++ b/tests/test_gc_config.sh
@@ -86,6 +86,25 @@ worktree_out="$(cd "$repo" && bash "$REPO_DIR/scripts/gc/gc-worktrees.sh" --dry-
 assert_contains "$worktree_out" "old: 10 days" "gc-worktrees inspects old worktree"
 assert_contains "$worktree_out" "reserved" "configured 42-day retention prevents deletion"
 
+linux_stat_repo="${TMP_ROOT}/linux-stat-repo"
+mkdir -p "${linux_stat_repo}/.vibeguard/worktrees/current" "${TMP_ROOT}/bin"
+git -C "$linux_stat_repo" init -q
+cat > "${TMP_ROOT}/bin/stat" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-f" ]]; then
+  printf '  File: "%s"\n' "${3:-}"
+  exit 0
+fi
+if [[ "${1:-}" == "-c" ]]; then
+  date +%s
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+SH
+chmod +x "${TMP_ROOT}/bin/stat"
+linux_stat_out="$(cd "$linux_stat_repo" && PATH="${TMP_ROOT}/bin:$PATH" VIBEGUARD_GC_WORKTREE_MAX_DAYS=42 bash "$REPO_DIR/scripts/gc/gc-worktrees.sh" --dry-run)"
+assert_contains "$linux_stat_out" "current: 0 days" "gc-worktrees ignores GNU stat -f filesystem output"
+
 header "schema exposes gc contract"
 
 assert_cmd "project schema accepts gc config" python3 - "$REPO_DIR/schemas/vibeguard-project.schema.json" "$cfg" <<'PY'

--- a/tests/test_gc_logs_concurrent.sh
+++ b/tests/test_gc_logs_concurrent.sh
@@ -51,6 +51,22 @@ current_ts() {
   date -u '+%Y-%m-01T00:00:00Z'
 }
 
+file_mode() {
+  local path="$1"
+  local mode
+  mode=$(stat -f '%Lp' "$path" 2>/dev/null || true)
+  if [[ "$mode" =~ ^[0-9]+$ ]]; then
+    echo "$mode"
+    return 0
+  fi
+  mode=$(stat -c '%a' "$path" 2>/dev/null || true)
+  if [[ "$mode" =~ ^[0-9]+$ ]]; then
+    echo "$mode"
+    return 0
+  fi
+  echo ""
+}
+
 write_fixture_log() {
   local log_dir="$1"
   mkdir -p "$log_dir"
@@ -90,7 +106,7 @@ assert_contains "$archive_out" "archive 1 items, retain 1 items" "archive run re
 assert_contains "$remaining" "current-line" "current month line remains in events.jsonl"
 assert_not_contains "$remaining" "old-line" "old month line is removed from events.jsonl"
 assert_contains "$archived" "old-line" "old month line is archived"
-assert_cmd "events.jsonl remains mode 600" test "$(stat -f '%Lp' "${archive_dir}/events.jsonl" 2>/dev/null || stat -c '%a' "${archive_dir}/events.jsonl")" = "600"
+assert_cmd "events.jsonl remains mode 600" test "$(file_mode "${archive_dir}/events.jsonl")" = "600"
 
 header "gc-logs.sh waits for active writer lock"
 
@@ -131,7 +147,7 @@ assert_contains "$project_out" "archive 1 items, retain 1 items" "project log ar
 assert_contains "$project_remaining" "current-line" "project current-month line remains in events.jsonl"
 assert_not_contains "$project_remaining" "old-line" "project old-month line is removed from events.jsonl"
 assert_contains "$project_archived" "old-line" "project old-month line is archived"
-assert_cmd "project events.jsonl remains mode 600" test "$(stat -f '%Lp' "${project_log_dir}/events.jsonl" 2>/dev/null || stat -c '%a' "${project_log_dir}/events.jsonl")" = "600"
+assert_cmd "project events.jsonl remains mode 600" test "$(file_mode "${project_log_dir}/events.jsonl")" = "600"
 
 printf '\n==============================\n'
 printf 'Total: %s  Pass: \033[32m%s\033[0m  Fail: \033[31m%s\033[0m\n' "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_gc_scheduled.sh
+++ b/tests/test_gc_scheduled.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# VibeGuard scheduled GC integration tests.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+PASS=0
+FAIL=0
+TOTAL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$output" | grep -qF -- "$expected"; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if ! printf '%s' "$output" | grep -qF -- "$unexpected"; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (unexpectedly contains: $unexpected)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc"; FAIL=$((FAIL + 1))
+  fi
+}
+
+header "gc-scheduled.py helpers compile"
+assert_cmd "scheduled GC Python helpers compile" python3 -m py_compile \
+  scripts/gc/session_metrics_cleanup.py \
+  scripts/gc/learn_digest.py \
+  scripts/gc/reflection_digest.py
+
+header "gc-scheduled.sh orchestrates helpers"
+
+log_dir="${TMP_ROOT}/logs"
+project_dir="${log_dir}/projects/abc123"
+mkdir -p "$project_dir"
+today="$(date -u '+%Y-%m-%dT00:00:00Z')"
+
+cat > "${project_dir}/session-metrics.jsonl" <<EOF
+{"ts":"2020-01-01T00:00:00Z","event_count":1,"decisions":{"warn":1},"hooks":{"old":1},"top_edited_files":{"old.py":1}}
+{"ts":"${today}","event_count":5,"decisions":{"pass":3,"warn":2},"hooks":{"post-edit-guard":2},"top_edited_files":{"src/app.py":2},"warn_ratio":0.4}
+EOF
+printf '%s\n' "$TMP_ROOT/project" > "${project_dir}/.project-root"
+mkdir -p "$TMP_ROOT/project"
+
+cfg="${TMP_ROOT}/.vibeguard.json"
+cat > "$cfg" <<'JSON'
+{
+  "gc": {
+    "session_metrics_retain_days": 30,
+    "learning_window_days": 7,
+    "gc_log_max_kb": 1024
+  }
+}
+JSON
+
+VIBEGUARD_LOG_DIR="$log_dir" VIBEGUARD_PROJECT_CONFIG="$cfg" bash scripts/gc/gc-scheduled.sh
+
+gc_log="$(cat "${log_dir}/gc-cron.log")"
+metrics_after="$(cat "${project_dir}/session-metrics.jsonl")"
+reflection="$(cat "${log_dir}/reflection-digest.md")"
+
+assert_contains "$gc_log" "--- Session Metrics Cleanup ---" "scheduled GC runs metrics cleanup section"
+assert_contains "$gc_log" "Clean 1 expired metrics" "scheduled GC prunes expired metrics"
+assert_contains "$gc_log" "--- Regular learning" "scheduled GC runs learning digest section"
+assert_contains "$gc_log" "---Session Quality Reflection" "scheduled GC runs reflection section"
+assert_contains "$metrics_after" "$today" "current session metric remains"
+assert_not_contains "$metrics_after" "2020-01-01" "expired session metric is removed"
+assert_contains "$reflection" "VibeGuard Weekly Reflection Report" "reflection report is generated"
+
+printf '\n==============================\n'
+printf 'Total: %s  Pass: \033[32m%s\033[0m  Fail: \033[31m%s\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
+printf '==============================\n'
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -83,14 +83,44 @@ assert_claude_rule_banner_matches_installed_rules() {
 
 ORIG_HOME="${HOME}"
 TMP_HOME="$(mktemp -d)"
+ORIG_PATH="${PATH}"
 
 cleanup() {
   export HOME="${ORIG_HOME}"
+  export PATH="${ORIG_PATH}"
   rm -rf "${TMP_HOME}"
 }
 trap cleanup EXIT
 
 export HOME="${TMP_HOME}"
+mkdir -p "${TMP_HOME}/bin"
+cat > "${TMP_HOME}/bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+state="${HOME}/.launchctl-vibeguard-loaded"
+case "${1:-}" in
+  bootstrap)
+    touch "$state"
+    exit 0
+    ;;
+  bootout)
+    rm -f "$state"
+    exit 0
+    ;;
+  print)
+    [[ -f "$state" ]] && exit 0
+    exit 113
+    ;;
+  list)
+    [[ -f "$state" ]] && printf '0\t0\tcom.vibeguard.gc\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "${TMP_HOME}/bin/launchctl"
+export PATH="${TMP_HOME}/bin:${PATH}"
 
 header "setup scripts syntax"
 assert_cmd "setup.sh syntax is correct" bash -n "${REPO_DIR}/setup.sh"


### PR DESCRIPTION
## Summary
- split `gc-scheduled.sh` into a small scheduler plus focused Python helpers for session-metrics pruning, learning digest generation, and reflection reporting
- pass the repository root to learning digest guard discovery so code-scan learning can actually find `guards/`
- fix Linux `stat -f` handling in `gc-worktrees.sh` and GC log mode tests after the new GC CI step exposed the failures
- add a scheduled GC integration test, mock `launchctl` in setup tests to avoid touching the real user service, and wire GC regression tests into CI

## Tests
- `bash -n scripts/gc/gc-scheduled.sh tests/test_gc_scheduled.sh scripts/gc/gc-worktrees.sh tests/test_gc_config.sh tests/test_setup.sh tests/test_gc_logs_concurrent.sh`
- `python3 -m py_compile scripts/gc/session_metrics_cleanup.py scripts/gc/learn_digest.py scripts/gc/reflection_digest.py`
- `bash tests/test_gc_config.sh && bash tests/test_gc_logs_concurrent.sh && bash tests/test_gc_scheduled.sh`
- `bash tests/test_setup.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash setup.sh --check`
- `bash scripts/ci/validate-doc-paths.sh`
- `git diff --check`