### PR TITLE
Improve Codex usage diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md instructions for VibeGuard
+
+VibeGuard is an anti-hallucination rules, hooks, and workflow repository. There is no ORM, no front-end framework, and no microservices layer in this project.
+
+## Project Rules
+
+- Search first before adding files, functions, rules, hooks, workflows, or tests.
+- Keep names snake_case unless an external API boundary requires camelCase.
+- Do not swallow errors silently. User-visible missing data or wrong output must fail loudly.
+- Do only the requested scope; avoid opportunistic refactors.
+- Follow `workflows/references/routing-contract.md` for `execute_direct`, `plan_first`, `clarify_first`, and shared handoff fields.
+- High-context files such as `AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, setup scripts, and hooks must not be modified by generated output without explicit intent.
+
+## Validation
+
+Before completion, run the focused test or check that covers the changed surface.
+
+Before submission:
+
+- Rust: `cargo check` and `cargo test`
+- Shell/setup changes: `bash tests/test_setup.sh`
+- Manifest/routing changes: `bash tests/test_manifest_contract.sh`
+- Documentation path changes: `bash scripts/ci/validate-doc-paths.sh` and `bash scripts/ci/validate-doc-command-paths.sh`
+
+If a validation command cannot run, report the exact blocker instead of claiming completion.

--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -1,7 +1,7 @@
 <!-- vibeguard-start -->
 #VibeGuard — AI anti-hallucination rules
 
-> __VIBEGUARD_RULE_COUNT__ rules loaded natively via `~/.claude/rules/vibeguard/`. There is no ORM, no front-end framework, and no microservices in this project.
+> __VIBEGUARD_RULE_COUNT__ rules total. Claude loads the full set from `~/.claude/rules/vibeguard/`; Codex sees the L1-L7 layers + Key Detailed Rules table below. Repo-specific facts belong in the repo-level `AGENTS.md`.
 
 ## Constraints (L1-L7 are enforced by Hooks)
 
@@ -58,4 +58,25 @@ Rule: Workflows without manual validation are prohibited from direct automation.
 ## Priority
 
 Security > Logic > Data Splitting > Repeating Types > Unwrap > Naming
+
+## Key Detailed Rules (full set in `rules/claude-rules/**`)
+
+| ID | Severity | Rule |
+|----|----------|------|
+| U-16 | Guideline | Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. Files above 800 must be split. |
+| U-17 | Strict | Handle errors completely. Do not swallow exceptions silently. |
+| U-22 | Strict | New code minimum 80% line coverage; critical paths 100%. |
+| U-25 | Strict | Fix build failures first before any other edit; do not add new code while build is red. |
+| U-26 | Strict | Declaration-execution completeness: declared Config / Trait / persistence layers must be wired into startup. |
+| U-29 | Strict | No silent degradation: errors causing user-visible missing data or wrong output must `error` or raise, not `warning` + fallback. |
+| W-01 | Strict | No fixes without root cause: reproduce first, then form one hypothesis, then fix. |
+| W-02 | Strict | After 3 consecutive failed fixes on the same problem, stop and challenge the hypothesis or architecture. |
+| W-03 | Strict | Verify before claiming completion: produce fresh command output proving the claim. |
+| W-12 | Strict | Protect test integrity: fix production code, never weaken assertions or tamper with test infrastructure. |
+| W-14 | Strict | Parallel agents must have explicit, disjoint file ownership; no shared writable file. |
+| W-16 | Strict | Verification commands must come from this session. "Earlier passed" / "should work" do not count. |
+| SEC-01 | Critical | No SQL / NoSQL / OS command injection: use parameterized queries and array argument lists. |
+| SEC-02 | Critical | No hardcoded keys, credentials, or API tokens. Load from env / secret manager. |
+| SEC-11 | Strict | AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`. |
+| SEC-13 | Strict | High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators. |
 <!-- vibeguard-end -->

--- a/docs/internal/plans/agent-rules-distribution.md
+++ b/docs/internal/plans/agent-rules-distribution.md
@@ -1,0 +1,357 @@
+# SPEC: Codex Experience Remediation
+
+- Date: 2026-05-05
+- Status: P0-P2 implemented, P3 optional
+- Owner: VibeGuard setup/runtime
+- Scope: Codex CLI native hooks, AGENTS rule distribution, setup/check UX, regression tests
+- Related files: `AGENTS.md`, `claude-md/vibeguard-rules.md`, `templates/AGENTS.md`, `scripts/setup/targets/codex-home.sh`, `scripts/setup/install.sh`, `scripts/lib/codex_hooks_json.py`, `hooks/run-hook-codex.sh`, `hooks/_lib/codex_adapter.sh`, `tests/test_setup.sh`, `tests/test_codex_runtime.sh`, `tests/test_hook_health.sh`
+
+## Goal
+
+Make VibeGuard's Codex experience accurate, observable, and repairable. After this remediation, a user should be able to run one status/check command and know whether Codex can see the rules, whether native hooks are installed and firing, which protection surface is actually covered, and what concrete repair command is needed if the install is dirty.
+
+This SPEC replaces the earlier partial "Agent Rules Distribution" draft. The earlier P1 fix already injected VibeGuard rules into `~/.codex/AGENTS.md`; the remaining work is to remove misleading global context, tighten AGENTS hygiene checks, expose Codex status clearly, and close test gaps.
+
+## Implementation Status
+
+P0 is implemented:
+
+- repo-level `AGENTS.md` now carries VibeGuard-local facts
+- global injected rules no longer include repo-specific architecture facts
+- `templates/AGENTS.md` is now a starter template and aligns with U-16
+- `setup.sh --check` validates `~/.codex/AGENTS.md` structure and warns on unmanaged content outside the VibeGuard block
+- setup tests cover dry-run behavior, install anchors, broken marker cases, unmanaged-content warnings, read-only checks, and clean preserving unmanaged content
+
+P1-P2 are also implemented:
+
+- `setup.sh --codex-status` provides a read-only Codex-focused status surface
+- shared `~/.codex/config.toml` and `~/.codex/hooks.json` checksum drift is downgraded when semantic checks pass
+- `hooks/run-hook-codex.sh` stays thin and writes diagnostics to `~/.vibeguard/codex-wrapper.jsonl`
+- `scripts/codex-contract-check.sh` runs the Codex setup/status/runtime/health contract tests in one place
+
+P3 remains optional: `codex debug prompt-input` proof is still version-gated and should be added only if the local Codex CLI keeps that debug surface stable.
+
+## Non-goals
+
+- Do not claim Claude Code parity for Codex native hooks.
+- Do not add Edit/Write/Read native hook support unless Codex itself supports those events. VibeGuard may document the app-server wrapper as the full-surface alternative.
+- Do not delete user-managed content from `~/.codex/AGENTS.md` automatically. Marker-external content is reported first; cleanup requires explicit setup/clean behavior or user confirmation.
+- Do not rewrite the whole install system. Keep changes scoped to Codex-specific status, rule distribution, wrapper diagnostics, and tests.
+- Do not introduce a new daemon, MCP server, ORM, front-end framework, or microservice.
+
+## Facts
+
+- `~/.codex/AGENTS.md` and `~/.codex/agents.md` were previously 0 bytes; when no repo-level `AGENTS.md` exists, Codex has no durable VibeGuard reasoning context.
+- The current setup path injects `claude-md/vibeguard-rules.md` into `~/.codex/AGENTS.md` through `scripts/setup/targets/codex-home.sh`.
+- Current Codex native hook support must be described as `PreToolUse(Bash)`, `PostToolUse(Bash)`, and `Stop(stop-guard/learn-evaluator)`.
+- `scripts/lib/codex_hooks_json.py` generates `~/.codex/hooks.json` commands as `bash <wrapper> <vibeguard-*.sh>`, with matcher and timeout derived from `hooks/manifest.json`.
+- `hooks/run-hook-codex.sh` sets `VIBEGUARD_CLI=codex` and `VIBEGUARD_AGENT_TYPE=codex`, then adapts Claude-style hook output to Codex output.
+- The latest audit found that `~/.codex/AGENTS.md` can contain marker-external content after the managed block, while `setup.sh --check` still reports OK.
+- `~/.codex/config.toml` and `~/.codex/hooks.json` are shared files that other tools may legitimately mutate; whole-file checksum drift can be noisy even when VibeGuard-managed semantics remain healthy.
+
+## Inferences
+
+- The product problem is not "Codex hooks do not run"; it is "users cannot easily tell which Codex surfaces are protected, and setup/check can overstate health."
+- Global `~/.codex/AGENTS.md` should contain only cross-repo durable rules. Repo-specific facts such as "no ORM, no front-end framework, no microservices" belong in a repo-level `AGENTS.md`.
+- Wrapper-level silent exits are acceptable for normal Codex UX only if there is a separate diagnostic path. Without that path, broken installs look like "VibeGuard did nothing."
+- A Codex-specific contract gate is needed because generic local checks do not currently prove AGENTS visibility, native payload shape, or Codex status output.
+
+## Requirements
+
+### R1: Accurate Codex Capability Contract
+
+Codex-facing output and docs must state the exact native support:
+
+- `PreToolUse(Bash)` -> command approval guard via `vibeguard-pre-bash-guard.sh`
+- `PostToolUse(Bash)` -> build/post-command feedback via `vibeguard-post-build-check.sh`
+- `Stop` -> `vibeguard-stop-guard.sh` and `vibeguard-learn-evaluator.sh`
+- `Edit`, `Write`, `Read`, `Glob`, `Grep`, and `analysis-paralysis` are not native Codex CLI hooks in this contract.
+- Full edit/write/read quality coverage requires Claude Code or `scripts/codex/app_server_wrapper.py`.
+
+Done-when:
+
+- `setup.sh --check` prints the exact capability list.
+- README and Codex rule text do not imply Claude Code parity.
+- Tests assert the capability wording contains `PreToolUse(Bash)`, `PostToolUse(Bash)`, and `Stop`.
+
+### R2: Rule Distribution Split
+
+Codex rule content must be split by scope:
+
+- Global `~/.codex/AGENTS.md`: cross-repo VibeGuard rules only.
+- Repo-level `AGENTS.md`: VibeGuard repo facts and local constraints.
+- `templates/AGENTS.md`: safe starter template for a project, not a VibeGuard repo fact dump.
+
+Global content may include:
+
+- Chat Contract
+- L1-L7 summary
+- Key U/W/SEC rules
+- validation requirement
+- Codex capability matrix
+
+Global content must not include:
+
+- "There is no ORM"
+- "There is no front-end framework"
+- "There are no microservices"
+- any other current-repo architecture fact that would be false in another repo
+
+Done-when:
+
+- `claude-md/vibeguard-rules.md` or the new Codex injection source has no cross-repo-invalid project facts.
+- VibeGuard repo root has an `AGENTS.md` carrying local repo constraints.
+- `templates/AGENTS.md` no longer claims equivalence to full `CLAUDE.md` unless it actually carries the same contract.
+- `templates/AGENTS.md` no longer conflicts with U-16.
+
+### R3: AGENTS Hygiene and SEC-13 Check
+
+`check_codex_home_installation` must validate managed AGENTS content structurally:
+
+- file exists
+- file is non-empty
+- exactly one `vibeguard-start`
+- exactly one `vibeguard-end`
+- start appears before end
+- managed block contains required anchors: `Chat Contract`, `L1`, `Key Detailed Rules`, `W-03`, `SEC-13`
+- marker-external non-empty content is reported as WARN, with a short count and first suspicious line
+- duplicate marker or missing end marker is FAIL
+
+The check should not auto-delete marker-external content. Cleanup belongs to an explicit repair command or confirmed setup write.
+
+Done-when:
+
+- 0-byte `~/.codex/AGENTS.md` is reported as BROKEN.
+- missing end marker is reported as BROKEN.
+- duplicate start/end marker is reported as BROKEN.
+- marker-external content is reported as WARN.
+- valid managed-only content is OK.
+
+### R4: Codex Status Command
+
+Add a single status surface, either as `bash setup.sh --codex-status` or `bash scripts/setup/check.sh --codex`, that answers:
+
+- Codex CLI path and version if available
+- `~/.codex/AGENTS.md` hygiene status
+- whether `~/.codex/hooks.json` has all VibeGuard-managed entries
+- whether `[features].codex_hooks = true`
+- whether legacy VibeGuard MCP config remains
+- installed wrapper path and executable status
+- latest VibeGuard Codex event timestamp, hook, decision, and project root
+- semantic drift summary for shared Codex files
+- exact native capability list
+- suggested repair command
+
+This command must be read-only.
+
+Done-when:
+
+- Running the status command does not modify `~/.codex/*` or `~/.vibeguard/*`.
+- Missing AGENTS, disabled `codex_hooks`, stale hooks, and no recent log events produce distinct messages.
+- A healthy install reports "Codex native support: PreToolUse(Bash), PostToolUse(Bash), Stop".
+
+### R5: Semantic Drift Instead of Whole-file Drift
+
+For shared Codex files, `setup.sh --check` must prefer semantic checks over whole-file checksum failure:
+
+- `~/.codex/config.toml`: OK if `codex_hooks = true` and no legacy VibeGuard MCP block exists.
+- `~/.codex/hooks.json`: OK if all VibeGuard-managed hooks are present with expected command, matcher, type, and timeout.
+- Whole-file checksum mismatch may be INFO, not a red failure, when semantic checks pass.
+
+Done-when:
+
+- User edits unrelated Codex config but keeps `codex_hooks = true`; status reports semantic OK and checksum INFO.
+- A missing VibeGuard hook entry remains a WARN or FAIL.
+- A malformed TOML/JSON remains BROKEN.
+
+### R6: Wrapper Diagnostics Without Noisy Stdout
+
+`hooks/run-hook-codex.sh` must keep normal pass paths silent, but expose installation failures through diagnostics:
+
+- missing `~/.vibeguard/repo-path`
+- missing installed hook directory
+- missing target hook
+- missing `codex_adapter.sh`
+- non-namespaced hook name
+- non-PreToolUse wrapped-hook nonzero
+- PostToolUse invalid JSON
+
+Default behavior should not spam Codex stdout. Use a diagnostic sink such as `~/.vibeguard/codex-wrapper.jsonl`, or emit only when `VIBEGUARD_DEBUG=1`.
+
+Done-when:
+
+- Existing pass-with-no-output tests still pass.
+- Missing adapter can be diagnosed after the fact.
+- PreToolUse failure remains fail-closed with `permissionDecision=deny`.
+
+### R7: Native Payload Test Coverage
+
+Tests must prove the native Codex contract, not only hand-built idealized payloads:
+
+- AGENTS install/check/clean/idempotency
+- AGENTS 0-byte, missing marker, duplicate marker, external content
+- `codex_hooks` semantic status
+- native Bash-shaped `PostToolUse` payload behavior
+- `hook-health.sh` with `cli=codex` and `cli=claude` fixture rows
+- `run-hook-codex.sh` wrapper diagnostics
+- optional: `codex debug prompt-input` proves AGENTS content reaches prompt input without model call
+
+Done-when:
+
+- `tests/test_setup.sh` covers AGENTS injection and hygiene.
+- `tests/test_codex_runtime.sh` covers native payload and wrapper diagnostics.
+- `tests/test_hook_health.sh` covers CLI distribution.
+- A Codex contract command runs the Codex-relevant tests in one place.
+
+## Proposed File Changes
+
+### P0: Fix User-visible Truth and Hygiene
+
+- `claude-md/vibeguard-rules.md`
+  - remove global project-specific facts
+  - add Codex capability matrix
+  - keep Key Detailed Rules compact
+- `AGENTS.md`
+  - add repo-level VibeGuard constraints: no ORM, no front-end framework, no microservices, setup/test commands, routing contract pointer
+- `templates/AGENTS.md`
+  - reword as starter template
+  - remove conflicting `<=200 lines` hard rule or align it with U-16
+- `scripts/setup/targets/codex-home.sh`
+  - strengthen AGENTS check
+  - print exact native capability list
+- `README.md`
+  - document global AGENTS injection and native capability limits
+
+Verification:
+
+- `bash setup.sh --check`
+- `bash tests/test_setup.sh`
+- `git diff --check`
+
+### P1: Add Codex Status and Semantic Drift
+
+- `scripts/setup/check.sh`
+  - add Codex-only status mode or factor a helper called by `--check`
+- `scripts/setup/targets/codex-home.sh`
+  - expose reusable status functions
+- `scripts/lib/codex_config_toml.py`
+  - keep semantic `check-codex-hooks`
+- `scripts/lib/codex_hooks_json.py`
+  - keep semantic managed-entry checker
+- `scripts/local-contract-check.sh` or a new Codex contract script under `scripts/`
+  - run Codex contract tests
+
+Verification:
+
+- `bash setup.sh --check`
+- the Codex contract command created in P1
+- `bash tests/test_manifest_contract.sh`
+
+### P2: Wrapper Diagnostics and Native Payload Coverage
+
+- `hooks/run-hook-codex.sh`
+  - add diagnostic sink for silent failure paths
+- `hooks/_lib/codex_adapter.sh`
+  - keep fail-closed PreToolUse adapter behavior
+- `tests/test_codex_runtime.sh`
+  - add missing-adapter/missing-hook diagnostic tests
+  - add native Bash-shaped PostToolUse payload fixture
+- `tests/test_hook_health.sh`
+  - add Codex/Claude CLI distribution fixture
+
+Verification:
+
+- `bash tests/test_codex_runtime.sh`
+- `bash tests/test_hook_health.sh`
+- `bash scripts/ci/self-application/check-codex-wrapper-thin.sh`
+
+### P3: Prompt-input Proof and Docs Cleanup
+
+- a new optional prompt-input test under `tests/`
+  - optional, skipped when `codex` is unavailable
+  - uses temp HOME and `codex debug prompt-input`
+  - asserts `vibeguard-start`, `Chat Contract`, and `Key Detailed Rules`
+- `docs/openai-codex-best-practices.md`
+  - keep as reference only; do not treat as VibeGuard runtime contract
+- `docs/internal/plans/agent-rules-distribution.md`
+  - update status as steps land
+
+Verification:
+
+- the optional prompt-input test created in P3
+- `bash scripts/ci/validate-doc-paths.sh`
+
+## Acceptance Criteria
+
+The remediation is complete when all of the following are true:
+
+- `setup.sh --check` reports Codex health using semantic checks and exact native capability language.
+- A healthy Codex install does not show red drift solely because unrelated `config.toml` fields changed.
+- `~/.codex/AGENTS.md` managed block is validated for start/end marker integrity.
+- Marker-external AGENTS content is visible in status output.
+- Global Codex AGENTS content contains only cross-repo valid rules.
+- VibeGuard repo-specific constraints live in repo-level `AGENTS.md`.
+- Wrapper failure paths can be diagnosed without changing normal Codex stdout.
+- Codex contract tests run from one command and pass in the current session.
+
+## Validation Matrix
+
+| Scenario | Input | Expected output | Verify command |
+|---|---|---|---|
+| Healthy Codex install | current machine with managed hooks and AGENTS | semantic OK, exact capability list | `bash setup.sh --check` |
+| 0-byte AGENTS | temp HOME with empty `.codex/AGENTS.md` | BROKEN | `bash tests/test_setup.sh` |
+| marker-external AGENTS text | managed block plus extra non-empty line | WARN, not silent OK | `bash tests/test_setup.sh` |
+| missing adapter | wrapper with missing `hooks/_lib/codex_adapter.sh` | diagnostic event/log | `bash tests/test_codex_runtime.sh` |
+| PreToolUse hook failure | wrapped hook exits nonzero | `permissionDecision=deny` | `bash tests/test_codex_runtime.sh` |
+| native PostToolUse Bash payload | Bash output payload without `file_path` | documented behavior, no false claim | `bash tests/test_codex_runtime.sh` |
+| hook-health mixed CLIs | fixture with codex and claude rows | CLI distribution counts both | `bash tests/test_hook_health.sh` |
+| prompt-input visibility | temp HOME with injected AGENTS | prompt input contains VibeGuard anchors | optional P3 prompt-input test |
+
+## Rollout Plan
+
+1. Land P0 in one PR because it fixes user-facing truth and global-context safety.
+2. Land P1 in a second PR because it changes status/check semantics for shared files.
+3. Land P2 in a third PR because wrapper diagnostics touch runtime behavior.
+4. Keep P3 optional if `codex debug prompt-input` is unstable across Codex versions; if skipped, document the skip condition in test output.
+
+Each PR must include:
+
+- changed file list
+- before/after command output for the relevant status command
+- test commands run in that PR
+- any remaining Evidence gaps
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| AGENTS cleanup removes user notes | High | only report marker-external content by default; require confirmation for cleanup |
+| status command becomes too noisy | Medium | group output into OK/WARN/BROKEN and keep exact repair command |
+| whole-file drift still causes confusion | Medium | downgrade checksum-only drift to INFO when semantic checks pass |
+| Codex CLI changes prompt debug output | Medium | make prompt-input test optional and version-gated |
+| wrapper diagnostics leak command content | Medium | reuse existing redaction helpers or cap detail length |
+
+## Handoff
+
+```yaml
+handoff:
+  mode: plan_first
+  artifacts:
+    - docs/internal/plans/agent-rules-distribution.md
+  verification_owner: main agent
+  stop_conditions:
+    - Codex native hook support expands beyond Bash/Stop and invalidates the capability contract
+    - setup/check changes would delete user-managed AGENTS content without confirmation
+    - tests require real model calls instead of local CLI/debug surfaces
+  lane_map:
+    codex_rules_distribution: main agent
+    setup_status_semantics: main agent
+    wrapper_diagnostics: main agent
+    codex_contract_tests: main agent
+```
+
+## Open Evidence Gaps
+
+- Need a current-session `codex debug prompt-input` proof before claiming Codex prompt visibility beyond file presence.
+- Need a real native Bash `PostToolUse` payload sample from Codex logs or controlled hook fixture before changing `post-build-check` behavior.
+- Need to decide whether the status command is `setup.sh --codex-status`, `setup.sh --check --codex`, or a standalone script under `scripts/`.

--- a/hooks/_lib/codex_adapter.sh
+++ b/hooks/_lib/codex_adapter.sh
@@ -85,7 +85,7 @@ import sys
 try:
     data = json.loads(os.environ.get("CODEX_HOOK_OUTPUT", ""))
 except Exception:
-    sys.exit(0)
+    sys.exit(3)
 
 decision = data.get("decision", "pass")
 reason = data.get("reason", "")

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Codex wrapper diagnostics and tiny JSON helpers.
+
+codex_raw_event_name() {
+  local input="$1"
+  CODEX_INPUT="${input}" python3 - <<'PY'
+import json
+import os
+
+try:
+    print(json.loads(os.environ.get("CODEX_INPUT", "")).get("hook_event_name", ""))
+except Exception:
+    print("")
+PY
+}
+
+codex_pretool_deny_raw() {
+  local reason="$1"
+  CODEX_REASON="${reason}" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": os.environ.get("CODEX_REASON", ""),
+    }
+}, ensure_ascii=False))
+PY
+}
+
+codex_diag() {
+  local hook_name="$1" event_name="$2" reason="$3" detail="${4:-}"
+  local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
+  mkdir -p "$(dirname "${diag_file}")" 2>/dev/null || return 0
+  VIBEGUARD_DIAG_FILE="${diag_file}" \
+  VIBEGUARD_DIAG_HOOK="${hook_name}" \
+  VIBEGUARD_DIAG_EVENT="${event_name}" \
+  VIBEGUARD_DIAG_REASON="${reason}" \
+  VIBEGUARD_DIAG_DETAIL="${detail}" \
+  VIBEGUARD_DIAG_CWD="${PWD}" \
+    python3 - <<'PY' 2>/dev/null || true
+import datetime
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["VIBEGUARD_DIAG_FILE"])
+entry = {
+    "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "cli": "codex",
+    "hook": os.environ.get("VIBEGUARD_DIAG_HOOK", ""),
+    "event": os.environ.get("VIBEGUARD_DIAG_EVENT", ""),
+    "reason": os.environ.get("VIBEGUARD_DIAG_REASON", ""),
+    "detail": os.environ.get("VIBEGUARD_DIAG_DETAIL", "")[:300],
+    "cwd": os.environ.get("VIBEGUARD_DIAG_CWD", ""),
+}
+with path.open("a", encoding="utf-8") as f:
+    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+try:
+    path.chmod(0o600)
+except OSError:
+    pass
+PY
+}

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -29,7 +29,7 @@ if [[ -f "${DIAG_PATH}" ]]; then
   # shellcheck source=hooks/_lib/codex_diag.sh
   source "${DIAG_PATH}"
 else
-  codex_raw_event_name() { printf '\n'; }
+  codex_raw_event_name() { [[ "$1" =~ \"hook_event_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]] && printf '%s\n' "${BASH_REMATCH[1]}"; }
   codex_pretool_deny_raw() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"VIBEGUARD install incomplete."}}\n'; }
   codex_diag() { return 0; }
 fi

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
-# VibeGuard Codex Hook Wrapper — Adapt the output format of Codex CLI
-#
-# The I/O formats of Codex CLI hooks and Claude Code hooks are different:
-# - PreToolUse block: Codex requires hookSpecificOutput.permissionDecision="deny"
-# - PreToolUse warn: Codex uses systemMessage
-# - updatedInput (correction): Codex CLI cannot apply it directly, emit an explicit note instead
-# - SessionStart/Stop: The format is basically compatible, direct transparent transmission
-#
-# Usage: bash run-hook-codex.sh <hook-script-name> [args...]
+# VibeGuard Codex Hook Wrapper: adapt Claude-style hook output to Codex.
 
 set -euo pipefail
 
@@ -18,53 +10,94 @@ WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK_NAME="${1:?Usage: run-hook-codex.sh <hook-name>}"
 shift
 
-# Codex path is namespaced-only. Non-namespaced hook names are unsupported.
+INSTALLED_DIR="${HOME}/.vibeguard/installed/hooks"
+DIAG_PATH="${WRAPPER_DIR}/_lib/codex_diag.sh"
+if [[ ! -f "${DIAG_PATH}" && -f "${INSTALLED_DIR}/_lib/codex_diag.sh" ]]; then
+  DIAG_PATH="${INSTALLED_DIR}/_lib/codex_diag.sh"
+fi
+if [[ ! -f "${DIAG_PATH}" ]]; then
+  REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
+  if [[ -f "${REPO_PATH_FILE}" ]]; then
+    REPO_DIR=$(<"${REPO_PATH_FILE}")
+    if [[ -f "${REPO_DIR}/hooks/_lib/codex_diag.sh" ]]; then
+      DIAG_PATH="${REPO_DIR}/hooks/_lib/codex_diag.sh"
+    fi
+  fi
+fi
+
+if [[ -f "${DIAG_PATH}" ]]; then
+  # shellcheck source=hooks/_lib/codex_diag.sh
+  source "${DIAG_PATH}"
+else
+  codex_raw_event_name() { printf '\n'; }
+  codex_pretool_deny_raw() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"VIBEGUARD install incomplete."}}\n'; }
+  codex_diag() { return 0; }
+fi
+
+INPUT=$(cat)
+EVENT_NAME=$(codex_raw_event_name "$INPUT")
+
 if [[ "${HOOK_NAME}" != vibeguard-* ]]; then
+  codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "non-namespaced-hook" "${HOOK_NAME}"
   exit 0
 fi
 
-INSTALLED_DIR="${HOME}/.vibeguard/installed/hooks"
 HOOK_PATH="${INSTALLED_DIR}/${HOOK_NAME}"
-ADAPTER_PATH="${WRAPPER_DIR}/_lib/codex_adapter.sh"
-if [[ ! -f "${ADAPTER_PATH}" && -f "${INSTALLED_DIR}/_lib/codex_adapter.sh" ]]; then
-  ADAPTER_PATH="${INSTALLED_DIR}/_lib/codex_adapter.sh"
+if [[ -n "${VIBEGUARD_CODEX_ADAPTER_PATH:-}" ]]; then
+  ADAPTER_PATH="${VIBEGUARD_CODEX_ADAPTER_PATH}"
+else
+  ADAPTER_PATH="${WRAPPER_DIR}/_lib/codex_adapter.sh"
+  if [[ ! -f "${ADAPTER_PATH}" && -f "${INSTALLED_DIR}/_lib/codex_adapter.sh" ]]; then
+    ADAPTER_PATH="${INSTALLED_DIR}/_lib/codex_adapter.sh"
+  fi
 fi
 
 if [[ ! -d "$INSTALLED_DIR" ]]; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ ! -f "$REPO_PATH_FILE" ]]; then
+    codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-repo-path" "${REPO_PATH_FILE}"
+    if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
+      codex_pretool_deny_raw "VIBEGUARD install incomplete: missing repo-path."
+    fi
     exit 0
   fi
   REPO_DIR=$(<"$REPO_PATH_FILE")
   HOOK_PATH="${REPO_DIR}/hooks/${HOOK_NAME}"
-  if [[ ! -f "${ADAPTER_PATH}" && -f "${REPO_DIR}/hooks/_lib/codex_adapter.sh" ]]; then
+  if [[ -z "${VIBEGUARD_CODEX_ADAPTER_PATH:-}" && ! -f "${ADAPTER_PATH}" && -f "${REPO_DIR}/hooks/_lib/codex_adapter.sh" ]]; then
     ADAPTER_PATH="${REPO_DIR}/hooks/_lib/codex_adapter.sh"
   fi
 fi
 
 if [[ ! -f "$HOOK_PATH" ]]; then
+  codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"
+  if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
+    codex_pretool_deny_raw "VIBEGUARD install incomplete: missing hook ${HOOK_NAME}."
+  fi
   exit 0
 fi
 
 if [[ ! -f "${ADAPTER_PATH}" ]]; then
+  codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-adapter" "${ADAPTER_PATH}"
+  if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
+    codex_pretool_deny_raw "VIBEGUARD install incomplete: missing Codex adapter."
+  fi
   exit 0
 fi
 
-# shellcheck source=hooks/_lib/codex_adapter.sh
 source "${ADAPTER_PATH}"
 
-export PYTHONUTF8=1
-export PYTHONIOENCODING=utf-8
-
-INPUT=$(cat)
+export PYTHONUTF8=1 PYTHONIOENCODING=utf-8
 
 HOOK_OUTPUT=""
 HOOK_EXIT=0
-HOOK_OUTPUT=$(printf '%s' "$INPUT" | bash "$HOOK_PATH" "$@" 2>/dev/null) || HOOK_EXIT=$?
-
+HOOK_ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-hook.XXXXXX")"
+HOOK_OUTPUT=$(printf '%s' "$INPUT" | bash "$HOOK_PATH" "$@" 2>"${HOOK_ERR_FILE}") || HOOK_EXIT=$?
+HOOK_ERR="$(cat "${HOOK_ERR_FILE}" 2>/dev/null || true)"
+rm -f "${HOOK_ERR_FILE}" 2>/dev/null || true
 EVENT_NAME=$(codex_event_name "$INPUT")
 
 if [[ $HOOK_EXIT -ne 0 ]]; then
+  codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "wrapped-hook-nonzero" "${HOOK_ERR:-${HOOK_OUTPUT}}"
   if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
     codex_pretool_deny "VIBEGUARD hook failed: wrapped hook exited nonzero."
     exit 0
@@ -91,9 +124,16 @@ if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
     printf '%s\n' "$pretool_output"
   fi
 elif [[ "$EVENT_NAME" == "PostToolUse" ]]; then
-  codex_adapt_posttool "$HOOK_OUTPUT" 2>/dev/null
+  posttool_status=0
+  posttool_output=$(codex_adapt_posttool "$HOOK_OUTPUT" 2>/dev/null) || posttool_status=$?
+  if [[ ${posttool_status} -ne 0 ]]; then
+    codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "posttool-adapter-failed" "$HOOK_OUTPUT"
+    exit 0
+  fi
+  if [[ -n "${posttool_output}" ]]; then
+    printf '%s\n' "${posttool_output}"
+  fi
 else
-  # SessionStart / Stop / UserPromptSubmit — direct transparent transmission
   printf '%s\n' "$HOOK_OUTPUT"
 fi
 

--- a/scripts/codex-contract-check.sh
+++ b/scripts/codex-contract-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run the Codex-specific VibeGuard contract checks in one place.
+
+set -euo pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+
+echo "=== Codex Contract Gate ==="
+echo
+
+bash "${REPO_DIR}/tests/test_setup.sh"
+bash "${REPO_DIR}/tests/test_codex_status.sh"
+bash "${REPO_DIR}/tests/test_codex_runtime.sh"
+bash "${REPO_DIR}/tests/test_hook_health.sh"
+
+echo
+echo "Codex contract checks passed."

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -111,10 +111,25 @@ elif echo "$drift_output" | grep -q "STATUS: CLEAN"; then
   tracked=$(echo "$drift_output" | grep "Total tracked" | head -1)
   green "[OK] ${tracked}"
 else
-  echo "$drift_output" | grep -E "^(MISSING|DRIFT):" | while read -r line; do
-    red "  ${line}"
-  done
-  yellow "[WARN] Run 'bash setup.sh' to repair drifted files"
+  _hard_drift=0
+  _semantic_drift=0
+  while IFS= read -r line; do
+    [[ "${line}" =~ ^(MISSING|DRIFT): ]] || continue
+    _drift_path="${line#*: }"
+    _drift_path="${_drift_path%% (*}"
+    if [[ "${line}" == DRIFT:* ]] && _semantic_msg="$(codex_semantic_drift_message "${_drift_path}" 2>/dev/null)"; then
+      yellow "  INFO: ${_semantic_msg}"
+      _semantic_drift=1
+    else
+      red "  ${line}"
+      _hard_drift=1
+    fi
+  done <<< "${drift_output}"
+  if [[ "${_hard_drift}" -eq 1 ]]; then
+    yellow "[WARN] Run 'bash setup.sh' to repair drifted files"
+  elif [[ "${_semantic_drift}" -eq 1 ]]; then
+    yellow "[INFO] Install-state checksum drift is semantic-only for shared Codex files"
+  fi
 fi
 
 # Check awk POSIX compliance (BSD awk has no \s \d \w \b)

--- a/scripts/setup/codex-status.sh
+++ b/scripts/setup/codex-status.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+source "${SCRIPT_DIR}/../lib/install-state.sh"
+source "${SCRIPT_DIR}/targets/codex-home.sh"
+
+print_codex_status

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -28,6 +28,7 @@ source "${SCRIPT_DIR}/targets/codex-home.sh"
 case "${1:-}" in
   --check) exec bash "${SCRIPT_DIR}/check.sh" ;;
   --clean) exec bash "${SCRIPT_DIR}/clean.sh" ;;
+  --codex-status) exec bash "${SCRIPT_DIR}/codex-status.sh" ;;
 esac
 
 # --- Argument parsing ---
@@ -124,6 +125,7 @@ fi
 if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
   configure_claude_home_runtime
   inject_claude_home_rules
+  inject_codex_home_rules
   yellow "Dry run complete. No files were written by setup.sh --dry-run."
   exit 0
 fi
@@ -142,6 +144,8 @@ mkdir -p "${VIBEGUARD_HOME}"
 printf '%s' "${REPO_DIR}" > "${VIBEGUARD_HOME}/repo-path"
 cp "${REPO_DIR}/hooks/run-hook.sh" "${VIBEGUARD_HOME}/run-hook.sh"
 cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${VIBEGUARD_HOME}/run-hook-codex.sh"
+mkdir -p "${VIBEGUARD_HOME}/_lib"
+cp "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${VIBEGUARD_HOME}/_lib/codex_diag.sh"
 chmod +x "${VIBEGUARD_HOME}/run-hook.sh" "${VIBEGUARD_HOME}/run-hook-codex.sh"
 green "  ~/.vibeguard/repo-path + run-hook.sh + run-hook-codex.sh ready"
 
@@ -216,6 +220,7 @@ fi
 state_init "$PROFILE" "$LANGUAGES"
 state_record_file "${VIBEGUARD_HOME}/repo-path" "generated/repo-path" "copy"
 state_record_file "${VIBEGUARD_HOME}/run-hook.sh" "hooks/run-hook.sh" "copy"
+state_record_file "${VIBEGUARD_HOME}/_lib/codex_diag.sh" "hooks/_lib/codex_diag.sh" "copy"
 green "  Install state tracker initialized"
 echo
 
@@ -291,6 +296,7 @@ fi
 echo
 
 inject_claude_home_rules
+inject_codex_home_rules
 
 # 11. Verification
 echo "Step 11: Verification"

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -98,6 +98,11 @@ inject_codex_home_rules() {
     fi
     return 1
   fi
+  if [[ "${rules_diff}" == "SKIP" ]]; then
+    green "  ~/.codex/AGENTS.md already up to date"
+    echo
+    return 0
+  fi
   local result
   if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${agents_md}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
     if [[ -f "${agents_md}" ]]; then

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -20,8 +20,11 @@ install_codex_home_assets() {
   echo "Step 6.5: Install Codex hooks"
   # Copy Codex-specific hook wrapper
   cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${HOME}/.vibeguard/run-hook-codex.sh"
+  mkdir -p "${HOME}/.vibeguard/_lib"
+  cp "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${HOME}/.vibeguard/_lib/codex_diag.sh"
   chmod +x "${HOME}/.vibeguard/run-hook-codex.sh"
   state_record_file "${HOME}/.vibeguard/run-hook-codex.sh" "hooks/run-hook-codex.sh" "copy"
+  state_record_file "${HOME}/.vibeguard/_lib/codex_diag.sh" "hooks/_lib/codex_diag.sh" "copy"
   green "  ~/.vibeguard/run-hook-codex.sh ready"
 
   # Merge VibeGuard hooks into ~/.codex/hooks.json (do not overwrite existing hooks)
@@ -73,6 +76,40 @@ _has_legacy_codex_mcp_config() {
   [[ -f "${config}" ]] && grep -q '^\[mcp_servers\.vibeguard\]' "${config}" 2>/dev/null
 }
 
+codex_native_capability_summary() {
+  printf '%s\n' "Codex native support: PreToolUse(Bash), PostToolUse(Bash), Stop"
+}
+
+inject_codex_home_rules() {
+  echo "Step 10.1: Update VibeGuard rules in ~/.codex/AGENTS.md"
+  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
+  local agents_md="${CODEX_DIR}/AGENTS.md"
+  local rules_diff rule_count
+  rule_count=$(claude_rule_count_for_banner)
+  mkdir -p "${CODEX_DIR}"
+  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${agents_md}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
+    red "  Failed to compute ~/.codex/AGENTS.md diff"
+    return 1
+  fi
+  if ! confirm_high_context_write "~/.codex/AGENTS.md" "${rules_diff}"; then
+    if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
+      echo
+      return 0
+    fi
+    return 1
+  fi
+  local result
+  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${agents_md}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
+    if [[ -f "${agents_md}" ]]; then
+      state_record_file "${agents_md}" "generated/AGENTS.md" "copy"
+    fi
+    green "  VibeGuard rules synced to ~/.codex/AGENTS.md (${result})"
+  else
+    red "  Failed to update ~/.codex/AGENTS.md"
+  fi
+  echo
+}
+
 configure_codex_home_runtime() {
   echo "Step 9.2: Remove legacy Codex MCP config"
   local cleanup_result
@@ -92,6 +129,8 @@ configure_codex_home_runtime() {
 }
 
 check_codex_home_installation() {
+  check_codex_agents_hygiene
+
   local link skill_links source_path skill
   skill_links="$(manifest_skill_links_checked "~/.codex/skills/")" || return 1
   while IFS=$'\t' read -r source_path skill; do
@@ -136,7 +175,7 @@ print(total)
     yellow "[MISSING] Codex hook wrapper not installed"
   fi
 
-  yellow "[INFO] Codex runtime scope: Bash approvals + Stop hooks only; Edit/Write/analysis-paralysis require Claude Code or the app-server wrapper"
+  yellow "[INFO] Codex native hooks: PreToolUse(Bash), PostToolUse(Bash), Stop(stop-guard/learn-evaluator); Edit/Write/Read require Claude Code or the app-server wrapper"
 
   # Check feature flag
   local config="${CODEX_DIR}/config.toml"
@@ -159,7 +198,231 @@ print(total)
   fi
 }
 
+codex_semantic_drift_message() {
+  local path="$1"
+  local config="${CODEX_DIR}/config.toml"
+  local hooks_file="${CODEX_DIR}/hooks.json"
+
+  if [[ "${path}" == "${config}" ]]; then
+    local codex_hooks_status="MISSING"
+    if [[ -f "${config}" ]]; then
+      codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${config}" 2>/dev/null || true)"
+    fi
+    if [[ "${codex_hooks_status}" == "OK" ]] && ! _has_legacy_codex_mcp_config; then
+      printf '%s\n' "${path} (checksum drift; Codex config semantics OK)"
+      return 0
+    fi
+  fi
+
+  if [[ "${path}" == "${hooks_file}" ]]; then
+    local wrapper="${HOME}/.vibeguard/run-hook-codex.sh"
+    if [[ -f "${hooks_file}" ]] && python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${hooks_file}" --wrapper "${wrapper}" >/dev/null 2>&1; then
+      printf '%s\n' "${path} (checksum drift; VibeGuard hook semantics OK)"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+codex_latest_event_line() {
+  python3 - <<'PY' "${HOME}" "${VIBEGUARD_LOG_DIR:-}"
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+home = Path(sys.argv[1])
+log_root = Path(sys.argv[2]) if sys.argv[2] else home / ".vibeguard"
+files = []
+root_file = log_root / "events.jsonl"
+if root_file.exists():
+    files.append(root_file)
+projects_dir = log_root / "projects"
+if projects_dir.exists():
+    files.extend(sorted(projects_dir.glob("*/events.jsonl")))
+
+latest = None
+latest_project = ""
+for file in files:
+    project_root_file = file.parent / ".project-root"
+    project_root = project_root_file.read_text(encoding="utf-8", errors="replace").strip() if project_root_file.exists() else ""
+    try:
+        lines = file.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        continue
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("cli") != "codex" and event.get("agent_type") != "codex":
+            continue
+        ts = str(event.get("ts", ""))
+        key = ts or "0000"
+        if latest is None or key >= str(latest.get("ts", "")):
+            latest = event
+            latest_project = str(event.get("project_root") or project_root or file.parent)
+
+if latest is None:
+    print("NO_CODEX_EVENTS")
+else:
+    print(
+        f"{latest.get('ts', 'unknown')} | "
+        f"{latest.get('hook', 'unknown')} | "
+        f"{latest.get('decision', 'unknown')} | "
+        f"{latest_project}"
+    )
+PY
+}
+
+print_codex_status() {
+  echo "VibeGuard Codex Status"
+  echo "=============================="
+
+  if command -v codex >/dev/null 2>&1; then
+    local codex_path codex_version
+    codex_path="$(command -v codex)"
+    codex_version="$(codex --version 2>/dev/null | head -1 || true)"
+    green "[OK] Codex CLI: ${codex_path}${codex_version:+ (${codex_version})}"
+  else
+    yellow "[INFO] Codex CLI not found"
+  fi
+
+  check_codex_agents_hygiene
+
+  local hooks_file="${CODEX_DIR}/hooks.json"
+  local wrapper="${HOME}/.vibeguard/run-hook-codex.sh"
+  if [[ -f "${hooks_file}" ]]; then
+    green "[OK] Codex hooks.json present"
+    if python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${hooks_file}" --wrapper "${wrapper}" >/dev/null 2>&1; then
+      green "[OK] VibeGuard-managed Codex hooks semantic check passed"
+    else
+      yellow "[WARN] VibeGuard-managed Codex hooks semantic check failed (repair: bash setup.sh --yes)"
+    fi
+  else
+    yellow "[MISSING] Codex hooks.json not installed"
+  fi
+
+  if [[ -x "${wrapper}" ]]; then
+    green "[OK] Codex hook wrapper executable: ${wrapper}"
+  elif [[ -f "${wrapper}" ]]; then
+    red "[BROKEN] Codex hook wrapper is not executable: ${wrapper}"
+  else
+    yellow "[MISSING] Codex hook wrapper: ${wrapper}"
+  fi
+
+  local config="${CODEX_DIR}/config.toml"
+  local codex_hooks_status="MISSING"
+  if [[ -f "${config}" ]]; then
+    codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${config}" 2>/dev/null || true)"
+  fi
+  if [[ "${codex_hooks_status}" == "OK" ]]; then
+    green "[OK] codex_hooks feature enabled"
+  elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
+    red "[BROKEN] ~/.codex/config.toml is malformed TOML"
+  else
+    yellow "[MISSING] codex_hooks feature not enabled"
+  fi
+
+  if _has_legacy_codex_mcp_config; then
+    yellow "[LEGACY] Legacy VibeGuard MCP block still present"
+  else
+    green "[OK] No legacy VibeGuard MCP block"
+  fi
+
+  local latest_event
+  latest_event="$(codex_latest_event_line)"
+  if [[ "${latest_event}" == "NO_CODEX_EVENTS" ]]; then
+    yellow "[INFO] No Codex events found in VibeGuard logs"
+  else
+    green "[OK] Latest Codex event: ${latest_event}"
+  fi
+
+  yellow "[INFO] $(codex_native_capability_summary); Edit/Write/Read require Claude Code or the app-server wrapper"
+  echo "Repair command: bash setup.sh --yes"
+}
+
+check_codex_agents_hygiene() {
+  local agents_md="${CODEX_DIR}/AGENTS.md"
+  if [[ ! -f "${agents_md}" ]]; then
+    red "[MISSING] VibeGuard rules not in ~/.codex/AGENTS.md"
+    return 0
+  fi
+  if [[ ! -s "${agents_md}" ]]; then
+    red "[BROKEN] ~/.codex/AGENTS.md is 0 bytes (rerun setup)"
+    return 0
+  fi
+
+  local start_marker="<!-- vibeguard-start -->"
+  local end_marker="<!-- vibeguard-end -->"
+  local start_count end_count
+  start_count=$(grep -cF "${start_marker}" "${agents_md}" 2>/dev/null || true)
+  end_count=$(grep -cF "${end_marker}" "${agents_md}" 2>/dev/null || true)
+  if [[ "${start_count}" -ne 1 || "${end_count}" -ne 1 ]]; then
+    red "[BROKEN] ~/.codex/AGENTS.md marker mismatch (start=${start_count}, end=${end_count}; rerun setup)"
+    return 0
+  fi
+
+  local start_line end_line
+  start_line=$(grep -nF "${start_marker}" "${agents_md}" | head -1 | cut -d: -f1)
+  end_line=$(grep -nF "${end_marker}" "${agents_md}" | head -1 | cut -d: -f1)
+  if [[ "${start_line}" -ge "${end_line}" ]]; then
+    red "[BROKEN] ~/.codex/AGENTS.md marker order is invalid (rerun setup)"
+    return 0
+  fi
+
+  local managed_block anchor
+  local -a missing_anchors=()
+  managed_block=$(sed -n "${start_line},${end_line}p" "${agents_md}")
+  for anchor in \
+    "#VibeGuard" \
+    "## Constraints" \
+    "## Chat Contract" \
+    "## Key Detailed Rules" \
+    "| L1 |" \
+    "| W-03 |" \
+    "| SEC-13 |"; do
+    if ! grep -qF "${anchor}" <<< "${managed_block}"; then
+      missing_anchors+=("${anchor}")
+    fi
+  done
+  if [[ "${#missing_anchors[@]}" -gt 0 ]]; then
+    red "[BROKEN] ~/.codex/AGENTS.md missing required anchors: ${missing_anchors[*]} (rerun setup)"
+    return 0
+  fi
+
+  green "[OK] VibeGuard rules in ~/.codex/AGENTS.md"
+
+  local outside_count outside_first
+  outside_count=$(
+    awk -v start="${start_line}" -v end="${end_line}" '
+      (NR < start || NR > end) && $0 ~ /[^[:space:]]/ { count++ }
+      END { print count + 0 }
+    ' "${agents_md}"
+  )
+  if [[ "${outside_count}" -gt 0 ]]; then
+    outside_first=$(
+      awk -v start="${start_line}" -v end="${end_line}" '
+        (NR < start || NR > end) && $0 ~ /[^[:space:]]/ { print substr($0, 1, 100); exit }
+      ' "${agents_md}"
+    )
+    yellow "[WARN] ~/.codex/AGENTS.md has ${outside_count} non-empty unmanaged line(s) outside VibeGuard block: ${outside_first}"
+  fi
+}
+
 clean_codex_home_installation() {
+  if [[ -f "${CODEX_DIR}/AGENTS.md" ]]; then
+    local agents_md_result
+    agents_md_result=$(python3 "${CLAUDE_MD_HELPER}" remove "${CODEX_DIR}/AGENTS.md" 2>/dev/null || echo "ERROR")
+    case "${agents_md_result}" in
+      REMOVED|REMOVED_LEGACY) yellow "Removed VibeGuard rules from ~/.codex/AGENTS.md" ;;
+      NOT_FOUND) yellow "No VibeGuard rules found in ~/.codex/AGENTS.md" ;;
+      *) red "Failed to clean ~/.codex/AGENTS.md" ;;
+    esac
+  fi
+
   local skill_links source_path skill
   skill_links="$(manifest_skill_links_for_cleanup "~/.codex/skills/")"
   while IFS=$'\t' read -r source_path skill; do
