### PR TITLE
Formalize delegation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,12 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path                # dea
 **Routing Contract**
 
 Workflow routing is defined once in [workflows/references/routing-contract.md](workflows/references/routing-contract.md).
+Delegated team execution is defined in [workflows/references/delegation-contract.md](workflows/references/delegation-contract.md).
 
 - Precedence: `user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - Readiness outputs: `execute_direct`, `plan_first`, `clarify_first`
 - Planning surfaces emit the shared handoff fields: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, `lane_map`
+- Delegated lanes require `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, and `integration_owner`
 
 Use workflow prompts and dispatcher guidance as consumers of that contract, not as independent routing sources.
 

--- a/agents/dispatcher.md
+++ b/agents/dispatcher.md
@@ -13,6 +13,7 @@ Analyze task descriptions and change files and route to the most appropriate pro
 
 Boundary:
 - Workflow/lifecycle selection belongs to the higher-level workflow surface (`README.md`, `skills/`, `workflows/`) and follows [`workflows/references/routing-contract.md`](../workflows/references/routing-contract.md).
+- Delegated lane assignment and reintegration follow [`workflows/references/delegation-contract.md`](../workflows/references/delegation-contract.md).
 - This dispatcher only chooses the best role **within** the already chosen lifecycle.
 - If lifecycle and role routing disagree, lifecycle wins first and dispatcher refines inside that lane.
 
@@ -35,6 +36,7 @@ Dispatcher rules:
 - If upstream `mode` is `clarify_first`, return clarification needs instead of dispatching execution.
 - If a handoff is present, consume its `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` as authoritative routing context.
 - Do not schedule delegated work when `lane_map` is missing or leaves the target lane without an owner.
+- Do not schedule delegated work unless the target lane has a delegation assignment with `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, and `integration_owner`.
 
 ## Scheduling rules
 
@@ -92,6 +94,7 @@ Refer to the OpenAI Harness strategy to allocate model capabilities by stage:
    Scheduling decisions
    ========
    Target Agent: <agent_name>
+   Delegation assignment: <assignment id or none>
    Confidence: high/medium/low
    Reason: <why>
    Inference budget: <budget>

--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -12,7 +12,7 @@
 | L3 | Disable silent swallowing of exceptions; there is no public method of Any type |
 | L4 | No data = blank; no undeclared API/field exists |
 | L5 | Just do what is asked; there is no "easy improvement" |
-| L6 | Follow `workflows/references/routing-contract.md`: `execute_direct` / `plan_first` / `clarify_first`, plus the shared handoff fields |
+| L6 | Follow `workflows/references/routing-contract.md`: `execute_direct` / `plan_first` / `clarify_first`, plus the shared handoff fields; delegated work follows `workflows/references/delegation-contract.md` |
 | L7 | AI tag does not exist / force push / key submission |
 
 ## Chat Contract

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -18,10 +18,12 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 ### 1. Routing Contract
 
 Follow the canonical router in `workflows/references/routing-contract.md`.
+Follow delegated team execution in `workflows/references/delegation-contract.md`.
 
 - Precedence: `user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - Readiness outputs: `execute_direct`, `plan_first`, `clarify_first`
 - Planning handoff keys: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, `lane_map`
