### PR TITLE
log: version runtime event schema

### DIFF
--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -82,7 +82,7 @@ vg_log() {
   esc_reason="${esc_reason//$'\f'/\\f}" esc_detail="${esc_detail//$'\f'/\\f}"
 
   local json
-  json="{\"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""
+  json="{\"schema_version\": 1, \"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""
   [[ -n "$duration_ms" ]] && json="${json}, \"duration_ms\": ${duration_ms}"
   [[ -n "${VIBEGUARD_CLI:-}" ]] && json="${json}, \"cli\": \"${VIBEGUARD_CLI}\""
   [[ -n "${VIBEGUARD_AGENT_TYPE:-}" ]] && json="${json}, \"agent\": \"${VIBEGUARD_AGENT_TYPE}\""

--- a/plan/spec-codebase-audit-remediation.md
+++ b/plan/spec-codebase-audit-remediation.md
@@ -472,7 +472,7 @@ Each command must exit 0 with output captured in this session (W-16: verificatio
 
 - Shipping `mcp-server/` as a supported runtime surface (M12). Current state documents it as a legacy, unsupported prototype.
 - Skills directory consolidation (CFG-2 partial) — covered by T9's manifest extension but lifecycle is separate.
-- `events.jsonl` schema migration (M4) — partial fix in T9 via `vg-helper/src/event_schema.rs` constants; full schema versioning is a follow-up SPEC.
+- Full historical `events.jsonl` migration tooling (M4). New runtime events now carry `schema_version: 1`; backfilling old logs remains out of scope.
 - Workflow-template W-18 axis-1/2 coverage for tool-using agents — eval/run_eval.py is single-shot text completion; if other eval harnesses (eval-harness skill?) emerge later, they need their own SPEC entry.
 - vg-helper coverage automation (T13's `check-u22-coverage.sh`) requires `cargo-llvm-cov` install in CI — handled in T13.
 
@@ -503,7 +503,7 @@ Each command must exit 0 with output captured in this session (W-16: verificatio
 | M1 | (P3 — log redaction; bundled with T13 SEC-10 dog-food) |
 | M2 | (P3 — small fix; replace heredoc with `vg_json_output_kv`) |
 | M3 | T13 (`check-hook-output-rewriting.sh`) |
-| M4 | T9 (event_schema.rs constants are part of manifest convergence) |
+| M4 | T9 + P3 follow-up (`event_schema.rs` constants and additive runtime `schema_version: 1`) |
 | M5 | (P3 — `--strict` flag on `vg-helper json-field`; bundled with T11 split) |
 | M6 | T5 |
 | M7 | T13 (`check-u22-coverage.sh`) + add tests as separate small PRs |

--- a/tests/hooks/test_log_timer.sh
+++ b/tests/hooks/test_log_timer.sh
@@ -20,6 +20,7 @@ _timer_result=$(
 )
 rm -rf "$_timer_log"
 assert_contains "$_timer_result" '"duration_ms":' "vg_start_timer: duration_ms field written to events.jsonl"
+assert_contains "$_timer_result" '"schema_version": 1' "vg_log: events.jsonl includes schema_version"
 
 # Extract duration_ms value and verify it's a positive integer >= 1
 _dur=$(echo "$_timer_result" | python3 -c "import sys,json; e=json.loads(sys.stdin.read()); print(e.get('duration_ms','missing'))" 2>/dev/null || echo "missing")


### PR DESCRIPTION
## Summary
- add `schema_version: 1` to new runtime events written by `vg_log`
- cover the additive event field in log timer tests
- update the audit remediation spec to distinguish new-event versioning from historical backfill

## Tests
- `bash tests/hooks/test_log_timer.sh`
- `bash tests/hooks/test_log_injection.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/verify/doc-freshness-check.sh`
- `bash tests/test_stats.sh`
- `bash tests/test_quality_grader.sh`
- `bash setup.sh --check`
- `bash scripts/ci/self-application/run-all.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `git diff --check`
- `bash -n hooks/_lib/log_write.sh tests/hooks/test_log_timer.sh`