### PR TITLE
ci: guard package correction argv contract

### DIFF
--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -207,6 +207,8 @@ if [[ -n "$_PKG_CORRECTION" ]]; then
     exit 0
   fi
   vg_log "pre-bash-guard" "Bash" "correction" "package manager auto-rewrite" "${COMMAND:0:120} → $_PKG_CORRECTION"
+  # PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+  # Never interpolate _PKG_CORRECTION into inline Python source or shell eval.
   python3 -c "
 import json, sys
 corrected = sys.argv[1]

--- a/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
+++ b/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
@@ -1105,8 +1105,12 @@ Append entries here after each implemented step.
       - `scripts/gc/gc-logs.sh`
       - `scripts/gc/gc-worktrees.sh`
       - `scripts/gc/gc-scheduled.sh`
+      - `scripts/ci/self-application/check-pkg-correction-argv-only.sh`
+      - `scripts/ci/self-application/run-all.sh`
+      - `hooks/pre-bash-guard.sh`
       - `README.md`
       - `tests/test_gc_config.sh`
+      - `tests/test_self_application_ci.sh`
     - Main changes:
       - Replaced the session-metrics `/bin/date` subprocess path with shared Rust `SystemTime` utilities.
       - Added a 30-minute timestamp window for `paralysis-count` while preserving legacy events that do not carry timestamps.
@@ -1115,6 +1119,7 @@ Append entries here after each implemented step.
       - Added install-state version guards so unsupported future state files fail visibly instead of being misread.
       - Added GC retention/threshold schema keys and a shared shell config reader for `.vibeguard.json` / `VIBEGUARD_GC_*` overrides.
       - Documented `mcp-server/` as a legacy, unsupported runtime prototype instead of a silently orphaned install surface.
+      - Added a package-correction argv-only contract and self-application sentinel so `_PKG_CORRECTION` cannot be inlined into Python source.
     - Tests:
       - `cargo fmt --manifest-path vg-helper/Cargo.toml` -> pass
       - `(cd vg-helper && cargo test)` -> pass, 49/49
@@ -1124,6 +1129,8 @@ Append entries here after each implemented step.
       - `bash tests/test_setup.sh` -> pass, 114/114
       - `bash scripts/ci/validate-manifest-contract.sh` -> pass
       - `bash tests/test_manifest_contract.sh` -> pass, 30/30
+      - Follow-up sentinel: `bash scripts/ci/self-application/check-pkg-correction-argv-only.sh` -> pass
+      - Follow-up sentinel: `bash tests/test_self_application_ci.sh` -> pass
       - `bash scripts/ci/self-application/run-all.sh` -> pass
       - `bash tests/test_self_application_ci.sh` -> pass, 5/5
       - `bash tests/test_gc_config.sh` -> pass, 7/7

--- a/plan/spec-codebase-audit-remediation.md
+++ b/plan/spec-codebase-audit-remediation.md
@@ -412,7 +412,7 @@ Each item below is small enough to bundle. Severity is low; do as a single PR af
 
 | Sub-task | Fix | Verification |
 |----------|-----|--------------|
-| L1 | Add header comment to `pre-bash-guard.sh:185-189` documenting the argv-isolation contract; add a CI grep that `_PKG_CORRECTION` only appears in argv position. | `bash scripts/ci/check-pkg-correction-argv-only.sh` exits 0 |
+| L1 | Add header comment to `pre-bash-guard.sh:185-189` documenting the argv-isolation contract; add a CI grep that `_PKG_CORRECTION` only appears in argv position. | Implemented as `bash scripts/ci/self-application/check-pkg-correction-argv-only.sh` |
 | L2 | Carve-out comment in `rules/claude-rules/common/security.md` declaring the file allow-listed in SEC-14 self-test. | `bash scripts/ci/self-application/check-sec14-self.sh` exits 0 |
 | L3 | Wrap heredoc-stripping regex in `signal.alarm(2)` Python timeout. | `bash tests/test_hooks.sh test_pre_bash_redos` exits 0 |
 | L4 | Change `run-hook-codex.sh` deny path `exit 0` → `exit 1` (consistent with shell convention; document at script head). | manual code review |

