### PR TITLE
Cover json field helpers

### DIFF
--- a/vg-helper/src/json_field.rs
+++ b/vg-helper/src/json_field.rs
@@ -80,3 +80,66 @@ pub fn run_two_fields(args: &[String]) -> Result {
     println!("{f2}");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn get_nested_follows_dot_separated_object_path() {
+        let data = json!({
+            "tool_input": {
+                "command": "cargo test",
+                "meta": {"attempt": 2}
+            }
+        });
+
+        assert_eq!(
+            get_nested(&data, "tool_input.command").and_then(Value::as_str),
+            Some("cargo test")
+        );
+        assert_eq!(
+            get_nested(&data, "tool_input.meta.attempt"),
+            Some(&json!(2))
+        );
+    }
+
+    #[test]
+    fn get_nested_returns_none_for_missing_or_non_object_path() {
+        let data = json!({"tool_input": {"command": "cargo test"}});
+
+        assert!(get_nested(&data, "tool_input.file_path").is_none());
+        assert!(get_nested(&data, "tool_input.command.value").is_none());
+    }
+
+    #[test]
+    fn value_to_string_preserves_contract_matrix_values() {
+        assert_eq!(value_to_string(&json!("")), "");
+        assert_eq!(value_to_string(&Value::Null), "");
+        assert_eq!(value_to_string(&json!(true)), "true");
+        assert_eq!(value_to_string(&json!(["a", "b"])), "[\"a\",\"b\"]");
+        assert_eq!(value_to_string(&json!({"n": 1})), "{\"n\":1}");
+    }
+
+    #[test]
+    fn parse_field_args_accepts_tolerant_and_strict_forms() {
+        let tolerant = vec!["tool".to_string()];
+        let strict = vec!["--strict".to_string(), "tool_input.command".to_string()];
+
+        assert_eq!(parse_field_args(&tolerant).unwrap(), (false, "tool"));
+        assert_eq!(
+            parse_field_args(&strict).unwrap(),
+            (true, "tool_input.command")
+        );
+    }
+
+    #[test]
+    fn parse_field_args_rejects_missing_or_unknown_flags() {
+        let missing: Vec<String> = Vec::new();
+        let unknown = vec!["--lax".to_string(), "tool".to_string()];
+
+        assert!(parse_field_args(&missing).is_err());
+        assert!(parse_field_args(&unknown).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add module tests for `vg-helper/src/json_field.rs`
- cover nested dot-path lookup, missing/non-object paths, contract-matrix value rendering, and strict/tolerant arg parsing
- close another M7/U-22 module-test gap without changing production behavior

## Tests
- `cargo fmt --manifest-path vg-helper/Cargo.toml --check`
- `cargo test --manifest-path vg-helper/Cargo.toml json_field`
- `cargo test --manifest-path vg-helper/Cargo.toml`
- `bash scripts/ci/self-application/check-u22-coverage.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash setup.sh --check`
- `git diff --check`