@@ -184,6 +447,8 @@ clean_codex_home_installation() {
   esac
 
   rm -f "${HOME}/.vibeguard/run-hook-codex.sh"
+  rm -f "${HOME}/.vibeguard/_lib/codex_diag.sh"
+  rmdir "${HOME}/.vibeguard/_lib" 2>/dev/null || true
   yellow "Removed Codex hook wrapper"
 
   # Keep codex_hooks flag untouched to avoid affecting other toolchains.

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,10 @@ case "${1:-}" in
     shift || true
     run_setup "clean.sh" "$@"
     ;;
+  --codex-status)
+    shift || true
+    run_setup "codex-status.sh" "$@"
+    ;;
   *)
     run_setup "install.sh" "$@"
     ;;

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,7 +1,7 @@
-# AGENTS.md — VibeGuard Constraints for Codex/OpenAI Agents
+# AGENTS.md — VibeGuard Starter Constraints for Codex/OpenAI Agents
 
-> This file is equivalent to the VibeGuard rules of CLAUDE.md and adapts to the OpenAI Codex agent format.
-> Copy to the project root directory and the Codex agent will automatically read it.
+> This starter carries the compact VibeGuard contract for Codex-style agents. It is not a replacement for the full Claude rule tree.
+> Copy it to a project root directory, then add project-specific facts for that repository.
 > Scope = the entire subtree of the directory where this file is located, with increasing priority for deep AGENTS.md.
 
 ## Chat Contract