+- Delegated lane assignment keys: `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, `integration_owner`
 
 Do not recreate a separate file-count router inside project-specific CLAUDE instructions.
 
@@ -38,8 +40,9 @@ When readiness resolves to `execute_direct`, make the change directly without ov
 ### 3. Subagent Strategy
 
 - Use child agents to keep the main context window clean
-- Research, exploration, and parallel analysis** offloaded to sub-agents**
+- Research, exploration, and parallel analysis may be offloaded to sub-agents
 - One focused task per sub-agent
+- Write lanes must have disjoint file ownership and one integration owner
 
 ### 4. Autonomous Execution
 
@@ -86,7 +89,7 @@ Hooks + guard script **mechanized execution** without relying on AI consciousnes
 | **L3** | Disable silent exception swallowing; disable Any type | **Hook warning** |
 | **L4** | Blank display with no data; API not invented | **Hook Warning** |
 | **L5** | Only do what is asked | Review constraints |
-| **L6** | Follow the canonical routing contract in `workflows/references/routing-contract.md` | Process constraints |
+| **L6** | Follow the canonical routing contract in `workflows/references/routing-contract.md` and delegated execution in `workflows/references/delegation-contract.md` | Process constraints |
 | **L7** | Disable AI tag / force push / key | **Hook interception** |
 
 ---

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -165,10 +165,12 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 ### 路由契约
 
 工作流路由只在一个地方定义：[`workflows/references/routing-contract.md`](../workflows/references/routing-contract.md)。
+委派式团队执行由 [`workflows/references/delegation-contract.md`](../workflows/references/delegation-contract.md) 定义。
 
 - 优先级：`user_override` → `risk/destructive gate` → `ambiguity gate` → `readiness classifier` → `execution/delegation lane`
 - readiness 输出只有三种：`execute_direct`、`plan_first`、`clarify_first`
 - 规划类工作流统一输出 handoff 字段：`mode`、`artifacts`、`runtime_pinning_snapshot`、`verification_owner`、`stop_conditions`、`lane_map`
+- 委派 lane 必须声明 `task_slice`、`allowed_files`、`forbidden_files`、`authority`、`required_evidence`、`blocker_conditions`、`integration_owner`
 
 README、workflow prompts、dispatcher 都应该消费这份契约，而不是各自再写一套本地路由规则。
 

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -3,6 +3,7 @@
 JSON Schema definition for structured communication between commands. Each command can optionally output JSON format for downstream consumption.
 
 Canonical routing decisions and planning handoffs are defined in `workflows/references/routing-contract.md`.
+Delegated lane assignment and reintegration are defined in `workflows/references/delegation-contract.md`.
 
 ## routing decision Schema
 
@@ -56,6 +57,40 @@ Required handoff keys:
 - `verification_owner`
 - `stop_conditions`
 - `lane_map`
+
+## delegation assignment Schema
+
+```json
+{
+  "command": "delegation_assignment",
+  "lane": "docs | tests | implementation | custom",
+  "task_slice": "Bounded objective for this lane",
+  "allowed_files": [
+    "paths or globs this lane may read/write"
+  ],
+  "forbidden_files": [
+    "paths or globs this lane must not modify"
+  ],
+  "authority": "readonly | propose_patch | write_patch | verify_only",
+  "required_evidence": [
+    "commands, logs, screenshots, or diff evidence required from this lane"
+  ],
+  "blocker_conditions": [
+    "conditions that stop this lane and escalate to the leader"
+  ],
+  "integration_owner": "single owner who merges or rejects this lane"
+}
+```
+
+Required delegation assignment keys:
+
+- `task_slice`
+- `allowed_files`
+- `forbidden_files`
+- `authority`
+- `required_evidence`
+- `blocker_conditions`
+- `integration_owner`
 
 ## preflight output Schema
 

--- a/docs/openai-codex-best-practices.md
+++ b/docs/openai-codex-best-practices.md
@@ -195,7 +195,7 @@ The Codex app UI makes thread management easiest because you can pin threads and
 
 Keep one thread per coherent unit of work. If the work is still part of the same problem, staying in the same thread is often better because it preserves the reasoning trail. Fork only when the work truly branches.
 
-> Use Codex's [multi-agent](/codex/concepts/multi-agents) workflows to offload bounded work from the main thread. Keep the main agent focused on the core problem, and use subagents for tasks like exploration, tests, or triage.
+> Use Codex's [multi-agent](/codex/concepts/multi-agents) workflows to offload bounded work from the main thread. Keep the main agent focused on the core problem, and use subagents for tasks like exploration, tests, or triage. In VibeGuard-managed repos, delegated work should follow `workflows/references/delegation-contract.md`.
 
 ## Common mistakes
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -21,7 +21,7 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 | L3 | No silent exception swallowing. No `Any` in public signatures |
 | L4 | No data = show blank. Never invent APIs or fields that don't exist |
 | L5 | Only do what was asked. No extra improvements, comments, or abstractions |
-| L6 | Follow `workflows/references/routing-contract.md`: `execute_direct`, `plan_first`, `clarify_first`, and the shared handoff fields |
+| L6 | Follow `workflows/references/routing-contract.md`: `execute_direct`, `plan_first`, `clarify_first`, and the shared handoff fields; delegated work follows `workflows/references/delegation-contract.md` |
 | L7 | No AI markers. No force push. No secrets in commits |
 
 ## Project Constraints To Fill In

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -161,6 +161,14 @@ assert_cmd "routing contract includes clarify_first" grep -qF "clarify_first" "$
 assert_cmd "routing contract requires handoff fields" bash -c "for key in mode artifacts verification_owner stop_conditions lane_map; do grep -qF \"\$key\" '${ROUTING_CONTRACT}' || exit 1; done"
 assert_cmd "routing surfaces reference canonical contract" bash -c "for file in '${REPO_DIR}/README.md' '${REPO_DIR}/agents/dispatcher.md' '${REPO_DIR}/workflows/fixflow/SKILL.md' '${REPO_DIR}/workflows/plan-flow/SKILL.md' '${REPO_DIR}/workflows/plan-mode/SKILL.md' '${REPO_DIR}/workflows/auto-optimize/SKILL.md' '${REPO_DIR}/workflows/references/delivery-base.md' '${REPO_DIR}/workflows/plan-flow/references/execplan-integration.md' '${REPO_DIR}/docs/command-schemas.md' '${REPO_DIR}/docs/CLAUDE.md.example' '${REPO_DIR}/docs/README_CN.md' '${REPO_DIR}/claude-md/vibeguard-rules.md' '${REPO_DIR}/templates/AGENTS.md'; do grep -qF 'routing-contract.md' \"\$file\" || exit 1; done"
 
+header "delegation contract"
+DELEGATION_CONTRACT="${REPO_DIR}/workflows/references/delegation-contract.md"
+assert_cmd "canonical delegation contract exists" test -f "${DELEGATION_CONTRACT}"
+assert_cmd "delegation contract requires assignment fields" bash -c "for key in task_slice allowed_files forbidden_files authority required_evidence blocker_conditions integration_owner; do grep -qF \"\$key\" '${DELEGATION_CONTRACT}' || exit 1; done"
+assert_cmd "delegation contract includes staged pipeline" bash -c "for stage in solo delegate-readonly team-plan team-exec team-verify fix-loop; do grep -qF \"\$stage\" '${DELEGATION_CONTRACT}' || exit 1; done"
+assert_cmd "delegation contract defines parallelism serialization decisions" bash -c "grep -qF 'Default maximum concurrent write lanes' '${DELEGATION_CONTRACT}' && grep -qF 'Serialize' '${DELEGATION_CONTRACT}'"
+assert_cmd "delegation consumers reference canonical contract" bash -c "for file in '${REPO_DIR}/README.md' '${REPO_DIR}/agents/dispatcher.md' '${REPO_DIR}/workflows/fixflow/SKILL.md' '${REPO_DIR}/workflows/plan-flow/SKILL.md' '${REPO_DIR}/workflows/plan-mode/SKILL.md' '${REPO_DIR}/workflows/auto-optimize/SKILL.md' '${REPO_DIR}/workflows/references/routing-contract.md' '${REPO_DIR}/workflows/references/delivery-base.md' '${REPO_DIR}/docs/command-schemas.md' '${REPO_DIR}/docs/CLAUDE.md.example' '${REPO_DIR}/docs/README_CN.md' '${REPO_DIR}/docs/openai-codex-best-practices.md' '${REPO_DIR}/claude-md/vibeguard-rules.md' '${REPO_DIR}/templates/AGENTS.md'; do grep -qF 'delegation-contract.md' \"\$file\" || exit 1; done"
+
 header "codex config helper"
 CONFIG_FILE="${TMP_DIR}/config.toml"
 enable_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"

--- a/workflows/auto-optimize/SKILL.md
+++ b/workflows/auto-optimize/SKILL.md
@@ -9,6 +9,7 @@ Integrate the project autonomous optimization workflow of the VibeGuard guard sy
 ## Routing Contract Integration
 
 Auto-Optimize follows the canonical router in [`workflows/references/routing-contract.md`](../references/routing-contract.md).
+Any delegated scan or repair lane must follow [`workflows/references/delegation-contract.md`](../references/delegation-contract.md).
 
 Start autonomous optimization only when both conditions are true:
 
@@ -20,6 +21,7 @@ Do not start autonomous execution when:
 - readiness is `clarify_first`
 - readiness is `plan_first` and no execution handoff exists yet
 - delegation ownership is missing, shared, or contradictory
+- delegated lanes do not have assignment blocks with allowed files, authority, required evidence, blockers, and an integration owner
 
 When Auto-Optimize consumes a planning handoff, it must honor:
 
@@ -70,7 +72,7 @@ The user can specify the dimensions, otherwise the most needed dimensions will b
    for guard in guards/python/check_*.sh; do bash "$guard" /path/to/project; done
    for guard in guards/rust/check_*.sh; do bash "$guard" /path/to/project; done
    ```
