### PR TITLE
Enforce strict U-22 inventory

### DIFF
--- a/scripts/ci/self-application/check-u22-coverage.sh
+++ b/scripts/ci/self-application/check-u22-coverage.sh
@@ -19,6 +19,9 @@ if src_dir.exists():
     for path in sorted(src_dir.rglob("*.rs")):
         if path.name == "main.rs":
             continue
+        rel_parts = path.relative_to(src_dir).parts
+        if "tests" in rel_parts:
+            continue
         text = path.read_text(encoding="utf-8")
         loc = sum(1 for line in text.splitlines() if line.strip())
         has_module_tests = "#[cfg(test)]" in text

--- a/scripts/ci/self-application/run-all.sh
+++ b/scripts/ci/self-application/run-all.sh
@@ -17,7 +17,13 @@ echo "Running VibeGuard self-application checks..."
 for check in "${checks[@]}"; do
   echo
   echo "==> ${check}"
-  if bash "${SCRIPT_DIR}/${check}" "${REPO_DIR}"; then
+  if [[ "${check}" == "check-u22-coverage.sh" ]]; then
+    check_cmd=(env VIBEGUARD_U22_STRICT=1 bash "${SCRIPT_DIR}/${check}" "${REPO_DIR}")
+  else
+    check_cmd=(bash "${SCRIPT_DIR}/${check}" "${REPO_DIR}")
+  fi
+
+  if "${check_cmd[@]}"; then
     echo "OK: ${check}"
   else
     echo "FAIL: ${check}"

