### PR TITLE
Remove runtime Python helper fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard
 bash ~/vibeguard/setup.sh
 ```
 
+Requires Python 3 and Rust/Cargo for the `vg-helper` runtime binary.
+
 Open a new Claude Code or Codex session. Run `bash ~/vibeguard/setup.sh --check` to verify.
 
 ## What you actually get

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -31,6 +31,8 @@ git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard
 bash ~/vibeguard/setup.sh
 ```
 
+安装需要 Python 3 和 Rust/Cargo，用于构建运行时 `vg-helper`。
+
 安装后重新打开 Claude Code 或 Codex 会话。用下面的命令检查安装状态：
 
 ```bash

--- a/docs/directory-map.md
+++ b/docs/directory-map.md
@@ -12,7 +12,7 @@ VibeGuard keeps runtime and installable source directories at the repository roo
 | `schemas/` | Install/runtime contracts and project schema definitions. |
 | `scripts/setup/`, `setup.sh` | Public setup entrypoint and target-specific install adapters. |
 | `scripts/lib/`, `scripts/codex/` | Shared install/runtime helpers and Codex adapters. |
-| `vg-helper/` | Optional Rust helper used to speed up hook-side parsing. |
+| `vg-helper/` | Required Rust helper for hook-side JSON, metrics, and package-rewrite logic. |
 
 ## Workflow Surface
 

--- a/hooks/learn-evaluator.sh
+++ b/hooks/learn-evaluator.sh
@@ -33,12 +33,8 @@ if [[ -n "$_VG_HELPER" ]]; then
   LEARN_SUGGESTION=$("$_VG_HELPER" session-metrics "$VIBEGUARD_SESSION_ID" "$VIBEGUARD_PROJECT_LOG_DIR" \
     < "$VIBEGUARD_LOG_FILE" 2>/dev/null || true)
 else
-  _SESSION_METRICS_SCRIPT="$(dirname "$0")/_lib/session_metrics.py"
-  vg_log "learn-evaluator" "Stop" "warn" "session metrics python fallback deprecated: vg-helper unavailable" "$_SESSION_METRICS_SCRIPT"
-  LEARN_SUGGESTION=$(VIBEGUARD_LOG_FILE="$VIBEGUARD_LOG_FILE" \
-    VIBEGUARD_SESSION_ID="$VIBEGUARD_SESSION_ID" \
-    VIBEGUARD_PROJECT_LOG_DIR="$VIBEGUARD_PROJECT_LOG_DIR" \
-    python3 "$_SESSION_METRICS_SCRIPT" 2>/dev/null || true)
+  vg_log "learn-evaluator" "Stop" "warn" "session metrics skipped: vg-helper unavailable" "run setup.sh to install vg-helper"
+  LEARN_SUGGESTION=""
 fi
 
 # If a correction signal is detected, output suggestions (not blocking)

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -50,7 +50,7 @@ vg_is_source_file() {
   return 1
 }
 
-# Resolve vg-helper binary path (Rust, ~4ms) with Python fallback (~55ms)
+# Resolve the canonical vg-helper binary path (Rust, ~4ms).
 _VG_HELPER=""
 for _candidate in \
   "${HOME}/.vibeguard/installed/bin/vg-helper" \

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -187,9 +187,8 @@ fi
 if [[ -n "$_VG_HELPER" ]]; then
   _PKG_CORRECTION=$(printf '%s' "$COMMAND" | "$_VG_HELPER" pkg-rewrite 2>/dev/null || echo "")
 else
-  _PKG_REWRITE_SCRIPT="$(dirname "$0")/_lib/pkg_rewrite.py"
-  vg_log "pre-bash-guard" "Bash" "warn" "pkg-rewrite python fallback deprecated: vg-helper unavailable" "$_PKG_REWRITE_SCRIPT"
-  _PKG_CORRECTION=$(printf '%s' "$COMMAND" | python3 "$_PKG_REWRITE_SCRIPT" 2>/dev/null || echo "")
+  vg_log "pre-bash-guard" "Bash" "warn" "pkg-rewrite skipped: vg-helper unavailable" "run setup.sh to install vg-helper"
+  _PKG_CORRECTION=""
 fi
 
 if [[ -n "$_PKG_CORRECTION" ]]; then

--- a/scripts/ci/self-application/check-u29-no-silent-degrade.sh
+++ b/scripts/ci/self-application/check-u29-no-silent-degrade.sh
@@ -77,6 +77,15 @@ if prebash.exists():
     if "invalid Bash hook input JSON; fail-closed" not in text:
         errors.append("hooks/pre-bash-guard.sh: missing fail-closed parse warning")
 
+runtime_python_fallbacks = {
+    "hooks/pre-bash-guard.sh": "_lib/pkg_rewrite.py",
+    "hooks/learn-evaluator.sh": "_lib/session_metrics.py",
+}
+for rel, fallback_ref in runtime_python_fallbacks.items():
+    path = repo / rel
+    if path.exists() and fallback_ref in path.read_text(encoding="utf-8"):
+        errors.append(f"{rel}: runtime Python fallback reference remains ({fallback_ref})")
+
 eval_runner = repo / "eval/run_eval.py"
 if eval_runner.exists():
     text = eval_runner.read_text(encoding="utf-8")
@@ -84,6 +93,13 @@ if eval_runner.exists():
         errors.append("eval/run_eval.py: API exceptions must produce skipped=True")
     if "EVAL_MAX_API_FAILURES" not in text:
         errors.append("eval/run_eval.py: missing API failure threshold knob")
+
+setup_install = repo / "scripts/setup/install.sh"
+if setup_install.exists():
+    text = setup_install.read_text(encoding="utf-8")
+    for phrase in ("falls back to Python", "falling back to Python", "using Python fallback"):
+        if phrase in text:
+            errors.append(f"scripts/setup/install.sh: helper build must not advertise {phrase!r}")
 
 if errors:
     print("FAIL: U-29 silent-degradation checks failed")

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -23,6 +23,11 @@ if [[ -f "${VIBEGUARD_HOME}/repo-path" ]] && [[ -f "${VIBEGUARD_HOME}/run-hook.s
 else
   yellow "[MISSING] Hook wrapper not installed (~/.vibeguard/run-hook.sh)"
 fi
+if [[ -x "${VIBEGUARD_HOME}/installed/bin/vg-helper" ]]; then
+  green "[OK] vg-helper runtime binary installed"
+else
+  red "[MISSING] vg-helper runtime binary (~/.vibeguard/installed/bin/vg-helper)"
+fi
 
 check_claude_home_installation
 

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -158,6 +158,36 @@ trap 'rm -rf "$_INSTALL_TMP"' EXIT
 cp -r "${REPO_DIR}/hooks" "${_INSTALL_TMP}/"
 cp -r "${REPO_DIR}/guards" "${_INSTALL_TMP}/"
 printf '%s' "$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')" > "${_INSTALL_TMP}/version"
+
+# Build vg-helper Rust binary before swapping the installed snapshot.
+# The Python predecessors are no longer runtime fallbacks; missing vg-helper is
+# an explicit degraded install only when VIBEGUARD_ALLOW_NO_HELPER=1 is set.
+if [[ -f "${REPO_DIR}/vg-helper/Cargo.toml" ]]; then
+  if command -v cargo &>/dev/null; then
+    echo "  Building vg-helper (Rust)..."
+    if cargo build --release --manifest-path "${REPO_DIR}/vg-helper/Cargo.toml" --quiet 2>/dev/null; then
+      mkdir -p "${_INSTALL_TMP}/bin"
+      cp "${REPO_DIR}/vg-helper/target/release/vg-helper" "${_INSTALL_TMP}/bin/vg-helper"
+      chmod +x "${_INSTALL_TMP}/bin/vg-helper"
+      green "  vg-helper binary prepared"
+    else
+      if [[ "${VIBEGUARD_ALLOW_NO_HELPER:-0}" == "1" ]]; then
+        yellow "  WARN: vg-helper build failed; installing explicit degraded mode (no package rewrite/session metrics)"
+      else
+        red "  ERROR: vg-helper build failed. Install Rust/Cargo or set VIBEGUARD_ALLOW_NO_HELPER=1 for explicit degraded mode."
+        exit 2
+      fi
+    fi
+  else
+    if [[ "${VIBEGUARD_ALLOW_NO_HELPER:-0}" == "1" ]]; then
+      yellow "  WARN: cargo not found; installing explicit degraded mode (no package rewrite/session metrics)"
+    else
+      red "  ERROR: cargo not found. Install Rust/Cargo or set VIBEGUARD_ALLOW_NO_HELPER=1 for explicit degraded mode."
+      exit 2
+    fi
+  fi
+fi
+
 # Swap: move old installed aside, rename new into place, restore on failure
 if [[ -d "${INSTALLED_DIR}" ]]; then
   mv "${INSTALLED_DIR}" "${INSTALLED_DIR}.old.$$"
@@ -170,26 +200,10 @@ else
     mv "${INSTALLED_DIR}.old.$$" "${INSTALLED_DIR}" 2>/dev/null || true
   fi
   red "  Failed to install snapshot (old version restored)"
+  exit 1
 fi
 trap - EXIT
 green "  ~/.vibeguard/installed/ hooks+guards snapshot ($(cat "${INSTALLED_DIR}/version"))"
-
-# Build vg-helper Rust binary (optional — falls back to Python if cargo unavailable)
-if [[ -f "${REPO_DIR}/vg-helper/Cargo.toml" ]]; then
-  if command -v cargo &>/dev/null; then
-    echo "  Building vg-helper (Rust)..."
-    if cargo build --release --manifest-path "${REPO_DIR}/vg-helper/Cargo.toml" --quiet 2>/dev/null; then
-      mkdir -p "${INSTALLED_DIR}/bin"
-      cp "${REPO_DIR}/vg-helper/target/release/vg-helper" "${INSTALLED_DIR}/bin/vg-helper"
-      chmod +x "${INSTALLED_DIR}/bin/vg-helper"
-      green "  vg-helper binary installed (~4ms vs ~55ms Python)"
-    else
-      yellow "  vg-helper build failed (falling back to Python — hooks still work)"
-    fi
-  else
-    yellow "  SKIP vg-helper (cargo not found — using Python fallback)"
-  fi
-fi
 
 # Initialize install state tracking
 state_init "$PROFILE" "$LANGUAGES"
@@ -289,6 +303,7 @@ echo "  VIBEGUARD_PROFILE=minimal|core|full|strict   Runtime profile"
 echo "  VIBEGUARD_ENFORCEMENT=block|warn|off          Enforcement level"
 echo "  VIBEGUARD_DISABLED_HOOKS=hook1,hook2           Disable specific hooks"
 echo "  VIBEGUARD_GC_*                                 GC thresholds; see schemas/vibeguard-project.schema.json"
+echo "  VIBEGUARD_ALLOW_NO_HELPER=1                    Explicit degraded install without vg-helper"
 echo
 echo "Git Pre-Commit Guard:"
 echo "Automatically installed to VibeGuard repository"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -6,6 +6,16 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
+if [[ -n "${VIBEGUARD_TEST_UPDATED_INPUT:-}" ]] \
+    && [[ -f "vg-helper/Cargo.toml" ]] \
+    && [[ ! -x "vg-helper/target/release/vg-helper" ]]; then
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "VIBEGUARD_TEST_UPDATED_INPUT requires cargo to build vg-helper" >&2
+    exit 2
+  fi
+  cargo build --release --manifest-path vg-helper/Cargo.toml --quiet
+fi
+
 shards=(
   "tests/hooks/test_log_injection.sh"
   "tests/hooks/test_pre_bash_guard.sh"

--- a/tests/test_self_application_ci.sh
+++ b/tests/test_self_application_ci.sh
@@ -89,6 +89,25 @@ def x():
 PY
 assert_fails "silent Exception pass fails U-29 check" bash "${SELF_DIR}/check-u29-no-silent-degrade.sh" "${bad_u29}"
 
+bad_runtime_fallback="${TMP_DIR}/bad-runtime-fallback"
+mkdir -p "${bad_runtime_fallback}/hooks" "${bad_runtime_fallback}/scripts/setup" "${bad_runtime_fallback}/eval"
+cat > "${bad_runtime_fallback}/hooks/pre-bash-guard.sh" <<'EOF'
+COMMAND=$(vg_json_field_strict "tool_input.command")
+vg_log "pre-bash-guard" "Bash" "block" "invalid Bash hook input JSON; fail-closed" ""
+python3 "$(dirname "$0")/_lib/pkg_rewrite.py"
+EOF
+cat > "${bad_runtime_fallback}/hooks/learn-evaluator.sh" <<'EOF'
+python3 "$(dirname "$0")/_lib/session_metrics.py"
+EOF
+cat > "${bad_runtime_fallback}/scripts/setup/install.sh" <<'EOF'
+echo "SKIP vg-helper (cargo not found — using Python fallback)"
+EOF
+cat > "${bad_runtime_fallback}/eval/run_eval.py" <<'PY'
+def x():
+    return {"skipped": True, "EVAL_MAX_API_FAILURES": 1}
+PY
+assert_fails "runtime Python fallback references fail U-29 check" bash "${SELF_DIR}/check-u29-no-silent-degrade.sh" "${bad_runtime_fallback}"
+
 header "SEC-14 sentinel"
 bad_sec14="${TMP_DIR}/bad-sec14"
 mkdir -p "${bad_sec14}/mcp-server/dist"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -94,6 +94,13 @@ cleanup() {
 trap cleanup EXIT
 
 export HOME="${TMP_HOME}"
+# Keep rustup/cargo usable after HOME is redirected into the test sandbox.
+if [[ -z "${CARGO_HOME:-}" && -d "${ORIG_HOME}/.cargo" ]]; then
+  export CARGO_HOME="${ORIG_HOME}/.cargo"
+fi
+if [[ -z "${RUSTUP_HOME:-}" && -d "${ORIG_HOME}/.rustup" ]]; then
+  export RUSTUP_HOME="${ORIG_HOME}/.rustup"
+fi
 mkdir -p "${TMP_HOME}/bin"
 cat > "${TMP_HOME}/bin/launchctl" <<'SH'
 #!/usr/bin/env bash
@@ -282,6 +289,7 @@ assert_contains "${confirm_fail_out}" "requires explicit confirmation" "non-inte
 
 install_out="$(bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
+assert_cmd "vg-helper binary installed after setup" test -x "${HOME}/.vibeguard/installed/bin/vg-helper"
 assert_cmd "~/.claude/skills/vibeguard exists after installation" test -L "${HOME}/.claude/skills/vibeguard"
 assert_cmd "~/.codex/skills/vibeguard exists after installation" test -L "${HOME}/.codex/skills/vibeguard"
 assert_cmd "~/.claude/skills/agentsmd-audit exists after installation" test -L "${HOME}/.claude/skills/agentsmd-audit"
@@ -393,6 +401,7 @@ before_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
 check_again_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 after_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
 assert_contains "${check_again_out}" "CLAUDE.md declares 999 rules" "--check reports CLAUDE.md drift"
+assert_contains "${check_again_out}" "[OK] vg-helper runtime binary installed" "--check reports vg-helper installed"
 assert_cmd "--check does not rewrite ~/.claude/CLAUDE.md" test "${before_sha}" = "${after_sha}"
 assert_cmd "--check does not drop or duplicate the chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 repair_out="$(bash "${REPO_DIR}/setup.sh" --yes)"

--- a/vg-helper/src/pkg_rewrite.rs
+++ b/vg-helper/src/pkg_rewrite.rs
@@ -1,5 +1,5 @@
 //! Package manager transparent correction: npm/yarn→pnpm, pip→uv.
-//! Canonical implementation. hooks/_lib/pkg_rewrite.py is a deprecated fallback.
+//! Canonical implementation. The legacy Python predecessor is not used at runtime.
 
 use regex::Regex;
 use std::io::{self, Read};

--- a/vg-helper/src/session_metrics/mod.rs
+++ b/vg-helper/src/session_metrics/mod.rs
@@ -1,5 +1,5 @@
 //! Session metrics collection + correction signal detection.
-//! Canonical implementation. hooks/_lib/session_metrics.py is a deprecated fallback.
+//! Canonical implementation. The legacy Python predecessor is not used at runtime.
 
 mod engine;
 mod signals;


### PR DESCRIPTION
## Summary
- stop executing Python fallback implementations for package rewrite and session metrics when vg-helper is unavailable
- require vg-helper during setup by default, with only an explicit VIBEGUARD_ALLOW_NO_HELPER=1 degraded install path
- add setup --check visibility and U-29 self-application coverage for runtime Python fallback drift

## Tests
- bash -n hooks/log.sh hooks/learn-evaluator.sh hooks/pre-bash-guard.sh scripts/setup/install.sh tests/test_hooks.sh tests/test_self_application_ci.sh scripts/ci/self-application/check-u29-no-silent-degrade.sh
- cargo test --manifest-path vg-helper/Cargo.toml
- VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/hooks/test_pre_bash_guard.sh
- bash tests/test_self_application_ci.sh
- bash tests/test_setup.sh
- VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh
- bash tests/unit/run_all.sh
- bash scripts/ci/self-application/run-all.sh
- bash scripts/ci/validate-hooks.sh && bash scripts/ci/validate-hooks-manifest.sh && bash scripts/ci/check-event-schema-literals.sh && git diff --check
- bash setup.sh --check