### PR TITLE
setup: drive skill installs from manifest

### DIFF
--- a/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
+++ b/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
@@ -1138,10 +1138,50 @@ Append entries here after each implemented step.
     - Notes:
       - The legacy MCP subtree remains outside setup intentionally; the supported integration matrix is now explicit in README.
       - GC defaults are unchanged unless `.vibeguard.json` or environment overrides are provided.
+  - Step P3.5: `completed`
+    - Modified files:
+      - `schemas/install-modules.json`
+      - `scripts/lib/vibeguard_manifest.py`
+      - `scripts/setup/lib.sh`
+      - `scripts/setup/targets/claude-home.sh`
+      - `scripts/setup/targets/codex-home.sh`
+      - `tests/test_manifest_contract.sh`
+      - `tests/test_setup.sh`
+      - `plan/spec-codebase-audit-remediation.md`
+    - Main changes:
+      - Added a `skill-links` manifest helper so setup target scripts derive active skill symlinks from `schemas/install-modules.json`.
+      - Added `workflows/auto-optimize/` to the Claude skill target in the install manifest, matching existing install behavior.
+      - Replaced hardcoded Claude/Codex skill install, check, and clean lists with manifest-driven loops.
+      - Made manifest skill enumeration fail visibly before setup loops run, instead of treating helper failures as an empty skill list.
+      - Emitted manifest skill enumeration failures on stderr so command substitution callers cannot swallow diagnostics.
+      - Kept cleanup recoverable when manifest skill enumeration fails: clean now warns and continues removing agents, rules, settings hooks, Codex hooks, wrappers, and legacy MCP config.
+      - Made manifest validation report malformed skill link structures as contract errors instead of Python tracebacks.
+      - Made install/check skill enumeration fail when a target yields zero links, while leaving cleanup recoverable.
+      - Made install/check skill enumeration fail when a target yields whitespace-only output.
+      - Made cleanup warn and emit no links when a target yields whitespace-only output, instead of silently skipping skill cleanup.
+      - Made `skill-links` reject malformed manifest module shapes before emitting install data.
+      - Made `skill-links` reject empty, absolute, backslash, or `..` skill paths before setup can resolve them under the repository root.
+      - Updated contract tests so installed skill symlinks must match manifest output.
+    - Tests:
+      - `python3 -m py_compile scripts/lib/vibeguard_manifest.py` -> pass
+      - `python3 scripts/lib/vibeguard_manifest.py validate` -> pass
+      - `python3 scripts/lib/vibeguard_manifest.py skill-links --target '~/.claude/skills/'` -> pass
+      - `bash -n scripts/setup/lib.sh scripts/setup/targets/claude-home.sh scripts/setup/targets/codex-home.sh tests/test_setup.sh tests/test_manifest_contract.sh` -> pass
+      - `bash tests/test_manifest_contract.sh` -> pass, 43/43
+      - `bash scripts/ci/validate-manifest-contract.sh` -> pass
+      - `bash scripts/ci/validate-doc-paths.sh` -> pass
+      - `bash scripts/ci/validate-doc-command-paths.sh` -> pass
+      - `bash tests/test_setup.sh` -> pass, 146/146
+      - `bash scripts/ci/self-application/run-all.sh` -> pass
+      - `bash setup.sh --check` -> pass
+      - `python3 -m json.tool schemas/install-modules.json >/dev/null` -> pass
+      - `git diff --check` -> pass
+    - Notes:
+      - Active skill lifecycle is now load-bearing on `schemas/install-modules.json`; cleanup of historical retired symlinks remains out of scope.
   - Final regression matrix: `passed`
-    - `bash setup.sh --check` -> pass exit 0, known local install drift only: missing `agentsmd-audit` / `trajectory-review` skills, stale rule-count banner, unloaded scheduled GC plist, and `~/.codex/config.toml` checksum drift.
+    - `bash setup.sh --check` -> pass exit 0.
     - `bash tests/test_hooks.sh` -> pass, all hook shards.
-    - `bash tests/test_setup.sh` -> pass, 114/114.
+    - `bash tests/test_setup.sh` -> pass, 141/141.
     - `bash tests/test_codex_runtime.sh` -> pass, 40/40.
     - `bash tests/test_gc_logs_concurrent.sh` -> pass, 13/13.
     - `bash tests/test_gc_config.sh` -> pass, 7/7.
@@ -1154,6 +1194,6 @@ Append entries here after each implemented step.
     - `bash scripts/ci/validate-hooks.sh` -> pass.
     - `bash scripts/verify/check-test-file-sizes.sh` -> pass.
     - `bash tests/test_eval_contract.sh` -> pass, 3/3.