--- a/scripts/ci/self-application/check-pkg-correction-argv-only.sh
+++ b/scripts/ci/self-application/check-pkg-correction-argv-only.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Ensure package-manager correction strings are passed as argv, never inlined.
+set -euo pipefail
+
+REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+HOOK="${REPO_DIR}/hooks/pre-bash-guard.sh"
+
+python3 - <<'PY' "${HOOK}"
+import re
+import shlex
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+errors: list[str] = []
+
+
+def shell_var_ref(name: str) -> re.Pattern[str]:
+    escaped = re.escape(name)
+    return re.compile(rf"\${escaped}(?![A-Za-z0-9_])|\$\{{{escaped}[^}}]*\}}")
+
+
+pkg_correction_ref = shell_var_ref("_PKG_CORRECTION")
+
+
+def shell_word_plain(raw: str) -> str:
+    try:
+        parts = shlex.split(raw, posix=True)
+    except ValueError:
+        return raw
+    return parts[0] if len(parts) == 1 else raw
+
+
+def iter_shell_words(text: str):
+    i = 0
+    n = len(text)
+    separators = set(";|&()<>")
+    while i < n:
+        if text[i].isspace():
+            i += 1
+            continue
+        if text[i] == "#":
+            newline = text.find("\n", i)
+            i = n if newline == -1 else newline + 1
+            continue
+        if text[i] in separators:
+            i += 1
+            continue
+
+        start = i
+        while i < n and not text[i].isspace() and text[i] not in separators:
+            if text[i] == "\\":
+                i += 2
+                continue
+            if text[i] == "'":
+                i += 1
+                while i < n and text[i] != "'":
+                    i += 1
+                if i < n:
+                    i += 1
+                continue
+            if text[i] == '"':
+                i += 1
+                while i < n:
+                    if text[i] == "\\" and i + 1 < n:
+                        i += 2
+                        continue
+                    if text[i] == '"':
+                        i += 1
+                        break
+                    i += 1
+                continue
+            i += 1
+        yield text[start:i], start, i
+
+
+def iter_python_c_sources(text: str):
+    """Yield (source_word, source_start, source_end) for python3 -c snippets."""
+    words = list(iter_shell_words(text))
+    for idx, (word, _start, _end) in enumerate(words):
+        if shell_word_plain(word) != "python3":
+            continue
+        if idx + 2 >= len(words) or shell_word_plain(words[idx + 1][0]) != "-c":
+            continue
+        yield words[idx + 2]
+
+
+def iter_python_stdin_sources(text: str):
+    """Yield (source, source_start_line) for python3 - heredoc snippets."""
+    lines = text.splitlines()
+    heredoc_re = re.compile(
+        r"\bpython3\s+-\s*<<(?P<tabs>-?)\s*(?P<quote>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)"
+    )
+    line_no = 0
+    while line_no < len(lines):
+        match = heredoc_re.search(lines[line_no])
+        if not match:
+            line_no += 1
+            continue
+
+        delimiter = match.group("tag")
+        allow_tab_strip = match.group("tabs") == "-"
+        body_start = line_no + 2
+        body_lines: list[str] = []
+        line_no += 1
+        while line_no < len(lines):
+            candidate = lines[line_no].lstrip("\t") if allow_tab_strip else lines[line_no]
+            if candidate == delimiter:
+                break
+            body_lines.append(lines[line_no])
+            line_no += 1
+        yield "\n".join(body_lines), body_start
+        line_no += 1
+
+
+def iter_shell_logical_lines(text: str):
+    buffer = ""
+    start_line = 1
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        if not buffer:
+            start_line = line_no
+        stripped = raw_line.rstrip()
+        if stripped.endswith("\\"):
+            buffer += stripped[:-1] + " "
+            continue
+        buffer += raw_line
+        yield start_line, buffer
+        buffer = ""
+    if buffer:
+        yield start_line, buffer
+
+if not path.exists():
+    errors.append("missing hooks/pre-bash-guard.sh")
+else:
+    text = path.read_text(encoding="utf-8")
+
+    if "PKG-CORRECTION-ARGV-CONTRACT" not in text:
+        errors.append("missing PKG-CORRECTION-ARGV-CONTRACT comment")
+
+    if "corrected = sys.argv[1]" not in text:
+        errors.append("package correction JSON emitter must read sys.argv[1]")
+
+    python_sources = list(iter_python_c_sources(text))
+    argv_ref_pattern = re.compile(
+        r'\s+"(?:\$_PKG_CORRECTION|\$\{_PKG_CORRECTION\})"'
+    )
+    if not any(
+        "sys.argv[1]" in src and argv_ref_pattern.match(text[quote_end:])
+        for src, _start, quote_end in python_sources
+    ):
+        errors.append("_PKG_CORRECTION is not passed as a python3 argv argument")
+
+    for src, start, _quote_end in python_sources:
+        if pkg_correction_ref.search(src):
+            line = text[:start].count("\n") + 1
+            errors.append(
+                f"line {line}: _PKG_CORRECTION is interpolated into inline Python source"
+            )
+
+    for src, line in iter_python_stdin_sources(text):
+        if pkg_correction_ref.search(src):
+            errors.append(
+                f"line {line}: _PKG_CORRECTION is interpolated into stdin Python source"
+            )
+
+    shell_eval_pattern = re.compile(r"\b(?:eval|bash\s+-c|sh\s+-c)\b")
+    assignment_pattern = re.compile(
+        r"(?<![A-Za-z0-9_$])"
+        r"(?:(?:local|readonly|export)\s+|declare(?:\s+-[A-Za-z]+)*\s+)?"
+        r"([A-Za-z_][A-Za-z0-9_]*)=([^;#]*)"
+    )
+    set_positional_pattern = re.compile(r"(?:^|[;&|])\s*set\s+--\s+([^;#]*)")
+    tainted_vars = {"_PKG_CORRECTION"}
+    for line_no, line in iter_shell_logical_lines(text):
+        if line.lstrip().startswith("#"):
+            continue
+        for match in assignment_pattern.finditer(line):
+            var_name, value = match.groups()
+            if any(shell_var_ref(tainted).search(value) for tainted in tainted_vars):
+                tainted_vars.add(var_name)
+        for match in set_positional_pattern.finditer(line):
+            value = match.group(1)
+            if any(shell_var_ref(tainted).search(value) for tainted in tainted_vars):
+                tainted_vars.update({"1", "@", "*"})
+        if shell_eval_pattern.search(line) and any(
+            shell_var_ref(tainted).search(line) for tainted in tainted_vars
+        ):
+            errors.append(f"line {line_no}: _PKG_CORRECTION flows through shell evaluation")
+
+if errors:
+    print("FAIL: package correction argv-only contract failed")
+    for error in errors:
+        print(error)
+    raise SystemExit(1)
+
+print("OK: package correction is passed through argv-only contract")
+PY