-4. Scan in parallel according to the current dimension (use sub-agent to scan by module partition, load `rules/` corresponding language rules)
+4. Scan in parallel only after creating delegation assignments for each module partition; read-only scans may use broad paths, but write lanes require disjoint `allowed_files`
 5. **Merge guard results + LLM scan results**, output the evaluation report to the user, and confirm the optimization direction
 
 ### Phase 2: Classification and design (comply with VibeGuard specification)

--- a/workflows/fixflow/SKILL.md
+++ b/workflows/fixflow/SKILL.md
@@ -26,6 +26,7 @@ Trigger this skill when the user asks for one or more of:
 ## Routing Contract Integration
 
 Use the canonical router in [`workflows/references/routing-contract.md`](../references/routing-contract.md).
+Delegated execution must also satisfy [`workflows/references/delegation-contract.md`](../references/delegation-contract.md).
 
 Fixflow can start directly when either of these is true:
 
@@ -46,7 +47,7 @@ When Fixflow receives a planning handoff, it must honor all required keys:
 - `stop_conditions`
 - `lane_map`
 
-If `lane_map` does not assign Fixflow-owned work clearly, stop and clarify before editing.
+If `lane_map` does not assign Fixflow-owned work clearly, or a delegated Fixflow lane lacks a valid delegation assignment, stop and clarify before editing.
 
 ## Workflow
 
