### PR TITLE
docs: refresh Python helper removal plan

### DIFF
--- a/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
+++ b/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
@@ -274,20 +274,21 @@ Use the closest subset when the full command is unrelated or too slow, and recor
 ### Step P1.3 Canonicalize Session Metrics
 
 - Status: `completed`
+- Current implementation note (2026-05-02): PR #146 removed runtime Python fallback use, and PR #147 deleted the legacy Python implementation.
 - Findings: H4
 - Target: one canonical implementation emits LEARN/session metrics.
 - Expected files:
   - `vg-helper/src/session_metrics.rs`
-  - `hooks/_lib/session_metrics.py`
+  - `hooks/_lib/session_metrics.py` (deleted by PR #147)
   - `hooks/learn-evaluator.sh`
   - `scripts/setup/install.sh`
   - `vg-helper/tests/cli.rs`
   - `tests/fixtures/session-metrics/**`
 - Detailed changes:
   - Decide and record canonical implementation: Rust is preferred.
-  - Add a deprecation warning to Python fallback for one release, or remove it if compatibility is not required.
+  - Remove the Python fallback after production callers use `vg-helper session-metrics`.
   - Align Signal 6 depth and repeat-rule top-N behavior before removing fallback.
-  - Make setup fail loudly if `vg-helper` cannot build and the affected hooks would drift.
+  - Make setup fail loudly if `vg-helper` cannot build, unless `VIBEGUARD_ALLOW_NO_HELPER=1` explicitly requests degraded mode.
 - Step tests:
   - `(cd vg-helper && cargo test session_metrics)`
   - `bash tests/test_hooks.sh test_session_metrics_canonical`
@@ -301,17 +302,18 @@ Use the closest subset when the full command is unrelated or too slow, and recor
 ### Step P1.4 Canonicalize Package Rewrite
 
 - Status: `completed`
+- Current implementation note (2026-05-02): PR #146 removed runtime Python fallback use, and PR #147 deleted the legacy Python implementation.
 - Findings: M6
 - Target: `pkg_rewrite` follows the same single-implementation policy as session metrics.
 - Expected files:
   - `vg-helper/src/pkg_rewrite.rs`
-  - `hooks/_lib/pkg_rewrite.py`
+  - `hooks/_lib/pkg_rewrite.py` (deleted by PR #147)
   - `hooks/pre-bash-guard.sh`
   - `vg-helper/tests/cli.rs`
 - Detailed changes:
   - Add Rust test coverage for every package-manager rewrite branch.
   - Migrate production callers to `vg-helper`.
-  - Deprecate/remove Python fallback under the same policy as P1.3.
+  - Remove Python fallback under the same policy as P1.3.
 - Step tests:
   - `(cd vg-helper && cargo test pkg_rewrite)`
   - `bash tests/test_hooks.sh test_pkg_rewrite_canonical`
@@ -810,45 +812,51 @@ Append entries here after each implemented step.
     - Modified files:
       - `vg-helper/src/session_metrics.rs`
       - `hooks/learn-evaluator.sh`
-      - `hooks/_lib/session_metrics.py`
+      - `hooks/_lib/session_metrics.py` (deleted in PR #147)
     - Main changes:
-      - Declared Rust `vg-helper session-metrics` as canonical and Python as deprecated fallback.
+      - Declared Rust `vg-helper session-metrics` as canonical.
+      - Removed runtime fallback use in PR #146 and deleted the Python helper in PR #147.
       - Aligned Signal 6 with Python by including max `Nx` analysis-paralysis depth.
       - Made repeated-rule signals deterministic and capped to top 3 by count then rule id.
-      - Runtime Python fallback now writes a visible warn event before use.
+      - Setup now builds `vg-helper` by default and only permits missing helper via explicit degraded mode.
     - Tests:
       - `(cd vg-helper && cargo test session_metrics)` -> pass, 25/25
       - `bash -n hooks/learn-evaluator.sh hooks/log.sh` -> pass
-      - `python3 -m py_compile hooks/_lib/session_metrics.py` -> pass
       - `bash tests/test_hooks.sh` -> pass, 145/145
       - `bash tests/test_gc_logs_concurrent.sh` -> pass, 13/13
       - `bash tests/test_setup.sh` -> pass, 100/100
       - `bash setup.sh --check` -> pass exit 0, existing drift warnings for missing skills/rule count/config checksum
       - `(cd vg-helper && cargo test)` -> pass, 36/36
       - `python3 -m unittest scripts/test_constraint_recommender.py eval/test_run_eval.py` -> pass, 6/6
+      - Follow-up PR #147: `(cd vg-helper && cargo test)` -> pass, 52 unit + 13 CLI tests
+      - Follow-up PR #147: `bash tests/unit/run_all.sh` -> pass, 20/20
+      - Follow-up PR #147: `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh` -> pass, all hook shards
     - Notes:
-      - Python fallback remains for compatibility, but it is no longer a silent downgrade.
+      - Python fallback no longer exists; historical path references are kept only in audit/spec docs and CI sentinel fixtures.
   - Step P1.4: `completed`
     - Modified files:
       - `vg-helper/src/pkg_rewrite.rs`
       - `hooks/pre-bash-guard.sh`
-      - `hooks/_lib/pkg_rewrite.py`
+      - `hooks/_lib/pkg_rewrite.py` (deleted in PR #147)
     - Main changes:
-      - Declared Rust `vg-helper pkg-rewrite` as canonical and Python as deprecated fallback.
+      - Declared Rust `vg-helper pkg-rewrite` as canonical.
+      - Removed runtime fallback use in PR #146 and deleted the Python helper in PR #147.
       - Added Rust branch tests for npm/yarn/pip/python -m pip rewrites, unsupported flags, and complex command pass-through.
-      - Runtime Python fallback now writes a visible warn event before use.
+      - Setup now builds `vg-helper` by default and only permits missing helper via explicit degraded mode.
     - Tests:
       - `(cd vg-helper && cargo test pkg_rewrite)` -> pass, 9/9
       - `bash -n hooks/pre-bash-guard.sh hooks/log.sh` -> pass
-      - `python3 -m py_compile hooks/_lib/pkg_rewrite.py` -> pass
       - `bash tests/test_hooks.sh` -> pass, 145/145
       - `bash tests/test_gc_logs_concurrent.sh` -> pass, 13/13
       - `bash tests/test_setup.sh` -> pass, 100/100
       - `bash setup.sh --check` -> pass exit 0, existing drift warnings for missing skills/rule count/config checksum
       - `(cd vg-helper && cargo test)` -> pass, 45/45
       - `python3 -m unittest scripts/test_constraint_recommender.py eval/test_run_eval.py` -> pass, 6/6
+      - Follow-up PR #147: `(cd vg-helper && cargo test)` -> pass, 52 unit + 13 CLI tests
+      - Follow-up PR #147: `bash tests/unit/run_all.sh` -> pass, 20/20
+      - Follow-up PR #147: `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/hooks/test_pre_bash_guard.sh` -> pass, 54/54
     - Notes:
-      - Python fallback remains for compatibility, but it is no longer a silent downgrade.
+      - Python fallback no longer exists; historical path references are kept only in audit/spec docs and CI sentinel fixtures.
   - Step P1.5: `completed`
     - Modified files:
       - `eval/run_eval.py`

--- a/plan/spec-codebase-audit-remediation.md
+++ b/plan/spec-codebase-audit-remediation.md
@@ -203,21 +203,22 @@ Rollback: revert both files; no schema change since `skipped` is an additive fie
 #### T4 · Collapse Python/Rust session_metrics into a single canonical implementation (H4)
 
 - **Goal**: only one implementation of session-metrics emits LEARN signals.
-- **Context**: `vg-helper/src/session_metrics.rs` (canonical, 755 LOC) vs `hooks/_lib/session_metrics.py` (212 LOC fallback) drift in Signal-6 depth and top-3 truncation.
+- **Context**: at audit time, `vg-helper/src/session_metrics.rs` (canonical, 755 LOC) and `hooks/_lib/session_metrics.py` (212 LOC fallback) drifted in Signal-6 depth and top-3 truncation.
 - **Constraints**:
   - **Decision**: delete the Python fallback. Setup must require cargo OR fail loudly with a one-line install hint (not a silent fallback).
-  - Migration grace: ship one release where Python emits a deprecation warning on every invocation; remove in the following release.
+  - Implementation note (2026-05-02): PR #146 removed runtime Python fallback use and PR #147 deleted the legacy Python implementation, with `VIBEGUARD_ALLOW_NO_HELPER=1` as the explicit degraded install escape hatch.
   - All hook entry points that import `hooks/_lib/session_metrics.py` switch to `vg-helper session-metrics` subcommand.
 - **Done-when**:
   - `rg "from session_metrics import|import session_metrics"` in `hooks/` and `scripts/` returns zero hits.
+  - `test ! -e hooks/_lib/session_metrics.py` exits 0.
   - `bash setup.sh --check` reports cargo as required, not optional.
   - Integration test in `vg-helper/tests/cli.rs` covers Signal 1-6 emission with a fixture from `tests/fixtures/session-metrics/`.
   - Verification: `cargo test --test cli session_metrics` exits 0; `bash tests/test_hooks.sh test_session_metrics_canonical` exits 0.
 
 Fix sketch:
-1. Add deprecation banner to `hooks/_lib/session_metrics.py` head: `print("DEPRECATED ...", file=sys.stderr)`.
-2. Search-replace `python3 -m hooks._lib.session_metrics` callers to `vg-helper session-metrics`.
-3. After one release window, delete the Python file in a follow-up commit.
+1. Search-replace runtime Python helper calls with `vg-helper session-metrics`.
+2. Make setup build/install `vg-helper` by default and fail loudly on cargo/build errors.
+3. Delete `hooks/_lib/session_metrics.py` once no runtime caller remains.
 
 Alternative (if cargo-required is unacceptable): keep both implementations and add a CI diff test feeding the same fixture to both. Less preferred — drift will recur.
 
@@ -226,10 +227,11 @@ Rollback: revert the deprecation banner and the search-replace; Python file rema
 #### T5 · pkg_rewrite same treatment as T4 (M6)
 
 - **Goal**: same as T4 for `pkg_rewrite`.
-- **Context**: `vg-helper/src/pkg_rewrite.rs:16` vs `hooks/_lib/pkg_rewrite.py` (99 LOC) — structural pattern identical to session_metrics.
+- **Context**: at audit time, `vg-helper/src/pkg_rewrite.rs:16` and `hooks/_lib/pkg_rewrite.py` (99 LOC) followed the same parallel-implementation pattern as session_metrics.
 - **Constraints**: identical to T4. Bundled with T4 in the same PR if scoped together; otherwise separate.
 - **Done-when**:
   - `rg "from pkg_rewrite import"` returns zero hits in non-test code.
+  - `test ! -e hooks/_lib/pkg_rewrite.py` exits 0.
   - `cargo test --test cli pkg_rewrite` covers each translation branch (~20 cases).
   - Verification: `bash tests/test_hooks.sh test_pkg_rewrite_canonical` exits 0.
 
@@ -428,7 +430,7 @@ Each item below is small enough to bundle. Severity is low; do as a single PR af
 ### Decision: delete Python fallback for vg-helper-replaced modules (T4, T5)
 
 - **Risk**: users without cargo or with cargo build failures lose all hook functionality.
-- **Mitigation**: setup.sh fails loudly with a one-line install hint (`Install cargo: curl https://sh.rustup.rs -sSf | sh`); offers `--no-rust` flag that disables the affected hooks rather than silently degrading.
+- **Mitigation**: setup.sh fails loudly with a one-line install hint (`Install cargo: curl https://sh.rustup.rs -sSf | sh`); `VIBEGUARD_ALLOW_NO_HELPER=1` enables an explicit degraded install that disables package rewrite/session-metrics instead of silently degrading to Python.
 - **Alternative considered**: keep both implementations with CI diff test. Rejected because parallel implementations have already drifted twice (session_metrics, pkg_rewrite); cost of guaranteeing equivalence forever exceeds cost of a clean uninstall path.
 - **Confidence**: medium. If cargo-required turns out to break a meaningful user segment (e.g. a Codex-only ChromeOS workflow), revert to keep-both with diff test.
 


### PR DESCRIPTION
## Summary
- update the audit remediation SPEC to match the merged Python helper removal path
- mark session_metrics/pkg_rewrite Python helpers as deleted after PR #146/#147
- replace stale fallback/grace-period wording with the explicit degraded install behavior

## Tests
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/check-u29-no-silent-degrade.sh
- bash scripts/ci/self-application/run-all.sh
- bash setup.sh --check
- git diff --check