### PR TITLE
fix(hooks): silence pre-write batch advisories + drop Go same-name false positives

### DIFF
--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -138,6 +138,16 @@ else
     2>/dev/null | head -"${MAX_MATCHES}" || true)
 fi
 
+# Skip same-name detection for Go: each package is a directory, so two files
+# with the same basename are necessarily in different packages
+# (e.g. internal/foo/config.go vs internal/cli/config.go) and that is the
+# standard convention, not a duplicate. Multi-binary repos likewise have
+# many cmd/*/main.go files. Real cross-package duplicates of struct/func
+# definitions are still caught by Check 2 below.
+if [[ "$EXT" == "go" ]]; then
+  SAME_NAME_FILES=""
+fi
+
 if [[ -n "$SAME_NAME_FILES" ]]; then
   FILE_LIST=$(echo "$SAME_NAME_FILES" | tr '\n' ', ' | sed 's/,$//')
   WARNINGS="[L1] [review] [this-edit] OBSERVATION: duplicate filename found in project: ${FILE_LIST}

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -12,14 +12,23 @@
 set -euo pipefail
 
 source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer
+
+# Helper: a write that does not trigger a new-source advisory should reset the
+# warn-mode breaker so its count tracks consecutive batched-source writes, not
+# cumulative session-wide advisories.
+_pass_and_exit() {
+  vg_cb_record_pass "pre-write-guard"
+  exit 0
+}
 
 INPUT=$(cat)
 
 FILE_PATH=$(echo "$INPUT" | vg_json_field "tool_input.file_path")
 
 if [[ -z "$FILE_PATH" ]]; then
-  exit 0
+  _pass_and_exit
 fi
 
 # W-12: Block writes to test infrastructure files (new or existing)
@@ -106,7 +115,7 @@ fi
 
 # File already exists (edit) → Release
 if [[ -e "$FILE_PATH" ]]; then
-  exit 0
+  _pass_and_exit
 fi
 
 #Extract file name and extension
@@ -116,24 +125,24 @@ EXT="${BASENAME##*.}"
 # Release list: configuration, document, lock file, test file
 case "$BASENAME" in
   *.md|*.txt|*.json|*.yaml|*.yml|*.toml|*.lock|*.css|*.html|*.svg|*.png|*.jpg)
-    exit 0 ;;
+    _pass_and_exit ;;
   *.test.*|*.spec.*|*_test.*|*_spec.*)
-    exit 0 ;;
+    _pass_and_exit ;;
   test_*|spec_*)
-    exit 0 ;;
+    _pass_and_exit ;;
   .gitignore|.env*|Makefile|Dockerfile|*.sh)