@@ -103,6 +104,7 @@ For `per_step` (default):
   - Run step-level checks.
   - Commit immediately after step checks pass.
   - Record step -> commit hash mapping.
+  - For delegated lanes, the integration owner accepts the lane before the next dependent step starts.
 
 ### 5. Apply No-Backward-Compatibility Mode (When Requested)
 

--- a/workflows/plan-flow/SKILL.md
+++ b/workflows/plan-flow/SKILL.md
@@ -17,6 +17,7 @@ This skill is repository-agnostic. It defines how to analyze and plan, not only 
 ## Routing Contract Integration
 
 Plan Flow owns the task only after the canonical router in [`workflows/references/routing-contract.md`](../references/routing-contract.md) resolves to `plan_first`.
+Delegated execution plans must also satisfy [`workflows/references/delegation-contract.md`](../references/delegation-contract.md).
 
 Route into Plan Flow when these readiness signals are true:
 
@@ -35,7 +36,7 @@ When Plan Flow finishes planning, emit the shared execution handoff with these r
 - `stop_conditions`
 - `lane_map`
 
-`artifacts` must include the generated `plan/*.md` path. `runtime_pinning_snapshot` must point at the W-20 snapshot for long tasks, or be `None` for short direct work. `lane_map` must name the owner for every delegated lane before execution starts.
+`artifacts` must include the generated `plan/*.md` path. `runtime_pinning_snapshot` must point at the W-20 snapshot for long tasks, or be `None` for short direct work. `lane_map` must name the owner for every delegated lane before execution starts, and each delegated lane must have a child-agent assignment with file ownership, authority, required evidence, blockers, and integration owner.
 
 ## Core Workflow (Analyze -> Plan -> Execute)
 

--- a/workflows/plan-mode/SKILL.md
+++ b/workflows/plan-mode/SKILL.md
@@ -20,11 +20,13 @@ Goal: Develop a implementable and traceable technical execution plan for the tas
 ## Routing Contract Integration
 
 Plan Mode follows the canonical router in [`workflows/references/routing-contract.md`](../references/routing-contract.md).
