### PR TITLE
fix(setup): pass install-state values via argv

### DIFF
--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -28,20 +28,27 @@ STATE_FILE="${HOME}/.vibeguard/install-state.json"
 # Initialize or load state
 state_init() {
   local profile="${1:-core}" languages="${2:-}"
-  python3 -c "
-import json, datetime
+  local repo_dir
+  repo_dir="$(cat "${HOME}/.vibeguard/repo-path" 2>/dev/null || true)"
+
+  python3 - "$STATE_FILE" "$STATE_VERSION" "$profile" "$languages" "$repo_dir" <<'PY'
+import datetime
+import json
+import sys
+
+state_file, state_version, profile, languages, repo_dir = sys.argv[1:6]
 state = {
-    'version': ${STATE_VERSION},
+    'version': int(state_version),
     'installed_at': datetime.datetime.now().astimezone().isoformat(),
-    'profile': '${profile}',
-    'languages': '${languages}'.split(',') if '${languages}' else [],
-    'repo_dir': '$(cat "${HOME}/.vibeguard/repo-path" 2>/dev/null || echo "")',
+    'profile': profile,
+    'languages': languages.split(',') if languages else [],
+    'repo_dir': repo_dir,
     'files': {}
 }
-with open('${STATE_FILE}', 'w') as f:
+with open(state_file, 'w', encoding='utf-8') as f:
     json.dump(state, f, indent=2)
     f.write('\n')
-"
+PY
 }
 
 # Record a file installation
@@ -57,28 +64,32 @@ state_record_file() {
     fi
   fi
 
-  python3 -c "
+  python3 - "$STATE_FILE" "$STATE_VERSION" "$dest" "$source" "$install_type" "$checksum" <<'PY'
 import json
+import sys
+
+state_file, state_version, dest, source, install_type, checksum = sys.argv[1:7]
+expected_version = int(state_version)
+
 try:
-    with open('${STATE_FILE}') as f:
+    with open(state_file, encoding='utf-8') as f:
         state = json.load(f)
 except (FileNotFoundError, json.JSONDecodeError):
-    state = {'version': ${STATE_VERSION}, 'files': {}}
+    state = {'version': expected_version, 'files': {}}
 
-version = state.get('version', ${STATE_VERSION})
-if version != ${STATE_VERSION}:
-    raise SystemExit(f'unsupported install-state version: {version} (expected ${STATE_VERSION})')
+version = state.get('version', expected_version)
+if version != expected_version:
+    raise SystemExit(f'unsupported install-state version: {version} (expected {expected_version})')
 
-entry = {'source': '${source}', 'type': '${install_type}'}
-checksum = '${checksum}'
+entry = {'source': source, 'type': install_type}
 if checksum:
     entry['checksum'] = checksum
-state.setdefault('files', {})['${dest}'] = entry
+state.setdefault('files', {})[dest] = entry
 
-with open('${STATE_FILE}', 'w') as f:
+with open(state_file, 'w', encoding='utf-8') as f:
     json.dump(state, f, indent=2)
     f.write('\n')
-"
+PY
 }
 
 # Record all files (regular or symlink) under a directory as installed artifacts.
@@ -103,15 +114,18 @@ state_check_drift() {
     return 0
   fi
 
-  python3 -c "
+  python3 - "$STATE_FILE" "$STATE_VERSION" 2>/dev/null <<'PY'
 import json, os, subprocess
+import sys
 
-with open('${STATE_FILE}') as f:
+state_file, state_version = sys.argv[1], int(sys.argv[2])
+
+with open(state_file, encoding='utf-8') as f:
     state = json.load(f)
 
 version = state.get('version', 1)
-if version != ${STATE_VERSION}:
-    print(f'UNSUPPORTED_STATE_VERSION: {version} (expected ${STATE_VERSION})')
+if version != state_version:
+    print(f'UNSUPPORTED_STATE_VERSION: {version} (expected {state_version})')
     raise SystemExit(0)
 
 files = state.get('files', {})
@@ -153,7 +167,7 @@ if drift_count + missing_count == 0:
     print('STATUS: CLEAN')
 else:
     print(f'STATUS: DRIFT ({drift_count} drifted, {missing_count} missing)')
-" 2>/dev/null
+PY
 }
 
 # List all tracked files
