### PR TITLE
ci: guard codex wrapper adapter extraction

### DIFF
--- a/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
+++ b/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
@@ -940,12 +940,16 @@ Append entries here after each implemented step.
       - `hooks/run-hook-codex.sh`
       - `hooks/_lib/codex_adapter.sh`
       - `scripts/ci/validate-hooks.sh`
+      - `scripts/ci/self-application/check-codex-wrapper-thin.sh`
+      - `scripts/ci/self-application/run-all.sh`
       - `tests/test_codex_runtime.sh`
+      - `tests/test_self_application_ci.sh`
     - Main changes:
       - Extracted Codex event parsing plus PreToolUse/PostToolUse output adaptation into `hooks/_lib/codex_adapter.sh`.
       - Reduced `run-hook-codex.sh` to hook resolution, execution, failure policy, and adapter dispatch.
       - Added direct PostToolUse block adaptation coverage.
       - Extended hook syntax CI to include `hooks/_lib/*.sh`.
+      - Added a self-application sentinel that fails if `run-hook-codex.sh` grows inline Python/heredoc adapter logic again.
     - Tests:
       - `bash -n hooks/run-hook-codex.sh hooks/_lib/codex_adapter.sh scripts/ci/validate-hooks.sh` -> pass
       - `bash scripts/ci/validate-hooks.sh` -> pass
@@ -957,6 +961,8 @@ Append entries here after each implemented step.
       - `bash setup.sh --check` -> pass exit 0, existing drift warnings for missing skills/rule count/config checksum
       - `(cd vg-helper && cargo test)` -> pass, 45/45
       - `bash tests/test_eval_contract.sh` -> pass, 3/3
+      - Follow-up sentinel: `bash tests/test_self_application_ci.sh` -> pass, 39/39
+      - Follow-up sentinel: `bash scripts/ci/self-application/run-all.sh` -> pass
     - Notes:
       - `run-hook-codex.sh` is now 100 lines; adapter logic lives in a dedicated 105-line shared library.
   - Step P2.4: `completed`