--- a/scripts/ci/self-application/run-all.sh
+++ b/scripts/ci/self-application/run-all.sh
@@ -9,6 +9,7 @@ checks=(
   "check-sec13-self-apply.sh"
   "check-sec14-mcp-descriptions.sh"
   "check-u29-no-silent-degrade.sh"
+  "check-pkg-correction-argv-only.sh"
   "check-codex-wrapper-thin.sh"
   "check-hook-output-rewriting.sh"
   "check-u22-coverage.sh"

--- a/tests/test_self_application_ci.sh
+++ b/tests/test_self_application_ci.sh
@@ -94,6 +94,271 @@ codex_adapt_posttool() { :; }
 EOF
 assert_fails "inline Python in run-hook-codex fails thinness check" bash "${SELF_DIR}/check-codex-wrapper-thin.sh" "${bad_codex_wrapper}"
 
+header "package correction argv sentinel"
+good_pkg_correction="${TMP_DIR}/good-pkg-correction"
+mkdir -p "${good_pkg_correction}/hooks"
+cat > "${good_pkg_correction}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+EOF
+assert_cmd "argv-only package correction passes" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${good_pkg_correction}"
+
+bad_pkg_correction="${TMP_DIR}/bad-pkg-correction"
+mkdir -p "${bad_pkg_correction}/hooks"
+cat > "${bad_pkg_correction}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': '$_PKG_CORRECTION'}}))
+"
+EOF
+assert_fails "inline package correction interpolation fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_correction}"
+
+bad_pkg_braced="${TMP_DIR}/bad-pkg-braced"
+mkdir -p "${bad_pkg_braced}/hooks"
+cat > "${bad_pkg_braced}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': '${_PKG_CORRECTION}'}}))
+" "$_PKG_CORRECTION"
+EOF
+assert_fails "braced package correction interpolation fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_braced}"
+
+bad_pkg_param_expansion="${TMP_DIR}/bad-pkg-param-expansion"
+mkdir -p "${bad_pkg_param_expansion}/hooks"
+cat > "${bad_pkg_param_expansion}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': '${_PKG_CORRECTION:-fallback}'}}))
+" "$_PKG_CORRECTION"
+EOF
+assert_fails "parameter-expanded package correction interpolation fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_param_expansion}"
+
+bad_pkg_escaped_quote="${TMP_DIR}/bad-pkg-escaped-quote"
+mkdir -p "${bad_pkg_escaped_quote}/hooks"
+cat > "${bad_pkg_escaped_quote}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(\"$_PKG_CORRECTION\")
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+EOF
+assert_fails "escaped-quote package correction interpolation fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_escaped_quote}"
+
+bad_pkg_single_quote_python="${TMP_DIR}/bad-pkg-single-quote-python"
+mkdir -p "${bad_pkg_single_quote_python}/hooks"
+cat > "${bad_pkg_single_quote_python}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c 'import json, sys
+corrected = sys.argv[1]
+print("'"$_PKG_CORRECTION"'")
+print(json.dumps({"decision": "allow", "updatedInput": {"command": corrected}}))
+' "$_PKG_CORRECTION"
+EOF
+assert_fails "single-quoted package correction interpolation fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_single_quote_python}"
+
+bad_pkg_stdin_python="${TMP_DIR}/bad-pkg-stdin-python"
+mkdir -p "${bad_pkg_stdin_python}/hooks"
+cat > "${bad_pkg_stdin_python}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+python3 - <<PY
+print("$_PKG_CORRECTION")
+PY
+EOF
+assert_fails "stdin-fed package correction interpolation fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_stdin_python}"
+
+bad_pkg_eval="${TMP_DIR}/bad-pkg-eval"
+mkdir -p "${bad_pkg_eval}/hooks"
+cat > "${bad_pkg_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+if [[ -n "$_PKG_CORRECTION" ]]; then
+  eval "$_PKG_CORRECTION"
+fi
+EOF
+assert_fails "indented shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_eval}"
+
+bad_pkg_same_line_eval="${TMP_DIR}/bad-pkg-same-line-eval"
+mkdir -p "${bad_pkg_same_line_eval}/hooks"
+cat > "${bad_pkg_same_line_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+if [[ -n "$_PKG_CORRECTION" ]]; then eval "$_PKG_CORRECTION"; fi
+EOF
+assert_fails "same-line shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_same_line_eval}"
+
+bad_pkg_braced_eval="${TMP_DIR}/bad-pkg-braced-eval"
+mkdir -p "${bad_pkg_braced_eval}/hooks"
+cat > "${bad_pkg_braced_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+if [[ -n "${_PKG_CORRECTION}" ]]; then
+  bash -c "${_PKG_CORRECTION}"
+fi
+EOF
+assert_fails "braced shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_braced_eval}"
+
+bad_pkg_multiline_eval="${TMP_DIR}/bad-pkg-multiline-eval"
+mkdir -p "${bad_pkg_multiline_eval}/hooks"
+cat > "${bad_pkg_multiline_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+eval \
+  "$_PKG_CORRECTION"
+EOF
+assert_fails "multiline shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_multiline_eval}"
+
+bad_pkg_indirect_eval="${TMP_DIR}/bad-pkg-indirect-eval"
+mkdir -p "${bad_pkg_indirect_eval}/hooks"
+cat > "${bad_pkg_indirect_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+cmd="$_PKG_CORRECTION"
+eval "$cmd"
+EOF
+assert_fails "indirect shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_indirect_eval}"
+
+bad_pkg_indented_indirect_eval="${TMP_DIR}/bad-pkg-indented-indirect-eval"
+mkdir -p "${bad_pkg_indented_indirect_eval}/hooks"
+cat > "${bad_pkg_indented_indirect_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+if [[ -n "$_PKG_CORRECTION" ]]; then
+  cmd="$_PKG_CORRECTION"
+  eval "$cmd"
+fi
+EOF
+assert_fails "indented indirect shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_indented_indirect_eval}"
+
+bad_pkg_then_assignment_eval="${TMP_DIR}/bad-pkg-then-assignment-eval"
+mkdir -p "${bad_pkg_then_assignment_eval}/hooks"
+cat > "${bad_pkg_then_assignment_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+if true; then cmd="$_PKG_CORRECTION"; fi
+eval "$cmd"
+EOF
+assert_fails "same-line control assignment shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_then_assignment_eval}"
+
+bad_pkg_export_eval="${TMP_DIR}/bad-pkg-export-eval"
+mkdir -p "${bad_pkg_export_eval}/hooks"
+cat > "${bad_pkg_export_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+export cmd="$_PKG_CORRECTION"
+eval "$cmd"
+EOF
+assert_fails "exported indirect shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_export_eval}"
+
+bad_pkg_positional_eval="${TMP_DIR}/bad-pkg-positional-eval"
+mkdir -p "${bad_pkg_positional_eval}/hooks"
+cat > "${bad_pkg_positional_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+set -- "$_PKG_CORRECTION"
+eval "$1"
+EOF
+assert_fails "positional shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_positional_eval}"
+
+bad_pkg_positional_all_eval="${TMP_DIR}/bad-pkg-positional-all-eval"
+mkdir -p "${bad_pkg_positional_all_eval}/hooks"
+cat > "${bad_pkg_positional_all_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+_PKG_CORRECTION="pnpm install"
+# PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
+python3 -c "
+import json, sys
+corrected = sys.argv[1]
+print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
+" "$_PKG_CORRECTION"
+set -- "$_PKG_CORRECTION"
+eval "$@"
+EOF
+assert_fails "positional all shell eval of package correction fails argv check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_pkg_positional_all_eval}"
+
 header "hook output rewriting sentinel"
 bad_root="${TMP_DIR}/bad-output-rewrite"
 mkdir -p "${bad_root}/hooks" "${bad_root}/scripts"


### PR DESCRIPTION
## Summary
- document the package-correction argv-only contract in `pre-bash-guard.sh`
- add a self-application sentinel that fails if `_PKG_CORRECTION` is interpolated into inline Python or shell eval
- add positive/negative regression fixtures and wire the check into self-application CI

## Tests
- bash -n hooks/pre-bash-guard.sh scripts/ci/self-application/check-pkg-correction-argv-only.sh scripts/ci/self-application/run-all.sh tests/test_self_application_ci.sh
- bash scripts/ci/self-application/check-pkg-correction-argv-only.sh
- bash tests/test_self_application_ci.sh
- VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/hooks/test_pre_bash_guard.sh
- bash scripts/ci/self-application/run-all.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-doc-paths.sh && bash scripts/ci/validate-doc-command-paths.sh
- bash setup.sh --check
- git diff --check