@@ -163,24 +177,28 @@ state_list() {
     return 1
   fi
 
-  python3 -c "
+  python3 - "$STATE_FILE" "$STATE_VERSION" <<'PY'
 import json
-with open('${STATE_FILE}') as f:
+import sys
+
+state_file, expected_version = sys.argv[1], int(sys.argv[2])
+
+with open(state_file, encoding='utf-8') as f:
     state = json.load(f)
 version = state.get('version', 1)
-if version != ${STATE_VERSION}:
-    raise SystemExit(f'Unsupported install-state version: {version} (expected ${STATE_VERSION})')
-print(f'Profile: {state.get(\"profile\", \"unknown\")}')
-print(f'Installed: {state.get(\"installed_at\", \"unknown\")}')
+if version != expected_version:
+    raise SystemExit(f'Unsupported install-state version: {version} (expected {expected_version})')
+print(f'Profile: {state.get("profile", "unknown")}')
+print(f'Installed: {state.get("installed_at", "unknown")}')
 langs = state.get('languages', [])
 if langs:
-    print(f'Languages: {\", \".join(langs)}')
-print(f'Tracked files: {len(state.get(\"files\", {}))}')
+    print(f'Languages: {", ".join(langs)}')
+print(f'Tracked files: {len(state.get("files", {}))}')
 print()
 for dest, info in sorted(state.get('files', {}).items()):
     t = info.get('type', '?')
     print(f'  [{t:7s}] {dest}')
-"
+PY
 }
 
 state_list_tracked_symlinks_under() {

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -156,6 +156,7 @@ assert_cmd "scripts/setup/clean.sh syntax is correct" bash -n "${REPO_DIR}/scrip
 assert_cmd "scripts/setup/codex-status.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/codex-status.sh"
 assert_cmd "scripts/codex-contract-check.sh syntax is correct" bash -n "${REPO_DIR}/scripts/codex-contract-check.sh"
 assert_cmd "scripts/install-systemd.sh syntax is correct" bash -n "${REPO_DIR}/scripts/install-systemd.sh"
+assert_cmd "scripts/lib/install-state.sh syntax is correct" bash -n "${REPO_DIR}/scripts/lib/install-state.sh"
 assert_cmd "scripts/lib/settings_json.py syntax is correct" python3 -m py_compile "${SETTINGS_HELPER}"
 assert_cmd "scripts/lib/hooks_manifest.py syntax is correct" python3 -m py_compile "${HOOKS_MANIFEST_HELPER}"
 assert_cmd "scripts/lib/project_config_validate.py syntax is correct" python3 -m py_compile "${PROJECT_CONFIG_HELPER}"
@@ -165,6 +166,53 @@ assert_cmd "scripts/lib/codex_config_toml.py syntax is correct" python3 -m py_co
 assert_cmd "scripts/setup/regenerate-hooks-from-manifest.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/regenerate-hooks-from-manifest.sh"
 assert_cmd "scripts/ci/validate-hooks-manifest.sh syntax is correct" bash -n "${REPO_DIR}/scripts/ci/validate-hooks-manifest.sh"
 assert_cmd "CLAUDE.md template uses generated rule count placeholder" grep -q "__VIBEGUARD_RULE_COUNT__" "${REPO_DIR}/claude-md/vibeguard-rules.md"
+
+header "install-state argv safety"
+install_state_home="${TMP_HOME}/install-state quote ' home"
+install_state_repo="${TMP_HOME}/repo quote ' newline"$'\n'"dir"
+install_state_dest="${install_state_home}/tracked quote ' newline"$'\n'"file.txt"
+install_state_source="generated/source quote ' newline"$'\n'"file.txt"
+install_state_profile="core quote ' profile"
+install_state_languages="rust,py'thon"$'\n'"go"
+mkdir -p "${install_state_home}/.vibeguard" "$(dirname "${install_state_dest}")" "${install_state_repo}"
+printf '%s' "${install_state_repo}" > "${install_state_home}/.vibeguard/repo-path"
+printf 'tracked\n' > "${install_state_dest}"
+assert_cmd "install-state accepts quoted/newline values via argv" env \
+  HOME="${install_state_home}" \
+  SPECIAL_PROFILE="${install_state_profile}" \
+  SPECIAL_LANGUAGES="${install_state_languages}" \
+  SPECIAL_DEST="${install_state_dest}" \
+  SPECIAL_SOURCE="${install_state_source}" \
+  bash -c '
+    set -euo pipefail
+    source "$1"
+    state_init "$SPECIAL_PROFILE" "$SPECIAL_LANGUAGES"
+    state_record_file "$SPECIAL_DEST" "$SPECIAL_SOURCE" "copy"
+    state_check_drift >/dev/null
+    state_list >/dev/null
+  ' bash "${REPO_DIR}/scripts/lib/install-state.sh"
+assert_cmd "install-state preserves quoted/newline JSON values" python3 - \
+  "${install_state_home}/.vibeguard/install-state.json" \
+  "${install_state_profile}" \
+  "${install_state_languages}" \
+  "${install_state_repo}" \
+  "${install_state_dest}" \
+  "${install_state_source}" <<'PY'
+import json
+import sys
+
+state_file, profile, languages, repo_dir, dest, source = sys.argv[1:7]
+with open(state_file, encoding="utf-8") as f:
+    state = json.load(f)
+
+entry = state["files"][dest]
+assert state["profile"] == profile
+assert state["languages"] == languages.split(",")
+assert state["repo_dir"] == repo_dir
+assert entry["source"] == source
+assert entry["type"] == "copy"
+assert entry["checksum"].startswith("sha256:")
+PY
 
 header "manifest skill enumeration failure"
 manifest_failure_stdout="${TMP_HOME}/manifest-failure.stdout"


### PR DESCRIPTION
## Summary

- Replace install-state `python3 -c` shell interpolation with heredoc Python programs that receive dynamic values through `sys.argv`.
- Route profile, languages, repo path, state file, destination/source paths, install type, and checksum as data instead of generated Python source.
- Add setup regression coverage for quotes and newlines in languages, repo path, destination, and source values.

Closes #166

## Verification

- `bash tests/test_setup.sh` — 174/174 pass
- `bash tests/test_self_application_ci.sh` — 56/56 pass
- `bash -n scripts/lib/install-state.sh tests/test_setup.sh`
- `git diff --check`