+Delegated execution plans must also follow [`workflows/references/delegation-contract.md`](../references/delegation-contract.md).
 
 - Explicit `/plan` usage is a user override that selects the planning lane.
 - User override does not bypass the ambiguity gate. If non-goals, decision boundaries, or delegation ownership are missing, return `clarify_first` questions before writing the plan.
 - Once ambiguity is resolved, Plan Mode operates as the `plan_first` planner for one-session work.
 - When execution is expected after planning, emit the shared handoff fields: `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map`.
+- When the plan delegates work, include child-agent assignments for each lane and name one integration owner before execution starts.
 
 ## 1. Overall behavioral agreement (must be observed)
 

--- a/workflows/references/delegation-contract.md
+++ b/workflows/references/delegation-contract.md
@@ -1,0 +1,198 @@
+# Delegation Contract
+
+Canonical contract for assigning, running, and reintegrating delegated agent work in VibeGuard. Use this document with [`routing-contract.md`](routing-contract.md): routing decides whether delegation is allowed, and this contract defines how delegated lanes must be shaped before work starts.
+
+This contract implements W-14 parallel-agent ownership and complements W-20 runtime pinning for long tasks.
+
+## When Delegation Is Allowed
+
+Delegation is allowed only when all of these are true:
+
+- The canonical router resolved to `execute_direct`, or a planning workflow emitted an execution handoff.
+- `lane_map` assigns one owner to every delegated lane.
+- Each write lane has an explicit child-agent assignment block.
+- Writable file ownership is disjoint across lanes.
+- One integration owner is named before any parallel work starts.
+- Verification ownership is named in the handoff and reflected in the final verification loop.
+
+If any condition is missing, return to `clarify_first` or serialize the work under the main executor.
+
+## Child-Agent Assignment Template
+
+Every delegated lane must be assigned with this template:
+
+```yaml
+delegation_assignment:
+  task_slice: <bounded objective for this lane>
+  allowed_files:
+    - <paths or globs the lane may read/write>
+  forbidden_files:
+    - <paths or globs the lane must not modify>
+  authority: readonly | propose_patch | write_patch | verify_only
+  required_evidence:
+    - <commands, logs, screenshots, or diff evidence required from the lane>
+  blocker_conditions:
+    - <conditions that stop this lane and escalate to the leader>
+  integration_owner: <single owner who merges or rejects this lane's output>
+```
+
+Field rules:
+
+- `task_slice` must be narrow enough that a worker can finish without redefining scope.
+- `allowed_files` must be exact for write lanes. Broad globs are acceptable only for `readonly` exploration.
+- `forbidden_files` must include files owned by adjacent write lanes and high-context files outside the lane.
+- `authority` limits what the worker may do:
+  - `readonly`: inspect and report only.
+  - `propose_patch`: produce a patch or recommendation, but do not apply it.
+  - `write_patch`: edit only `allowed_files`.
+  - `verify_only`: run checks and report evidence only.
+- `required_evidence` must include enough proof for the integration owner to accept or reject the lane.
+- `blocker_conditions` must halt the worker before it guesses about scope, ownership, or failing checks.
+- `integration_owner` must be a single named role or person, not a shared group.
+
+## Leader Responsibilities
+
+The leader owns orchestration, not every local detail:
+
+- Choose `solo`, `delegate-readonly`, `team-plan`, `team-exec`, `team-verify`, or `fix-loop` stage.
+- Emit or consume the routing handoff from [`routing-contract.md`](routing-contract.md).
+- Build `lane_map` and one assignment block per delegated lane.
+- Confirm writable lanes have disjoint `allowed_files`.
+- Set the integration owner and verification owner before execution starts.
+- Stop or serialize work when ownership overlaps.
+- Integrate results, resolve conflicts, and produce the final verification record.
+
+The leader must not treat worker output as merged merely because a worker completed.
+
+## Worker Responsibilities
+
+Workers own the assigned slice only:
+
+- Stay inside `task_slice`, `allowed_files`, and `authority`.
+- Do not edit `forbidden_files`.
+- Do not redefine scope, public contracts, or verification ownership.
+- Report blockers using the assigned `blocker_conditions`.
+- Return the required evidence before marking the lane complete.
+- Mention any files read or modified so the integration owner can audit the lane.
+
+If the worker discovers a needed edit outside `allowed_files`, it must stop and escalate instead of expanding scope locally.
+
+## Blocker Escalation
+
+Escalate to the leader when any of these occur:
+
+- The lane needs to touch a forbidden or ownerless file.
+- Two lanes need the same writable file.
+- A failing check requires changes outside the lane.
+- The worker finds a schema, API, migration, security, or high-context instruction change.
+- Required context is missing or contradicts the handoff.
+- The same lane fails the same check three times.
+
+Escalation output must include:
+
+- blocker summary
+- affected files
+- evidence gathered
+- proposed next routing: `serialize`, `revise_lane_map`, `clarify_first`, or `defer`
+
+## Reintegration Ownership
+
+Parallel work must converge through one integration owner:
+
+- The integration owner reviews every lane's diff or report.
+- The integration owner resolves conflicts and performs the final merge/synthesis.
+- Workers do not merge adjacent lanes into shared files unless their assignment explicitly grants ownership of those files.
+- Final verification must run after reintegration, even when each lane passed local checks.
+- The final handoff must name accepted lanes, rejected lanes, rerun checks, and unresolved risks.
+
+When reintegration changes behavior beyond a worker's output, it becomes a new execution step and must be verified as such.
+
+## Staged Team Pipeline
+
+Use this pipeline for multi-agent work:
+
+1. `solo`
+   - One executor owns discovery and edits.
+   - Default for small, local, or unclear work.
+
+2. `delegate-readonly`
+   - Child agents may inspect independent areas and report findings.
+   - No delegated writes are allowed.
+   - Use this when the leader needs faster evidence without introducing merge risk.
+
+3. `team-plan`
+   - The leader creates `lane_map`, assignment blocks, stop conditions, and verification ownership.
+   - Write lanes are not started until file ownership is explicit.
+
+4. `team-exec`
+   - Workers execute only their assigned slices.
+   - The leader monitors blockers and serializes overlapping work.
+
+5. `team-verify`
+   - Verification lanes run assigned checks.
+   - The integration owner reruns final checks after merge/synthesis.
+
+6. `fix-loop`
+   - Failed checks route back to the smallest responsible lane.
+   - If ownership is ambiguous, serialize under the integration owner.
+   - After three failed attempts on the same lane, stop and challenge the plan.
+
+## Parallelism Decision Table
+
+| Situation | Decision | Reason |
+| --- | --- | --- |
+| Independent read-only exploration | Parallelize | No writable state is shared. |
+| Disjoint file ownership with explicit assignments | Parallelize | W-14 ownership is satisfied. |
+| Independent test or verification commands | Parallelize | Results can be merged by evidence. |
+| Same writable file needed by multiple lanes | Serialize | The merge point is shared state. |
+| Schema, API, migration, or lockfile changes | Serialize | Downstream lanes depend on one contract. |
+| Generated files or broad formatting changes | Serialize | Outputs commonly touch many owners. |
+| Security-sensitive or high-context instruction files | Serialize unless explicitly owned | Incorrect merges can change agent authority or safety posture. |
+
+Default maximum concurrent write lanes: `3`. Higher concurrency requires explicit worktree isolation, exact `allowed_files`, and a named integration owner for each branch of work.
+
+## Worktree and File Ownership Isolation
+
+- Use a separate worktree when the main checkout has unrelated user edits or when multiple write lanes would otherwise share a checkout.
+- Each write lane must own a disjoint file set before edits begin.
+- Shared generated outputs, lockfiles, migrations, schemas, and release metadata belong to the integration owner unless a lane assignment says otherwise.
+- Read-only lanes may inspect broad paths but must not produce edits.
+- The integration owner must inspect `git diff --name-only` before accepting each lane.
+
+## Handoff Integration
+
+Planning handoffs should keep the existing required keys from [`routing-contract.md`](routing-contract.md). The `lane_map` entry for each delegated lane points to an assignment block shaped by this contract.
+
+Example:
+
+```yaml
+handoff:
+  mode: fixflow
+  artifacts:
+    - plan/delegated-fix.md
+  runtime_pinning_snapshot: .vibeguard/runtime-pinning.snapshot
+  verification_owner: integration-owner
+  stop_conditions:
+    - any lane needs a forbidden file
+  lane_map:
+    docs: doc-worker
+    tests: test-worker
+
+delegation_assignments:
+  docs:
+    task_slice: update workflow docs to reference the new contract
+    allowed_files:
+      - README.md
+      - docs/README_CN.md
+      - workflows/**/*.md
+    forbidden_files:
+      - tests/**
+      - scripts/**
+    authority: write_patch
+    required_evidence:
+      - git diff --name-only
+      - bash scripts/ci/validate-doc-paths.sh
+    blocker_conditions:
+      - documentation change requires a schema or generated file update
+    integration_owner: integration-owner
+```

