### PR TITLE
feat(workflow): add execution pinning guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Workflow routing is defined once in [workflows/references/routing-contract.md](w
 
 - Precedence: `user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - Readiness outputs: `execute_direct`, `plan_first`, `clarify_first`
-- Planning surfaces emit the shared handoff fields: `mode`, `artifacts`, `verification_owner`, `stop_conditions`, `lane_map`
+- Planning surfaces emit the shared handoff fields: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, `lane_map`
 
 Use workflow prompts and dispatcher guidance as consumers of that contract, not as independent routing sources.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,9 @@ The following issues are considered **in scope** for VibeGuard:
 ### Bash Pre-tool Guard
 - **pre-bash-guard.sh bypass** — techniques that evade the shell-level command interceptor in `pre-bash-guard.sh`, which blocks force-pushes (`git push --force`), destructive resets (`git reset --hard`), and dangerous `rm -rf` operations.
 
+### Runtime Drift Decisions
+- **Accepted W-20 runtime drift** — if a long-running task continues after a runtime, tool inventory, or VibeGuard rule-set hash changes, record the acceptance here or in an equivalent project decision log before continuing. Each entry must include the snapshot path, current check output, accepted surface, reason, approver, and timestamp.
+
 ## Out of Scope
 
 The following are **not** considered security vulnerabilities for VibeGuard:

--- a/agents/dispatcher.md
+++ b/agents/dispatcher.md
@@ -23,6 +23,7 @@ mode: execute_direct | plan_first | clarify_first
 handoff:
   mode: <optional preselected execution mode>
   artifacts: [...]
+  runtime_pinning_snapshot: <path | None>
   verification_owner: <owner>
   stop_conditions: [...]
   lane_map: { <lane>: <owner> }
@@ -32,7 +33,7 @@ Dispatcher rules:
 
 - Never infer `plan` vs `execute` locally.
 - If upstream `mode` is `clarify_first`, return clarification needs instead of dispatching execution.
-- If a handoff is present, consume its `mode`, `artifacts`, `verification_owner`, `stop_conditions`, and `lane_map` as authoritative routing context.
+- If a handoff is present, consume its `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` as authoritative routing context.
 - Do not schedule delegated work when `lane_map` is missing or leaves the target lane without an owner.
 
 ## Scheduling rules

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -21,7 +21,7 @@ Follow the canonical router in `workflows/references/routing-contract.md`.
 
 - Precedence: `user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - Readiness outputs: `execute_direct`, `plan_first`, `clarify_first`
-- Planning handoff keys: `mode`, `artifacts`, `verification_owner`, `stop_conditions`, `lane_map`
+- Planning handoff keys: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, `lane_map`
 
 Do not recreate a separate file-count router inside project-specific CLAUDE instructions.
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -168,7 +168,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 
 - 优先级：`user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - readiness 输出只有三种：`execute_direct`、`plan_first`、`clarify_first`
-- 规划类工作流统一输出 handoff 字段：`mode`、`artifacts`、`verification_owner`、`stop_conditions`、`lane_map`
+- 规划类工作流统一输出 handoff 字段：`mode`、`artifacts`、`runtime_pinning_snapshot`、`verification_owner`、`stop_conditions`、`lane_map`
 
 README、workflow prompts、dispatcher 都应该消费这份契约，而不是各自再写一套本地路由规则。
 

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -36,6 +36,7 @@ Canonical routing decisions and planning handoffs are defined in `workflows/refe
     "plan/task.md",
     "SPEC.md"
   ],
