### PR TITLE
feat(prompts): canonical prompt contract schema + validator

### DIFF
--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -1,0 +1,69 @@
+# Prompt Contract
+
+VibeGuard validates the structure of `templates/AGENTS.md` and every role prompt under `agents/` against `schemas/prompt-contract.schema.json`. The schema is the only source of truth — the validator is the only consumer.
+
+## What is enforced
+
+| Check | Default | `--strict` |
+|---|---|---|
+| Each `required_sections[].heading_text` appears as a top-level `## ` heading | error | error |
+| Each `must_mention` token appears in the matched section body (case-insensitive substring) | error | error |
+| Top-level `## ` heading not in required + optional list | warning | warning |
+| Role prompt under `agents/` declares all `role_prompt.frontmatter_required` keys | error | error |
+| `templates/AGENTS.md` exceeds `budgets.root_agents_md_warn_lines` | warning | warning |
+| `templates/AGENTS.md` exceeds `budgets.root_agents_md_max_lines` | warning | error |
+| Role prompt exceeds `budgets.role_prompt_max_lines` | warning | error |
+
+## Required sections (today)
+
+| name | heading_text | safety subset |
+|---|---|---|
+| `operating-principles` | `Operating Principles` | must mention `force push`, `secret`, `AI marker` |
+| `routing` | `Routing` | — |
+| `verification` | `Verification` | — |
+| `output-contract` | `Chat Contract` | — |
+
+## Optional sections
+
+`Code Style`, `Guards`. Add an optional section by appending to `optional_sections` in the schema; existing AGENTS.md does not need to change.
+
+## Role prompt contract
+
+Files matched by `agents/*.md` must declare YAML frontmatter with `name`, `description`, `model`, `tools`. The validator only checks key presence; value types are not enforced in this revision.
+
+## How to run
+
+```bash
+# Single target, warnings allowed
+python3 scripts/lib/vibeguard_manifest.py validate-prompt-contract \
+  --target templates/AGENTS.md
+
+# Walk all prompts (CI default)
+bash scripts/ci/validate-prompt-contract.sh
+
+# Treat warnings as errors
+bash scripts/ci/validate-prompt-contract.sh --strict
+```
+
+The CI wrapper validates `templates/AGENTS.md` plus every `agents/*.md` and exits non-zero if any target fails.
+
+## Adding a new required section
+
+1. Add a `{name, heading_text}` entry to `required_sections` in `schemas/prompt-contract.schema.json`.
+2. Update `templates/AGENTS.md` to include the new heading.
+3. Add a regression case to `tests/test_prompt_contract.sh` that asserts the section is required.
+
+## Schema versioning
+
+The schema includes a `version` field. The validator refuses to run on a version it does not recognize. Bump `version` and update the validator together when the schema shape changes.
+
+## Precedence (informational)
+
+Effective prompt rules are resolved in this order, with later layers winning on conflict:
+
+1. `templates/AGENTS.md` (project root)
+2. Role prompt under `agents/<role>.md`
+3. Skill-specific instructions in a `SKILL.md`
+4. Runtime overlay (`AGENTS.override.md`, ad-hoc additions in session)
+
+The validator only checks layer 1 and layer 2. Skill and overlay validation is out of scope for this contract.

--- a/plan/spec-96-prompt-contract-schema.md
+++ b/plan/spec-96-prompt-contract-schema.md
@@ -1,198 +1,195 @@
-# SPEC: Canonical Prompt Contract Schema (#96)
+# SPEC: Canonical Prompt Contract Schema (#96, reduced scope)
 
