### PR TITLE
Strip heredocs linearly in Bash guard

### DIFF
--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -53,7 +53,7 @@ for line in sys.stdin.read().splitlines(keepends=True):
         continue
 
     out.append(line)
-    match = re.search(r"<<(?P<dash>-?)\s*([\"'"'"']?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)\2", line)
+    match = re.search(r"<<(?P<dash>-?)\s*([\"'"'"']?)(?P<tag>[A-Za-z0-9_]+)\2", line)
     if match:
         terminator = match.group("tag")
         strip_tabs = bool(match.group("dash"))

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -31,15 +31,35 @@ if [[ -z "$COMMAND" ]]; then
   exit 0
 fi
 
-# Remove heredoc content to avoid false positives caused by multi-line text
+# Remove heredoc bodies to avoid false positives caused by multi-line text.
 # Cover variants: <<EOF, <<'EOF', <<"EOF", <<-EOF, <<-'EOF', << 'EOF' etc.
-COMMAND_NO_HEREDOC=$(echo "$COMMAND" | python3 -c '
+# This is intentionally line-oriented rather than a DOTALL regex so adversarial
+# unterminated heredocs cannot force broad backtracking across the full command.
+COMMAND_NO_HEREDOC=$(printf '%s' "$COMMAND" | python3 -c '
 import re, sys
-cmd = sys.stdin.read()
-# Matches <<[-]? Optional spaces Optional quotes Terminator Optional quotes until end of line terminator
-cmd = re.sub(r"<<-?\s*[\"'"'"']?(\w+)[\"'"'"']?.*?\n\1", "", cmd, flags=re.DOTALL)
-print(cmd)
-' 2>/dev/null || echo "$COMMAND")
+
+terminator = None
+strip_tabs = False
+out = []
+
+for line in sys.stdin.read().splitlines(keepends=True):
+    if terminator is not None:
+        candidate = line.rstrip("\r\n")
+        if strip_tabs:
+            candidate = candidate.lstrip("\t")
+        if candidate == terminator:
+            terminator = None
+            strip_tabs = False
+        continue
+
+    out.append(line)
+    match = re.search(r"<<(?P<dash>-?)\s*([\"'"'"']?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)\2", line)
+    if match:
+        terminator = match.group("tag")
+        strip_tabs = bool(match.group("dash"))
+
+sys.stdout.write("".join(out))
+' 2>/dev/null || printf '%s' "$COMMAND")
 
 # Strip quotation marks (commit message, echo string, etc.) to avoid text content triggering false alarms
 # Keep the command structure and replace the quoted content with an empty string
@@ -84,9 +104,10 @@ block() {
 # git checkout . / git restore . (discard all changes)
 # Only matches pure "." endings, excluding legal path operations such as git checkout ./src/file
 # COMMAND_STRIPPED_WITH_DOT converts "." / '.' to a bare dot then strips other quoted content,
-# so a no-anchor regex safely detects all wrapper forms (env vars, pipes, `command`, `env`)
-# without false-positives from separators inside commit messages or string arguments.
-if echo "$COMMAND_STRIPPED_WITH_DOT" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||$)'; then
+# so a no-anchor regex safely detects all wrapper forms (env vars, pipes, `command`, `env`,
+# and shell redirections such as heredoc openers) without false-positives from separators
+# inside commit messages or string arguments.
+if echo "$COMMAND_STRIPPED_WITH_DOT" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||[<>]|$)'; then
   block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
 fi
 

--- a/tests/hooks/test_pre_bash_guard.sh
+++ b/tests/hooks/test_pre_bash_guard.sh
@@ -241,6 +241,13 @@ assert_not_contains "$result" '"decision": "block"' "tab-stripped heredoc body i
 
 result=$(python3 - <<'PY' | bash hooks/pre-bash-guard.sh
 import json
+print(json.dumps({"tool_input": {"command": "cat <<123\ngit checkout .\nrm -rf /\n123"}}))
+PY
+)
+assert_not_contains "$result" '"decision": "block"' "digit-start heredoc delimiter body is not misreported"
+
+result=$(python3 - <<'PY' | bash hooks/pre-bash-guard.sh
+import json
 print(json.dumps({"tool_input": {"command": "git checkout . <<'EOF'\nnot command text\nEOF"}}))
 PY
 )

--- a/tests/hooks/test_pre_bash_guard.sh
+++ b/tests/hooks/test_pre_bash_guard.sh
@@ -225,6 +225,27 @@ assert_not_contains "$result" '"decision": "block"' "commit message containing f
 result=$(echo '{"tool_input":{"command":"cat <<'\''EOF'\''\ngit push --force\nEOF"}}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "heredoc contains force push and no false positives"
 
+result=$(python3 - <<'PY' | bash hooks/pre-bash-guard.sh
+import json
+print(json.dumps({"tool_input": {"command": "cat <<'EOF'\ngit checkout .\nrm -rf /\nEOF"}}))
+PY
+)
+assert_not_contains "$result" '"decision": "block"' "heredoc body containing destructive commands is not misreported"
+
+result=$(python3 - <<'PY' | bash hooks/pre-bash-guard.sh
+import json
+print(json.dumps({"tool_input": {"command": "cat <<-EOF\n\tgit checkout .\n\tEOF"}}))
+PY
+)
+assert_not_contains "$result" '"decision": "block"' "tab-stripped heredoc body is not misreported"
+
+result=$(python3 - <<'PY' | bash hooks/pre-bash-guard.sh
+import json
+print(json.dumps({"tool_input": {"command": "git checkout . <<'EOF'\nnot command text\nEOF"}}))
+PY
+)
+assert_contains "$result" '"decision": "block"' "real destructive command before heredoc still blocks"
+
 # =========================================================
 
 hook_test_finish


### PR DESCRIPTION
## Summary
- replace the pre-bash heredoc body stripper's DOTALL regex with a line-oriented parser
- keep destructive-command detection active when `git checkout .` / `git restore .` are followed by shell redirections
- add heredoc regression cases for destructive text inside heredoc bodies, tab-stripped heredocs, and real destructive commands before heredocs

## Tests
- `bash -n hooks/pre-bash-guard.sh tests/hooks/test_pre_bash_guard.sh`
- `bash tests/hooks/test_pre_bash_guard.sh`
- `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/hooks/test_pre_bash_guard.sh`
- `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/validate-hooks.sh && bash scripts/ci/self-application/run-all.sh`
- `bash setup.sh --check && bash tests/test_setup.sh`
- `git diff --check`