+  "runtime_pinning_snapshot": ".vibeguard/runtime-pinning.snapshot | null",
   "verification_owner": "planner | executor | reviewer | named lane owner",
   "stop_conditions": [
     "Condition that must halt execution"
@@ -51,6 +52,7 @@ Required handoff keys:
 
 - `mode`
 - `artifacts`
+- `runtime_pinning_snapshot`
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`

--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -77,6 +77,7 @@ Canonical source of truth: `rules/claude-rules/`
 | W-17 | Fewer smarter gates beat more mechanical gates | Strict | When the user asks to add a new gate or rule, first ask whether an existing gate can absorb the new condition instead of creating one mor... |
 | W-18 | Evaluations must validate path, not only output | Strict | Output-only evaluations miss systemic failures. |
 | W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Medium | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
+| W-20 | Long tasks must pin runtime, tools, and rules | Strict | Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot... |
 
 ---
 
@@ -199,6 +200,7 @@ Static analysis scripts that enforce rules mechanically:
 | `check_test_integrity.sh` | Test shadowing and test-environment integrity problems |
 | `check_dependency_changes.sh` | Dependency version changes requiring OSV/Snyk and human review |
 | `check_test_weakening.sh` | Source+test diffs that weaken assertions, add skips, or add AI-authored tests |
+| `check_runtime_drift.sh` | W-20 runtime, tool inventory, and rule-set drift across long tasks |
 
 ### Rust
 

--- a/guards/universal/check_runtime_drift.sh
+++ b/guards/universal/check_runtime_drift.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# VibeGuard Guard - W-20 runtime/tool/rule pinning drift check.
+
+set -euo pipefail
+
+MODE=""
+SNAPSHOT=""
+TOOL_INVENTORY=""
+RUNTIME_INVENTORY=""
+RULES_DIR=""
+DECISION_LOG=""
+REASON=""
+HEAD="HEAD"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash check_runtime_drift.sh snapshot --snapshot FILE --tool-inventory FILE [--runtime-inventory FILE] [--rules-dir DIR]
+  bash check_runtime_drift.sh check    --snapshot FILE --tool-inventory FILE [--runtime-inventory FILE] [--rules-dir DIR]
+  bash check_runtime_drift.sh accept   --snapshot FILE --tool-inventory FILE --decision-log FILE --reason TEXT [--runtime-inventory FILE] [--rules-dir DIR]
+
+Tool inventory format:
+  Each non-comment line must contain: <kind> <name> <description_sha256>
+  Example: mcp github.get_pull_request 2b7e151628aed2a6abf7158809cf4f3c...
+
+Exit codes:
+  0  Snapshot written, no drift, or acceptance logged
+  1  Runtime, tool, or rule drift detected
+  2  Usage or input error
+EOF
+}
+
+die_usage() {
+  echo "[W-20] $1" >&2
+  usage >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    snapshot|check|accept)
+      [[ -z "${MODE}" ]] || die_usage "mode specified more than once"
+      MODE="$1"
+      shift
+      ;;
+    --snapshot)
+      SNAPSHOT="${2:-}"
+      shift 2
+      ;;
+    --tool-inventory)
+      TOOL_INVENTORY="${2:-}"
+      shift 2
+      ;;
+    --runtime-inventory)
+      RUNTIME_INVENTORY="${2:-}"
+      shift 2
+      ;;
+    --rules-dir)
+      RULES_DIR="${2:-}"
+      shift 2
+      ;;
+    --decision-log)
+      DECISION_LOG="${2:-}"
+      shift 2
+      ;;
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die_usage "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "${MODE}" ]] || die_usage "missing mode"
+[[ -n "${SNAPSHOT}" ]] || die_usage "missing --snapshot"
+[[ -n "${TOOL_INVENTORY}" ]] || die_usage "missing --tool-inventory"
+
+if [[ "${MODE}" == "accept" ]]; then
+  [[ -n "${DECISION_LOG}" ]] || die_usage "accept requires --decision-log"
+  [[ -n "${REASON}" ]] || die_usage "accept requires --reason"
+fi
+
+if [[ -z "${RULES_DIR}" ]]; then
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    RULES_DIR="$(git rev-parse --show-toplevel)/rules/claude-rules"
+  else
+    RULES_DIR="rules/claude-rules"
+  fi
+fi
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+  else
+    shasum -a 256 "${file}" | awk '{print $1}'
+  fi
+}
+
+validate_rules_dir() {
+  [[ -d "${RULES_DIR}" ]] || die_usage "rules directory not found: ${RULES_DIR}"
+  find "${RULES_DIR}" -type f -name '*.md' | grep -q . || die_usage "rules directory has no markdown rules: ${RULES_DIR}"
+}
+
+validate_runtime_inventory() {
+  [[ -z "${RUNTIME_INVENTORY}" || -f "${RUNTIME_INVENTORY}" ]] || die_usage "runtime inventory not found: ${RUNTIME_INVENTORY}"
+}
+
+capture_runtime() {
+  local tmp="$1"
+  : > "${tmp}"
+
+  if [[ -n "${RUNTIME_INVENTORY}" ]]; then
+    sed 's/[[:space:]]\+$//' "${RUNTIME_INVENTORY}" >> "${tmp}"
+    return
+  fi
+
+  printf 'model_id=%s\n' "${VIBEGUARD_MODEL_ID:-<unset>}" >> "${tmp}"
+  local cmd
+  for cmd in codex claude node python3 cargo go; do
+    if command -v "${cmd}" >/dev/null 2>&1; then
+      case "${cmd}" in
+        go) printf '%s=%s\n' "${cmd}" "$("${cmd}" version 2>&1 | head -n 1)" >> "${tmp}" ;;
+        *) printf '%s=%s\n' "${cmd}" "$("${cmd}" --version 2>&1 | head -n 1)" >> "${tmp}" ;;
+      esac
+    else
+      printf '%s=<missing>\n' "${cmd}" >> "${tmp}"
+    fi
+  done
+}
+
+validate_tool_inventory() {
+  [[ -f "${TOOL_INVENTORY}" ]] || die_usage "tool inventory not found: ${TOOL_INVENTORY}"
+  [[ -s "${TOOL_INVENTORY}" ]] || die_usage "tool inventory is empty: ${TOOL_INVENTORY}"
+
+  local line_no=0
+  local data_lines=0
+  local line kind name hash extra
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line_no=$((line_no + 1))
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    data_lines=$((data_lines + 1))
+    read -r kind name hash extra <<< "${line}"
+    if [[ -z "${kind:-}" || -z "${name:-}" || -z "${hash:-}" || -n "${extra:-}" ]]; then
+      die_usage "tool inventory line ${line_no} must be: <kind> <name> <description_sha256>"
+    fi
+    if [[ ! "${hash}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+      die_usage "tool inventory line ${line_no} has invalid description hash"
+    fi
+  done < "${TOOL_INVENTORY}"
+
+  [[ "${data_lines}" -gt 0 ]] || die_usage "tool inventory has no entries: ${TOOL_INVENTORY}"
+}
+
+hash_tool_inventory() {
+  validate_tool_inventory
+  local tmp
+  tmp="$(mktemp)"
+  grep -vE '^[[:space:]]*(#|$)' "${TOOL_INVENTORY}" | sed 's/[[:space:]]\+/ /g; s/[[:space:]]$//' | LC_ALL=C sort > "${tmp}"
+  sha256_file "${tmp}"
+  rm -f "${tmp}"
+}
+
+hash_rules() {
+  local tmp
+  tmp="$(mktemp)"
+  while IFS= read -r file; do
+    printf '%s  %s\n' "$(sha256_file "${file}")" "${file}" >> "${tmp}"
+  done < <(find "${RULES_DIR}" -type f -name '*.md' | LC_ALL=C sort)
+  local digest
+  digest="$(sha256_file "${tmp}")"
+  rm -f "${tmp}"
+  printf '%s\n' "${digest}"
+}
+
+validate_inputs_for_current_hashes() {
+  validate_runtime_inventory
+  validate_tool_inventory
+  validate_rules_dir
+}
+
+current_hashes() {
+  validate_inputs_for_current_hashes
+  local runtime_tmp
+  runtime_tmp="$(mktemp)"
+  capture_runtime "${runtime_tmp}"
+  local runtime_hash tool_hash rules_hash
+  runtime_hash="$(sha256_file "${runtime_tmp}")"
+  rm -f "${runtime_tmp}"
+  tool_hash="$(hash_tool_inventory)"
+  rules_hash="$(hash_rules)"
+  printf 'runtime_hash=%s\n' "${runtime_hash}"
+  printf 'tool_hash=%s\n' "${tool_hash}"
+  printf 'rules_hash=%s\n' "${rules_hash}"
+}
+
+write_snapshot() {
+  local hashes
+  hashes="$(current_hashes)"
+  mkdir -p "$(dirname "${SNAPSHOT}")"
+  {
+    printf '# VibeGuard W-20 runtime pinning snapshot\n'
+    printf 'version=1\n'
+    printf 'created_at_utc=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'head=%s\n' "$(git rev-parse --verify "${HEAD}" 2>/dev/null || printf '<no-git>')"
+    printf 'rules_dir=%s\n' "${RULES_DIR}"
+    printf 'tool_inventory=%s\n' "${TOOL_INVENTORY}"
+    [[ -n "${RUNTIME_INVENTORY}" ]] && printf 'runtime_inventory=%s\n' "${RUNTIME_INVENTORY}"
+    printf '%s\n' "${hashes}"
+  } > "${SNAPSHOT}"
+  echo "[W-20] snapshot written: ${SNAPSHOT}"
+}
+
+read_snapshot_hashes() {
+  [[ -f "${SNAPSHOT}" ]] || die_usage "snapshot not found: ${SNAPSHOT}"
+  SNAP_RUNTIME=""
+  SNAP_TOOL=""
+  SNAP_RULES=""
+  local key value
+  while IFS='=' read -r key value || [[ -n "${key}" ]]; do
+    case "${key}" in
+      runtime_hash) SNAP_RUNTIME="${value}" ;;
+      tool_hash) SNAP_TOOL="${value}" ;;
+      rules_hash) SNAP_RULES="${value}" ;;
+    esac
+  done < "${SNAPSHOT}"
+  [[ -n "${SNAP_RUNTIME}" && -n "${SNAP_TOOL}" && -n "${SNAP_RULES}" ]] || die_usage "snapshot is missing required hashes"
+}
+
+check_drift() {
+  read_snapshot_hashes
+  validate_inputs_for_current_hashes
+  local hashes current_runtime current_tool current_rules
+  hashes="$(current_hashes)"
+  current_runtime="$(awk -F= '$1=="runtime_hash"{print $2}' <<< "${hashes}")"
+  current_tool="$(awk -F= '$1=="tool_hash"{print $2}' <<< "${hashes}")"
+  current_rules="$(awk -F= '$1=="rules_hash"{print $2}' <<< "${hashes}")"
+
+  local drift=0
+  if [[ "${SNAP_RUNTIME}" != "${current_runtime}" ]]; then
+    echo "[W-20] runtime drift: ${SNAP_RUNTIME} -> ${current_runtime}"
+    drift=1
+  fi
+  if [[ "${SNAP_TOOL}" != "${current_tool}" ]]; then
+    echo "[W-20] tools drift: ${SNAP_TOOL} -> ${current_tool}"
+    drift=1
+  fi
+  if [[ "${SNAP_RULES}" != "${current_rules}" ]]; then
+    echo "[W-20] rules drift: ${SNAP_RULES} -> ${current_rules}"
+    drift=1
+  fi
+
+  if [[ "${drift}" -eq 0 ]]; then
+    echo "[W-20] OK: runtime, tools, and rules match snapshot"
+    return 0
+  fi
+
+  echo "[W-20] drift detected; stop or record explicit user acceptance before continuing"
+  return 1
+}
+
+accept_drift() {
+  local output rc
+  set +e
+  output="$(check_drift 2>&1)"
+  rc=$?
+  set -e
+  if [[ "${rc}" -eq 2 ]]; then
+    printf '%s\n' "${output}" >&2
+    return 2
+  fi
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "[W-20] no drift to accept"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "${DECISION_LOG}")"
+  {
+    printf '\n## Runtime Drift Acceptance - %s\n\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s\n' "- Snapshot: \`${SNAPSHOT}\`"
+    printf '%s\n' "- Tool inventory: \`${TOOL_INVENTORY}\`"
+    printf '%s\n' "- Rules directory: \`${RULES_DIR}\`"
+    printf '%s\n\n' "- Reason: ${REASON}"
+    printf 'Check output:\n\n'
+    printf '```text\n%s\n```\n' "${output}"
+  } >> "${DECISION_LOG}"
+  echo "[W-20] drift acceptance recorded: ${DECISION_LOG}"
+}
+
+case "${MODE}" in
+  snapshot) write_snapshot ;;
+  check) check_drift ;;
+  accept) accept_drift ;;
+  *) die_usage "unknown mode: ${MODE}" ;;
+esac

--- a/rules/claude-rules/common/execution-pinning.md
+++ b/rules/claude-rules/common/execution-pinning.md
@@ -1,0 +1,50 @@
+# Execution Pinning Rules
+
+## W-20: Long tasks must pin runtime, tools, and rules (strict)
+Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot silently alter the result.
+
+**Trigger**:
+- The task crosses 3 or more agent steps.
+- The task is expected to run for 10 minutes or longer.
+- The task enters `/vibeguard:interview` or `/vibeguard:exec-plan`.
+- The task delegates work to child agents, background sessions, or scheduled automation.
+
+**Required pinned surfaces**:
+
+| Surface | Required evidence |
+|------|------|
+| Runtime | agent CLI version, selected model ID, and key SDK/runtime versions relevant to the task |
+| Tools | complete tool / MCP server / skill inventory, including a stable description hash for every entry |
+| Rules | hash of the loaded VibeGuard rule set for the task |
+
+**Protocol**:
+1. Before execution starts, write or generate a tool inventory file that lists every tool, MCP entry, or skill available to the task.
+2. Run `bash guards/universal/check_runtime_drift.sh snapshot --snapshot <file> --tool-inventory <file>`.
+3. Store the snapshot path in the SPEC, ExecPlan, or shared planning handoff.
+4. Before resuming a long task in a later session, run `bash guards/universal/check_runtime_drift.sh check --snapshot <file> --tool-inventory <file>`.
+5. If drift is detected, stop and show the changed surface before continuing.
+
+**Mechanical checks (agent execution rules)**:
+- `interview` and `exec-plan` flows must capture the runtime pinning snapshot path before they hand off to execution.
+- A task cannot claim deterministic replay or stable review evidence unless the runtime, tools, and rules hashes match the original snapshot.
+- Tool inventory entries must include description hashes; a name-only tool list is not enough because MCP and skill descriptions are instruction-bearing surfaces.
+- Runtime pinning complements SEC-12 and SEC-13: SEC-12 covers MCP description drift after installation, SEC-13 covers high-context file tampering, and W-20 covers task-local drift during execution.
+
+**Downgrade path**:
+If the user explicitly accepts drift, record the decision in a project-level security or decision log before continuing. The record must include the old snapshot, current check output, accepted surface, reason, approver, and timestamp.
+
+Use:
+
+```bash
+bash guards/universal/check_runtime_drift.sh accept \
+  --snapshot .vibeguard/runtime-pinning.snapshot \
+  --tool-inventory .vibeguard/tool-inventory.txt \
+  --decision-log SECURITY.md \
+  --reason "User accepted Codex CLI upgrade during this task"
+```
+
+**Anti-patterns**:
+- Continuing a cross-session ExecPlan after the agent CLI auto-updated without showing the user.
+- Treating a tool name list as stable while tool descriptions changed.
+- Re-running verification after rule files changed and presenting it as equivalent to the original task.
+- Recording "user accepted drift" only in chat, with no durable project log.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -59,6 +59,7 @@ Reference index for VibeGuard rules that apply across languages, workflows, and 
 | W-17 | Fewer smarter gates beat more mechanical gates | Strict | When the user asks to add a new gate or rule, first ask whether an existing gate can absorb the new condition instead of creating one mor... |
 | W-18 | Evaluations must validate path, not only output | Strict | Output-only evaluations miss systemic failures. |
 | W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Medium | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
+| W-20 | Long tasks must pin runtime, tools, and rules | Strict | Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot... |
 
 ## FIX / SKIP / DEFER guidance
 

--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -5,10 +5,11 @@
     {
       "id": "rules-common",
       "kind": "rules",
-      "description": "Common rules (U-01 to U-32, W-01 to W-17, SEC-01 to SEC-12)",
+      "description": "Common rules (U-01 to U-32, W-01 to W-20, SEC-01 to SEC-14)",
       "paths": [
         "rules/claude-rules/common/coding-style.md",
         "rules/claude-rules/common/data-consistency.md",
+        "rules/claude-rules/common/execution-pinning.md",
         "rules/claude-rules/common/fact-inference-separation.md",
         "rules/claude-rules/common/no-silent-degradation.md",
         "rules/claude-rules/common/publish-action-confirmation.md",
@@ -199,14 +200,15 @@
     {
       "id": "guards-universal",
       "kind": "guards",
-      "description": "Universal guard scripts (code slop, dependency layers, circular deps, doc overload, SEC-11 review gates)",
+      "description": "Universal guard scripts (code slop, dependency layers, circular deps, doc overload, SEC-11 review gates, W-20 runtime drift)",
       "paths": [
         "guards/universal/check_code_slop.sh",
         "guards/universal/check_dependency_layers.py",
         "guards/universal/check_circular_deps.py",
         "guards/universal/check_doc_overload.sh",
         "guards/universal/check_dependency_changes.sh",
-        "guards/universal/check_test_weakening.sh"
+        "guards/universal/check_test_weakening.sh",
+        "guards/universal/check_runtime_drift.sh"
       ],
       "defaultInstall": true,
       "languages": [],

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -444,6 +444,7 @@ Static analysis scripts that enforce rules mechanically:
 | `check_test_integrity.sh` | Test shadowing and test-environment integrity problems |
 | `check_dependency_changes.sh` | Dependency version changes requiring OSV/Snyk and human review |
 | `check_test_weakening.sh` | Source+test diffs that weaken assertions, add skips, or add AI-authored tests |
+| `check_runtime_drift.sh` | W-20 runtime, tool inventory, and rule-set drift across long tasks |
 
 ### Rust
 

--- a/tests/unit/test_runtime_drift_guard.sh
+++ b/tests/unit/test_runtime_drift_guard.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Unit tests for guards/universal/check_runtime_drift.sh (W-20).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GUARD="${REPO_DIR}/guards/universal/check_runtime_drift.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red() { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+
+run_expect() {
+  local desc="$1"
+  local expected="$2"
+  local pattern="$3"
+  shift 3
+
+  TOTAL=$((TOTAL + 1))
+  local out rc
+  set +e
+  out="$("$@" 2>&1)"
+  rc=$?
+  set -e
+
+  if [[ "${rc}" -ne "${expected}" ]]; then
+    red "${desc} (expected exit ${expected}, got ${rc})"
+    printf '%s\n' "${out}" | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "${pattern}" ]] && ! grep -qF "${pattern}" <<< "${out}"; then
+    red "${desc} (missing: ${pattern})"
+    printf '%s\n' "${out}" | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "${desc}"
+  PASS=$((PASS + 1))
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+RUNTIME_FILE="${TMP_DIR}/runtime.txt"
+TOOLS_FILE="${TMP_DIR}/tools.txt"
+RULES_DIR="${TMP_DIR}/rules"
+SNAPSHOT="${TMP_DIR}/runtime-pinning.snapshot"
+DECISION_LOG="${TMP_DIR}/SECURITY.md"
+
+mkdir -p "${RULES_DIR}/common"
+printf 'codex=codex 1.0.0\nmodel_id=gpt-test\n' > "${RUNTIME_FILE}"
+printf 'mcp github.get_pull_request %064d\n' 1 > "${TOOLS_FILE}"
+printf '## W-20: Long tasks must pin runtime, tools, and rules (strict)\n' > "${RULES_DIR}/common/execution-pinning.md"
+
+printf '\n=== check_runtime_drift (W-20) ===\n'
+
+run_expect "snapshot writes baseline" 0 "snapshot written" \
+  bash "${GUARD}" snapshot \
+    --snapshot "${SNAPSHOT}" \
+    --tool-inventory "${TOOLS_FILE}" \
+    --runtime-inventory "${RUNTIME_FILE}" \
+    --rules-dir "${RULES_DIR}"
+
+run_expect "unchanged runtime tools and rules pass" 0 "OK" \
+  bash "${GUARD}" check \
+    --snapshot "${SNAPSHOT}" \
+    --tool-inventory "${TOOLS_FILE}" \
+    --runtime-inventory "${RUNTIME_FILE}" \
+    --rules-dir "${RULES_DIR}"
+
+printf 'skill vibeguard %064d\n' 2 >> "${TOOLS_FILE}"
+run_expect "tool inventory drift fails" 1 "tools drift" \
+  bash "${GUARD}" check \
+    --snapshot "${SNAPSHOT}" \
+    --tool-inventory "${TOOLS_FILE}" \
+    --runtime-inventory "${RUNTIME_FILE}" \
+    --rules-dir "${RULES_DIR}"
+
+run_expect "accept records drift decision" 0 "drift acceptance recorded" \
+  bash "${GUARD}" accept \
+    --snapshot "${SNAPSHOT}" \
+    --tool-inventory "${TOOLS_FILE}" \
+    --runtime-inventory "${RUNTIME_FILE}" \
+    --rules-dir "${RULES_DIR}" \
+    --decision-log "${DECISION_LOG}" \
+    --reason "User accepted tool inventory change for test"
+
+if grep -qF "User accepted tool inventory change for test" "${DECISION_LOG}"; then
+  green "acceptance log includes reason"
+  PASS=$((PASS + 1))
+else
+  red "acceptance log includes reason"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+
+printf 'mcp invalid not-a-sha\n' > "${TOOLS_FILE}"
+run_expect "malformed tool inventory fails as usage error" 2 "invalid description hash" \
+  bash "${GUARD}" check \
+    --snapshot "${SNAPSHOT}" \
+    --tool-inventory "${TOOLS_FILE}" \
+    --runtime-inventory "${RUNTIME_FILE}" \
+    --rules-dir "${RULES_DIR}"
+
+printf 'mcp github.get_pull_request %064d\n' 1 > "${TOOLS_FILE}"
+printf '\n## W-21: Changed rule\n' >> "${RULES_DIR}/common/execution-pinning.md"
+run_expect "rules drift fails" 1 "rules drift" \
+  bash "${GUARD}" check \
+    --snapshot "${SNAPSHOT}" \
+    --tool-inventory "${TOOLS_FILE}" \
+    --runtime-inventory "${RUNTIME_FILE}" \
+    --rules-dir "${RULES_DIR}"
+
+echo
+printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "${TOTAL}" "${PASS}" "${FAIL}"
+[[ "${FAIL}" -gt 0 ]] && exit 1 || exit 0

--- a/workflows/auto-optimize/SKILL.md
+++ b/workflows/auto-optimize/SKILL.md
@@ -25,6 +25,7 @@ When Auto-Optimize consumes a planning handoff, it must honor:
 
 - `mode`
 - `artifacts`
+- `runtime_pinning_snapshot`
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`

--- a/workflows/fixflow/SKILL.md
+++ b/workflows/fixflow/SKILL.md
@@ -41,6 +41,7 @@ When Fixflow receives a planning handoff, it must honor all required keys:
 
 - `mode`
 - `artifacts`
+- `runtime_pinning_snapshot`
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`

--- a/workflows/plan-flow/SKILL.md
+++ b/workflows/plan-flow/SKILL.md
@@ -30,11 +30,12 @@ When Plan Flow finishes planning, emit the shared execution handoff with these r
 
 - `mode`
 - `artifacts`
+- `runtime_pinning_snapshot`
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`
 
-`artifacts` must include the generated `plan/*.md` path. `lane_map` must name the owner for every delegated lane before execution starts.
+`artifacts` must include the generated `plan/*.md` path. `runtime_pinning_snapshot` must point at the W-20 snapshot for long tasks, or be `None` for short direct work. `lane_map` must name the owner for every delegated lane before execution starts.
 
 ## Core Workflow (Analyze -> Plan -> Execute)
 

--- a/workflows/plan-flow/references/execplan-integration.md
+++ b/workflows/plan-flow/references/execplan-integration.md
@@ -56,11 +56,11 @@ SPEC.md
 /vibeguard:exec-plan init
     │
     ▼
-*-execplan.md + shared handoff
+*-execplan.md + W-20 runtime pinning snapshot + shared handoff
     │
     ▼
 execution workflow consumes:
-  mode / artifacts / verification_owner / stop_conditions / lane_map
+  mode / artifacts / runtime_pinning_snapshot / verification_owner / stop_conditions / lane_map
     │
     ├── step complete → /vibeguard:exec-plan update
     ├── new session → /vibeguard:exec-plan status
@@ -79,6 +79,16 @@ ExecPlan and preflight are complementary:
 
 Recommended process: First generate ExecPlan (clear execution path), then run preflight (establish protection boundary), and then perform self-check against preflight constraint set when executing ExecPlan steps.
 
+Before a long-running ExecPlan or interview handoff begins execution, capture W-20 pinning evidence:
+
+```bash
+bash guards/universal/check_runtime_drift.sh snapshot \
+  --snapshot .vibeguard/runtime-pinning.snapshot \
+  --tool-inventory .vibeguard/tool-inventory.txt
+```
+
+On cross-session resume, run the same guard in `check` mode before continuing execution. If it reports runtime, tool, or rule drift, stop until the user either rejects the drift or accepts it with a durable decision-log entry.
+
 ## Cross-session recovery protocol
 
 When execution resumes with a new session:
@@ -91,7 +101,9 @@ When execution resumes with a new session:
 6. Reuse the last shared handoff fields:
    - `mode`
    - `artifacts`
+   - `runtime_pinning_snapshot`
    - `verification_owner`
    - `stop_conditions`
    - `lane_map`
-7. Continue execution
+7. Run `check_runtime_drift.sh check` against `runtime_pinning_snapshot`
+8. Continue execution only if the snapshot still matches or accepted drift has been recorded

--- a/workflows/plan-mode/SKILL.md
+++ b/workflows/plan-mode/SKILL.md
@@ -24,7 +24,7 @@ Plan Mode follows the canonical router in [`workflows/references/routing-contrac
 - Explicit `/plan` usage is a user override that selects the planning lane.
 - User override does not bypass the ambiguity gate. If non-goals, decision boundaries, or delegation ownership are missing, return `clarify_first` questions before writing the plan.
 - Once ambiguity is resolved, Plan Mode operates as the `plan_first` planner for one-session work.
-- When execution is expected after planning, emit the shared handoff fields: `mode`, `artifacts`, `verification_owner`, `stop_conditions`, and `lane_map`.
+- When execution is expected after planning, emit the shared handoff fields: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map`.
 
 ## 1. Overall behavioral agreement (must be observed)
 

--- a/workflows/references/delivery-base.md
+++ b/workflows/references/delivery-base.md
@@ -19,6 +19,7 @@ handoff:
   mode: <execution mode selected by the planner>
   artifacts:
     - <required plan/spec paths>
+  runtime_pinning_snapshot: <path | None>
   verification_owner: <who closes verification>
   stop_conditions:
     - <conditions that halt execution>
@@ -30,6 +31,7 @@ Execution workflows must treat these keys as required:
 
 - `mode`
 - `artifacts`
+- `runtime_pinning_snapshot`
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`
@@ -38,6 +40,7 @@ Consumption rules:
 
 - `mode` is authoritative for the execution lane.
 - `artifacts` are the only canonical planning inputs.
+- `runtime_pinning_snapshot` is the W-20 runtime/tool/rule baseline for long tasks, or `None` for short direct work.
 - `verification_owner` must be reflected in the verification loop and final handoff.
 - `stop_conditions` must halt work when triggered.
 - `lane_map` must define a single owner for each delegated lane before parallel work starts.

--- a/workflows/references/routing-contract.md
+++ b/workflows/references/routing-contract.md
@@ -58,6 +58,7 @@ File count may be used as a secondary hint, but it is not the contract and must 
 - `execute_direct` enters an execution workflow immediately.
 - `plan_first` enters a planning workflow that emits the shared handoff block below.
 - Delegation is allowed only when `lane_map` assigns a single owner to each lane and no lane is left ownerless.
+- Long tasks that cross 3 or more agent steps, run for 10 minutes or longer, or enter `/vibeguard:interview` / `/vibeguard:exec-plan` must capture a W-20 runtime pinning snapshot before execution starts.
 
 If delegation ownership is missing or conflicting, stop and return `clarify_first`.
 
@@ -70,6 +71,7 @@ handoff:
   mode: <execution mode selected by the planner>
   artifacts:
     - <paths to the plan, spec, or other required artifacts>
+  runtime_pinning_snapshot: <path to W-20 snapshot | None for short direct tasks>
   verification_owner: <who owns verification for this handoff>
   stop_conditions:
     - <conditions that must halt execution>
@@ -81,15 +83,17 @@ Required keys:
 
 - `mode`
 - `artifacts`
+- `runtime_pinning_snapshot`
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`
 
 Consumption rules:
 
-- Execution workflows must honor all five keys.
+- Execution workflows must honor all required keys.
 - `mode` is preselected by planning; execution workflows do not re-route back to planning on their own.
 - `artifacts` are the canonical inputs for downstream execution.
+- `runtime_pinning_snapshot` records the pinned runtime, tool inventory, and VibeGuard rule hash for long tasks.
 - `verification_owner` names who closes the verification loop.
 - `stop_conditions` are hard boundaries, not suggestions.
 - `lane_map` must show ownership for every delegated lane before parallel work starts.


### PR DESCRIPTION
## Summary

Adds W-20 execution pinning for long-running agent work, including a runtime/tool/rule drift guard, install manifest coverage, generated rule docs, and ExecPlan/routing handoff guidance.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] New guard script

## Checklist

- [x] Guard scripts tested
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used (`feat:` / `fix:` / `chore:` etc.)

## Related issues

Closes #165

## Proof

- `bash tests/unit/test_runtime_drift_guard.sh`
- `bash scripts/ci/validate-guards.sh`
- `python3 scripts/generate_rule_docs.py --check`
- `bash tests/test_manifest_contract.sh`
- `bash tests/test_setup.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

## AI Role

AI-authored guard script, tests, and documentation updates. Risk level: medium, because this adds a guard script and workflow contract but does not touch auth, billing, secrets, dependency versions, or dynamic execution surfaces beyond local validation.

## Review Focus

- Tool inventory contract: every entry must include a stable description hash.
- W-20 handoff semantics: long tasks now carry `runtime_pinning_snapshot` through planning and resume.