### PR TITLE
Validate project config at runtime

### DIFF
--- a/scripts/lib/project_config.sh
+++ b/scripts/lib/project_config.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Lightweight .vibeguard.json reader for shell scripts.
 
+_VG_PROJECT_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_VG_PROJECT_CONFIG_VALIDATOR="${_VG_PROJECT_CONFIG_LIB_DIR}/project_config_validate.py"
+_VG_PROJECT_CONFIG_SCHEMA="${_VG_PROJECT_CONFIG_LIB_DIR}/../../schemas/vibeguard-project.schema.json"
+
 vg_project_config_file() {
   if [[ -n "${VIBEGUARD_PROJECT_CONFIG:-}" ]]; then
     printf '%s\n' "${VIBEGUARD_PROJECT_CONFIG}"
@@ -19,6 +23,32 @@ vg_project_config_file() {
   fi
 }
 
+vg_validate_project_config() {
+  local config_file="${1:-}"
+  if [[ -z "$config_file" ]]; then
+    config_file="$(vg_project_config_file)"
+  fi
+
+  if [[ -z "$config_file" || ! -f "$config_file" ]]; then
+    return 0
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf 'VibeGuard project config invalid: python3 is required to validate %s\n' "$config_file" >&2
+    return 1
+  fi
+  if [[ ! -f "$_VG_PROJECT_CONFIG_VALIDATOR" ]]; then
+    printf 'VibeGuard project config invalid: validator missing at %s\n' "$_VG_PROJECT_CONFIG_VALIDATOR" >&2
+    return 1
+  fi
+  if [[ ! -f "$_VG_PROJECT_CONFIG_SCHEMA" ]]; then
+    printf 'VibeGuard project config invalid: schema missing at %s\n' "$_VG_PROJECT_CONFIG_SCHEMA" >&2
+    return 1
+  fi
+
+  python3 "$_VG_PROJECT_CONFIG_VALIDATOR" --quiet "$config_file" "$_VG_PROJECT_CONFIG_SCHEMA"
+}
+
 vg_config_value() {
   local key_path="$1"
   local default_value="${2:-}"
@@ -28,6 +58,10 @@ vg_config_value() {
   if [[ -z "$config_file" || ! -f "$config_file" ]] || ! command -v python3 >/dev/null 2>&1; then
     printf '%s\n' "$default_value"
     return 0
+  fi
+
+  if ! vg_validate_project_config "$config_file"; then
+    return 2
   fi
 
   python3 - "$config_file" "$key_path" "$default_value" <<'PY'
@@ -47,8 +81,9 @@ try:
         print(default)
     else:
         print(value)
-except Exception:
-    print(default)
+except Exception as exc:
+    print(f"VibeGuard project config read failed: {path}: {exc}", file=sys.stderr)
+    sys.exit(2)
 PY
 }
 
@@ -59,7 +94,9 @@ vg_config_positive_int() {
   local raw_value="${!env_name:-}"
 
   if [[ -z "$raw_value" ]]; then
-    raw_value="$(vg_config_value "$key_path" "$default_value")"
+    if ! raw_value="$(vg_config_value "$key_path" "$default_value")"; then
+      return 2
+    fi
   fi
 
   if [[ "$raw_value" =~ ^[0-9]+$ && "$raw_value" -gt 0 ]]; then

--- a/scripts/lib/project_config_validate.py
+++ b/scripts/lib/project_config_validate.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Validate a project-level .vibeguard.json without third-party deps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _label(path: list[str]) -> str:
+    return "." + ".".join(path) if path else "$"
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        with path.open(encoding="utf-8") as f:
+            return json.load(f)
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{path}: invalid UTF-8 ({exc})") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot read file ({exc})") from exc
+
+
+def _enum(schema: dict[str, Any], key: str) -> set[str]:
+    return set(schema["properties"][key]["items"].get("enum", []))
+
+
+def _string_enum(schema: dict[str, Any], key: str) -> set[str]:
+    return set(schema["properties"][key].get("enum", []))
+
+
+def _validate_string_enum(
+    value: Any,
+    allowed: set[str],
+    path: list[str],
+    errors: list[str],
+) -> None:
+    if not isinstance(value, str):
+        errors.append(f"{_label(path)}: expected string")
+        return
+    if value not in allowed:
+        errors.append(f"{_label(path)}: unsupported value {value!r}; expected one of {sorted(allowed)}")
+
+
+def _validate_string_array(
+    value: Any,
+    path: list[str],
+    errors: list[str],
+    *,
+    allowed: set[str] | None = None,
+    pattern: re.Pattern[str] | None = None,
+) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{_label(path)}: expected array")
+        return
+
+    for index, item in enumerate(value):
+        item_path = path + [str(index)]
+        if not isinstance(item, str):
+            errors.append(f"{_label(item_path)}: expected string")
+            continue
+        if allowed is not None and item not in allowed:
+            errors.append(f"{_label(item_path)}: unsupported value {item!r}; expected one of {sorted(allowed)}")
+        if pattern is not None and not pattern.match(item):
+            errors.append(f"{_label(item_path)}: does not match {pattern.pattern}")
+
+
+def _validate_gc(value: Any, schema: dict[str, Any], errors: list[str]) -> None:
+    path = ["gc"]
+    if not isinstance(value, dict):
+        errors.append(f"{_label(path)}: expected object")
+        return
+
+    gc_schema = schema["properties"]["gc"]
+    props = gc_schema.get("properties", {})
+    allowed = set(props)
+    for key in sorted(set(value) - allowed):
+        errors.append(f"{_label(path + [key])}: unknown property")
+
+    for key, item in value.items():
+        if key not in props:
+            continue
+        minimum = props[key].get("minimum", 1)
+        item_path = path + [key]
+        if isinstance(item, bool) or not isinstance(item, int):
+            errors.append(f"{_label(item_path)}: expected integer >= {minimum}")
+        elif item < minimum:
+            errors.append(f"{_label(item_path)}: expected integer >= {minimum}")
+
+
+def validate(config: Any, schema: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(config, dict):
+        return ["$: expected object"]
+
+    props = schema.get("properties", {})
+    allowed_top = set(props)
+    for key in sorted(set(config) - allowed_top):
+        errors.append(f"{_label([key])}: unknown property")
+
+    if "profile" in config:
+        _validate_string_enum(config["profile"], _string_enum(schema, "profile"), ["profile"], errors)
+    if "enforcement" in config:
+        _validate_string_enum(config["enforcement"], _string_enum(schema, "enforcement"), ["enforcement"], errors)
+    if "languages" in config:
+        _validate_string_array(config["languages"], ["languages"], errors, allowed=_enum(schema, "languages"))
+    if "disabled_hooks" in config:
+        _validate_string_array(
+            config["disabled_hooks"],
+            ["disabled_hooks"],
+            errors,
+            allowed=_enum(schema, "disabled_hooks"),
+        )
+    if "disabled_guards" in config:
+        _validate_string_array(
+            config["disabled_guards"],
+            ["disabled_guards"],
+            errors,
+            allowed=_enum(schema, "disabled_guards"),
+        )
+    if "disabled_rules" in config:
+        pattern = re.compile(props["disabled_rules"]["items"]["pattern"])
+        _validate_string_array(config["disabled_rules"], ["disabled_rules"], errors, pattern=pattern)
+    if "gc" in config:
+        _validate_gc(config["gc"], schema, errors)
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate .vibeguard.json against the project schema")
+    parser.add_argument("config", type=Path)
+    parser.add_argument("schema", type=Path)
+    parser.add_argument("--quiet", action="store_true", help="Suppress success output")
+    args = parser.parse_args()
+
+    try:
+        config = _load_json(args.config)
+        schema = _load_json(args.schema)
+    except ValueError as exc:
+        print(f"VibeGuard project config invalid: {exc}", file=sys.stderr)
+        return 1
+
+    errors = validate(config, schema)
+    if errors:
+        print(f"VibeGuard project config invalid: {args.config}", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(f"OK: {args.config}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 source "${SCRIPT_DIR}/../lib/install-state.sh"
+source "${SCRIPT_DIR}/../lib/project_config.sh"
 source "${SCRIPT_DIR}/targets/claude-home.sh"
 source "${SCRIPT_DIR}/targets/codex-home.sh"
 
@@ -45,6 +46,24 @@ elif [[ "$(uname)" == "Linux" ]] && command -v systemctl &>/dev/null; then
 fi
 
 check_codex_home_installation
+
+# Check project-level runtime config
+echo
+echo "Project Config"
+echo "------------------------------"
+project_config_file="$(vg_project_config_file)"
+if [[ -z "${project_config_file}" || ! -f "${project_config_file}" ]]; then
+  yellow "[INFO] No project config found (.vibeguard.json optional)"
+else
+  if project_config_out="$(vg_validate_project_config "${project_config_file}" 2>&1)"; then
+    green "[OK] Project config valid (${project_config_file})"
+  else
+    red "[FAIL] Project config invalid (${project_config_file})"
+    while IFS= read -r line; do
+      red "  ${line}"
+    done <<< "${project_config_out}"
+  fi
+fi
 
 # Check AUTO_RUN_AGENT_DIR
 if [[ -n "${AUTO_RUN_AGENT_DIR:-}" ]] && [[ -d "${AUTO_RUN_AGENT_DIR}" ]]; then

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 source "${SCRIPT_DIR}/../lib/install-state.sh"
+source "${SCRIPT_DIR}/../lib/project_config.sh"
 source "${SCRIPT_DIR}/targets/claude-home.sh"
 source "${SCRIPT_DIR}/targets/codex-home.sh"
 
@@ -105,6 +106,20 @@ if [[ "${VIBEGUARD_SETUP_FORCE_OVERWRITE}" == "1" ]]; then
 fi
 echo "=============================="
 echo
+
+project_config_file="$(vg_project_config_file)"
+if [[ -n "${project_config_file}" && -f "${project_config_file}" ]]; then
+  if project_config_out="$(vg_validate_project_config "${project_config_file}" 2>&1)"; then
+    green "Project config valid: ${project_config_file}"
+  else
+    red "ERROR: invalid project config: ${project_config_file}"
+    while IFS= read -r line; do
+      red "  ${line}"
+    done <<< "${project_config_out}"
+    exit 1
+  fi
+  echo
+fi
 
 if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
   configure_claude_home_runtime

--- a/tests/test_gc_config.sh
+++ b/tests/test_gc_config.sh
@@ -67,6 +67,31 @@ assert_contains "$env_out" "9" "environment override wins over project config"
 missing_out="$(VIBEGUARD_PROJECT_CONFIG="${TMP_ROOT}/missing.json" bash -c 'source scripts/lib/project_config.sh; vg_config_positive_int VIBEGUARD_GC_LOG_THRESHOLD_MB gc.log_threshold_mb 10')"
 assert_contains "$missing_out" "10" "missing config falls back to default"
 
+bad_cfg="${TMP_ROOT}/bad-vibeguard.json"
+cat > "$bad_cfg" <<'JSON'
+{
+  "gc": {
+    "log_threshold_mb": 0,
+    "unexpected_gc_key": 1
+  },
+  "unknown_top_level": true
+}
+JSON
+invalid_helper_out_file="${TMP_ROOT}/invalid-helper.out"
+TOTAL=$((TOTAL + 1))
+if VIBEGUARD_PROJECT_CONFIG="$bad_cfg" bash -c 'source scripts/lib/project_config.sh; vg_config_positive_int VIBEGUARD_GC_LOG_THRESHOLD_MB gc.log_threshold_mb 10' > "$invalid_helper_out_file" 2>&1; then
+  red "invalid project config fails instead of defaulting"
+  FAIL=$((FAIL + 1))
+else
+  green "invalid project config fails instead of defaulting"
+  PASS=$((PASS + 1))
+fi
+invalid_helper_out="$(<"$invalid_helper_out_file")"
+assert_contains "$invalid_helper_out" "VibeGuard project config invalid" "invalid helper read reports project config failure"
+assert_contains "$invalid_helper_out" ".gc.log_threshold_mb: expected integer >= 1" "invalid helper read reports bad gc threshold"
+assert_contains "$invalid_helper_out" ".gc.unexpected_gc_key: unknown property" "invalid helper read reports unknown gc key"
+assert_contains "$invalid_helper_out" ".unknown_top_level: unknown property" "invalid helper read reports unknown top-level key"
+
 header "gc-logs.sh reads project config"
 
 log_dir="${TMP_ROOT}/logs"
@@ -74,6 +99,18 @@ mkdir -p "$log_dir"
 printf '%s\n' '{"ts":"2026-05-01T00:00:00Z","detail":"current"}' > "${log_dir}/events.jsonl"
 gc_logs_out="$(VIBEGUARD_PROJECT_CONFIG="$cfg" VIBEGUARD_LOG_DIR="$log_dir" bash scripts/gc/gc-logs.sh --dry-run)"
 assert_contains "$gc_logs_out" "Threshold: 7MB" "gc-logs uses configured threshold"
+
+invalid_gc_logs_out_file="${TMP_ROOT}/invalid-gc-logs.out"
+TOTAL=$((TOTAL + 1))
+if VIBEGUARD_PROJECT_CONFIG="$bad_cfg" VIBEGUARD_LOG_DIR="$log_dir" bash scripts/gc/gc-logs.sh --dry-run > "$invalid_gc_logs_out_file" 2>&1; then
+  red "gc-logs fails on invalid project config"
+  FAIL=$((FAIL + 1))
+else
+  green "gc-logs fails on invalid project config"
+  PASS=$((PASS + 1))
+fi
+invalid_gc_logs_out="$(<"$invalid_gc_logs_out_file")"
+assert_contains "$invalid_gc_logs_out" "VibeGuard project config invalid" "gc-logs surfaces invalid project config"
 
 header "gc-worktrees.sh reads project config"
 
@@ -107,6 +144,8 @@ assert_contains "$linux_stat_out" "current: 0 days" "gc-worktrees ignores GNU st
 
 header "schema exposes gc contract"
 
+assert_cmd "project config validator syntax is correct" python3 -m py_compile "$REPO_DIR/scripts/lib/project_config_validate.py"
+assert_cmd "project config validator accepts valid config" python3 "$REPO_DIR/scripts/lib/project_config_validate.py" --quiet "$cfg" "$REPO_DIR/schemas/vibeguard-project.schema.json"
 assert_cmd "project schema accepts gc config" python3 - "$REPO_DIR/schemas/vibeguard-project.schema.json" "$cfg" <<'PY'
 import json
 import sys

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -9,6 +9,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SETTINGS_HELPER="${REPO_DIR}/scripts/lib/settings_json.py"
 CODEX_HOOKS_HELPER="${REPO_DIR}/scripts/lib/codex_hooks_json.py"
 HOOKS_MANIFEST_HELPER="${REPO_DIR}/scripts/lib/hooks_manifest.py"
+PROJECT_CONFIG_HELPER="${REPO_DIR}/scripts/lib/project_config_validate.py"
 CHAT_CONTRACT_ANCHOR="Compact Chat Contract: progress updates, concise answers, plain formatting."
 CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
 
@@ -130,6 +131,7 @@ assert_cmd "scripts/setup/clean.sh syntax is correct" bash -n "${REPO_DIR}/scrip
 assert_cmd "scripts/install-systemd.sh syntax is correct" bash -n "${REPO_DIR}/scripts/install-systemd.sh"
 assert_cmd "scripts/lib/settings_json.py syntax is correct" python3 -m py_compile "${SETTINGS_HELPER}"
 assert_cmd "scripts/lib/hooks_manifest.py syntax is correct" python3 -m py_compile "${HOOKS_MANIFEST_HELPER}"
+assert_cmd "scripts/lib/project_config_validate.py syntax is correct" python3 -m py_compile "${PROJECT_CONFIG_HELPER}"
 assert_cmd "scripts/lib/claude_md.py syntax is correct" python3 -m py_compile "${REPO_DIR}/scripts/lib/claude_md.py"
 assert_cmd "scripts/lib/codex_hooks_json.py syntax is correct" python3 -m py_compile "${CODEX_HOOKS_HELPER}"
 assert_cmd "scripts/lib/codex_config_toml.py syntax is correct" python3 -m py_compile "${CODEX_CONFIG_HELPER}"
@@ -241,6 +243,23 @@ assert_cmd "Pre-existing non-VibeGuard Codex hook is present" grep -q 'node /exi
 header "setup --check"
 check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 assert_contains "${check_out}" "VibeGuard Installation Status" "--check route to status check"
+
+bad_project_config="${TMP_HOME}/bad-vibeguard.json"
+cat > "${bad_project_config}" <<'JSON'
+{
+  "profile": "strictest",
+  "gc": {
+    "log_threshold_mb": 0
+  }
+}
+JSON
+invalid_project_check_out="$(VIBEGUARD_PROJECT_CONFIG="${bad_project_config}" bash "${REPO_DIR}/setup.sh" --check 2>&1)"
+assert_contains "${invalid_project_check_out}" "[FAIL] Project config invalid" "--check reports invalid .vibeguard.json"
+assert_contains "${invalid_project_check_out}" ".profile: unsupported value" "--check reports invalid project profile"
+assert_contains "${invalid_project_check_out}" ".gc.log_threshold_mb: expected integer >= 1" "--check reports invalid project gc threshold"
+invalid_project_install_out="$(VIBEGUARD_PROJECT_CONFIG="${bad_project_config}" bash "${REPO_DIR}/setup.sh" --dry-run 2>&1 || true)"
+assert_contains "${invalid_project_install_out}" "ERROR: invalid project config" "setup install refuses invalid .vibeguard.json"
+assert_contains "${invalid_project_install_out}" ".profile: unsupported value" "setup install reports invalid project profile"
 
 header "setup install"
 dry_run_settings_sha_before="$(shasum -a 256 "${HOME}/.claude/settings.json" | cut -d' ' -f1)"


### PR DESCRIPTION
## Summary
- add a dependency-free `.vibeguard.json` validator backed by `schemas/vibeguard-project.schema.json`
- fail visibly when setup or GC runtime sees invalid project config instead of silently defaulting
- extend setup and GC tests to cover invalid profile, bad GC thresholds, unknown keys, and runtime failure paths

## Tests
- `bash -n scripts/setup/install.sh scripts/setup/check.sh scripts/lib/project_config.sh tests/test_setup.sh`
- `python3 -m py_compile scripts/lib/project_config_validate.py`
- `bash tests/test_gc_config.sh`
- `bash tests/test_setup.sh`
- `bash tests/test_gc_logs_concurrent.sh`
- `bash tests/test_gc_scheduled.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash setup.sh --check`
- CI parity batches: guard/hook/doc validation, hook/codex/manifest/eval/rust regressions, hook health/stats/quality/local-contract/unit tests, precision/perf/benchmark commands
