### PR TITLE
docs(workflow): formalize delegation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Workflow routing is defined once in [workflows/references/routing-contract.md](w
 - Precedence: `user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - Readiness outputs: `execute_direct`, `plan_first`, `clarify_first`
 - Planning surfaces emit the shared handoff fields: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, `lane_map`
+- Delegated multi-agent work uses [workflows/references/delegation-contract.md](workflows/references/delegation-contract.md) for child-agent assignments, parallelism limits, and single-owner reintegration
 
 Use workflow prompts and dispatcher guidance as consumers of that contract, not as independent routing sources.
 

--- a/agents/dispatcher.md
+++ b/agents/dispatcher.md
@@ -13,6 +13,7 @@ Analyze task descriptions and change files and route to the most appropriate pro
 
 Boundary:
 - Workflow/lifecycle selection belongs to the higher-level workflow surface (`README.md`, `skills/`, `workflows/`) and follows [`workflows/references/routing-contract.md`](../workflows/references/routing-contract.md).
+- Delegated child-agent assignments follow [`workflows/references/delegation-contract.md`](../workflows/references/delegation-contract.md).
 - This dispatcher only chooses the best role **within** the already chosen lifecycle.
 - If lifecycle and role routing disagree, lifecycle wins first and dispatcher refines inside that lane.
 
@@ -27,6 +28,15 @@ handoff:
   verification_owner: <owner>
   stop_conditions: [...]
   lane_map: { <lane>: <owner> }
+  # Required only when child-agent or parallel lanes are used.
+  delegation_assignments:
+    - task_slice: <specific bounded outcome>
+      allowed_files: [...]
+      forbidden_files: [...]
+      authority: readonly | propose_patch | write_owned_files | verify_only
+      required_evidence: [...]
+      blocker_conditions: [...]
+      integration_owner: <single owner>
 ```
 
 Dispatcher rules:
@@ -35,6 +45,7 @@ Dispatcher rules:
 - If upstream `mode` is `clarify_first`, return clarification needs instead of dispatching execution.
 - If a handoff is present, consume its `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` as authoritative routing context.
 - Do not schedule delegated work when `lane_map` is missing or leaves the target lane without an owner.
+- Do not schedule child-agent work when the matching delegation assignment is missing `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, or `integration_owner`.
 
 ## Scheduling rules
 

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -37,8 +37,10 @@ When readiness resolves to `execute_direct`, make the change directly without ov
 
 ### 3. Subagent Strategy
 
-- Use child agents to keep the main context window clean
-- Research, exploration, and parallel analysis** offloaded to sub-agents**
+- Use child agents to keep the main context window clean only after the routing contract allows delegation
+- Follow `workflows/references/delegation-contract.md` for every child-agent assignment
+- Research, exploration, and parallel analysis can run in `readonly` mode before write ownership is clear
+- Write lanes require a task slice, allowed files, forbidden files, authority, required evidence, blockers, and a single integration owner
 - One focused task per sub-agent
 
 ### 4. Autonomous Execution

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -169,6 +169,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 - 优先级：`user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - readiness 输出只有三种：`execute_direct`、`plan_first`、`clarify_first`
 - 规划类工作流统一输出 handoff 字段：`mode`、`artifacts`、`runtime_pinning_snapshot`、`verification_owner`、`stop_conditions`、`lane_map`
+- 多 agent 委派统一使用 [`workflows/references/delegation-contract.md`](../workflows/references/delegation-contract.md)，明确子任务模板、并发限制和单一集成负责人
 
 README、workflow prompts、dispatcher 都应该消费这份契约，而不是各自再写一套本地路由规则。
 

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -2,7 +2,7 @@
 
 JSON Schema definition for structured communication between commands. Each command can optionally output JSON format for downstream consumption.
 
-Canonical routing decisions and planning handoffs are defined in `workflows/references/routing-contract.md`.
+Canonical routing decisions and planning handoffs are defined in `workflows/references/routing-contract.md`. Delegated work assignments are defined in `workflows/references/delegation-contract.md`.
 
 ## routing decision Schema
 
@@ -56,6 +56,38 @@ Required handoff keys:
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`
+
+## delegation assignment Schema
+
+```json
+{
+  "command": "delegation_assignment",
+  "task_slice": "Specific bounded outcome",
+  "allowed_files": [
+    "Files or directories this worker may modify"
+  ],
+  "forbidden_files": [
+    "Files or directories this worker must not modify"
+  ],
+  "read_only_files": [
+    "Files or directories this worker may inspect but not modify"
+  ],
+  "authority": "readonly | propose_patch | write_owned_files | verify_only",
+  "required_evidence": [
+    "Commands, diffs, logs, or findings required for completion"
+  ],
+  "blocker_conditions": [
+    "Conditions that require stopping and escalating"
+  ],
+  "integration_owner": "single named owner",
+  "verification_owner": "owner who runs or accepts checks",
+  "handoff_artifacts": [
+    "Paths or summaries the worker must return"
+  ]
+}
+```
+
+Delegation assignments are required before any child-agent write lane starts. Parallel work must serialize unless assignment file ownership is disjoint or isolated worktrees are explicitly used.
 
 ## preflight output Schema
 

--- a/docs/openai-codex-best-practices.md
+++ b/docs/openai-codex-best-practices.md
@@ -197,6 +197,8 @@ Keep one thread per coherent unit of work. If the work is still part of the same
 
 > Use Codex's [multi-agent](/codex/concepts/multi-agents) workflows to offload bounded work from the main thread. Keep the main agent focused on the core problem, and use subagents for tasks like exploration, tests, or triage.
 
+In VibeGuard repositories, apply [`workflows/references/delegation-contract.md`](../workflows/references/delegation-contract.md) before starting parallel write lanes so each child agent has explicit file ownership, evidence requirements, blockers, and a single integration owner.
+
 ## Common mistakes
 
 A few common mistakes to avoid when first using Codex:

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -154,12 +154,17 @@ assert_not_contains "${absolute_skill_validate_out}" "Traceback" "manifest valid
 
 header "routing contract"
 ROUTING_CONTRACT="${REPO_DIR}/workflows/references/routing-contract.md"
+DELEGATION_CONTRACT="${REPO_DIR}/workflows/references/delegation-contract.md"
 assert_cmd "canonical routing contract exists" test -f "${ROUTING_CONTRACT}"
 assert_cmd "routing contract includes execute_direct" grep -qF "execute_direct" "${ROUTING_CONTRACT}"
 assert_cmd "routing contract includes plan_first" grep -qF "plan_first" "${ROUTING_CONTRACT}"
 assert_cmd "routing contract includes clarify_first" grep -qF "clarify_first" "${ROUTING_CONTRACT}"
 assert_cmd "routing contract requires handoff fields" bash -c "for key in mode artifacts verification_owner stop_conditions lane_map; do grep -qF \"\$key\" '${ROUTING_CONTRACT}' || exit 1; done"
 assert_cmd "routing surfaces reference canonical contract" bash -c "for file in '${REPO_DIR}/README.md' '${REPO_DIR}/agents/dispatcher.md' '${REPO_DIR}/workflows/fixflow/SKILL.md' '${REPO_DIR}/workflows/plan-flow/SKILL.md' '${REPO_DIR}/workflows/plan-mode/SKILL.md' '${REPO_DIR}/workflows/auto-optimize/SKILL.md' '${REPO_DIR}/workflows/references/delivery-base.md' '${REPO_DIR}/workflows/plan-flow/references/execplan-integration.md' '${REPO_DIR}/docs/command-schemas.md' '${REPO_DIR}/docs/CLAUDE.md.example' '${REPO_DIR}/docs/README_CN.md' '${REPO_DIR}/claude-md/vibeguard-rules.md' '${REPO_DIR}/templates/AGENTS.md'; do grep -qF 'routing-contract.md' \"\$file\" || exit 1; done"
+assert_cmd "canonical delegation contract exists" test -f "${DELEGATION_CONTRACT}"
+assert_cmd "delegation contract defines assignment fields" bash -c "for key in task_slice allowed_files forbidden_files authority required_evidence blocker_conditions integration_owner; do grep -qF \"\$key\" '${DELEGATION_CONTRACT}' || exit 1; done"
+assert_cmd "delegation contract defines staged team pipeline" bash -c "for stage in solo delegate_readonly team_plan team_exec team_verify fix_loop; do grep -qF \"\$stage\" '${DELEGATION_CONTRACT}' || exit 1; done"
+assert_cmd "delegation consumers reference canonical contract" bash -c "for file in '${REPO_DIR}/README.md' '${REPO_DIR}/agents/dispatcher.md' '${REPO_DIR}/workflows/fixflow/SKILL.md' '${REPO_DIR}/workflows/plan-flow/SKILL.md' '${REPO_DIR}/workflows/plan-mode/SKILL.md' '${REPO_DIR}/workflows/auto-optimize/SKILL.md' '${REPO_DIR}/workflows/references/routing-contract.md' '${REPO_DIR}/workflows/references/delivery-base.md' '${REPO_DIR}/workflows/plan-flow/references/execplan-integration.md' '${REPO_DIR}/docs/command-schemas.md' '${REPO_DIR}/docs/CLAUDE.md.example' '${REPO_DIR}/docs/openai-codex-best-practices.md' '${REPO_DIR}/docs/README_CN.md'; do grep -qF 'delegation-contract.md' \"\$file\" || exit 1; done"
 
 header "codex config helper"
 CONFIG_FILE="${TMP_DIR}/config.toml"

--- a/workflows/auto-optimize/SKILL.md
+++ b/workflows/auto-optimize/SKILL.md
@@ -30,7 +30,7 @@ When Auto-Optimize consumes a planning handoff, it must honor:
 - `stop_conditions`
 - `lane_map`
 
-Workflow-local judgment does not replace the shared readiness or delegation contract.
+Workflow-local judgment does not replace the shared readiness or delegation contract in [`workflows/references/delegation-contract.md`](../references/delegation-contract.md).
 
 ## Core principles (extracted from 30+ practical sessions)
 
@@ -70,7 +70,7 @@ The user can specify the dimensions, otherwise the most needed dimensions will b
    for guard in guards/python/check_*.sh; do bash "$guard" /path/to/project; done
    for guard in guards/rust/check_*.sh; do bash "$guard" /path/to/project; done
    ```
-4. Scan in parallel according to the current dimension (use sub-agent to scan by module partition, load `rules/` corresponding language rules)
+4. Scan in parallel according to the current dimension only after creating delegation assignments with `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, and `integration_owner`
 5. **Merge guard results + LLM scan results**, output the evaluation report to the user, and confirm the optimization direction
 
 ### Phase 2: Classification and design (comply with VibeGuard specification)

--- a/workflows/fixflow/SKILL.md
+++ b/workflows/fixflow/SKILL.md
@@ -48,6 +48,8 @@ When Fixflow receives a planning handoff, it must honor all required keys:
 
 If `lane_map` does not assign Fixflow-owned work clearly, stop and clarify before editing.
 
+If Fixflow delegates any task to a child agent or parallel worker, it must use [`workflows/references/delegation-contract.md`](../references/delegation-contract.md) and keep a single integration owner for shared outputs.
+
 ## Workflow
 
 ### 1. Define Ready Criteria (DoR)

--- a/workflows/plan-flow/SKILL.md
+++ b/workflows/plan-flow/SKILL.md
@@ -37,6 +37,8 @@ When Plan Flow finishes planning, emit the shared execution handoff with these r
 
 `artifacts` must include the generated `plan/*.md` path. `runtime_pinning_snapshot` must point at the W-20 snapshot for long tasks, or be `None` for short direct work. `lane_map` must name the owner for every delegated lane before execution starts.
 
+When Plan Flow proposes child-agent or parallel execution, it must also emit delegation assignments that follow [`workflows/references/delegation-contract.md`](../references/delegation-contract.md). Missing assignment boundaries keep the route in `clarify_first`.
+
 ## Core Workflow (Analyze -> Plan -> Execute)
 
 1. Establish scope and constraints.

--- a/workflows/plan-flow/references/execplan-integration.md
+++ b/workflows/plan-flow/references/execplan-integration.md
@@ -61,6 +61,7 @@ SPEC.md
     ▼
 execution workflow consumes:
   mode / artifacts / runtime_pinning_snapshot / verification_owner / stop_conditions / lane_map
+  delegation assignments from workflows/references/delegation-contract.md when child agents or parallel lanes are used
     │
     ├── step complete → /vibeguard:exec-plan update
     ├── new session → /vibeguard:exec-plan status
@@ -105,5 +106,6 @@ When execution resumes with a new session:
    - `verification_owner`
    - `stop_conditions`
    - `lane_map`
-7. Run `check_runtime_drift.sh check` against `runtime_pinning_snapshot`
-8. Continue execution only if the snapshot still matches or accepted drift has been recorded
+7. Reuse delegation assignments from [`workflows/references/delegation-contract.md`](../../references/delegation-contract.md) before restarting any child-agent or parallel lane
+8. Run `check_runtime_drift.sh check` against `runtime_pinning_snapshot`
+9. Continue execution only if the snapshot still matches or accepted drift has been recorded

--- a/workflows/plan-mode/SKILL.md
+++ b/workflows/plan-mode/SKILL.md
@@ -25,6 +25,7 @@ Plan Mode follows the canonical router in [`workflows/references/routing-contrac
 - User override does not bypass the ambiguity gate. If non-goals, decision boundaries, or delegation ownership are missing, return `clarify_first` questions before writing the plan.
 - Once ambiguity is resolved, Plan Mode operates as the `plan_first` planner for one-session work.
 - When execution is expected after planning, emit the shared handoff fields: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map`.
+- When the plan delegates work, include assignments from [`workflows/references/delegation-contract.md`](../references/delegation-contract.md) before any child-agent write lane starts.
 
 ## 1. Overall behavioral agreement (must be observed)
 

--- a/workflows/references/delegation-contract.md
+++ b/workflows/references/delegation-contract.md
@@ -1,0 +1,120 @@
+# Delegation Contract
+
+Canonical delegation contract for VibeGuard multi-agent work. Use this document whenever work is split across child agents, background sessions, worktrees, or specialist prompts.
+
+This contract extends the routing handoff in [`routing-contract.md`](routing-contract.md). The routing handoff decides whether delegation is allowed; this document defines how delegated work is assigned, executed, verified, and reintegrated.
+
+## Roles
+
+| Role | Responsibility |
+|------|----------------|
+| `leader` | Owns scope, task slicing, `lane_map`, stop conditions, and final user handoff. |
+| `worker` | Owns only the assigned task slice and allowed files. Reports evidence and blockers. |
+| `verification_owner` | Owns the required checks and decides whether evidence is sufficient. |
+| `integration_owner` | Single writer for shared outputs, conflict resolution, final diff shaping, and merge readiness. |
+
+The same person or agent may hold multiple roles, but each delegated lane must name exactly one owner. Parallel work without a single `integration_owner` is not allowed.
+
+## Child-Agent Assignment Template
+
+Every delegated task must receive this assignment before work starts:
+
+```yaml
+delegation_assignment:
+  task_slice: <specific bounded outcome>
+  allowed_files:
+    - <files or directories this worker may modify>
+  forbidden_files:
+    - <files or directories this worker must not modify>
+  read_only_files:
+    - <files or directories this worker may inspect but not modify>
+  authority: readonly | propose_patch | write_owned_files | verify_only
+  required_evidence:
+    - <commands, diffs, logs, or findings required for completion>
+  blocker_conditions:
+    - <conditions that require stopping and escalating>
+  integration_owner: <single owner who merges shared outputs>
+  verification_owner: <owner who runs or accepts checks>
+  handoff_artifacts:
+    - <paths or summaries the worker must return>
+```
+
+Field rules:
+
+- `task_slice` must be narrow enough to finish without redefining the goal.
+- `allowed_files` is the only writable set for `write_owned_files`.
+- `forbidden_files` must include high-context files unless the task explicitly owns them.
+- `read_only_files` may overlap across workers; writable files must not.
+- `authority` must not exceed the task slice. Use `readonly` for discovery, `propose_patch` for suggested diffs, `write_owned_files` for exclusive owned files, and `verify_only` for checks.
+- `required_evidence` must be concrete enough for the `integration_owner` to audit without redoing the work.
+- `blocker_conditions` must include missing ownership, conflicting scope, and unexpected shared-file edits.
+
+## Team Execution Pipeline
+
+Use the staged pipeline below when work may outgrow a single direct execution lane:
+
+| Stage | Entry condition | Owner | Output |
+|-------|-----------------|-------|--------|
+| `solo` | Task is bounded and no delegation is needed. | leader | Direct implementation and verification evidence. |
+| `delegate_readonly` | More context is useful, but write ownership is not yet clear. | leader | Read-only findings, candidate file boundaries, and blockers. |
+| `team_plan` | Multiple lanes are useful and scope is clear. | leader | `lane_map`, assignment templates, stop conditions, and integration owner. |
+| `team_exec` | Assignments have disjoint writable files or isolated worktrees. | workers | Owned changes or patch proposals plus required evidence. |
+| `team_verify` | Worker outputs are ready for integration. | verification_owner | Check results, review notes, and unresolved blockers. |
+| `fix_loop` | Verification or review finds actionable issues. | integration_owner | Focused fixes, rerun checks, and updated evidence. |
+
+Do not skip directly from `delegate_readonly` to `team_exec`. Write lanes require a `team_plan` assignment first.
+
+## Parallelism Rules
+
+Parallelize only when at least one of these is true:
+
+- Work is read-only exploration.
+- Writable files are disjoint and listed in `allowed_files`.
+- Each worker uses an isolated worktree and the `integration_owner` performs the final merge.
+- Verification can run independently from implementation without mutating shared files.
+
+Serialize when any of these are true:
+
+- Two workers need the same writable file.
+- The work touches high-context files such as `AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks, setup scripts, or rule manifests.
+- Generated artifacts and their source files must be updated together.
+- A security-sensitive area is involved: auth, secrets, payments, shell execution, eval, or permissions.
+- The owner of a lane, verifier, or integration step is missing or contradictory.
+
+Safe write-lane limits:
+
+- Default: one write lane.
+- Up to two write lanes are allowed only when writable file sets are disjoint and explicit.
+- More than two write lanes require isolated worktrees or a durable plan artifact that names every lane and its owner.
+- Shared outputs must be written to temporary artifacts first, then merged by the `integration_owner`.
+
+## Reintegration Protocol
+
+Workers must return:
+
+- changed paths or proposed patch paths
+- commands run and outcomes
+- unresolved blockers
+- any deviation from the assignment
+
+The `integration_owner` must:
+
+- inspect worker outputs before merging
+- resolve conflicts in one place
+- update generated artifacts with their sources
+- rerun the checks owned by `verification_owner`
+- keep the final diff within the original scope
+
+If a worker edited outside `allowed_files`, stop integration and treat the output as untrusted until reviewed.
+
+## Blocker Escalation
+
+Escalate back to `clarify_first` or a planning workflow when:
+
+- the goal or non-goals are unclear
+- ownership cannot be made disjoint
+- a required tool, runtime, or rule snapshot is unavailable
+- verification requires credentials or services the current session cannot access
+- review finds a security-sensitive issue outside the assignment
+
+Escalation must include the blocked lane, exact blocker, affected files, and the smallest decision needed to continue.

--- a/workflows/references/delivery-base.md
+++ b/workflows/references/delivery-base.md
@@ -9,6 +9,7 @@ Before execution starts, consume the canonical router in [`workflows/references/
 - Start direct execution only after upstream routing resolves to `execute_direct`, or after a planning workflow emits a handoff that preselects execution.
 - If upstream routing resolves to `clarify_first`, stop and clarify before building a plan or editing code.
 - Do not reinterpret the route locally with file-count shortcuts.
+- If execution delegates work, consume [`workflows/references/delegation-contract.md`](delegation-contract.md) before any child-agent or parallel write lane starts.
 
 ## Execution Handoff Contract
 
@@ -44,6 +45,18 @@ Consumption rules:
 - `verification_owner` must be reflected in the verification loop and final handoff.
 - `stop_conditions` must halt work when triggered.
 - `lane_map` must define a single owner for each delegated lane before parallel work starts.
+
+## Delegation Contract
+
+Delegated execution must use the assignment template in [`workflows/references/delegation-contract.md`](delegation-contract.md).
+
+Before starting delegated work:
+
+- name the `leader`, `verification_owner`, and single `integration_owner`
+- assign each child agent a `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, and `blocker_conditions`
+- serialize shared-file, high-context-file, generated-artifact, and security-sensitive work unless isolated worktrees or a single integration owner make the write boundary explicit
+
+Worker outputs are not complete until the `integration_owner` inspects them, merges shared outputs, and reruns the checks owned by `verification_owner`.
 
 ## Define Ready Criteria (DoR)
 

--- a/workflows/references/routing-contract.md
+++ b/workflows/references/routing-contract.md
@@ -2,6 +2,8 @@
 
 Canonical routing contract for VibeGuard workflow selection. All workflow prompts, public docs, and dispatcher guidance must reference this document instead of redefining routing rules locally.
 
+Delegated execution is defined by [`delegation-contract.md`](delegation-contract.md). This routing contract decides whether delegation can start; the delegation contract defines assignments, parallelism, verification, and reintegration.
+
 ## Precedence
 
 Apply routing in this order:
@@ -58,6 +60,7 @@ File count may be used as a secondary hint, but it is not the contract and must 
 - `execute_direct` enters an execution workflow immediately.
 - `plan_first` enters a planning workflow that emits the shared handoff block below.
 - Delegation is allowed only when `lane_map` assigns a single owner to each lane and no lane is left ownerless.
+- Delegated child-agent work must use the assignment template in [`delegation-contract.md`](delegation-contract.md) before any write lane starts.
 - Long tasks that cross 3 or more agent steps, run for 10 minutes or longer, or enter `/vibeguard:interview` / `/vibeguard:exec-plan` must capture a W-20 runtime pinning snapshot before execution starts.
 
 If delegation ownership is missing or conflicting, stop and return `clarify_first`.
@@ -96,7 +99,7 @@ Consumption rules:
 - `runtime_pinning_snapshot` records the pinned runtime, tool inventory, and VibeGuard rule hash for long tasks.
 - `verification_owner` names who closes the verification loop.
 - `stop_conditions` are hard boundaries, not suggestions.
-- `lane_map` must show ownership for every delegated lane before parallel work starts.
+- `lane_map` must show ownership for every delegated lane before parallel work starts, and every delegated lane must receive a matching delegation assignment.
 
 ## Workflow Ownership
 
@@ -105,6 +108,7 @@ Consumption rules:
 - `fixflow` and other execution workflows own direct execution after `execute_direct`, or after a planning handoff preselects them.
 - `auto-optimize` only runs autonomously when readiness and delegation ownership are already explicit.
 - `agents/dispatcher.md` chooses a specialist inside the already selected lane; it does not infer `plan` vs `execute`.
+- `workflows/references/delegation-contract.md` owns child-agent assignment, team pipeline stages, parallelism limits, and reintegration rules.
 
 ## Examples
 
@@ -151,3 +155,10 @@ Planner proposes parallel execution but omits who owns doc verification.
 
 - `lane_map` is incomplete
 - output: `clarify_first` until ownership is explicit
+
+### Delegation Without Assignment Boundaries
+
+Planner names lane owners but does not provide allowed files, forbidden files, authority, evidence, blockers, or integration owner.
+
+- delegation assignment is incomplete
+- output: `clarify_first` until the missing assignment fields are explicit


### PR DESCRIPTION
Closes #99.

## Summary
- add a canonical delegation contract for child-agent assignments, staged team execution, parallelism limits, reintegration, and blocker escalation
- wire routing, delivery, dispatcher, Plan/Fix/Auto-Optimize workflows, and public docs to the canonical contract
- add manifest contract coverage so the delegation contract and its consumers cannot drift silently

## Verification
- bash tests/test_manifest_contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- git diff --check

## Review Focus
- workflow contract clarity and whether the delegation assignment fields are sufficient for safe parallel execution
- documentation link consistency across routing, dispatcher, and workflow consumers