@@ -12,9 +12,7 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 - Default verbosity: keep answers concise by default; use short paragraphs for simple tasks and expand only when the work is complex or the user asks for depth.
 - Formatting: use Markdown only when it helps; prefer prose first, flat bullets only for natural lists, and avoid decorative structure.
 
-## Operating Principles
-
-### Rules
+## Constraints
 
 | ID | Rule |
 |----|------|
@@ -26,13 +24,12 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 | L6 | Follow `workflows/references/routing-contract.md`: `execute_direct`, `plan_first`, `clarify_first`, and the shared handoff fields |
 | L7 | No AI markers. No force push. No secrets in commits |
 
-### Prohibitions
+## Project Constraints To Fill In
 
-- This project does NOT use an ORM
-- This project does NOT have a frontend framework
-- This project does NOT use microservices
-- There is NO "similar file" pattern — always extend existing code
-- There is NO backward compatibility requirement — delete old code directly
+- Record repo-specific facts here, such as architecture layers, storage boundaries, supported runtimes, and test commands.
+- Do not put repo-specific facts into the global `~/.codex/AGENTS.md` block.
+- There is no "similar file" shortcut. Search for existing code and extend it when the existing contract supports the change.
+- Do not add backward compatibility layers unless the project contract or migration plan requires them.
 
 ## Verification
 