--- a/tests/test_self_application_ci.sh
+++ b/tests/test_self_application_ci.sh
@@ -48,6 +48,7 @@ trap cleanup EXIT
 header "self-application scripts"
 assert_cmd "all self-application scripts have valid syntax" bash -n "${SELF_DIR}"/*.sh
 assert_cmd "self-application run-all passes on this repository" bash "${SELF_DIR}/run-all.sh" "${REPO_DIR}"
+assert_cmd "strict U-22 coverage inventory passes on this repository" env VIBEGUARD_U22_STRICT=1 bash "${SELF_DIR}/check-u22-coverage.sh" "${REPO_DIR}"
 
 header "hook output rewriting sentinel"
 bad_root="${TMP_DIR}/bad-output-rewrite"

--- a/vg-helper/src/session_metrics/engine.rs
+++ b/vg-helper/src/session_metrics/engine.rs
@@ -179,3 +179,78 @@ pub(super) fn run_inner(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    fn make_args(dir: &str) -> Vec<String> {
+        vec!["sess-A".to_string(), dir.to_string()]
+    }
+
+    fn tmp_dir_for_test(suffix: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("vg-sm-engine-test-{}-{suffix}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn run_inner_writes_metrics_for_three_clean_events() {
+        let dir = tmp_dir_for_test("clean-events");
+        let metrics_path = dir.join("session-metrics.jsonl");
+        let input = concat!(
+            "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\",\"tool\":\"Read\"}\n",
+            "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\",\"tool\":\"Read\"}\n",
+            "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\",\"tool\":\"Read\"}\n",
+        );
+        let mut out = Vec::<u8>::new();
+
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            0,
+        )
+        .unwrap();
+
+        assert!(out.is_empty());
+        let metrics_text = std::fs::read_to_string(metrics_path).unwrap();
+        let metrics: Value = serde_json::from_str(metrics_text.lines().last().unwrap()).unwrap();
+        assert_eq!(
+            metrics[metric_field::SCHEMA_VERSION],
+            SESSION_METRICS_SCHEMA_VERSION
+        );
+        assert_eq!(metrics[metric_field::EVENT_COUNT], 3);
+        assert_eq!(metrics[metric_field::WARN_RATIO], 0.0);
+    }
+
+    #[test]
+    fn run_inner_filters_invalid_json_and_other_sessions_before_threshold() {
+        let dir = tmp_dir_for_test("filters");
+        let metrics_path = dir.join("session-metrics.jsonl");
+        let input = concat!(
+            "not json\n",
+            "{\"hook\":\"pre-tool\",\"session\":\"sess-B\",\"decision\":\"warn\"}\n",
+            "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\"}\n",
+            "{\"hook\":\"pre-tool\",\"session\":\"sess-A\",\"decision\":\"pass\"}\n",
+        );
+        let mut out = Vec::<u8>::new();
+
+        run_inner(
+            &make_args(dir.to_str().unwrap()),
+            io::Cursor::new(input),
+            &mut out,
+            0,
+        )
+        .unwrap();
+
+        assert!(out.is_empty());
+        assert!(
+            !metrics_path.exists(),
+            "only two valid session events remain, so metrics should not be written"
+        );
+    }
+}

--- a/vg-helper/src/session_metrics/signals.rs
+++ b/vg-helper/src/session_metrics/signals.rs
@@ -177,3 +177,91 @@ pub(super) fn build_signals(
     }
     signals
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn decision_counts(entries: &[(&str, u64)]) -> HashMap<String, u64> {
+        entries
+            .iter()
+            .map(|(decision, count)| ((*decision).to_string(), *count))
+            .collect()
+    }
+
+    #[test]
+    fn extracts_max_paralysis_depth_from_reason_text() {
+        assert_eq!(extract_paralysis_depth("analysis paralysis 2x 7x"), Some(7));
+        assert_eq!(extract_paralysis_depth("analysis paralysis"), None);
+    }
+
+    #[test]
+    fn build_signals_reports_high_friction() {
+        let events = vec![
+            json!({"decision": "warn"}),
+            json!({"decision": "warn"}),
+            json!({"decision": "block"}),
+            json!({"decision": "pass"}),
+        ];
+        let decisions = decision_counts(&[(decision::WARN, 2), (decision::BLOCK, 1)]);
+        let edited_files = HashMap::new();
+
+        let signals = build_signals(&events, &decisions, &edited_files, 0.75, 3, "/no/such/dir");
+
+        assert!(
+            signals
+                .iter()
+                .any(|signal| signal.contains("High friction session: 3/4 events"))
+        );
+    }
+
+    #[test]
+    fn build_signals_caps_rule_repeats_to_deterministic_top_three() {
+        let mut events = Vec::new();
+        for tag in ["U-02", "U-02", "U-02", "U-02"] {
+            events.push(json!({"decision": "warn", "reason": format!("[{tag}] repeated")}));
+        }
+        for tag in [
+            "U-01", "U-01", "U-01", "U-03", "U-03", "U-03", "U-04", "U-04", "U-04",
+        ] {
+            events.push(json!({"decision": "warn", "reason": format!("[{tag}] repeated")}));
+        }
+
+        let signals = build_signals(
+            &events,
+            &HashMap::new(),
+            &HashMap::new(),
+            0.0,
+            0,
+            "/no/such/dir",
+        );
+        let joined = signals.join("\n");
+        let u02 = joined.find("Rule [U-02] triggered 4 times").unwrap();
+        let u01 = joined.find("Rule [U-01] triggered 3 times").unwrap();
+        let u03 = joined.find("Rule [U-03] triggered 3 times").unwrap();
+
+        assert!(u02 < u01 && u01 < u03);
+        assert!(!joined.contains("Rule [U-04]"));
+    }
+
+    #[test]
+    fn build_signals_reports_paralysis_max_depth() {
+        let events = vec![
+            json!({"reason": "analysis paralysis 3x"}),
+            json!({"reason": "analysis paralysis 11x"}),
+            json!({"reason": "ordinary event"}),
+        ];
+
+        let signals = build_signals(
+            &events,
+            &HashMap::new(),
+            &HashMap::new(),
+            0.0,
+            0,
+            "/no/such/dir",
+        );
+
+        assert!(signals.contains(&"Analysis paralysis: 2 triggers (max depth 11x)".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary
- skip Rust test fixture modules in the U-22 inventory so strict mode checks production modules only
- add direct session_metrics engine/signals module tests for the remaining >=100-line production modules
- add a self-application regression that runs `VIBEGUARD_U22_STRICT=1`

## Tests
- `cargo fmt --manifest-path vg-helper/Cargo.toml --check`
- `cargo test --manifest-path vg-helper/Cargo.toml session_metrics`
- `VIBEGUARD_U22_STRICT=1 bash scripts/ci/self-application/check-u22-coverage.sh`
- `bash tests/test_self_application_ci.sh`
- `cargo test --manifest-path vg-helper/Cargo.toml`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash tests/test_setup.sh`
- `bash setup.sh --check`
- `bash scripts/ci/check-event-schema-literals.sh && bash scripts/ci/validate-hooks-manifest.sh && bash scripts/ci/validate-hooks.sh && bash scripts/verify/check-test-file-sizes.sh`
- `python3 -m unittest scripts/test_constraint_recommender.py eval/test_run_eval.py && bash tests/test_eval_contract.sh && bash tests/test_gc_config.sh && bash tests/test_gc_logs_concurrent.sh && bash tests/test_manifest_contract.sh && bash scripts/ci/validate-manifest-contract.sh`
- `git diff --check`
