### PR TITLE
setup: clean retired skill symlinks

### DIFF
--- a/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
+++ b/plan/2026-05-01_18-56-41-vibeguard-audit-remediation.md
@@ -1177,7 +1177,28 @@ Append entries here after each implemented step.
       - `python3 -m json.tool schemas/install-modules.json >/dev/null` -> pass
       - `git diff --check` -> pass
     - Notes:
-      - Active skill lifecycle is now load-bearing on `schemas/install-modules.json`; cleanup of historical retired symlinks remains out of scope.
+      - Active skill lifecycle is now load-bearing on `schemas/install-modules.json`; historical retired symlink cleanup is handled by follow-up Step P3.6.
+  - Step P3.6: `completed`
+    - Modified files:
+      - `scripts/lib/install-state.sh`
+      - `scripts/setup/lib.sh`
+      - `scripts/setup/install.sh`
+      - `scripts/setup/targets/claude-home.sh`
+      - `scripts/setup/targets/codex-home.sh`
+      - `tests/test_setup.sh`
+      - `plan/spec-codebase-audit-remediation.md`
+    - Main changes:
+      - Added install-state controlled retired skill symlink discovery under Claude and Codex skill directories.
+      - During install, removed only previously tracked VibeGuard skill symlinks whose names are no longer declared by `schemas/install-modules.json`.
+      - During clean, removed both current manifest skills and previously tracked retired skill symlinks before deleting install-state.
+      - Preserved untracked user skill symlinks and non-symlink paths.
+    - Tests:
+      - `bash -n scripts/lib/install-state.sh scripts/setup/lib.sh scripts/setup/install.sh scripts/setup/targets/claude-home.sh scripts/setup/targets/codex-home.sh tests/test_setup.sh` -> pass
+      - `bash tests/test_setup.sh` -> pass, 155/155
+      - `bash setup.sh --check` -> pass
+      - `git diff --check` -> pass
+    - Notes:
+      - Regular directories that replace retired skill symlinks remain user-owned and are not removed automatically.
   - Final regression matrix: `passed`
     - `bash setup.sh --check` -> pass exit 0.
     - `bash tests/test_hooks.sh` -> pass, all hook shards.