@@ -42,18 +39,19 @@ Before completing any task:
 - Go: `go build ./...` then `go test ./...`
 - Python: `pytest`
 
-## Routing
+## Architecture Layers
 
 If `.vibeguard-architecture.yaml` exists, enforce dependency direction:
-`Types → Config → Repo → Service → Runtime → UI` (one-way only).
+`Types → Config → Repo → Service → Runtime → UI` (one-way only)
 
-Fix priority: security vulnerability > logic bug > data inconsistency > duplicate types > unwrap > naming.
+## Fix Priority
+
+security vulnerability > logic bug > data inconsistency > duplicate types > unwrap > naming
 
 ## Code Style
 
-- Single file ≤ 200 lines — split if exceeded
+- Keep file size under control: 200-400 lines typical, 800 lines hard ceiling
 - No hardcoded values (ports, URLs, configs)
-- No backward compatibility layers
 - Every fix must include a corresponding test
 - Follow existing project patterns
 

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -196,6 +196,47 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "run-hook-codex writes diagnostics without noisy stdout"
+TMP_HOME_DIAG="${TMP_DIR}/home-diagnostics"
+TMP_FAKE_REPO_DIAG="${TMP_DIR}/fake-repo-diagnostics"
+DIAG_FILE="${TMP_DIR}/codex-wrapper.jsonl"
+mkdir -p "${TMP_HOME_DIAG}/.vibeguard" "${TMP_FAKE_REPO_DIAG}/hooks"
+printf '%s' "${TMP_FAKE_REPO_DIAG}" > "${TMP_HOME_DIAG}/.vibeguard/repo-path"
+
+non_namespaced_out="$({
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo ok"}}' \
+    | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" pre-bash-guard.sh
+} 2>/dev/null)"
+TOTAL=$((TOTAL + 1))
+if [[ -z "${non_namespaced_out}" ]]; then
+  green "non-namespaced hook remains stdout-silent"
+  PASS=$((PASS + 1))
+else
+  red "non-namespaced hook remains stdout-silent"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "$(cat "${DIAG_FILE}")" "non-namespaced-hook" "non-namespaced hook writes diagnostic event"
+
+missing_hook_out="$(
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo ok"}}' \
+    | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${missing_hook_out}" '"permissionDecision": "deny"' "missing PreToolUse hook fails closed"
+assert_contains "$(cat "${DIAG_FILE}")" "missing-hook" "missing hook writes diagnostic event"
+
+cat > "${TMP_FAKE_REPO_DIAG}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+HOOK
+chmod +x "${TMP_FAKE_REPO_DIAG}/hooks/vibeguard-pre-bash-guard.sh"
+missing_adapter_out="$(
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo ok"}}' \
+    | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_ADAPTER_PATH="${TMP_DIR}/missing-adapter.sh" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${missing_adapter_out}" '"permissionDecision": "deny"' "missing adapter fails closed for PreToolUse"
+assert_contains "$(cat "${DIAG_FILE}")" "missing-adapter" "missing adapter writes diagnostic event"
+
 header "run-hook-codex adapts posttool block output"
 TMP_HOME_POSTTOOL="${TMP_DIR}/home-posttool"
 TMP_FAKE_REPO_POSTTOOL="${TMP_DIR}/fake-repo-posttool"