--- a/plan/spec-codebase-audit-remediation.md
+++ b/plan/spec-codebase-audit-remediation.md
@@ -497,7 +497,7 @@ Each command must exit 0 with output captured in this session (W-16: verificatio
 | H6 | T8 |
 | H7 | T7 |
 | H8 | T11 |
-| H9 | (deferred — depends on T9 manifest before refactoring `run-hook-codex.sh`) |
+| H9 | P2.3 execution-plan step (Codex adapter extracted; guarded by `check-codex-wrapper-thin.sh`) |
 | H10 | T9 |
 | M1 | (P3 — log redaction; bundled with T13 SEC-10 dog-food) |
 | M2 | (P3 — small fix; replace heredoc with `vg_json_output_kv`) |

--- a/scripts/ci/self-application/check-codex-wrapper-thin.sh
+++ b/scripts/ci/self-application/check-codex-wrapper-thin.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Ensure the Codex runtime wrapper stays thin and delegates JSON adaptation.
+set -euo pipefail
+
+REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+WRAPPER="${REPO_DIR}/hooks/run-hook-codex.sh"
+ADAPTER="${REPO_DIR}/hooks/_lib/codex_adapter.sh"
+
+errors=()
+
+add_error() {
+  errors+=("$1")
+}
+
+if [[ ! -f "${WRAPPER}" ]]; then
+  add_error "missing hooks/run-hook-codex.sh"
+fi
+
+if [[ ! -f "${ADAPTER}" ]]; then
+  add_error "missing hooks/_lib/codex_adapter.sh"
+fi
+
+if [[ -f "${WRAPPER}" ]]; then
+  wrapper_lines=$(wc -l <"${WRAPPER}" | tr -d ' ')
+  if [[ "${wrapper_lines}" -gt 140 ]]; then
+    add_error "hooks/run-hook-codex.sh is ${wrapper_lines} lines; keep wrapper <= 140 lines"
+  fi
+
+  if grep -nE "(^|[^A-Za-z0-9_])python3([^A-Za-z0-9_]|$)|(^|[^A-Za-z0-9_])python[[:space:]]+-|<<'?(PY|PYCODE)'?" "${WRAPPER}" >/dev/null; then
+    add_error "hooks/run-hook-codex.sh contains inline Python/heredoc adapter logic"
+  fi
+
+  if ! grep -q '_lib/codex_adapter.sh' "${WRAPPER}"; then
+    add_error "hooks/run-hook-codex.sh does not resolve hooks/_lib/codex_adapter.sh"
+  fi
+
+  if ! grep -q 'source "${ADAPTER_PATH}"' "${WRAPPER}"; then
+    add_error "hooks/run-hook-codex.sh does not source the Codex adapter"
+  fi
+
+  for fn in codex_event_name codex_pretool_deny codex_adapt_pretool codex_adapt_posttool; do
+    if ! grep -q "${fn}" "${WRAPPER}"; then
+      add_error "hooks/run-hook-codex.sh does not delegate through ${fn}"
+    fi
+  done
+fi
+
+if [[ -f "${ADAPTER}" ]]; then
+  for fn in codex_event_name codex_pretool_deny codex_adapt_pretool codex_adapt_posttool; do
+    if ! grep -q "^${fn}()" "${ADAPTER}"; then
+      add_error "hooks/_lib/codex_adapter.sh does not define ${fn}"
+    fi
+  done
+fi
+
+if [[ "${#errors[@]}" -gt 0 ]]; then
+  printf 'FAIL: Codex wrapper thinness check found %d issue(s):\n' "${#errors[@]}" >&2
+  for error in "${errors[@]}"; do
+    printf '  - %s\n' "${error}" >&2
+  done
+  exit 1
+fi
+
+echo "OK: Codex wrapper delegates adapter logic to hooks/_lib/codex_adapter.sh"

--- a/scripts/ci/self-application/run-all.sh
+++ b/scripts/ci/self-application/run-all.sh
@@ -9,6 +9,7 @@ checks=(
   "check-sec13-self-apply.sh"
   "check-sec14-mcp-descriptions.sh"
   "check-u29-no-silent-degrade.sh"
+  "check-codex-wrapper-thin.sh"
   "check-hook-output-rewriting.sh"
   "check-u22-coverage.sh"
 )

--- a/tests/test_self_application_ci.sh
+++ b/tests/test_self_application_ci.sh
@@ -50,6 +50,50 @@ assert_cmd "all self-application scripts have valid syntax" bash -n "${SELF_DIR}
 assert_cmd "self-application run-all passes on this repository" bash "${SELF_DIR}/run-all.sh" "${REPO_DIR}"
 assert_cmd "strict U-22 coverage inventory passes on this repository" env VIBEGUARD_U22_STRICT=1 bash "${SELF_DIR}/check-u22-coverage.sh" "${REPO_DIR}"
 
+header "Codex wrapper thinness sentinel"
+good_codex_wrapper="${TMP_DIR}/good-codex-wrapper"
+mkdir -p "${good_codex_wrapper}/hooks/_lib"
+cat > "${good_codex_wrapper}/hooks/run-hook-codex.sh" <<'EOF'
+#!/usr/bin/env bash
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_PATH="${WRAPPER_DIR}/_lib/codex_adapter.sh"
+source "${ADAPTER_PATH}"
+EVENT_NAME=$(codex_event_name "$INPUT")
+codex_pretool_deny "blocked"
+codex_adapt_pretool "$HOOK_OUTPUT"
+codex_adapt_posttool "$HOOK_OUTPUT"
+EOF
+cat > "${good_codex_wrapper}/hooks/_lib/codex_adapter.sh" <<'EOF'
+codex_event_name() { :; }
+codex_pretool_deny() { :; }
+codex_adapt_pretool() { :; }
+codex_adapt_posttool() { :; }
+EOF
+assert_cmd "thin Codex wrapper passes" bash "${SELF_DIR}/check-codex-wrapper-thin.sh" "${good_codex_wrapper}"
+
+bad_codex_wrapper="${TMP_DIR}/bad-codex-wrapper"
+mkdir -p "${bad_codex_wrapper}/hooks/_lib"
+cat > "${bad_codex_wrapper}/hooks/run-hook-codex.sh" <<'EOF'
+#!/usr/bin/env bash
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_PATH="${WRAPPER_DIR}/_lib/codex_adapter.sh"
+source "${ADAPTER_PATH}"
+EVENT_NAME=$(codex_event_name "$INPUT")
+codex_pretool_deny "blocked"
+codex_adapt_pretool "$HOOK_OUTPUT"
+codex_adapt_posttool "$HOOK_OUTPUT"
+python3 - <<'PY'
+print("inline adapter logic")
+PY
+EOF
+cat > "${bad_codex_wrapper}/hooks/_lib/codex_adapter.sh" <<'EOF'
+codex_event_name() { :; }
+codex_pretool_deny() { :; }
+codex_adapt_pretool() { :; }
+codex_adapt_posttool() { :; }
+EOF
+assert_fails "inline Python in run-hook-codex fails thinness check" bash "${SELF_DIR}/check-codex-wrapper-thin.sh" "${bad_codex_wrapper}"
+
 header "hook output rewriting sentinel"
 bad_root="${TMP_DIR}/bad-output-rewrite"
 mkdir -p "${bad_root}/hooks" "${bad_root}/scripts"


### PR DESCRIPTION
## Summary
- add a self-application sentinel that keeps `run-hook-codex.sh` as a thin wrapper
- fail CI if inline Python/heredoc adapter logic moves back into the wrapper
- add positive and negative regression fixtures and update the audit remediation plan mapping for H9

## Tests
- bash -n scripts/ci/self-application/check-codex-wrapper-thin.sh scripts/ci/self-application/run-all.sh tests/test_self_application_ci.sh
- bash scripts/ci/self-application/check-codex-wrapper-thin.sh
- bash tests/test_self_application_ci.sh
- bash tests/test_codex_runtime.sh
- bash scripts/ci/self-application/run-all.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-doc-paths.sh && bash scripts/ci/validate-doc-command-paths.sh
- bash setup.sh --check
- git diff --check