--- a/plan/spec-codebase-audit-remediation.md
+++ b/plan/spec-codebase-audit-remediation.md
@@ -471,7 +471,7 @@ Each command must exit 0 with output captured in this session (W-16: verificatio
 ## Out of scope (explicitly deferred)
 
 - Shipping `mcp-server/` as a supported runtime surface (M12). Current state documents it as a legacy, unsupported prototype.
-- Historical cleanup of retired skill links (CFG-2 residual). Active Claude/Codex skill install, check, and clean paths now use `schemas/install-modules.json`; deleting old links that are no longer declared remains a separate lifecycle policy.
+- Full historical cleanup of non-symlink retired skill directories (CFG-2 residual). Active Claude/Codex skill install, check, clean, and tracked retired symlink cleanup now use `schemas/install-modules.json` plus install-state; user-owned regular directories remain untouched.
 - Full historical `events.jsonl` migration tooling (M4). New runtime events now carry `schema_version: 1`; backfilling old logs remains out of scope.
 - Workflow-template W-18 axis-1/2 coverage for tool-using agents — eval/run_eval.py is single-shot text completion; if other eval harnesses (eval-harness skill?) emerge later, they need their own SPEC entry.
 - vg-helper coverage automation (T13's `check-u22-coverage.sh`) requires `cargo-llvm-cov` install in CI — handled in T13.

--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -183,6 +183,42 @@ for dest, info in sorted(state.get('files', {}).items()):
 "
 }
 
+state_list_tracked_symlinks_under() {
+  local dest_dir="$1"
+  [[ -f "$STATE_FILE" ]] || return 0
+
+  python3 - "$STATE_FILE" "$dest_dir" "$STATE_VERSION" <<'PY'
+import json
+import os
+import sys
+
+state_file, dest_dir, expected_version = sys.argv[1], sys.argv[2], int(sys.argv[3])
+dest_dir = os.path.abspath(os.path.expanduser(dest_dir))
+
+try:
+    with open(state_file, encoding="utf-8") as f:
+        state = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    raise SystemExit(0)
+
+version = state.get("version", expected_version)
+if version != expected_version:
+    print(
+        f"WARN: unsupported install-state version: {version} (expected {expected_version}); "
+        "skipping tracked symlink cleanup",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
+
+for dest, info in sorted(state.get("files", {}).items()):
+    if info.get("type") != "symlink":
+        continue
+    expanded = os.path.abspath(os.path.expanduser(dest))
+    if expanded == dest_dir or expanded.startswith(dest_dir + os.sep):
+        print(expanded)
+PY
+}
+
 # Remove state file (used by clean.sh)
 state_clean() {
   rm -f "$STATE_FILE"

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -205,6 +205,13 @@ fi
 trap - EXIT
 green "  ~/.vibeguard/installed/ hooks+guards snapshot ($(cat "${INSTALLED_DIR}/version"))"
 
+if [[ "${VIBEGUARD_SETUP_DRY_RUN}" != "1" ]]; then
+  echo "Step 1.5: Clean retired skill links"
+  cleanup_retired_manifest_skill_links "~/.claude/skills/" "${CLAUDE_DIR}/skills"
+  cleanup_retired_manifest_skill_links "~/.codex/skills/" "${CODEX_DIR}/skills"
+  echo
+fi
+
 # Initialize install state tracking
 state_init "$PROFILE" "$LANGUAGES"
 state_record_file "${VIBEGUARD_HOME}/repo-path" "generated/repo-path" "copy"

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -87,6 +87,40 @@ manifest_skill_links_for_cleanup() {
   printf '%s\n' "${output}"
 }
 
+cleanup_retired_manifest_skill_links() {
+  local target="$1"
+  local dest_dir="$2"
+  local active_links
+
+  if ! declare -F state_list_tracked_symlinks_under >/dev/null; then
+    return 0
+  fi
+
+  active_links="$(manifest_skill_links_for_cleanup "${target}")"
+  [[ -n "${active_links//[[:space:]]/}" ]] || return 0
+
+  local active_names=$'\n'
+  local source_path skill
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    active_names+="${skill}"$'\n'
+  done <<< "${active_links}"
+
+  local tracked_path name display
+  while IFS= read -r tracked_path; do
+    [[ -n "${tracked_path}" ]] || continue
+    name="$(basename "${tracked_path}")"
+    [[ "${active_names}" == *$'\n'"${name}"$'\n'* ]] && continue
+    display="${tracked_path/#${HOME}/~}"
+    if [[ -L "${tracked_path}" ]]; then
+      rm -f "${tracked_path}"
+      yellow "  Removed retired VibeGuard skill link: ${display}"
+    elif [[ -e "${tracked_path}" ]]; then
+      yellow "  SKIP retired VibeGuard skill path is not a symlink: ${display}"
+    fi
+  done < <(state_list_tracked_symlinks_under "${dest_dir}")
+}
+
 confirm_high_context_write() {
   local label="$1"
   local diff_output="$2"

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -377,6 +377,7 @@ clean_claude_home_installation() {
     [[ -n "${source_path}" && -n "${skill}" ]] || continue
     rm -f "${CLAUDE_DIR}/skills/${skill}"
   done <<< "${skill_links}"
+  cleanup_retired_manifest_skill_links "~/.claude/skills/" "${CLAUDE_DIR}/skills"
 
   local agent
   for agent in "${REPO_DIR}"/agents/*.md; do

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -166,6 +166,7 @@ clean_codex_home_installation() {
     [[ -n "${source_path}" && -n "${skill}" ]] || continue
     rm -f "${CODEX_DIR}/skills/${skill}"
   done <<< "${skill_links}"
+  cleanup_retired_manifest_skill_links "~/.codex/skills/" "${CODEX_DIR}/skills"
 
   # Remove only VibeGuard-managed entries from hooks.json (do not delete third-party hooks)
   local hooks_cleanup_result

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -273,6 +273,50 @@ assert_cmd "clean continues after Codex manifest failure" bash -c "! grep -q 'vi
 assert_cmd "clean removes Codex wrapper after manifest failure" test ! -e "${broken_clean_home}/.vibeguard/run-hook-codex.sh"
 assert_cmd "clean removes legacy Codex MCP after manifest failure" bash -c "! grep -q '^\[mcp_servers\.vibeguard\]' '${broken_clean_home}/.codex/config.toml'"
 
+header "retired manifest skill cleanup"
+retired_home="${TMP_HOME}/retired-skill-home"
+mkdir -p \
+  "${retired_home}/.claude/skills" \
+  "${retired_home}/.codex/skills" \
+  "${retired_home}/.vibeguard"
+ln -s "${REPO_DIR}/skills/vibeguard" "${retired_home}/.claude/skills/vibeguard"
+ln -s "${REPO_DIR}/skills/old-retired" "${retired_home}/.claude/skills/old-retired"
+ln -s "${REPO_DIR}/skills/user-skill" "${retired_home}/.claude/skills/user-skill"
+mkdir -p "${retired_home}/.claude/skills/old-dir"
+ln -s "${REPO_DIR}/workflows/old-flow" "${retired_home}/.codex/skills/old-flow"
+python3 - <<'PY' "${retired_home}"
+import json
+import sys
+from pathlib import Path
+
+home = Path(sys.argv[1])
+state = {
+    "version": 1,
+    "files": {
+        str(home / ".claude/skills/vibeguard"): {"source": "skills/vibeguard", "type": "symlink"},
+        str(home / ".claude/skills/old-retired"): {"source": "skills/old-retired", "type": "symlink"},
+        str(home / ".claude/skills/old-dir"): {"source": "skills/old-dir", "type": "symlink"},
+        str(home / ".codex/skills/old-flow"): {"source": "workflows/old-flow", "type": "symlink"},
+    },
+}
+(home / ".vibeguard/install-state.json").write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+PY
+retired_cleanup_out="$(
+  HOME="${retired_home}" bash -c "
+    set -euo pipefail
+    source '${REPO_DIR}/scripts/setup/lib.sh'
+    source '${REPO_DIR}/scripts/lib/install-state.sh'
+    cleanup_retired_manifest_skill_links '~/.claude/skills/' '${retired_home}/.claude/skills'
+    cleanup_retired_manifest_skill_links '~/.codex/skills/' '${retired_home}/.codex/skills'
+  " 2>&1
+)"
+assert_contains "${retired_cleanup_out}" "Removed retired VibeGuard skill link" "retired skill cleanup reports removed managed links"
+assert_cmd "retired cleanup keeps active manifest Claude skill" test -L "${retired_home}/.claude/skills/vibeguard"
+assert_cmd "retired cleanup removes tracked retired Claude skill" test ! -L "${retired_home}/.claude/skills/old-retired"
+assert_cmd "retired cleanup removes tracked retired Codex skill" test ! -L "${retired_home}/.codex/skills/old-flow"
+assert_cmd "retired cleanup preserves untracked user skill" test -L "${retired_home}/.claude/skills/user-skill"
+assert_cmd "retired cleanup preserves retired regular directories" test -d "${retired_home}/.claude/skills/old-dir"
+
 header "hooks manifest"
 assert_cmd "hooks manifest validates" bash "${REPO_DIR}/scripts/ci/validate-hooks-manifest.sh"
 assert_cmd "hooks/CLAUDE.md table is generated from manifest" bash "${REPO_DIR}/scripts/setup/regenerate-hooks-from-manifest.sh" --check
@@ -414,8 +458,29 @@ assert_cmd "--dry-run does not create ~/.claude/CLAUDE.md" test ! -e "${HOME}/.c
 confirm_fail_out="$(bash "${REPO_DIR}/setup.sh" 2>&1 || true)"
 assert_contains "${confirm_fail_out}" "requires explicit confirmation" "non-interactive setup requires --yes for high-context writes"
 
+mkdir -p "${HOME}/.claude/skills" "${HOME}/.codex/skills" "${HOME}/.vibeguard"
+ln -s "${REPO_DIR}/skills/old-retired" "${HOME}/.claude/skills/old-retired"
+ln -s "${REPO_DIR}/workflows/old-flow" "${HOME}/.codex/skills/old-flow"
+python3 - <<'PY' "${HOME}"
+import json
+import sys
+from pathlib import Path
+
+home = Path(sys.argv[1])
+state = {
+    "version": 1,
+    "files": {
+        str(home / ".claude/skills/old-retired"): {"source": "skills/old-retired", "type": "symlink"},
+        str(home / ".codex/skills/old-flow"): {"source": "workflows/old-flow", "type": "symlink"},
+    },
+}
+(home / ".vibeguard/install-state.json").write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+PY
 install_out="$(bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
+assert_contains "${install_out}" "Removed retired VibeGuard skill link" "setup install removes tracked retired skill links"
+assert_cmd "setup install removes tracked retired Claude skill" test ! -L "${HOME}/.claude/skills/old-retired"
+assert_cmd "setup install removes tracked retired Codex skill" test ! -L "${HOME}/.codex/skills/old-flow"
 assert_cmd "vg-helper binary installed after setup" test -x "${HOME}/.vibeguard/installed/bin/vg-helper"
 assert_cmd "~/.claude/skills/vibeguard exists after installation" test -L "${HOME}/.claude/skills/vibeguard"
 assert_cmd "~/.codex/skills/vibeguard exists after installation" test -L "${HOME}/.codex/skills/vibeguard"


### PR DESCRIPTION
## Summary
- clean retired VibeGuard skill symlinks tracked in install-state when they are no longer declared by schemas/install-modules.json
- run the same tracked retired cleanup during install and clean for Claude/Codex skill directories
- preserve untracked user symlinks and non-symlink paths, with setup tests for both cases

## Tests
- bash -n scripts/lib/install-state.sh scripts/setup/lib.sh scripts/setup/install.sh scripts/setup/targets/claude-home.sh scripts/setup/targets/codex-home.sh tests/test_setup.sh
- bash tests/test_setup.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/run-all.sh
- bash setup.sh --check
- git diff --check