@@ -218,6 +259,27 @@ posttool_out="$(
 )"
 assert_contains "${posttool_out}" '"decision": "block"' "run-hook-codex preserves posttool block decisions"
 assert_contains "${posttool_out}" '"additionalContext": "build failed"' "run-hook-codex maps posttool reason to additionalContext"
+
+cat > "${TMP_FAKE_REPO_POSTTOOL}/hooks/vibeguard-post-build-check.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{'
+HOOK
+chmod +x "${TMP_FAKE_REPO_POSTTOOL}/hooks/vibeguard-post-build-check.sh"
+posttool_bad_diag="${TMP_DIR}/posttool-bad.jsonl"
+bad_posttool_out="$({
+  printf '{"hook_event_name":"PostToolUse","tool_input":{"command":"cargo check"}}' \
+    | HOME="${TMP_HOME_POSTTOOL}" VIBEGUARD_CODEX_DIAG_FILE="${posttool_bad_diag}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-post-build-check.sh
+} 2>/dev/null)"
+TOTAL=$((TOTAL + 1))
+if [[ -z "${bad_posttool_out}" ]]; then
+  green "invalid PostToolUse hook output stays stdout-silent"
+  PASS=$((PASS + 1))
+else
+  red "invalid PostToolUse hook output stays stdout-silent"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "$(cat "${posttool_bad_diag}")" "posttool-adapter-failed" "invalid PostToolUse output writes diagnostic event"
 
 header "app-server adapter propagates explicit session context and feedback"
 adapter_json="$(python3 - "${REPO_DIR}" "${TMP_DIR}" <<'PYCODE'