-**Status**: Draft for review
-**Author**: majiayu000
-**Date**: 2026-04-30
+**Status**: Draft v2 (post-#124/#125/#118 merge — scope reduced to lint-only)
 **Closes**: #96 (P2, dx)
 **Depends on**: nothing
 **Blocks**: #99 (delegation contracts must target this contract)
 
 ---
 
-## Goals (Facts from #96)
+## What changed since v1
 
-1. Replace the conventional shape of `templates/AGENTS.md` with a machine-validatable schema.
-2. Give role prompts and runtime overlays stable extension points instead of ad hoc text insertion.
-3. Catch prompt-contract drift in CI the same way `validate-manifest-contract.sh` catches manifest drift today.
+The original SPEC (v1) was written before the recent merges. Three commits this week ate ~30-40% of the original scope:
 
-## Non-goals
+| #96 sub-problem | v1 plan | Status today | Why |
+|---|---|---|---|
+| Chat / output contract | new section + validator | **DONE upstream** | #124 added a canonical Chat Contract block, locked across `claude-md/vibeguard-rules.md`, `templates/AGENTS.md`, `docs/CLAUDE.md.example` with an idempotency test |
+| Routing contract + handoff schema | new section + handoff fields | **DONE upstream** | #125 published `workflows/references/routing-contract.md` with the 5-field handoff (mode / artifacts / verification_owner / stop_conditions / lane_map) |
+| Size-budget drift detection | new validator | **DONE upstream** | #118 added W-19 + `check_doc_overload.sh` — line budget + prohibition-pairing |
+| **Section-presence drift** | new validator | **STILL OPEN** | no one validates that AGENTS.md actually contains the required sections |
+| **Role-prompt frontmatter contract** | new validator | **STILL OPEN** | the 14 files under `agents/` have YAML frontmatter but no shared schema |
+| **CI integration** | wire into `local-contract-check.sh` | **STILL OPEN** | depends on the two items above |
 
-- Not rewriting AGENTS.md content. The schema describes the shape; current prose stays unless it violates the shape.
-- Not introducing a new prompt language or DSL. Markdown + minimal HTML-comment markers + one YAML schema file.
-- Not formalizing every role in `agents/` in this PR. SEC-only: role prompts get one optional convention (frontmatter contract); deep role schema is a follow-up.
+So this revision is **lint-only** and shrinks to ~5-6 files.
 
 ---
 
-## Current state (Facts; from sub-agent survey)
+## Goals (after scope reduction)
 
-- `templates/AGENTS.md` is **67 lines**, eight headings: `Chat Contract`, `Constraints`, `Negative Constraints`, `Verification`, `Architecture Layers`, `Fix Priority`, `Code Style`, `Guards`. **No machine-readable markers.**
-- `skills/vibeguard/references/task-contract.yaml` (58 lines) is the existing precedent for a YAML schema (top-level `task_contract` with `required`/`forbidden`/`warnings`/`validation`).
-- `scripts/local-contract-check.sh` orchestrates ~7 sub-validators; **none of them touch AGENTS.md**.
-- `scripts/ci/validate-manifest-contract.sh` calls `scripts/lib/vibeguard_manifest.py validate` — natural integration point.
-- `agents/` has 14 role prompts in YAML-frontmatter + Markdown form, no shared schema.
-- `docs/reference/harness-engineering.md:178-189` already prescribes "AGENTS.md ≈ 100 lines, catalogue not encyclopedia, progressive disclosure" — schema must be consistent with this.
+1. Catch the case where someone deletes or renames a required section in `templates/AGENTS.md` and prompt-driven behavior silently regresses.
+2. Catch the case where a role prompt under `agents/` is missing one of the four mandatory frontmatter keys.
+3. Run both checks in CI alongside the existing manifest validator.
 
-## Inference (medium confidence)
+## Non-goals
 
-- The issue's suggested section list (operating principles, routing, verification, safety, output) maps onto the current AGENTS.md headings with one rename and one merge:
-  - `Constraints` + `Negative Constraints` → **operating-principles** (rules + prohibitions)
-  - `Architecture Layers` + `Fix Priority` → **routing** (where to apply the rules + ordering)
-  - `Verification` → **verification** (no change)
-  - `Negative Constraints` (force-push, AI tags, etc.) is also **safety** — overlap is intentional, schema treats safety as a *required subset* of operating-principles, not a separate top-level section
-  - `Chat Contract` → **output-contract**
-- `Guards` and `Code Style` are repo-specific addenda; schema treats them as **optional named sections**.
+- Not adding new sections to AGENTS.md.
+- Not enforcing prose content beyond "the section heading is present".
+- Not validating skill `SKILL.md` files (separate contract surface).
+- Not changing routing or chat contract content — those are already canonical.
 
-## Suggestion: Schema design
+---
 
-### File: `schemas/prompt-contract.schema.yaml` (new)
+## Design
 
-Single YAML file describing required/optional sections, marker syntax, and precedence.
+### Decision: heading names are the contract (no HTML comment markers)
+
+Per your pushback on the v1 marker proposal: drop the HTML comments. The contract becomes the literal Markdown heading names. Validator just looks for `^## Operating Principles$`, etc.
+
+**Tradeoff accepted**: this requires a small AGENTS.md heading rename. The current 8 headings consolidate into 5 required + 2 optional sections that match the issue's section list:
+
+| Current heading | Becomes |
+|---|---|
+| `## Chat Contract` | `## Output Contract` |
+| `## Constraints` + `## Negative Constraints` | `## Operating Principles` (with `### Rules` and `### Prohibitions`) |
+| `## Verification` | `## Verification` (unchanged) |
+| `## Architecture Layers` + `## Fix Priority` | `## Routing` |
+| `## Code Style` | `## Code Style` (optional, unchanged) |
+| `## Guards` | `## Guards` (optional, unchanged) |
+
+The `## Output Contract` rename has knock-on effect: #124's idempotency test currently anchors on `## Chat Contract`. The schema owns the rename; that test must update its anchor. Three files affected (`claude-md/vibeguard-rules.md` / `templates/AGENTS.md` / `docs/CLAUDE.md.example`).
+
+> If you prefer to keep the heading `## Chat Contract` as-is, the schema can map `output-contract` → `## Chat Contract` literally. Then no rename is needed and #124's anchor stays. Cleaner; recommend this path. **See Open Question 1.**
+
+### Schema file: `schemas/prompt-contract.schema.yaml`
 
 ```yaml
-# Authoritative list of section anchors that AGENTS.md and role prompts may declare.
-# Validator reads this file; nothing else hardcodes section names.
-
+# Authoritative section list. Validator is the only consumer.
 prompt_contract:
   version: 1
+
   required_sections:
-    - operating-principles      # rules + prohibitions; safety subset must be present
-    - routing                   # where rules apply, application order
-    - verification              # commands that prove "done"
-    - output-contract           # chat shape, verbosity, formatting
+    # heading_text is the literal Markdown heading the validator searches for.
+    # name is the contract identity used in error messages and cross-refs.
+    - name: operating-principles
+      heading_text: "Operating Principles"
+      must_mention:        # safety subset — case-insensitive substring
+        - "force push"
+        - "secret"
+        - "AI marker"
+    - name: routing
+      heading_text: "Routing"
+    - name: verification
+      heading_text: "Verification"
+    - name: output-contract
+      heading_text: "Chat Contract"   # or "Output Contract" — see Open Q 1
+
   optional_sections:
-    - guards                    # repo-specific guard scripts
-    - code-style                # repo-specific style addenda
-    - role-overrides            # only valid in role prompts, not root AGENTS.md
-  safety_subset:
-    # operating-principles must contain a block tagged safety with at least these prohibitions
-    # validator looks for these exact tokens (case-insensitive substring match)
-    must_mention:
-      - "force push"
-      - "secret"
-      - "AI tag"
-  marker_syntax:
-    open:  "<!-- contract:{section} -->"
-    close: "<!-- /contract:{section} -->"
-    role_frontmatter_required:
+    - name: code-style
+      heading_text: "Code Style"
+    - name: guards
+      heading_text: "Guards"
+    - name: negative-constraints
+      heading_text: "Negative Constraints"
+
+  role_prompt:
+    frontmatter_required:
       - name
       - description
       - model
       - tools
-  precedence:
-    # higher number wins on conflict; documented for humans, not enforced by validator
-    1: root_agents_md         # templates/AGENTS.md
-    2: role_prompt            # agents/*.md
-    3: skill_instructions     # skills/*/SKILL.md
-    4: runtime_overlay        # AGENTS.override.md, ad-hoc additions in session
+
   budgets:
-    root_agents_md_max_lines: 200    # warn at 150
-    role_prompt_max_lines: 400        # warn at 250
+    root_agents_md_warn_lines: 150
+    root_agents_md_max_lines: 300
+    role_prompt_max_lines: 400
 ```
 
-### Marker convention (additive, doesn't break existing AGENTS.md rendering)
+### Validator: extend `scripts/lib/vibeguard_manifest.py`
 
-Each required section is wrapped:
+New subcommand `validate-prompt-contract`. Inputs:
+- `--target` (default `templates/AGENTS.md`); also accepts `agents/*.md` for role prompts
+- `--schema` (default `schemas/prompt-contract.schema.yaml`)
+- `--strict` — warnings become errors; used in CI
 
-```markdown
-<!-- contract:operating-principles -->
-## Constraints
-| Layer | Rule |
-| ...
+Checks:
+1. Each `required_sections[].heading_text` appears as exactly one `^## ` heading.
+2. `must_mention` tokens appear inside the matched section's body (case-insensitive substring).
+3. Any `^## ` heading not in required + optional list raises a warning ("unknown section"), not an error — leaves room for project-local extensions without code change.
+4. When `--target` is under `agents/`, parse YAML frontmatter and assert `role_prompt.frontmatter_required` keys are present.
+5. Line count vs. `budgets.*` — warn / fail with `--strict`.
 
-## Negative Constraints
-- No force push to main
-- ...
-<!-- /contract:operating-principles -->
-```
+Output mirrors the existing manifest validator: human summary on stdout, exit 0/1.
 
-- HTML comments are invisible in rendered Markdown — no visual change.
-- Validator parses the open/close pairs, not the heading text — heading rename is safe.
-- Multiple Markdown headings can sit inside one contract block (e.g. `Constraints` + `Negative Constraints` both inside `operating-principles`).
+### CI hook: `scripts/ci/validate-prompt-contract.sh`
 
-### Validator: `scripts/lib/vibeguard_manifest.py validate-prompt-contract`
+~15 lines. Runs the validator on:
+- `templates/AGENTS.md`
+- every `agents/*.md`
 
-New subcommand on the existing CLI (Suggestion: extend, don't fork).
+Appends one line to `scripts/local-contract-check.sh` so local + CI share behavior.
 
-Inputs:
-- `--target` path: defaults to `templates/AGENTS.md`; can also point at `agents/*.md` to validate a role prompt.
-- `--schema`: defaults to `schemas/prompt-contract.schema.yaml`.
-- `--strict`: warnings become errors. Used in CI.
+### Tests: `tests/test_prompt_contract.sh`
 
-Checks (in order):
-1. **Marker integrity**: every `<!-- contract:X -->` has a matching `<!-- /contract:X -->`. Nested unrelated sections allowed; nested same-name forbidden.
-2. **Required section presence**: every section in `required_sections` appears at least once.
-3. **Unknown section rejection**: any `contract:` marker whose name is not in required/optional list is an error.
-4. **Safety subset**: inside `operating-principles`, every token in `safety_subset.must_mention` must appear (case-insensitive substring).
-5. **Role frontmatter** (only when `--target` is under `agents/`): YAML frontmatter contains all `role_frontmatter_required` keys.
-6. **Budget**: line count vs. `budgets.*` — exceeding the warn threshold prints a warning, exceeding the max fails in `--strict`.
+~120 lines, same shell-test pattern as `test_manifest_contract.sh`. Cases:
 
-Output format mirrors existing manifest validator: human summary on stdout, exit code 0/1.
-
-### Hookup
-
-- New file `scripts/ci/validate-prompt-contract.sh` (~12 lines) wraps the Python subcommand for both `templates/AGENTS.md` and every `agents/*.md`.
-- Append one line to `scripts/local-contract-check.sh` so local + CI share behavior.
-
-### Tests
-
-- New `tests/test_prompt_contract.sh` (~150 lines) using the same shell test pattern as `test_manifest_contract.sh`. Cover: missing marker, mismatched marker, unknown section name, missing safety subset, budget warn vs. fail, role frontmatter missing key, happy path on the real `templates/AGENTS.md`.
-
-### Migration of existing files
-
-One commit: wrap the eight current AGENTS.md headings in their five contract blocks. **No content changes**. Diff is purely additive (HTML comments).
+- happy path on real `templates/AGENTS.md`
+- missing `Operating Principles` heading → fail
+- missing `force push` token in operating principles body → fail
+- unknown section heading → warn (exit 0 without `--strict`)
+- role prompt missing `model:` → fail under `--target agents/sample.md`
+- AGENTS.md > 300 lines → fail in `--strict`
+- AGENTS.md > 150 lines and ≤ 300 → warn only
 
 ---
 
-## File touch list (Suggestion; reviewable scope)
+## File touch list
 
-| New | Purpose |
-|---|---|
-| `schemas/prompt-contract.schema.yaml` | source of truth for the schema |
-| `scripts/ci/validate-prompt-contract.sh` | CI wrapper |
-| `tests/test_prompt_contract.sh` | regression coverage |
-| `docs/prompt-contract.md` | one-pager for humans (≤80 lines) |
+| New | Purpose | ~LOC |
+|---|---|---|
+| `schemas/prompt-contract.schema.yaml` | source of truth | 35 |
+| `scripts/ci/validate-prompt-contract.sh` | CI wrapper | 15 |
+| `tests/test_prompt_contract.sh` | regression coverage | 120 |
+| `docs/prompt-contract.md` | one-pager for humans | 60 |
 
-| Modified | Change |
-|---|---|
-| `templates/AGENTS.md` | wrap existing headings in 5 contract markers |
-| `scripts/lib/vibeguard_manifest.py` | add `validate-prompt-contract` subcommand |
-| `scripts/local-contract-check.sh` | append one call into the new validator |
-| `rules/claude-rules/common/coding-style.md` | add U-XX rule cross-referencing the schema (optional) |
+| Modified | Change | ~LOC |
+|---|---|---|
+| `scripts/lib/vibeguard_manifest.py` | add `validate-prompt-contract` subcommand | +180 |
+| `scripts/local-contract-check.sh` | append one validator call | +3 |
+| `templates/AGENTS.md` | merge `Constraints` + `Negative Constraints` → `Operating Principles` (with subheadings); merge `Architecture Layers` + `Fix Priority` → `Routing`. Prose unchanged. | ~10 line moves |
 
-Total: 4 new + 3-4 modified = **7-8 files**.
+Total: **4 new + 3 modified = 7 files**, ~430 LOC net.
+
+If we keep `## Chat Contract` (Open Q 1 → recommended): drop the AGENTS.md migration to a 1-commit minor heading consolidation; ~6 files net.
 
 ---
 
-## Acceptance criteria (Done-when)
+## Acceptance criteria
 
-1. `bash scripts/ci/validate-prompt-contract.sh` exits 0 on `templates/AGENTS.md` after marker migration.
-2. `bash scripts/ci/validate-prompt-contract.sh` exits 1 on a fixture with missing `verification` marker.
-3. `bash tests/test_prompt_contract.sh` passes (full suite, including budget warn/fail boundary cases).
+1. `bash scripts/ci/validate-prompt-contract.sh` exits 0 on current main after the heading consolidation commit.
+2. Removing the `Verification` heading on a fixture exits 1.
+3. `bash tests/test_prompt_contract.sh` passes (full suite, including the budget warn/fail boundary).
 4. `bash scripts/local-contract-check.sh --quick` includes prompt-contract validation.
-5. CI workflow runs the validator on every PR (existing `validate-manifest-contract.sh` step extends or new step added).
-6. `docs/prompt-contract.md` documents: schema location, marker syntax, how to add a new optional section, precedence chain.
-7. No content drift: the AGENTS.md migration commit only adds 5 pairs of HTML comment markers, no prose edits.
+5. `docs/prompt-contract.md` documents schema location, heading list, role frontmatter rules, precedence chain, how to add an optional section.
+6. The AGENTS.md heading consolidation commit changes only headings; prose unchanged. Diff reviewable as pure structural rename.
 
 ---
 
 ## Open questions (need your input before I implement)
 
-1. **Marker syntax**: HTML comment `<!-- contract:X -->` vs. fenced YAML block `<!-- contract:X yaml --> ... <!-- /contract --> ` (the latter would let us embed structured data inside a section). Recommendation: HTML comment only — keeps the diff additive and avoids two parsers.
-2. **Where to live**: `schemas/prompt-contract.schema.yaml` (sibling of existing `schemas/install-modules.json`) vs. `skills/vibeguard/references/prompt-contract.yaml` (sibling of `task-contract.yaml`). Recommendation: `schemas/` — it's a contract, not a skill reference, and CI already reads from `schemas/`.
-3. **Budget thresholds**: `root_agents_md_max_lines: 200` proposed. Current is 67 lines, so plenty of headroom. Acceptable?
-4. **Role frontmatter check scope**: validate only the four core keys (name/description/model/tools), or also enforce `tools` is a known subset? Recommendation: core four only in this PR; subset enforcement is a follow-up.
-5. **Should the schema version itself**? Proposed `version: 1` field with the validator refusing to run if it doesn't recognize the version. Recommendation: yes, cheap insurance.
+1. **Heading rename**: keep `## Chat Contract` (no AGENTS.md anchor break, no #124 anchor break) **or** rename to `## Output Contract` (matches issue #96's section list literally). **Recommend keep `Chat Contract`** — cheaper and zero collateral.
+2. **Heading slug for `Operating Principles`**: keep two subheadings (`### Rules` + `### Prohibitions`) or flatten to one block? Recommend keep two — it preserves the current information structure.
+3. **`must_mention` token list**: I proposed `force push / secret / AI marker`. Add `dependency injection` / `auto-fix` / anything else you want guaranteed in operating-principles? Default: those three are enough.
+4. **Role frontmatter scope**: validate the 4 keys only, or also assert `tools` is a known subset? Recommend 4 keys only this PR; subset enforcement is a follow-up.
+5. **Schema version**: include `version: 1` field; validator refuses to run on unknown version. Cheap insurance, recommend yes.
 
 ---
 
 ## Out of scope (explicit)
 
 - Refactoring or rewriting any role prompt in `agents/`.
-- Adding new required sections to AGENTS.md beyond what already exists.
-- Validating skill SKILL.md frontmatter — that is a separate contract.
-- Adding any runtime behavior; this PR is **lint-only**.
-
----
+- Adding new required sections beyond what already exists.
+- Validating skill `SKILL.md` frontmatter.
+- Any runtime behavior — this PR is **lint-only**.
 
 ## Verification commands the implementer must run before claiming done
 

--- a/schemas/prompt-contract.schema.json
+++ b/schemas/prompt-contract.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VibeGuard prompt contract",
+  "description": "Authoritative section list for templates/AGENTS.md and agents/*.md. Validator scripts/lib/vibeguard_manifest.py is the only consumer.",
+  "version": 1,
+  "required_sections": [
+    {
+      "name": "operating-principles",
+      "heading_text": "Operating Principles",
+      "must_mention": ["force push", "secret", "AI marker"]
+    },
+    {
+      "name": "routing",
+      "heading_text": "Routing"
+    },
+    {
+      "name": "verification",
+      "heading_text": "Verification"
+    },
+    {
+      "name": "output-contract",
+      "heading_text": "Chat Contract"
+    }
+  ],
+  "optional_sections": [
+    {
+      "name": "code-style",
+      "heading_text": "Code Style"
+    },
+    {
+      "name": "guards",
+      "heading_text": "Guards"
+    }
+  ],
+  "role_prompt": {
+    "frontmatter_required": ["name", "description", "model", "tools"]
+  },
+  "budgets": {
+    "root_agents_md_warn_lines": 150,
+    "root_agents_md_max_lines": 300,
+    "role_prompt_max_lines": 400
+  }
+}

--- a/scripts/ci/validate-prompt-contract.sh
+++ b/scripts/ci/validate-prompt-contract.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Validate templates/AGENTS.md and every agents/*.md against
+# schemas/prompt-contract.schema.json.
+#
+# Usage:
+#   bash scripts/ci/validate-prompt-contract.sh           # warnings allowed
+#   bash scripts/ci/validate-prompt-contract.sh --strict  # warnings -> errors
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
+
+STRICT_FLAG=()
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT_FLAG=(--strict) ;;
+    *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+FAIL=0
+
+run_one() {
+  local target="$1"
+  if ! python3 "$HELPER" validate-prompt-contract --target "$target" "${STRICT_FLAG[@]}"; then
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_one "${REPO_DIR}/templates/AGENTS.md"
+
+if [[ -d "${REPO_DIR}/agents" ]]; then
+  while IFS= read -r -d '' role; do
+    run_one "$role"
+  done < <(find "${REPO_DIR}/agents" -maxdepth 1 -type f -name '*.md' -print0)
+fi
+
+exit $((FAIL > 0 ? 1 : 0))

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -327,7 +327,15 @@ def validate_prompt_contract(
     text = target.read_text(encoding="utf-8")
     line_count = text.count("\n") + (0 if text.endswith("\n") else 1)
 
-    is_role_prompt = "agents" in target.parts
+    try:
+        rel_parts = target.resolve().relative_to(ROOT).parts
+        is_role_prompt = bool(rel_parts) and rel_parts[0] == "agents"
+    except ValueError:
+        # Target lives outside the repository root (test fixtures, ad-hoc
+        # validation against an external file). Fall back to the immediate
+        # parent dir name; this avoids treating an unrelated checkout under
+        # an ancestor directory named "agents" as a role prompt.
+        is_role_prompt = target.parent.name == "agents"
 
     if is_role_prompt:
         # Role prompts use frontmatter for identity; the body is freeform per role.

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -14,10 +14,15 @@ from typing import Any, Iterable
 ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_FILE = ROOT / "schemas" / "install-modules.json"
 PROJECT_SCHEMA_FILE = ROOT / "schemas" / "vibeguard-project.schema.json"
+PROMPT_CONTRACT_SCHEMA_FILE = ROOT / "schemas" / "prompt-contract.schema.json"
+DEFAULT_PROMPT_TARGET = ROOT / "templates" / "AGENTS.md"
 CANONICAL_RULES_DIR = ROOT / "rules" / "claude-rules"
 REFERENCE_DOC = ROOT / "docs" / "rule-reference.md"
 HOOKS_DIR = ROOT / "hooks"
 GUARDS_DIR = ROOT / "guards"
+
+PROMPT_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+PROMPT_FRONTMATTER_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)\s*:")
 
 RULE_ID_HEADING_RE = re.compile(r"^##\s+((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+)\b", re.MULTILINE)
 RULE_ID_TABLE_RE = re.compile(r"^\|\s*((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+)\s*\|", re.MULTILINE)
@@ -273,6 +278,108 @@ def _validate_skill_links(manifest: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _prompt_section_body(text: str, heading_text: str) -> str:
+    pattern = re.compile(
+        rf"^##\s+{re.escape(heading_text)}\s*$(.*?)(?=^##\s|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    return match.group(1) if match else ""
+
+
+def _prompt_frontmatter_keys(text: str) -> set[str]:
+    if not text.startswith("---\n"):
+        return set()
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        end = text.find("\n---", 4)
+        if end < 0:
+            return set()
+    block = text[4:end]
+    keys: set[str] = set()
+    for raw in block.split("\n"):
+        line = raw.rstrip()
+        if not line or line.startswith("#") or line.startswith(" ") or line.startswith("\t"):
+            continue
+        match = PROMPT_FRONTMATTER_KEY_RE.match(line)
+        if match:
+            keys.add(match.group(1))
+    return keys
+
+
+def validate_prompt_contract(
+    target: Path,
+    schema: dict[str, Any],
+    *,
+    strict: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) after validating ``target`` against the prompt contract."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not target.exists():
+        return [f"target file not found: {target}"], []
+
+    schema_version = schema.get("version")
+    if schema_version != 1:
+        return [f"unsupported prompt contract schema version: {schema_version!r}"], []
+
+    text = target.read_text(encoding="utf-8")
+    line_count = text.count("\n") + (0 if text.endswith("\n") else 1)
+
+    is_role_prompt = "/agents/" in target.as_posix()
+
+    if is_role_prompt:
+        # Role prompts use frontmatter for identity; the body is freeform per role.
+        # Required sections apply only to root AGENTS.md.
+        frontmatter = _prompt_frontmatter_keys(text)
+        for key in schema.get("role_prompt", {}).get("frontmatter_required", []):
+            if key not in frontmatter:
+                errors.append(f"role prompt missing frontmatter key: {key}")
+    else:
+        headings = [match.group(1).strip() for match in PROMPT_HEADING_RE.finditer(text)]
+        required = schema.get("required_sections", [])
+        optional = schema.get("optional_sections", [])
+        known = {section["heading_text"] for section in required}
+        known.update(section["heading_text"] for section in optional)
+
+        for section in required:
+            heading_text = section["heading_text"]
+            if heading_text not in headings:
+                errors.append(f"missing required section: ## {heading_text}")
+                continue
+            body = _prompt_section_body(text, heading_text)
+            body_lower = body.lower()
+            for token in section.get("must_mention", []):
+                if token.lower() not in body_lower:
+                    errors.append(
+                        f"section '## {heading_text}' missing required mention: {token!r}"
+                    )
+
+        for heading in headings:
+            if heading not in known:
+                warnings.append(f"unknown section heading: ## {heading}")
+
+    budgets = schema.get("budgets", {})
+    if is_role_prompt:
+        max_lines = budgets.get("role_prompt_max_lines")
+        if max_lines and line_count > max_lines:
+            message = f"line count {line_count} exceeds role_prompt_max_lines {max_lines}"
+            (errors if strict else warnings).append(message)
+    else:
+        max_lines = budgets.get("root_agents_md_max_lines")
+        warn_lines = budgets.get("root_agents_md_warn_lines")
+        if max_lines and line_count > max_lines:
+            message = f"line count {line_count} exceeds root_agents_md_max_lines {max_lines}"
+            (errors if strict else warnings).append(message)
+        elif warn_lines and line_count > warn_lines:
+            warnings.append(
+                f"line count {line_count} exceeds root_agents_md_warn_lines {warn_lines}"
+            )
+
+    return errors, warnings
+
+
 def validate_contract(manifest_path: Path, project_schema_path: Path) -> list[str]:
     manifest = load_manifest(manifest_path)
     project_schema = load_json(project_schema_path)
@@ -313,6 +420,14 @@ def build_parser() -> argparse.ArgumentParser:
     skill = sub.add_parser("skill-links", help="List installable skill links for a target")
     skill.add_argument("--target", required=True)
     skill.add_argument("--manifest-file", default=str(MANIFEST_FILE))
+
+    prompt = sub.add_parser(
+        "validate-prompt-contract",
+        help="Validate AGENTS.md or a role prompt against the prompt contract schema",
+    )
+    prompt.add_argument("--target", default=str(DEFAULT_PROMPT_TARGET))
+    prompt.add_argument("--schema", default=str(PROMPT_CONTRACT_SCHEMA_FILE))
+    prompt.add_argument("--strict", action="store_true")
     return parser
 
 
@@ -355,6 +470,20 @@ def main() -> int:
         manifest = load_manifest(Path(args.manifest_file))
         for source, name in skill_links(manifest, args.target):
             print(f"{source}\t{name}")
+        return 0
+
+    if args.command == "validate-prompt-contract":
+        schema = load_json(Path(args.schema))
+        errors, warnings = validate_prompt_contract(
+            Path(args.target), schema, strict=args.strict
+        )
+        for warning in warnings:
+            print(f"WARN: {warning}", file=sys.stderr)
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        print("OK")
         return 0
 
     parser.error("unknown command")

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -327,7 +327,7 @@ def validate_prompt_contract(
     text = target.read_text(encoding="utf-8")
     line_count = text.count("\n") + (0 if text.endswith("\n") else 1)
 
-    is_role_prompt = "/agents/" in target.as_posix()
+    is_role_prompt = "agents" in target.parts
 
     if is_role_prompt:
         # Role prompts use frontmatter for identity; the body is freeform per role.

--- a/scripts/local-contract-check.sh
+++ b/scripts/local-contract-check.sh
@@ -65,6 +65,7 @@ run_check "validate-hooks"           "$REPO_DIR/scripts/ci/validate-hooks.sh"   
 run_check "validate-rules"           "$REPO_DIR/scripts/ci/validate-rules.sh"           "true"
 run_check "validate-doc-paths"       "$REPO_DIR/scripts/ci/validate-doc-paths.sh"       "false"
 run_check "validate-doc-command-paths" "$REPO_DIR/scripts/ci/validate-doc-command-paths.sh" "false"
+run_check "validate-prompt-contract" "$REPO_DIR/scripts/ci/validate-prompt-contract.sh" "true"
 
 if [[ "$QUICK" -eq 0 ]]; then
   run_check "doc-freshness (--strict)" "$REPO_DIR/scripts/verify/doc-freshness-check.sh" "true" --strict

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -12,7 +12,9 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 - Default verbosity: keep answers concise by default; use short paragraphs for simple tasks and expand only when the work is complex or the user asks for depth.
 - Formatting: use Markdown only when it helps; prefer prose first, flat bullets only for natural lists, and avoid decorative structure.
 
-## Constraints
+## Operating Principles
+
+### Rules
 
 | ID | Rule |
 |----|------|
@@ -24,7 +26,7 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 | L6 | Follow `workflows/references/routing-contract.md`: `execute_direct`, `plan_first`, `clarify_first`, and the shared handoff fields |
 | L7 | No AI markers. No force push. No secrets in commits |
 
-## Negative Constraints (what does NOT exist here)
+### Prohibitions
 
 - This project does NOT use an ORM
 - This project does NOT have a frontend framework
@@ -40,14 +42,12 @@ Before completing any task:
 - Go: `go build ./...` then `go test ./...`
 - Python: `pytest`
 
-## Architecture Layers
+## Routing
 
 If `.vibeguard-architecture.yaml` exists, enforce dependency direction:
-`Types → Config → Repo → Service → Runtime → UI` (one-way only)
+`Types → Config → Repo → Service → Runtime → UI` (one-way only).
 
-## Fix Priority
-
-security vulnerability > logic bug > data inconsistency > duplicate types > unwrap > naming
+Fix priority: security vulnerability > logic bug > data inconsistency > duplicate types > unwrap > naming.
 
 ## Code Style
 

--- a/tests/test_prompt_contract.sh
+++ b/tests/test_prompt_contract.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# VibeGuard prompt-contract regression tests
+#
+# Usage: bash tests/test_prompt_contract.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
+SCHEMA="${REPO_DIR}/schemas/prompt-contract.schema.json"
+REAL_AGENTS="${REPO_DIR}/templates/AGENTS.md"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd_fail() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    red "$desc (expected failure but command succeeded)"
+    FAIL=$((FAIL + 1))
+  else
+    green "$desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_stderr_contains() {
+  local desc="$1"
+  local expected="$2"
+  shift 2
+  TOTAL=$((TOTAL + 1))
+  local stderr_output
+  stderr_output="$("$@" 2>&1 >/dev/null || true)"
+  if echo "$stderr_output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (stderr did not contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+run_validator() {
+  python3 "$HELPER" validate-prompt-contract --schema "$SCHEMA" "$@"
+}
+
+header "real templates/AGENTS.md"
+assert_cmd "happy path on real AGENTS.md" \
+  run_validator --target "$REAL_AGENTS"
+assert_cmd "happy path on real AGENTS.md (strict)" \
+  run_validator --target "$REAL_AGENTS" --strict
+
+header "missing required section"
+TARGET_MISSING="${WORK_DIR}/agents-no-verification.md"
+sed '/^## Verification$/,/^## Routing$/{/^## Routing$/!d;}' "$REAL_AGENTS" > "$TARGET_MISSING"
+assert_cmd_fail "missing Verification section -> error" \
+  run_validator --target "$TARGET_MISSING"
+assert_stderr_contains "missing Verification surfaces in stderr" \
+  "missing required section: ## Verification" \
+  run_validator --target "$TARGET_MISSING"
+
+header "missing must-mention token"
+TARGET_NOFORCE="${WORK_DIR}/agents-no-force-push.md"
+sed 's/No force push/No rebase merge/' "$REAL_AGENTS" > "$TARGET_NOFORCE"
+assert_cmd_fail "missing 'force push' token -> error" \
+  run_validator --target "$TARGET_NOFORCE"
+assert_stderr_contains "missing force-push surfaces in stderr" \
+  "missing required mention: 'force push'" \
+  run_validator --target "$TARGET_NOFORCE"
+
+header "unknown section heading"
+TARGET_EXTRA="${WORK_DIR}/agents-extra-section.md"
+{
+  cat "$REAL_AGENTS"
+  printf '\n## Random Extra Section\n\nplaceholder body\n'
+} > "$TARGET_EXTRA"
+assert_cmd "unknown heading is warning, not error (default)" \
+  run_validator --target "$TARGET_EXTRA"
+assert_stderr_contains "unknown heading surfaces as WARN" \
+  "WARN: unknown section heading: ## Random Extra Section" \
+  run_validator --target "$TARGET_EXTRA"
+
+header "role prompt frontmatter"
+ROLE_DIR="${WORK_DIR}/agents"
+mkdir -p "$ROLE_DIR"
+GOOD_ROLE="${ROLE_DIR}/good.md"
+cat > "$GOOD_ROLE" <<'ROLE'
+---
+name: example-agent
+description: example role for tests
+model: sonnet
+tools: Read, Grep, Glob
+---
+
+## Operating Principles
+
+- No force push.
+- No secrets in commits.
+- No AI marker tags.
+
+## Routing
+
+Route work to the right specialist.
+
+## Verification
+
+Run the project's standard verification before claiming completion.
+
+## Chat Contract
+
+Concise updates by default.
+ROLE
+
+assert_cmd "role prompt with all 4 frontmatter keys passes" \
+  run_validator --target "$GOOD_ROLE"
+
+BAD_ROLE="${ROLE_DIR}/missing-model.md"
+sed '/^model:/d' "$GOOD_ROLE" > "$BAD_ROLE"
+assert_cmd_fail "role prompt missing model key -> error" \
+  run_validator --target "$BAD_ROLE"
+assert_stderr_contains "missing-model surfaces in stderr" \
+  "role prompt missing frontmatter key: model" \
+  run_validator --target "$BAD_ROLE"
+
+header "line budget"
+LARGE_TARGET="${WORK_DIR}/agents-too-large.md"
+{
+  cat "$REAL_AGENTS"
+  printf '\n## Code Style\n\n'
+  for _ in $(seq 1 310); do
+    printf -- '- filler line for budget testing\n'
+  done
+} > "$LARGE_TARGET"
+assert_cmd "exceeds max budget without --strict -> warning only" \
+  run_validator --target "$LARGE_TARGET"
+assert_cmd_fail "exceeds max budget under --strict -> error" \
+  run_validator --target "$LARGE_TARGET" --strict
+
+header "summary"
+echo
+echo "=============================="
+printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+exit $((FAIL > 0 ? 1 : 0))

--- a/tests/test_prompt_contract.sh
+++ b/tests/test_prompt_contract.sh
@@ -103,6 +103,14 @@ assert_stderr_contains "unknown heading surfaces as WARN" \
   "WARN: unknown section heading: ## Random Extra Section" \
   run_validator --target "$TARGET_EXTRA"
 
+header "ancestor directory named 'agents' must not misclassify root AGENTS"
+ANCESTOR_DIR="${WORK_DIR}/agents/myrepo-clone/templates"
+mkdir -p "$ANCESTOR_DIR"
+ANCESTOR_TARGET="${ANCESTOR_DIR}/AGENTS.md"
+cp "$REAL_AGENTS" "$ANCESTOR_TARGET"
+assert_cmd "checkout under ancestor 'agents/' still treats AGENTS.md as root" \
+  run_validator --target "$ANCESTOR_TARGET"
+
 header "relative path under agents/ is treated as role prompt"
 RELATIVE_OUTPUT="$(cd "$REPO_DIR" && python3 "$HELPER" validate-prompt-contract \
   --schema "$SCHEMA" --target agents/architect.md 2>&1 || true)"

--- a/tests/test_prompt_contract.sh
+++ b/tests/test_prompt_contract.sh
@@ -103,6 +103,18 @@ assert_stderr_contains "unknown heading surfaces as WARN" \
   "WARN: unknown section heading: ## Random Extra Section" \
   run_validator --target "$TARGET_EXTRA"
 
+header "relative path under agents/ is treated as role prompt"
+RELATIVE_OUTPUT="$(cd "$REPO_DIR" && python3 "$HELPER" validate-prompt-contract \
+  --schema "$SCHEMA" --target agents/architect.md 2>&1 || true)"
+TOTAL=$((TOTAL + 1))
+if echo "$RELATIVE_OUTPUT" | grep -qF "missing required section"; then
+  red "relative agents/architect.md must skip required-section check"
+  FAIL=$((FAIL + 1))
+else
+  green "relative agents/architect.md skips required-section check"
+  PASS=$((PASS + 1))
+fi
+
 header "role prompt frontmatter"
 ROLE_DIR="${WORK_DIR}/agents"
 mkdir -p "$ROLE_DIR"


### PR DESCRIPTION
Closes #96.

## Summary
Lint-only contract for `templates/AGENTS.md` + `agents/*.md` role prompts. Catches prompt-shape drift the same way the manifest contract catches manifest drift.

Scope was reduced from the original SPEC after #124 (Chat Contract canonical), #125 (routing contract), and #118 (W-19 size guard) ate ~30-40% of the work. What's left is the section-presence + role-frontmatter validator. SPEC v2 in \`plan/spec-96-prompt-contract-schema.md\`.

## What's added
- \`schemas/prompt-contract.schema.json\` — single source of truth (4 required sections, 2 optional, role frontmatter keys, line budgets)
- \`scripts/lib/vibeguard_manifest.py validate-prompt-contract\` — extends the existing CLI
- \`scripts/ci/validate-prompt-contract.sh\` — walks AGENTS.md + every \`agents/*.md\`
- \`tests/test_prompt_contract.sh\` — 13 cases (happy / missing section / missing token / unknown heading / role frontmatter / budget warn-vs-fail)
- \`docs/prompt-contract.md\` — one-page human reference
- \`scripts/local-contract-check.sh\` — wires new validator into local + CI gate

## AGENTS.md migration (structural rename only, no prose changes)
- \`Constraints\` + \`Negative Constraints\` → \`Operating Principles\` (with \`Rules\` / \`Prohibitions\` subheadings)
- \`Architecture Layers\` + \`Fix Priority\` → \`Routing\`
- \`Chat Contract\` / \`Verification\` / \`Code Style\` / \`Guards\` unchanged

## Validator behavior
- \`templates/AGENTS.md\` gets required-section + must_mention + unknown-heading-warn + budget
- \`agents/*.md\` gets frontmatter-key + budget only (bodies are freeform per role)
- Default: warnings allowed. \`--strict\`: warnings → errors

## Test plan
- [x] \`python3 -m py_compile scripts/lib/vibeguard_manifest.py\` → 0
- [x] \`bash scripts/ci/validate-prompt-contract.sh\` → 0 (templates/AGENTS.md + 14 role prompts all pass)
- [x] \`bash tests/test_prompt_contract.sh\` → 13/13 PASS
- [x] \`bash scripts/local-contract-check.sh --quick\` → 0