-    exit 0 ;;
+    _pass_and_exit ;;
 esac
 
 # Release: files in the test directory
 case "$FILE_PATH" in
   */tests/*|*/test/*|*/__tests__/*|*/spec/*|*/fixtures/*|*/mocks/*)
-    exit 0 ;;
+    _pass_and_exit ;;
 esac
 
 # Source code file: check whether interception is required
 if ! vg_is_source_file "$FILE_PATH"; then
-  exit 0
+  _pass_and_exit
 fi
 
 # --- Source code files: reminder to search first and then write ---

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -137,7 +137,12 @@ if ! vg_is_source_file "$FILE_PATH"; then
 fi
 
 # --- Source code files: reminder to search first and then write ---
-# Default warn (reminder), set VIBEGUARD_WRITE_MODE=block to upgrade to hard interception
+# Default warn (reminder), set VIBEGUARD_WRITE_MODE=block to upgrade to hard interception.
+#
+# Circuit breaker (warn mode): after CB_THRESHOLD consecutive notices in the same
+# session the circuit OPENs and subsequent writes pass silently. This prevents
+# 6-file batch writes from injecting 6 redundant advisories. Block mode does not
+# use the circuit breaker so hard rejections are never silenced.
 MODE="${VIBEGUARD_WRITE_MODE:-warn}"
 
 if [[ "$MODE" == "block" ]]; then
@@ -149,13 +154,18 @@ if [[ "$MODE" == "block" ]]; then
 }
 EOF
 else
-  vg_log "pre-write-guard" "Write" "warn" "New source file reminder" "$FILE_PATH"
-  cat <<'EOF'
+  source "$(dirname "$0")/circuit-breaker.sh"
+  if vg_cb_check "pre-write-guard"; then
+    vg_log "pre-write-guard" "Write" "warn" "New source file reminder" "$FILE_PATH"
+    vg_cb_record_block "pre-write-guard"
+    cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "additionalContext": "VIBEGUARD [L1] [review] [this-edit] OBSERVATION: new source file creation without prior search\nSCOPE: search before proceeding — use Grep for functions/classes/structs, Glob for same-named files\nACTION: REVIEW"
+    "additionalContext": "VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\nSCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\nACTION: NONE — advisory only, continue without acknowledgement"
   }
 }
 EOF
+  fi
+  # Circuit OPEN: silent pass (vg_cb_check already logged the auto-pass).
 fi

--- a/tests/hooks/test_post_write_guard.sh
+++ b/tests/hooks/test_post_write_guard.sh
@@ -81,6 +81,39 @@ result=$(echo '{"tool_input":{"file_path":"'${REPO_DIR}'/hooks/subdir/log.sh","c
 # But .sh is not in VG_SOURCE_EXTS, so it is allowed
 assert_not_contains "$result" "VIBEGUARD" "Non-source extension (.sh) allowed"
 
+# Go: same basename across different packages is the standard convention
+# (e.g. internal/foo/config.go vs internal/cli/config.go) and must not warn.
+tmp_repo_go="$(mktemp -d)"
+git -C "$tmp_repo_go" init -q
+mkdir -p "$tmp_repo_go/internal/foo" "$tmp_repo_go/internal/cli"
+cat >"$tmp_repo_go/internal/foo/config.go" <<'EOF'
+package foo
+
+type FooConfig struct{}
+EOF
+cat >"$tmp_repo_go/internal/cli/config.go" <<'EOF'
+package cli
+
+type CLIConfig struct{}
+EOF
+json_payload=$(printf '{"tool_input":{"file_path":"%s","content":"package cli\\n\\ntype CLIConfig struct{}"}}' "$tmp_repo_go/internal/cli/config.go")
+result=$(echo "$json_payload" | bash hooks/post-write-guard.sh)
+assert_not_contains "$result" "duplicate filename" "Go: same basename across different packages does not warn"
+rm -rf "$tmp_repo_go"
+
+# Non-Go (Python) preserves same-name detection — regression guard for the Go-only carve-out.
+tmp_repo_py_check="$(mktemp -d)"
+git -C "$tmp_repo_py_check" init -q
+mkdir -p "$tmp_repo_py_check/pkg_a" "$tmp_repo_py_check/pkg_b"
+cat >"$tmp_repo_py_check/pkg_a/utils.py" <<'EOF'
+def alpha():
+    return 1
+EOF
+json_payload=$(printf '{"tool_input":{"file_path":"%s","content":"def beta():\\n    return 2"}}' "$tmp_repo_py_check/pkg_b/utils.py")
+result=$(echo "$json_payload" | bash hooks/post-write-guard.sh)
+assert_contains "$result" "duplicate filename" "Python: same basename across packages still warns (Go-only carve-out)"
+rm -rf "$tmp_repo_py_check"
+
 # =========================================================
 
 hook_test_finish

--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -63,6 +63,37 @@ assert_contains "$result" '"decision": "block"' "W-12: Block writes to babel.con
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_nonexist_myconfig.json"}}' | bash hooks/pre-write-guard.sh)
 assert_not_contains "$result" "W-12" "W-12: Normal config.json does not trigger test infrastructure protection"
 
+# Circuit breaker: warn-mode advisories must silence after CB_THRESHOLD consecutive
+# notices in the same session, so a 6-file batch write does not inject 6 redundant
+# L1 advisories.
+header "pre-write-guard.sh — circuit breaker silences batch advisories"
+
+# Override VIBEGUARD_LOG_DIR for this block, but restore it afterwards because
+# hook_test_lib registers a `trap EXIT 'rm -rf "$VIBEGUARD_LOG_DIR"'` that
+# fails under set -u if the variable is unset on exit.
+prev_log_dir="$VIBEGUARD_LOG_DIR"
+cb_state_dir=$(mktemp -d)
+export VIBEGUARD_LOG_DIR="$cb_state_dir"
+export VG_CB_THRESHOLD=2
+export VG_CB_COOLDOWN=300
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_test_1.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "CB CLOSED: write #1 emits L1 advisory"
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_test_2.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "CB CLOSED: write #2 emits L1 advisory (threshold reached)"
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_test_3.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "CB OPEN: write #3 is silent (no VIBEGUARD advisory)"
+assert_not_contains "$result" "[L1]" "CB OPEN: write #3 has no L1 marker"
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_test_4.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "CB OPEN: write #4 also silent"
+
+rm -rf "$cb_state_dir"
+export VIBEGUARD_LOG_DIR="$prev_log_dir"
+unset VG_CB_THRESHOLD VG_CB_COOLDOWN prev_log_dir cb_state_dir
+
 # =========================================================
 
 hook_test_finish

--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -91,8 +91,33 @@ result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_test_4.go"}}' | bash hooks
 assert_not_contains "$result" "VIBEGUARD" "CB OPEN: write #4 also silent"
 
 rm -rf "$cb_state_dir"
+unset VG_CB_THRESHOLD VG_CB_COOLDOWN cb_state_dir
+
+# Codex P2 regression: a non-advisory write between source-file writes must
+# reset the breaker so the threshold counts CONSECUTIVE advisories, not
+# cumulative session-wide ones.
+header "pre-write-guard.sh — non-advisory pass resets the breaker"
+
+cb_state_dir=$(mktemp -d)
+export VIBEGUARD_LOG_DIR="$cb_state_dir"
+export VG_CB_THRESHOLD=2
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_reset_1.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "reset: source #1 advises (count=1)"
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_reset_2.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "reset: source #2 advises (count=2, threshold)"
+
+# Non-advisory write — must reset the consecutive counter.
+echo '{"tool_input":{"file_path":"/tmp/vg_cb_reset.md","content":"hi"}}' | bash hooks/pre-write-guard.sh >/dev/null
+
+# After reset, the next source file should advise again instead of being silenced.
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_reset_3.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "reset: source #3 advises after .md pass (counter reset)"
+
+rm -rf "$cb_state_dir"
 export VIBEGUARD_LOG_DIR="$prev_log_dir"
-unset VG_CB_THRESHOLD VG_CB_COOLDOWN prev_log_dir cb_state_dir
+unset VG_CB_THRESHOLD prev_log_dir cb_state_dir
 
 # =========================================================
 


### PR DESCRIPTION
## Summary

Two independent hook fixes that together cut PreToolUse/PostToolUse(Write) noise in real batched-write sessions. Both surfaced when writing a Go project (atcli) — the agent was being interrupted ~6 times per 6-file batch and was reporting `internal/config/config.go` vs `internal/cli/config.go` as a "duplicate filename".

- **Commit 1**: `pre-write-guard` warn-mode advisory now goes through the existing `circuit-breaker.sh`. After `CB_THRESHOLD` (default 3) consecutive notices the circuit OPENs and subsequent writes pass silently until the cooldown expires. `VIBEGUARD_WRITE_MODE=block` still rejects every time. Self-violation cleanup of U-26: `vg_cb_check` was declared and already used by `analysis-paralysis-guard`, but pre-write-guard had never wired it.
- **Commit 2**: `post-write-guard` skips same-basename detection for `.go`. Go has one package per directory, so any same-basename hit is necessarily cross-package — `internal/foo/config.go` vs `internal/cli/config.go`, or many `cmd/*/main.go` binaries — which is conventional, not a duplicate. Real cross-package duplication of struct/func names is still caught by Check 2 (duplicate definitions).

Advisory text in pre-write-guard also changes from `ACTION: REVIEW` → `ACTION: NONE — advisory only, continue without acknowledgement` so the agent does not treat the notice as actionable.

## Test plan

- [x] `bash tests/hooks/test_pre_write_guard.sh` — 20/20 pass (5 new circuit-breaker cases)
- [x] `bash tests/hooks/test_post_write_guard.sh` — 12/12 pass (1 new Go cross-package case + 1 Python regression guard)
- [x] Full hook test suite (15 files): 0 failures
- [x] End-to-end smoke run, default threshold=3 over a synthetic 6-file `.go` batch:
  ```
  Write #1: ADVISORY emitted
  Write #2: ADVISORY emitted
  Write #3: ADVISORY emitted
  Write #4: silent
  Write #5: silent
  Write #6: silent
  ```
- [ ] CI green on ubuntu/macos/windows