--- a/workflows/references/delivery-base.md
+++ b/workflows/references/delivery-base.md
@@ -9,6 +9,7 @@ Before execution starts, consume the canonical router in [`workflows/references/
 - Start direct execution only after upstream routing resolves to `execute_direct`, or after a planning workflow emits a handoff that preselects execution.
 - If upstream routing resolves to `clarify_first`, stop and clarify before building a plan or editing code.
 - Do not reinterpret the route locally with file-count shortcuts.
+- If the handoff includes delegated lanes, consume [`workflows/references/delegation-contract.md`](delegation-contract.md) before scheduling or accepting parallel work.
 
 ## Execution Handoff Contract
 
@@ -44,6 +45,7 @@ Consumption rules:
 - `verification_owner` must be reflected in the verification loop and final handoff.
 - `stop_conditions` must halt work when triggered.
 - `lane_map` must define a single owner for each delegated lane before parallel work starts.
+- Delegated lanes must include assignment blocks with `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, and `integration_owner`.
 
 ## Define Ready Criteria (DoR)
 
@@ -76,6 +78,7 @@ Consumption rules:
 
 - Implement one step fully before moving to the next.
 - Include code, related config/docs, and immediate verification in the same step.
+- For delegated work, the integration owner must accept or reject each lane before the next dependent step starts.
 - For `per_step` (default):
   - Stage only files for current step.
   - Run step-level checks.

--- a/workflows/references/routing-contract.md
+++ b/workflows/references/routing-contract.md
@@ -58,6 +58,7 @@ File count may be used as a secondary hint, but it is not the contract and must 
 - `execute_direct` enters an execution workflow immediately.
 - `plan_first` enters a planning workflow that emits the shared handoff block below.
 - Delegation is allowed only when `lane_map` assigns a single owner to each lane and no lane is left ownerless.
+- Each delegated lane must follow the assignment, ownership, blocker, and reintegration rules in [`delegation-contract.md`](delegation-contract.md).
 - Long tasks that cross 3 or more agent steps, run for 10 minutes or longer, or enter `/vibeguard:interview` / `/vibeguard:exec-plan` must capture a W-20 runtime pinning snapshot before execution starts.
 
 If delegation ownership is missing or conflicting, stop and return `clarify_first`.
@@ -97,6 +98,7 @@ Consumption rules:
 - `verification_owner` names who closes the verification loop.
 - `stop_conditions` are hard boundaries, not suggestions.
 - `lane_map` must show ownership for every delegated lane before parallel work starts.
+- Delegated `lane_map` entries point to assignment blocks shaped by [`delegation-contract.md`](delegation-contract.md).
 
 ## Workflow Ownership
 
@@ -151,3 +153,10 @@ Planner proposes parallel execution but omits who owns doc verification.
 
 - `lane_map` is incomplete
 - output: `clarify_first` until ownership is explicit
+
+### Delegation With File Ownership Conflict
+
+Planner assigns two workers to edit `docs/README_CN.md`.
+
+- delegation contract fails because the same writable file has multiple owners
+- output: serialize under the integration owner, or revise `lane_map`


### PR DESCRIPTION
## Summary
- add a canonical delegation contract with child-agent assignments, leader/worker responsibilities, blocker escalation, reintegration ownership, and staged team pipeline
- wire routing, delivery, dispatcher, workflow skills, schemas, and docs to consume the contract
- add manifest regression assertions so delegation assignment fields and pipeline stages cannot drift silently

Closes #99

## Validation
- bash tests/test_manifest_contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/verify/doc-freshness-check.sh --strict
- bash tests/unit/run_all.sh
- bash tests/test_self_application_ci.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash tests/test_eval_contract.sh
- bash tests/test_quality_grader.sh
- bash tests/test_local_contract_gate.sh
- git diff --cached --check