--- a/tests/test_codex_status.sh
+++ b/tests/test_codex_status.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# VibeGuard Codex status and semantic drift regression tests
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF -- "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if ! echo "$output" | grep -qF -- "$unexpected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (unexpectedly contains: $unexpected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+ORIG_HOME="${HOME}"
+ORIG_PATH="${PATH}"
+TMP_HOME="$(mktemp -d)"
+
+cleanup() {
+  export HOME="${ORIG_HOME}"
+  export PATH="${ORIG_PATH}"
+  rm -rf "${TMP_HOME}"
+}
+trap cleanup EXIT
+
+export HOME="${TMP_HOME}"
+if [[ -z "${CARGO_HOME:-}" && -d "${ORIG_HOME}/.cargo" ]]; then
+  export CARGO_HOME="${ORIG_HOME}/.cargo"
+fi
+if [[ -z "${RUSTUP_HOME:-}" && -d "${ORIG_HOME}/.rustup" ]]; then
+  export RUSTUP_HOME="${ORIG_HOME}/.rustup"
+fi
+
+mkdir -p "${TMP_HOME}/bin"
+cat > "${TMP_HOME}/bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "${TMP_HOME}/bin/launchctl"
+export PATH="${TMP_HOME}/bin:${PATH}"
+
+header "install codex fixtures"
+install_out="$(bash "${REPO_DIR}/setup.sh" --yes 2>&1)"
+assert_contains "${install_out}" "Setup complete! All components installed." "setup install succeeds for Codex status tests"
+assert_cmd "Codex AGENTS installed" test -f "${HOME}/.codex/AGENTS.md"
+assert_cmd "Codex hooks installed" test -f "${HOME}/.codex/hooks.json"
+assert_cmd "Codex config installed" test -f "${HOME}/.codex/config.toml"
+
+header "codex status is read-only and reports current state"
+mkdir -p "${HOME}/.vibeguard/projects/codex-status"
+printf '%s' "${REPO_DIR}" > "${HOME}/.vibeguard/projects/codex-status/.project-root"
+printf '%s\n' '{"ts":"2026-05-05T00:00:00Z","cli":"codex","hook":"pre-bash-guard","decision":"pass"}' > "${HOME}/.vibeguard/projects/codex-status/events.jsonl"
+
+agents_before="$(shasum -a 256 "${HOME}/.codex/AGENTS.md" | cut -d' ' -f1)"
+hooks_before="$(shasum -a 256 "${HOME}/.codex/hooks.json" | cut -d' ' -f1)"
+config_before="$(shasum -a 256 "${HOME}/.codex/config.toml" | cut -d' ' -f1)"
+status_out="$(bash "${REPO_DIR}/setup.sh" --codex-status)"
+agents_after="$(shasum -a 256 "${HOME}/.codex/AGENTS.md" | cut -d' ' -f1)"
+hooks_after="$(shasum -a 256 "${HOME}/.codex/hooks.json" | cut -d' ' -f1)"
+config_after="$(shasum -a 256 "${HOME}/.codex/config.toml" | cut -d' ' -f1)"
+
+assert_contains "${status_out}" "VibeGuard Codex Status" "Codex status command has a clear title"
+assert_contains "${status_out}" "VibeGuard-managed Codex hooks semantic check passed" "Codex status reports hook semantic health"
+assert_contains "${status_out}" "Codex native support: PreToolUse(Bash), PostToolUse(Bash), Stop" "Codex status reports exact native support"
+assert_contains "${status_out}" "Latest Codex event: 2026-05-05T00:00:00Z | pre-bash-guard | pass | ${REPO_DIR}" "Codex status reports latest Codex event"
+assert_cmd "Codex status does not rewrite AGENTS" test "${agents_before}" = "${agents_after}"
+assert_cmd "Codex status does not rewrite hooks.json" test "${hooks_before}" = "${hooks_after}"
+assert_cmd "Codex status does not rewrite config.toml" test "${config_before}" = "${config_after}"
+
+header "setup --check downgrades semantic-only Codex drift"
+cp "${HOME}/.codex/config.toml" "${TMP_HOME}/config.toml.backup"
+cp "${HOME}/.codex/hooks.json" "${TMP_HOME}/hooks.json.backup"
+cat >> "${HOME}/.codex/config.toml" <<'TOML'
+
+[profiles.default]
+model = "gpt-5"
+TOML
+python3 - <<'PY' "${HOME}/.codex/hooks.json"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+data.setdefault("hooks", {}).setdefault("PreToolUse", []).append({
+    "matcher": "Bash",
+    "hooks": [{"type": "command", "command": "node /user/non-vibeguard.js"}],
+})
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+drift_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${TMP_HOME}/config.toml.backup" "${HOME}/.codex/config.toml"
+cp "${TMP_HOME}/hooks.json.backup" "${HOME}/.codex/hooks.json"
+
+assert_contains "${drift_out}" "${HOME}/.codex/config.toml (checksum drift; Codex config semantics OK)" "semantic config drift is downgraded"
+assert_contains "${drift_out}" "${HOME}/.codex/hooks.json (checksum drift; VibeGuard hook semantics OK)" "semantic hooks drift is downgraded"
+assert_not_contains "${drift_out}" "DRIFT: ${HOME}/.codex/config.toml" "semantic config drift is not reported as hard drift"
+assert_not_contains "${drift_out}" "DRIFT: ${HOME}/.codex/hooks.json" "semantic hooks drift is not reported as hard drift"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -153,6 +153,8 @@ assert_cmd "setup.sh syntax is correct" bash -n "${REPO_DIR}/setup.sh"
 assert_cmd "scripts/setup/install.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/install.sh"
 assert_cmd "scripts/setup/check.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/check.sh"
 assert_cmd "scripts/setup/clean.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/clean.sh"
+assert_cmd "scripts/setup/codex-status.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/codex-status.sh"
+assert_cmd "scripts/codex-contract-check.sh syntax is correct" bash -n "${REPO_DIR}/scripts/codex-contract-check.sh"
 assert_cmd "scripts/install-systemd.sh syntax is correct" bash -n "${REPO_DIR}/scripts/install-systemd.sh"
 assert_cmd "scripts/lib/settings_json.py syntax is correct" python3 -m py_compile "${SETTINGS_HELPER}"
 assert_cmd "scripts/lib/hooks_manifest.py syntax is correct" python3 -m py_compile "${HOOKS_MANIFEST_HELPER}"
@@ -450,10 +452,12 @@ dry_run_codex_config_sha_after="$(shasum -a 256 "${HOME}/.codex/config.toml" | c
 assert_contains "${dry_run_out}" "Mode: dry-run" "--dry-run reports dry-run mode"
 assert_contains "${dry_run_out}" "${HOME}/.claude/settings.json" "--dry-run prints settings.json diff"
 assert_contains "${dry_run_out}" "${HOME}/.claude/CLAUDE.md" "--dry-run prints CLAUDE.md diff"
+assert_contains "${dry_run_out}" "${HOME}/.codex/AGENTS.md" "--dry-run prints Codex AGENTS.md diff"
 assert_cmd "--dry-run does not modify ~/.claude/settings.json" test "${dry_run_settings_sha_before}" = "${dry_run_settings_sha_after}"
 assert_cmd "--dry-run does not modify ~/.codex/hooks.json" test "${dry_run_codex_hooks_sha_before}" = "${dry_run_codex_hooks_sha_after}"
 assert_cmd "--dry-run does not modify ~/.codex/config.toml" test "${dry_run_codex_config_sha_before}" = "${dry_run_codex_config_sha_after}"
 assert_cmd "--dry-run does not create ~/.claude/CLAUDE.md" test ! -e "${HOME}/.claude/CLAUDE.md"
+assert_cmd "--dry-run does not create ~/.codex/AGENTS.md" test ! -e "${HOME}/.codex/AGENTS.md"
 
 confirm_fail_out="$(bash "${REPO_DIR}/setup.sh" 2>&1 || true)"
 assert_contains "${confirm_fail_out}" "requires explicit confirmation" "non-interactive setup requires --yes for high-context writes"
@@ -510,6 +514,9 @@ assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existin
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 assert_cmd "~/.claude/CLAUDE.md includes the chat contract anchor after installation" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${HOME}/.claude/CLAUDE.md"
 assert_cmd "~/.claude/CLAUDE.md rule banner matches installed rules" assert_claude_rule_banner_matches_installed_rules
+assert_cmd "~/.codex/AGENTS.md exists after installation" test -f "${HOME}/.codex/AGENTS.md"
+assert_cmd "~/.codex/AGENTS.md includes managed markers after installation" bash -c "grep -q '<!-- vibeguard-start -->' '${HOME}/.codex/AGENTS.md' && grep -q '<!-- vibeguard-end -->' '${HOME}/.codex/AGENTS.md'"
+assert_cmd "~/.codex/AGENTS.md includes key Codex-visible anchors" bash -c "grep -qF 'Compact Chat Contract' '${HOME}/.codex/AGENTS.md' && grep -qF '| W-03 |' '${HOME}/.codex/AGENTS.md' && grep -qF '| SEC-13 |' '${HOME}/.codex/AGENTS.md'"
 assert_cmd "templates/AGENTS.md includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/templates/AGENTS.md"
 assert_cmd "docs/CLAUDE.md.example includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/docs/CLAUDE.md.example"
 assert_cmd "chat contract block matches across source, installed output, and templates" assert_chat_contract_blocks_match
@@ -582,6 +589,43 @@ cp "${_VALID_CODEX_CONFIG}" "${HOME}/.codex/config.toml"
 assert_contains "${invalid_utf8_codex_check_out}" "[BROKEN] ~/.codex/config.toml is malformed TOML" "--check reports invalid UTF-8 ~/.codex/config.toml"
 assert_cmd "invalid UTF-8 config does not report codex_hooks enabled" bash -c "! grep -qF '[OK] codex_hooks feature enabled in config.toml' <<< '${invalid_utf8_codex_check_out}'"
 
+header "setup --check validates codex AGENTS"
+_VALID_CODEX_AGENTS="${TMP_HOME}/AGENTS.md.valid.backup"
+cp "${HOME}/.codex/AGENTS.md" "${_VALID_CODEX_AGENTS}"
+: > "${HOME}/.codex/AGENTS.md"
+zero_byte_agents_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
+assert_contains "${zero_byte_agents_check_out}" "[BROKEN] ~/.codex/AGENTS.md is 0 bytes" "--check reports 0-byte ~/.codex/AGENTS.md"
+python3 - <<'PY' "${HOME}/.codex/AGENTS.md"
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+path.write_text(text.replace("<!-- vibeguard-end -->", "", 1), encoding="utf-8")
+PY
+missing_end_agents_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
+assert_contains "${missing_end_agents_check_out}" "[BROKEN] ~/.codex/AGENTS.md marker mismatch" "--check reports missing Codex AGENTS end marker"
+printf '<!-- vibeguard-start -->\n' >> "${HOME}/.codex/AGENTS.md"
+duplicate_start_agents_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
+assert_contains "${duplicate_start_agents_check_out}" "[BROKEN] ~/.codex/AGENTS.md marker mismatch" "--check reports duplicate Codex AGENTS start marker"
+python3 - <<'PY' "${HOME}/.codex/AGENTS.md"
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+path.write_text(text.replace("| SEC-13 |", "| SEC-X |", 1), encoding="utf-8")
+PY
+missing_anchor_agents_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
+assert_contains "${missing_anchor_agents_check_out}" "[BROKEN] ~/.codex/AGENTS.md missing required anchors" "--check reports missing Codex AGENTS required anchors"
+printf '# malicious injection appended by something\n' >> "${HOME}/.codex/AGENTS.md"
+external_agents_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
+assert_contains "${external_agents_check_out}" "[WARN] ~/.codex/AGENTS.md has 1 non-empty unmanaged line(s) outside VibeGuard block" "--check warns on unmanaged Codex AGENTS content"
+assert_contains "${external_agents_check_out}" "Codex native hooks: PreToolUse(Bash), PostToolUse(Bash), Stop(stop-guard/learn-evaluator)" "--check reports exact Codex native hook scope"
+
 header "setup --check stays read-only"
 python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"
 from pathlib import Path
@@ -592,11 +636,14 @@ updated = re.sub(r'\b\d+ rules\b', '999 rules', text, count=1)
 path.write_text(updated, encoding='utf-8')
 PY
 before_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
+agents_before_sha="$(shasum -a 256 "${HOME}/.codex/AGENTS.md" | cut -d' ' -f1)"
 check_again_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 after_sha="$(shasum -a 256 "${HOME}/.claude/CLAUDE.md" | cut -d' ' -f1)"
+agents_after_sha="$(shasum -a 256 "${HOME}/.codex/AGENTS.md" | cut -d' ' -f1)"
 assert_contains "${check_again_out}" "CLAUDE.md declares 999 rules" "--check reports CLAUDE.md drift"
 assert_contains "${check_again_out}" "[OK] vg-helper runtime binary installed" "--check reports vg-helper installed"
 assert_cmd "--check does not rewrite ~/.claude/CLAUDE.md" test "${before_sha}" = "${after_sha}"
+assert_cmd "--check does not rewrite ~/.codex/AGENTS.md" test "${agents_before_sha}" = "${agents_after_sha}"
 assert_cmd "--check does not drop or duplicate the chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 repair_out="$(bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${repair_out}" "Setup complete! All components installed." "re-running setup after drift still succeeds"
@@ -682,6 +729,7 @@ python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${_STALE_HOOKS}" 
 assert_cmd "upsert repairs Stop entry with spurious matcher; check-vibeguard then passes" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}"
 
 header "setup --clean"
+printf 'user codex note\n' >> "${HOME}/.codex/AGENTS.md"
 clean_out="$(bash "${REPO_DIR}/setup.sh" --clean)"
 assert_contains "${clean_out}" "VibeGuard cleaned." "--clean route to cleanup process"
 assert_cmd "~/.claude/skills/vibeguard has been removed after cleaning" test ! -e "${HOME}/.claude/skills/vibeguard"
@@ -690,6 +738,8 @@ assert_cmd "~/.claude/skills/trajectory-review has been removed after cleaning" 
 assert_cmd "~/.codex/skills/agentsmd-audit has been removed after cleaning" test ! -e "${HOME}/.codex/skills/agentsmd-audit"
 assert_cmd "~/.codex/skills/trajectory-review has been removed after cleaning" test ! -e "${HOME}/.codex/skills/trajectory-review"
 assert_cmd "~/.codex/hooks.json is preserved after cleaning (for non-VibeGuard hooks)" test -f "${HOME}/.codex/hooks.json"
+assert_cmd "VibeGuard managed Codex AGENTS block removed after cleaning" bash -c "! grep -q 'vibeguard-start' '${HOME}/.codex/AGENTS.md'"
+assert_cmd "Unmanaged Codex AGENTS content remains after cleaning" grep -q 'user codex note' "${HOME}/.codex/AGENTS.md"
 assert_cmd "VibeGuard managed Codex hooks removed after cleaning" bash -c "! grep -q 'vibeguard-pre-bash-guard.sh' '${HOME}/.codex/hooks.json' && ! grep -q 'vibeguard-post-build-check.sh' '${HOME}/.codex/hooks.json' && ! grep -q 'vibeguard-stop-guard.sh' '${HOME}/.codex/hooks.json' && ! grep -q 'vibeguard-learn-evaluator.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "Pre-existing non-VibeGuard hook remains after cleaning" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "legacy Codex MCP block has been removed after cleaning" bash -c "[ ! -f '${HOME}/.codex/config.toml' ] || ! grep -q '^\[mcp_servers\.vibeguard\]' '${HOME}/.codex/config.toml'"


### PR DESCRIPTION
## Summary
- add repo-level AGENTS.md and keep repo-specific facts out of global Codex/Claude templates
- install and validate managed Codex AGENTS.md rules, semantic drift checks, and a read-only Codex status command
- add Codex wrapper diagnostics and a single contract gate for Codex runtime checks

## Verification
- bash scripts/codex-contract-check.sh
- bash tests/test_manifest_contract.sh
- bash setup.sh --check
- bash setup.sh --codex-status
- bash scripts/ci/self-application/check-codex-wrapper-thin.sh && bash scripts/ci/validate-doc-paths.sh && bash scripts/ci/validate-doc-command-paths.sh && git diff --check