-    - `bash tests/test_manifest_contract.sh` -> pass, 30/30.
+    - `bash tests/test_manifest_contract.sh` -> pass, 35/35.
     - `bash scripts/ci/validate-manifest-contract.sh` -> pass.
 ```

--- a/plan/spec-codebase-audit-remediation.md
+++ b/plan/spec-codebase-audit-remediation.md
@@ -471,7 +471,7 @@ Each command must exit 0 with output captured in this session (W-16: verificatio
 ## Out of scope (explicitly deferred)
 
 - Shipping `mcp-server/` as a supported runtime surface (M12). Current state documents it as a legacy, unsupported prototype.
-- Skills directory consolidation (CFG-2 partial) — covered by T9's manifest extension but lifecycle is separate.
+- Historical cleanup of retired skill links (CFG-2 residual). Active Claude/Codex skill install, check, and clean paths now use `schemas/install-modules.json`; deleting old links that are no longer declared remains a separate lifecycle policy.
 - Full historical `events.jsonl` migration tooling (M4). New runtime events now carry `schema_version: 1`; backfilling old logs remains out of scope.
 - Workflow-template W-18 axis-1/2 coverage for tool-using agents — eval/run_eval.py is single-shot text completion; if other eval harnesses (eval-harness skill?) emerge later, they need their own SPEC entry.
 - vg-helper coverage automation (T13's `check-u22-coverage.sh`) requires `cargo-llvm-cov` install in CI — handled in T13.
@@ -508,7 +508,7 @@ Each command must exit 0 with output captured in this session (W-16: verificatio
 | M6 | T5 |
 | M7 | T13 (`check-u22-coverage.sh`) + add tests as separate small PRs |
 | M8 | (P3 — wire `validate_contract` into install or delete schema) |
-| M9 | T9 (manifest convergence covers skill modules too) |
+| M9 | T9 + P3 follow-up (hook manifest plus active skill links are now load-bearing) |
 | M10 | (P3 — dual-write log consolidation) |
 | M11 | T10 |
 | M12 | P3.4 legacy documentation; shipping support remains out of scope |

--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -141,9 +141,10 @@
     {
       "id": "skills-core",
       "kind": "skills",
-      "description": "Claude core skills (vibeguard, strategic-compact, eval-harness, iterative-retrieval, agentsmd-audit, trajectory-review)",
+      "description": "Claude core skills (vibeguard, auto-optimize, strategic-compact, eval-harness, iterative-retrieval, agentsmd-audit, trajectory-review)",
       "paths": [
         "skills/vibeguard/",
+        "workflows/auto-optimize/",
         "skills/strategic-compact/",
         "skills/eval-harness/",
         "skills/iterative-retrieval/",

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
 
@@ -113,6 +113,48 @@ def guard_names() -> list[str]:
     return sorted(names)
 
 
+def normalize_skill_source(path_str: str, module_id: str) -> str:
+    source = path_str.rstrip("/")
+    if not source:
+        raise ValueError(f"module {module_id}: skill path must name a skill directory: {path_str}")
+    if "\\" in source:
+        raise ValueError(f"module {module_id}: skill path must use forward slashes: {path_str}")
+    path = PurePosixPath(source)
+    if path.is_absolute():
+        raise ValueError(f"module {module_id}: skill path must be repo-relative: {path_str}")
+    if ".." in path.parts:
+        raise ValueError(f"module {module_id}: skill path must not contain '..': {path_str}")
+    normalized = path.as_posix()
+    if normalized in {"", "."} or not PurePosixPath(normalized).name:
+        raise ValueError(f"module {module_id}: skill path must name a skill directory: {path_str}")
+    return normalized
+
+
+def skill_links(manifest: dict[str, Any], target: str) -> list[tuple[str, str]]:
+    links: list[tuple[str, str]] = []
+    modules = manifest.get("modules", [])
+    if not isinstance(modules, list):
+        raise ValueError("manifest modules must be a list")
+    for module in modules:
+        if not isinstance(module, dict):
+            raise ValueError("manifest module entry is not an object")
+        if module.get("kind") != "skills" or module.get("target") != target:
+            continue
+        paths = module.get("paths", [])
+        if not isinstance(paths, list):
+            module_id = str(module.get("id", "<unknown>"))
+            raise ValueError(f"module {module_id}: paths must be a list")
+        for path_str in paths:
+            if not isinstance(path_str, str):
+                module_id = str(module.get("id", "<unknown>"))
+                raise ValueError(f"module {module_id}: non-string path entry")
+            module_id = str(module.get("id", "<unknown>"))
+            source = normalize_skill_source(path_str, module_id)
+            if source:
+                links.append((source, PurePosixPath(source).name))
+    return links
+
+
 def profile_names(manifest: dict[str, Any]) -> list[str]:
     profiles = manifest.get("profiles", {})
     if not isinstance(profiles, dict):
@@ -206,6 +248,31 @@ def _validate_project_schema(manifest: dict[str, Any], project_schema: dict[str,
     return errors
 
 
+def _validate_skill_links(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    seen: dict[tuple[str, str], str] = {}
+    for module in manifest.get("modules", []):
+        if not isinstance(module, dict) or module.get("kind") != "skills":
+            continue
+        target = str(module.get("target", ""))
+        module_id = str(module.get("id", "<unknown>"))
+        try:
+            links = skill_links({"modules": [module]}, target)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        for source, name in links:
+            key = (target, name)
+            previous = seen.get(key)
+            if previous is not None:
+                errors.append(
+                    f"duplicate skill target {target}/{name}: {previous} and {module_id}:{source}"
+                )
+            else:
+                seen[key] = f"{module_id}:{source}"
+    return errors
+
+
 def validate_contract(manifest_path: Path, project_schema_path: Path) -> list[str]:
     manifest = load_manifest(manifest_path)
     project_schema = load_json(project_schema_path)
@@ -217,6 +284,7 @@ def validate_contract(manifest_path: Path, project_schema_path: Path) -> list[st
     errors.extend(_validate_paths(manifest))
     errors.extend(_validate_profiles(manifest))
     errors.extend(_validate_project_schema(manifest, project_schema))
+    errors.extend(_validate_skill_links(manifest))
     return errors
 
 
@@ -242,6 +310,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("hook-names", help="List user-disableable hook names")
     sub.add_parser("guard-names", help="List known guard names")
+    skill = sub.add_parser("skill-links", help="List installable skill links for a target")
+    skill.add_argument("--target", required=True)
+    skill.add_argument("--manifest-file", default=str(MANIFEST_FILE))
     return parser
 
 
@@ -278,6 +349,12 @@ def main() -> int:
 
     if args.command == "guard-names":
         print_lines(guard_names())
+        return 0
+
+    if args.command == "skill-links":
+        manifest = load_manifest(Path(args.manifest_file))
+        for source, name in skill_links(manifest, args.target):
+            print(f"{source}\t{name}")
         return 0
 
     parser.error("unknown command")

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -48,6 +48,45 @@ settings_remove() {
   python3 "${SETTINGS_HELPER}" remove-vibeguard --settings-file "${settings_file}"
 }
 
+manifest_skill_links() {
+  local target="$1"
+  python3 "${MANIFEST_HELPER}" skill-links --target "${target}"
+}
+
+manifest_skill_links_checked() {
+  local target="$1"
+  local output
+  if ! output="$(manifest_skill_links "${target}" 2>&1)"; then
+    red "  ERROR: failed to enumerate manifest skills for ${target}" >&2
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && red "  ${line}" >&2
+    done <<< "${output}"
+    return 1
+  fi
+  if [[ -z "${output//[[:space:]]/}" ]]; then
+    red "  ERROR: no manifest skills declared for ${target}" >&2
+    return 1
+  fi
+  printf '%s\n' "${output}"
+}
+
+manifest_skill_links_for_cleanup() {
+  local target="$1"
+  local output
+  if ! output="$(manifest_skill_links "${target}" 2>&1)"; then
+    yellow "  WARN: failed to enumerate manifest skills for ${target}; skipping skill link cleanup" >&2
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && yellow "  ${line}" >&2
+    done <<< "${output}"
+    return 0
+  fi
+  if [[ -z "${output//[[:space:]]/}" ]]; then
+    yellow "  WARN: no manifest skills declared for ${target}; skipping skill link cleanup" >&2
+    return 0
+  fi
+  printf '%s\n' "${output}"
+}
+
 confirm_high_context_write() {
   local label="$1"
   local diff_output="$2"

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -51,21 +51,18 @@ _remove_rule_subtree_if_safe() {
 install_claude_home_assets() {
   echo "Step 2: Install Claude Code skills"
   mkdir -p "${CLAUDE_DIR}/skills"
-  safe_symlink "${REPO_DIR}/skills/vibeguard" "${CLAUDE_DIR}/skills/vibeguard"
-  state_record_file "${CLAUDE_DIR}/skills/vibeguard" "skills/vibeguard" "symlink"
-  green "  vibeguard -> ~/.claude/skills/vibeguard"
-  safe_symlink "${REPO_DIR}/workflows/auto-optimize" "${CLAUDE_DIR}/skills/auto-optimize"
-  state_record_file "${CLAUDE_DIR}/skills/auto-optimize" "workflows/auto-optimize" "symlink"
-  green "  auto-optimize -> ~/.claude/skills/auto-optimize"
-  for skill in strategic-compact eval-harness iterative-retrieval agentsmd-audit trajectory-review; do
-    if [[ -d "${REPO_DIR}/skills/${skill}" ]]; then
-      safe_symlink "${REPO_DIR}/skills/${skill}" "${CLAUDE_DIR}/skills/${skill}"
-      state_record_file "${CLAUDE_DIR}/skills/${skill}" "skills/${skill}" "symlink"
+  local skill_links source_path skill
+  skill_links="$(manifest_skill_links_checked "~/.claude/skills/")" || return 1
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    if [[ -d "${REPO_DIR}/${source_path}" ]]; then
+      safe_symlink "${REPO_DIR}/${source_path}" "${CLAUDE_DIR}/skills/${skill}"
+      state_record_file "${CLAUDE_DIR}/skills/${skill}" "${source_path}" "symlink"
       green "  ${skill} -> ~/.claude/skills/${skill}"
     else
-      yellow "  SKIP ${skill} (source not found)"
+      yellow "  SKIP ${skill} (source not found: ${source_path})"
     fi
-  done
+  done <<< "${skill_links}"
   echo
 
   echo "Step 3: Install agents"
@@ -275,8 +272,10 @@ check_claude_home_installation() {
     red "[MISSING] VibeGuard rules not in ~/.claude/CLAUDE.md"
   fi
 
-  local link
-  for skill in vibeguard auto-optimize strategic-compact eval-harness iterative-retrieval agentsmd-audit trajectory-review; do
+  local link skill_links source_path skill
+  skill_links="$(manifest_skill_links_checked "~/.claude/skills/")" || return 1
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
     link="${CLAUDE_DIR}/skills/${skill}"
     if [[ -L "${link}" ]]; then
       if [[ -e "${link}" ]]; then
@@ -287,7 +286,7 @@ check_claude_home_installation() {
     else
       red "[MISSING] ${skill} skill not in ~/.claude/skills/"
     fi
-  done
+  done <<< "${skill_links}"
 
   if [[ -L "${CLAUDE_DIR}/commands/vibeguard" ]]; then
     green "[OK] vibeguard commands symlinked to ~/.claude/commands/"
@@ -372,13 +371,12 @@ clean_claude_home_installation() {
   fi
 
   rm -f "${CLAUDE_DIR}/commands/vibeguard" 2>/dev/null || rm -rf "${CLAUDE_DIR}/commands/vibeguard" 2>/dev/null || true
-  rm -f "${CLAUDE_DIR}/skills/vibeguard"
-  rm -f "${CLAUDE_DIR}/skills/auto-optimize"
-  rm -f "${CLAUDE_DIR}/skills/strategic-compact"
-  rm -f "${CLAUDE_DIR}/skills/eval-harness"
-  rm -f "${CLAUDE_DIR}/skills/iterative-retrieval"
-  rm -f "${CLAUDE_DIR}/skills/agentsmd-audit"
-  rm -f "${CLAUDE_DIR}/skills/trajectory-review"
+  local skill_links source_path skill
+  skill_links="$(manifest_skill_links_for_cleanup "~/.claude/skills/")"
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    rm -f "${CLAUDE_DIR}/skills/${skill}"
+  done <<< "${skill_links}"
 
   local agent
   for agent in "${REPO_DIR}"/agents/*.md; do

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -3,24 +3,18 @@
 install_codex_home_assets() {
   echo "Step 6: Install Codex skills"
   mkdir -p "${CODEX_DIR}/skills"
-  for skill in plan-flow fixflow optflow plan-mode auto-optimize; do
-    if [[ -d "${REPO_DIR}/workflows/${skill}" ]]; then
-      safe_symlink "${REPO_DIR}/workflows/${skill}" "${CODEX_DIR}/skills/${skill}"
-      state_record_file "${CODEX_DIR}/skills/${skill}" "workflows/${skill}" "symlink"
+  local skill_links source_path skill
+  skill_links="$(manifest_skill_links_checked "~/.codex/skills/")" || return 1
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    if [[ -d "${REPO_DIR}/${source_path}" ]]; then
+      safe_symlink "${REPO_DIR}/${source_path}" "${CODEX_DIR}/skills/${skill}"
+      state_record_file "${CODEX_DIR}/skills/${skill}" "${source_path}" "symlink"
       green "  ${skill} -> ~/.codex/skills/${skill}"
     else
-      yellow "  SKIP ${skill} (source not found)"
+      yellow "  SKIP ${skill} (source not found: ${source_path})"
     fi
-  done
-  for skill in vibeguard agentsmd-audit trajectory-review; do
-    if [[ -d "${REPO_DIR}/skills/${skill}" ]]; then
-      safe_symlink "${REPO_DIR}/skills/${skill}" "${CODEX_DIR}/skills/${skill}"
-      state_record_file "${CODEX_DIR}/skills/${skill}" "skills/${skill}" "symlink"
-      green "  ${skill} -> ~/.codex/skills/${skill}"
-    else
-      yellow "  SKIP ${skill} (source not found)"
-    fi
-  done
+  done <<< "${skill_links}"
   echo
 
   echo "Step 6.5: Install Codex hooks"
@@ -98,8 +92,10 @@ configure_codex_home_runtime() {
 }
 
 check_codex_home_installation() {
-  local link
-  for skill in plan-flow fixflow optflow plan-mode vibeguard auto-optimize agentsmd-audit trajectory-review; do
+  local link skill_links source_path skill
+  skill_links="$(manifest_skill_links_checked "~/.codex/skills/")" || return 1
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
     link="${CODEX_DIR}/skills/${skill}"
     if [[ -L "${link}" ]]; then
       if [[ -e "${link}" ]]; then
@@ -110,7 +106,7 @@ check_codex_home_installation() {
     else
       yellow "[MISSING] ${skill} skill not in ~/.codex/skills/"
     fi
-  done
+  done <<< "${skill_links}"
 
   # Check hooks
   if [[ -f "${CODEX_DIR}/hooks.json" ]]; then
@@ -164,10 +160,12 @@ print(total)
 }
 
 clean_codex_home_installation() {
-  local skill
-  for skill in plan-flow fixflow optflow plan-mode vibeguard auto-optimize agentsmd-audit trajectory-review; do
+  local skill_links source_path skill
+  skill_links="$(manifest_skill_links_for_cleanup "~/.codex/skills/")"
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
     rm -f "${CODEX_DIR}/skills/${skill}"
-  done
+  done <<< "${skill_links}"
 
   # Remove only VibeGuard-managed entries from hooks.json (do not delete third-party hooks)
   local hooks_cleanup_result

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -30,6 +30,19 @@ assert_cmd() {
   fi
 }
 
+assert_cmd_fail() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    red "$desc (expected failure)"
+    FAIL=$((FAIL + 1))
+  else
+    green "$desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
 assert_contains() {
   local output="$1" expected="$2" desc="$3"
   TOTAL=$((TOTAL + 1))
@@ -39,6 +52,18 @@ assert_contains() {
   else
     red "$desc (expected to contain: $expected)"
     FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$unexpected"; then
+    red "$desc (unexpected content: $unexpected)"
+    FAIL=$((FAIL + 1))
+  else
+    green "$desc"
+    PASS=$((PASS + 1))
   fi
 }
 
@@ -62,6 +87,70 @@ assert_contains "${rules_out}" "W-17" "canonical common rule ids include W-17"
 assert_contains "${rules_out}" "U-32" "canonical common rule ids include U-32"
 reference_rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source reference)"
 assert_contains "${reference_rules_out}" "TASTE-ANSI" "reference rule ids include TASTE-prefixed rules"
+claude_skills_out="$(python3 "${MANIFEST_HELPER}" skill-links --target "~/.claude/skills/")"
+assert_contains "${claude_skills_out}" $'skills/vibeguard\tvibeguard' "manifest declares Claude vibeguard skill link"
+assert_contains "${claude_skills_out}" $'workflows/auto-optimize\tauto-optimize' "manifest declares Claude auto-optimize skill link"
+codex_skills_out="$(python3 "${MANIFEST_HELPER}" skill-links --target "~/.codex/skills/")"
+assert_contains "${codex_skills_out}" $'workflows/plan-flow\tplan-flow' "manifest declares Codex workflow skill links"
+assert_contains "${codex_skills_out}" $'skills/trajectory-review\ttrajectory-review' "manifest declares Codex core skill links"
+BAD_MANIFEST="${TMP_DIR}/bad-install-modules.json"
+printf '{"modules": {}}\n' > "${BAD_MANIFEST}"
+assert_cmd_fail "skill-links rejects malformed modules shape" python3 "${MANIFEST_HELPER}" skill-links --manifest-file "${BAD_MANIFEST}" --target "~/.claude/skills/"
+BAD_SKILL_PATHS_MANIFEST="${TMP_DIR}/bad-skill-paths-install-modules.json"
+cat > "${BAD_SKILL_PATHS_MANIFEST}" <<'JSON'
+{
+  "profiles": {},
+  "modules": [
+    {
+      "id": "bad-skill-module",
+      "kind": "skills",
+      "target": "~/.claude/skills/",
+      "paths": {}
+    }
+  ]
+}
+JSON
+bad_skill_paths_validate_out="$(python3 "${MANIFEST_HELPER}" validate --manifest-file "${BAD_SKILL_PATHS_MANIFEST}" 2>&1 || true)"
+assert_contains "${bad_skill_paths_validate_out}" "module bad-skill-module: paths must be a list" "manifest validation reports malformed skill paths"
+assert_not_contains "${bad_skill_paths_validate_out}" "Traceback" "manifest validation reports malformed skill paths without traceback"
+
+ESCAPING_SKILL_PATH_MANIFEST="${TMP_DIR}/escaping-skill-path-install-modules.json"
+cat > "${ESCAPING_SKILL_PATH_MANIFEST}" <<'JSON'
+{
+  "profiles": {},
+  "modules": [
+    {
+      "id": "escaping-skill-module",
+      "kind": "skills",
+      "target": "~/.claude/skills/",
+      "paths": ["../external/skill"]
+    }
+  ]
+}
+JSON
+assert_cmd_fail "skill-links rejects repo-escaping skill paths" python3 "${MANIFEST_HELPER}" skill-links --manifest-file "${ESCAPING_SKILL_PATH_MANIFEST}" --target "~/.claude/skills/"
+escaping_skill_validate_out="$(python3 "${MANIFEST_HELPER}" validate --manifest-file "${ESCAPING_SKILL_PATH_MANIFEST}" 2>&1 || true)"
+assert_contains "${escaping_skill_validate_out}" "module escaping-skill-module: skill path must not contain '..': ../external/skill" "manifest validation reports repo-escaping skill paths"
+assert_not_contains "${escaping_skill_validate_out}" "Traceback" "manifest validation reports repo-escaping skill paths without traceback"
+
+ABSOLUTE_SKILL_PATH_MANIFEST="${TMP_DIR}/absolute-skill-path-install-modules.json"
+cat > "${ABSOLUTE_SKILL_PATH_MANIFEST}" <<'JSON'
+{
+  "profiles": {},
+  "modules": [
+    {
+      "id": "absolute-skill-module",
+      "kind": "skills",
+      "target": "~/.claude/skills/",
+      "paths": ["/tmp/skill"]
+    }
+  ]
+}
+JSON
+assert_cmd_fail "skill-links rejects absolute skill paths" python3 "${MANIFEST_HELPER}" skill-links --manifest-file "${ABSOLUTE_SKILL_PATH_MANIFEST}" --target "~/.claude/skills/"
+absolute_skill_validate_out="$(python3 "${MANIFEST_HELPER}" validate --manifest-file "${ABSOLUTE_SKILL_PATH_MANIFEST}" 2>&1 || true)"
+assert_contains "${absolute_skill_validate_out}" "module absolute-skill-module: skill path must be repo-relative: /tmp/skill" "manifest validation reports absolute skill paths"
+assert_not_contains "${absolute_skill_validate_out}" "Traceback" "manifest validation reports absolute skill paths without traceback"
 
 header "routing contract"
 ROUTING_CONTRACT="${REPO_DIR}/workflows/references/routing-contract.md"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -9,6 +9,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SETTINGS_HELPER="${REPO_DIR}/scripts/lib/settings_json.py"
 CODEX_HOOKS_HELPER="${REPO_DIR}/scripts/lib/codex_hooks_json.py"
 HOOKS_MANIFEST_HELPER="${REPO_DIR}/scripts/lib/hooks_manifest.py"
+MANIFEST_HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
 PROJECT_CONFIG_HELPER="${REPO_DIR}/scripts/lib/project_config_validate.py"
 CHAT_CONTRACT_ANCHOR="Compact Chat Contract: progress updates, concise answers, plain formatting."
 CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
@@ -44,6 +45,23 @@ assert_cmd() {
     red "$desc (exit code: $?)"
     FAIL=$((FAIL + 1))
   fi
+}
+
+assert_manifest_skill_links_installed() {
+  local target="$1"
+  local dest_dir="$2"
+  local links
+  if ! links="$(python3 "${MANIFEST_HELPER}" skill-links --target "${target}")"; then
+    return 1
+  fi
+
+  local source_path skill found=0
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    found=1
+    [[ -L "${dest_dir}/${skill}" ]] || return 1
+  done <<< "${links}"
+  [[ "${found}" -eq 1 ]]
 }
 
 assert_chat_contract_blocks_match() {
@@ -145,6 +163,115 @@ assert_cmd "scripts/lib/codex_config_toml.py syntax is correct" python3 -m py_co
 assert_cmd "scripts/setup/regenerate-hooks-from-manifest.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/regenerate-hooks-from-manifest.sh"
 assert_cmd "scripts/ci/validate-hooks-manifest.sh syntax is correct" bash -n "${REPO_DIR}/scripts/ci/validate-hooks-manifest.sh"
 assert_cmd "CLAUDE.md template uses generated rule count placeholder" grep -q "__VIBEGUARD_RULE_COUNT__" "${REPO_DIR}/claude-md/vibeguard-rules.md"
+
+header "manifest skill enumeration failure"
+manifest_failure_stdout="${TMP_HOME}/manifest-failure.stdout"
+manifest_failure_stderr="${TMP_HOME}/manifest-failure.stderr"
+if bash -c "source '${REPO_DIR}/scripts/setup/lib.sh'; MANIFEST_HELPER=/bin/false; manifest_skill_links_checked '~/.claude/skills/'" >"${manifest_failure_stdout}" 2>"${manifest_failure_stderr}"; then
+  red "manifest skill enumeration fails on helper error (expected failure)"
+  FAIL=$((FAIL + 1))
+else
+  green "manifest skill enumeration fails on helper error"
+  PASS=$((PASS + 1))
+fi
+TOTAL=$((TOTAL + 1))
+manifest_failure_err="$(cat "${manifest_failure_stderr}")"
+assert_contains "${manifest_failure_err}" "failed to enumerate manifest skills" "manifest skill enumeration failure is visible on stderr"
+assert_cmd "manifest skill enumeration failure leaves stdout empty" test ! -s "${manifest_failure_stdout}"
+
+manifest_empty_helper="${TMP_HOME}/empty-manifest-helper.py"
+cat > "${manifest_empty_helper}" <<'PY'
+#!/usr/bin/env python3
+raise SystemExit(0)
+PY
+manifest_empty_stdout="${TMP_HOME}/manifest-empty.stdout"
+manifest_empty_stderr="${TMP_HOME}/manifest-empty.stderr"
+if bash -c "source '${REPO_DIR}/scripts/setup/lib.sh'; MANIFEST_HELPER='${manifest_empty_helper}'; manifest_skill_links_checked '~/.claude/skills/'" >"${manifest_empty_stdout}" 2>"${manifest_empty_stderr}"; then
+  red "manifest skill enumeration fails on empty target output (expected failure)"
+  FAIL=$((FAIL + 1))
+else
+  green "manifest skill enumeration fails on empty target output"
+  PASS=$((PASS + 1))
+fi
+TOTAL=$((TOTAL + 1))
+manifest_empty_err="$(cat "${manifest_empty_stderr}")"
+assert_contains "${manifest_empty_err}" "no manifest skills declared for ~/.claude/skills/" "manifest skill empty target failure is visible on stderr"
+assert_cmd "manifest skill empty target leaves stdout empty" test ! -s "${manifest_empty_stdout}"
+
+manifest_whitespace_helper="${TMP_HOME}/whitespace-manifest-helper.py"
+cat > "${manifest_whitespace_helper}" <<'PY'
+#!/usr/bin/env python3
+print("   ")
+raise SystemExit(0)
+PY
+manifest_whitespace_stdout="${TMP_HOME}/manifest-whitespace.stdout"
+manifest_whitespace_stderr="${TMP_HOME}/manifest-whitespace.stderr"
+if bash -c "source '${REPO_DIR}/scripts/setup/lib.sh'; MANIFEST_HELPER='${manifest_whitespace_helper}'; manifest_skill_links_checked '~/.claude/skills/'" >"${manifest_whitespace_stdout}" 2>"${manifest_whitespace_stderr}"; then
+  red "manifest skill enumeration fails on whitespace-only target output (expected failure)"
+  FAIL=$((FAIL + 1))
+else
+  green "manifest skill enumeration fails on whitespace-only target output"
+  PASS=$((PASS + 1))
+fi
+TOTAL=$((TOTAL + 1))
+manifest_whitespace_err="$(cat "${manifest_whitespace_stderr}")"
+assert_contains "${manifest_whitespace_err}" "no manifest skills declared for ~/.claude/skills/" "manifest skill whitespace-only target failure is visible on stderr"
+
+cleanup_whitespace_stdout="${TMP_HOME}/cleanup-whitespace.stdout"
+cleanup_whitespace_stderr="${TMP_HOME}/cleanup-whitespace.stderr"
+if bash -c "source '${REPO_DIR}/scripts/setup/lib.sh'; MANIFEST_HELPER='${manifest_whitespace_helper}'; manifest_skill_links_for_cleanup '~/.claude/skills/'" >"${cleanup_whitespace_stdout}" 2>"${cleanup_whitespace_stderr}"; then
+  green "cleanup skill enumeration warns on whitespace-only target output"
+  PASS=$((PASS + 1))
+else
+  red "cleanup skill enumeration warns on whitespace-only target output (exit code: $?)"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+cleanup_whitespace_err="$(cat "${cleanup_whitespace_stderr}")"
+assert_contains "${cleanup_whitespace_err}" "no manifest skills declared for ~/.claude/skills/" "cleanup whitespace-only target warning is visible on stderr"
+assert_cmd "cleanup whitespace-only target leaves stdout empty" test ! -s "${cleanup_whitespace_stdout}"
+
+header "clean continues when manifest skill enumeration fails"
+broken_clean_home="${TMP_HOME}/broken-clean-home"
+mkdir -p \
+  "${broken_clean_home}/.claude/commands" \
+  "${broken_clean_home}/.claude/agents" \
+  "${broken_clean_home}/.claude/context-profiles" \
+  "${broken_clean_home}/.claude/rules/vibeguard/common" \
+  "${broken_clean_home}/.codex" \
+  "${broken_clean_home}/.vibeguard"
+touch "${broken_clean_home}/.claude/commands/vibeguard"
+touch "${broken_clean_home}/.claude/agents/dispatcher.md"
+touch "${broken_clean_home}/.claude/context-profiles/dev.md"
+touch "${broken_clean_home}/.claude/rules/vibeguard/common/security.md"
+touch "${broken_clean_home}/.vibeguard/run-hook-codex.sh"
+python3 "${SETTINGS_HELPER}" upsert-vibeguard --settings-file "${broken_clean_home}/.claude/settings.json" --repo-dir "${REPO_DIR}" --profile full >/dev/null
+python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${broken_clean_home}/.codex/hooks.json" --wrapper "${broken_clean_home}/.vibeguard/run-hook-codex.sh" >/dev/null
+cat > "${broken_clean_home}/.codex/config.toml" <<'TOML'
+[mcp_servers.vibeguard]
+command = "node"
+args = ["/legacy/mcp-server/dist/index.js"]
+TOML
+broken_clean_out="$(
+  HOME="${broken_clean_home}" bash -c "
+    set -euo pipefail
+    source '${REPO_DIR}/scripts/setup/lib.sh'
+    source '${REPO_DIR}/scripts/lib/install-state.sh'
+    source '${REPO_DIR}/scripts/setup/targets/claude-home.sh'
+    source '${REPO_DIR}/scripts/setup/targets/codex-home.sh'
+    MANIFEST_HELPER=/bin/false
+    clean_claude_home_installation
+    clean_codex_home_installation
+  " 2>&1
+)"
+assert_contains "${broken_clean_out}" "skipping skill link cleanup" "clean warns when manifest skill enumeration fails"
+assert_cmd "clean continues after Claude manifest failure" test ! -e "${broken_clean_home}/.claude/commands/vibeguard"
+assert_cmd "clean removes Claude agents after manifest failure" test ! -e "${broken_clean_home}/.claude/agents/dispatcher.md"
+assert_cmd "clean removes Claude rules after manifest failure" test ! -e "${broken_clean_home}/.claude/rules/vibeguard"
+assert_cmd "clean removes Claude hooks after manifest failure" bash -c "! grep -q 'pre-bash-guard.sh' '${broken_clean_home}/.claude/settings.json'"
+assert_cmd "clean continues after Codex manifest failure" bash -c "! grep -q 'vibeguard-pre-bash-guard.sh' '${broken_clean_home}/.codex/hooks.json'"
+assert_cmd "clean removes Codex wrapper after manifest failure" test ! -e "${broken_clean_home}/.vibeguard/run-hook-codex.sh"
+assert_cmd "clean removes legacy Codex MCP after manifest failure" bash -c "! grep -q '^\[mcp_servers\.vibeguard\]' '${broken_clean_home}/.codex/config.toml'"
 
 header "hooks manifest"
 assert_cmd "hooks manifest validates" bash "${REPO_DIR}/scripts/ci/validate-hooks-manifest.sh"
@@ -296,6 +423,8 @@ assert_cmd "~/.claude/skills/agentsmd-audit exists after installation" test -L "
 assert_cmd "~/.claude/skills/trajectory-review exists after installation" test -L "${HOME}/.claude/skills/trajectory-review"
 assert_cmd "~/.codex/skills/agentsmd-audit exists after installation" test -L "${HOME}/.codex/skills/agentsmd-audit"
 assert_cmd "~/.codex/skills/trajectory-review exists after installation" test -L "${HOME}/.codex/skills/trajectory-review"
+assert_cmd "all manifest Claude skill links are installed" assert_manifest_skill_links_installed "~/.claude/skills/" "${HOME}/.claude/skills"
+assert_cmd "all manifest Codex skill links are installed" assert_manifest_skill_links_installed "~/.codex/skills/" "${HOME}/.codex/skills"
 assert_cmd "Clean legacy Claude MCP block after installation" bash -c "! grep -q 'mcp-server/dist/index.js' '${HOME}/.claude/settings.json'"
 assert_cmd "No longer write to mcpServers after installation" bash -c "! grep -q 'mcpServers' '${HOME}/.claude/settings.json'"
 assert_cmd "settings helper detects pre hooks configured" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target pre-hooks


### PR DESCRIPTION
## Summary
- add a `skill-links` manifest helper and duplicate skill-target validation
- make Claude/Codex skill install, check, and clean flows read active skill links from `schemas/install-modules.json`
- declare Claude `auto-optimize` in the manifest and sync the audit remediation plan status

## Tests
- `python3 -m py_compile scripts/lib/vibeguard_manifest.py`
- `python3 scripts/lib/vibeguard_manifest.py validate`
- `python3 scripts/lib/vibeguard_manifest.py skill-links --target '~/.claude/skills/'`
- `bash -n scripts/setup/lib.sh scripts/setup/targets/claude-home.sh scripts/setup/targets/codex-home.sh tests/test_setup.sh tests/test_manifest_contract.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-manifest-contract.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash tests/test_setup.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash setup.sh --check`
- `python3 -m json.tool schemas/install-modules.json >/dev/null`
- `git diff --check`