### PR TITLE
[codex] Fix high-priority setup and hook contract issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ which implies it) to make CI fail when the install is broken.
 
 VibeGuard deploys hooks and skills to both Claude Code and Codex CLI.
 
-Hooks live in `~/.codex/hooks.json` (requires `[features].codex_hooks = true` in `config.toml`):
+Hooks live in `~/.codex/hooks.json` (requires `[features].hooks = true` in `config.toml`):
 
 | Event | Hook | Function |
 |-------|------|----------|

--- a/docs/internal/plans/agent-rules-distribution.md
+++ b/docs/internal/plans/agent-rules-distribution.md
@@ -134,7 +134,7 @@ Add a single status surface, either as `bash setup.sh --codex-status` or `bash s
 - Codex CLI path and version if available
 - `~/.codex/AGENTS.md` hygiene status
 - whether `~/.codex/hooks.json` has all VibeGuard-managed entries
-- whether `[features].codex_hooks = true`
+- whether `[features].hooks = true`
 - whether legacy VibeGuard MCP config remains
 - installed wrapper path and executable status
 - latest VibeGuard Codex event timestamp, hook, decision, and project root
@@ -147,20 +147,20 @@ This command must be read-only.
 Done-when:
 
 - Running the status command does not modify `~/.codex/*` or `~/.vibeguard/*`.
-- Missing AGENTS, disabled `codex_hooks`, stale hooks, and no recent log events produce distinct messages.
+- Missing AGENTS, disabled `hooks`, deprecated `codex_hooks`, stale hooks, and no recent log events produce distinct messages.
 - A healthy install reports "Codex native support: PreToolUse(Bash), PostToolUse(Bash), Stop".
 
 ### R5: Semantic Drift Instead of Whole-file Drift
 
 For shared Codex files, `setup.sh --check` must prefer semantic checks over whole-file checksum failure:
 
-- `~/.codex/config.toml`: OK if `codex_hooks = true` and no legacy VibeGuard MCP block exists.
+- `~/.codex/config.toml`: OK if `hooks = true` and no legacy VibeGuard MCP block exists.
 - `~/.codex/hooks.json`: OK if all VibeGuard-managed hooks are present with expected command, matcher, type, and timeout.
 - Whole-file checksum mismatch may be INFO, not a red failure, when semantic checks pass.
 
 Done-when:
 
-- User edits unrelated Codex config but keeps `codex_hooks = true`; status reports semantic OK and checksum INFO.
+- User edits unrelated Codex config but keeps `hooks = true`; status reports semantic OK and checksum INFO.
 - A missing VibeGuard hook entry remains a WARN or FAIL.
 - A malformed TOML/JSON remains BROKEN.
 
@@ -190,7 +190,7 @@ Tests must prove the native Codex contract, not only hand-built idealized payloa
 
 - AGENTS install/check/clean/idempotency
 - AGENTS 0-byte, missing marker, duplicate marker, external content
-- `codex_hooks` semantic status
+- `hooks` semantic status plus `codex_hooks` deprecation status
 - native Bash-shaped `PostToolUse` payload behavior
 - `hook-health.sh` with `cli=codex` and `cli=claude` fixture rows
 - `run-hook-codex.sh` wrapper diagnostics

--- a/hooks/_lib/codex_adapter.sh
+++ b/hooks/_lib/codex_adapter.sh
@@ -52,6 +52,11 @@ except Exception:
 decision = data.get("decision", "pass")
 reason = data.get("reason", "")
 updated = data.get("updatedInput")
+hook_specific = data.get("hookSpecificOutput")
+
+if isinstance(hook_specific, dict):
+    print(json.dumps(data, ensure_ascii=False))
+    sys.exit(0)
 
 if decision == "block":
     print(json.dumps({

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -192,7 +192,17 @@ if echo "$COMMAND_STRIPPED" | grep -qE "(cat|echo|printf|tee)\s.*>.*\.md\b" 2>/d
   elif ! echo "$COMMAND_STRIPPED" | grep -qiE "(README|CLAUDE|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\.md" 2>/dev/null; then
     # Output a warning instead of blocking (probably reasonable document creation)
     vg_log "pre-bash-guard" "Bash" "warn" "Non-standard .md file" "$COMMAND"
-    vg_json_output_kv decision warn reason "VIBEGUARD Warning: Creation of non-standard .md file detected. Only README/CLAUDE/CONTRIBUTING/CHANGELOG/LICENSE/SKILL.md is allowed to be created. Please confirm the file purpose if necessary."
+    VG_CONTEXT="VIBEGUARD Warning: Creation of non-standard .md file detected. Only README/CLAUDE/CONTRIBUTING/CHANGELOG/LICENSE/SKILL.md is allowed to be created. Please confirm the file purpose if necessary." python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": os.environ["VG_CONTEXT"],
+    }
+}, ensure_ascii=False))
+PY
     exit 0
   fi
 fi

--- a/schemas/prompt-contract.schema.json
+++ b/schemas/prompt-contract.schema.json
@@ -24,6 +24,22 @@
   ],
   "optional_sections": [
     {
+      "name": "constraints",
+      "heading_text": "Constraints"
+    },
+    {
+      "name": "project-constraints",
+      "heading_text": "Project Constraints To Fill In"
+    },
+    {
+      "name": "architecture-layers",
+      "heading_text": "Architecture Layers"
+    },
+    {
+      "name": "fix-priority",
+      "heading_text": "Fix Priority"
+    },
+    {
       "name": "code-style",
       "heading_text": "Code Style"
     },

--- a/scripts/ci/validate-prompt-contract.sh
+++ b/scripts/ci/validate-prompt-contract.sh
@@ -11,10 +11,10 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
 
-STRICT_FLAG=()
+STRICT=0
 for arg in "$@"; do
   case "$arg" in
-    --strict) STRICT_FLAG=(--strict) ;;
+    --strict) STRICT=1 ;;
     *) echo "Unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -23,7 +23,11 @@ FAIL=0
 
 run_one() {
   local target="$1"
-  if ! python3 "$HELPER" validate-prompt-contract --target "$target" "${STRICT_FLAG[@]}"; then
+  local -a args=(validate-prompt-contract --target "$target")
+  if [[ "${STRICT}" -eq 1 ]]; then
+    args+=(--strict)
+  fi
+  if ! python3 "$HELPER" "${args[@]}"; then
     FAIL=$((FAIL + 1))
   fi
 }

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -30,7 +30,8 @@ def _table_name(line: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-CODEX_HOOKS_FEATURE = "codex_hooks"
+CODEX_HOOKS_FEATURE = "hooks"
+LEGACY_CODEX_HOOKS_FEATURE = "codex_hooks"
 
 
 def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
@@ -42,6 +43,7 @@ def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
     features_idx: int | None = None
     insert_idx: int | None = None
     in_features = False
+    found_hooks = False
 
     for idx, line in enumerate(lines):
         stripped = line.strip()
@@ -61,12 +63,16 @@ def _ensure_codex_hooks_enabled(text: str) -> tuple[str, bool]:
                 if stripped != f"{CODEX_HOOKS_FEATURE} = true":
                     lines[idx] = f"{CODEX_HOOKS_FEATURE} = true"
                     changed = True
-                return "\n".join(lines).rstrip() + "\n", changed
+                found_hooks = True
+            elif key == LEGACY_CODEX_HOOKS_FEATURE:
+                lines[idx] = ""
+                changed = True
 
     if features_idx is not None:
         assert insert_idx is not None
-        lines.insert(insert_idx, f"{CODEX_HOOKS_FEATURE} = true")
-        changed = True
+        if not found_hooks:
+            lines.insert(insert_idx, f"{CODEX_HOOKS_FEATURE} = true")
+            changed = True
         return "\n".join(lines).rstrip() + "\n", changed
 
     content = "\n".join(lines).rstrip()
@@ -108,6 +114,8 @@ def _check_codex_hooks_enabled(text: str) -> tuple[str, int]:
     features = data.get("features")
     if isinstance(features, dict) and features.get(CODEX_HOOKS_FEATURE) is True:
         return "OK", 0
+    if isinstance(features, dict) and features.get(LEGACY_CODEX_HOOKS_FEATURE) is True:
+        return "LEGACY", 1
     return "MISSING", 1
 
 
@@ -162,10 +170,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Structured Codex config.toml helper")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    enable = sub.add_parser("enable-codex-hooks", help="Ensure [features].codex_hooks = true")
+    enable = sub.add_parser("enable-codex-hooks", help="Ensure [features].hooks = true")
     enable.add_argument("--config-file", required=True)
 
-    check = sub.add_parser("check-codex-hooks", help="Validate [features].codex_hooks = true")
+    check = sub.add_parser("check-codex-hooks", help="Validate [features].hooks = true")
     check.add_argument("--config-file", required=True)
 
     remove = sub.add_parser("remove-legacy-vibeguard-mcp", help="Remove [mcp_servers.vibeguard] block")

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -217,12 +217,53 @@ run_legacy_checks() {
   echo "Guard Script Portability"
   echo "------------------------------"
   _awk_violations=$(create_tmpfile 2>/dev/null || mktemp)
-  # Detect non-POSIX regex shortcuts inside awk regex delimiters (/..\s../)
-  # awk uses /regex/ syntax; grep uses quoted strings — so /...\s.../ is awk-specific
-  find "${REPO_DIR}/guards" -name '*.sh' -print0 2>/dev/null \
-    | xargs -0 grep -rnE '/[^/"]*\\[sdwb]' 2>/dev/null \
-    | grep -vE '^\s*#|grep |sed ' \
-    >> "$_awk_violations" 2>/dev/null || true
+  # Detect non-POSIX regex shortcuts only in awk command contexts. Python
+  # heredocs and quoted Python regexes may legitimately use \s, \d, \w, or \b.
+  python3 - <<'PY' "${REPO_DIR}/guards" > "$_awk_violations" 2>/dev/null || true
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+awk_word = re.compile(r"\b(?:awk|gawk|mawk|nawk)\b")
+non_posix = re.compile(r"/[^/\"']*\\[sdwb][^/\"']*/")
+
+for path in sorted(root.rglob("*.sh")):
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        continue
+
+    in_awk_program = False
+    quote = ""
+    for line_no, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        inspect_line = False
+        if in_awk_program:
+            inspect_line = True
+            if quote and quote in line:
+                in_awk_program = False
+                quote = ""
+        elif awk_word.search(line):
+            inspect_line = True
+            after_awk = awk_word.split(line, maxsplit=1)[1]
+            single_count = after_awk.count("'")
+            double_count = after_awk.count('"')
+            if single_count % 2 == 1:
+                in_awk_program = True
+                quote = "'"
+            elif double_count % 2 == 1:
+                in_awk_program = True
+                quote = '"'
+
+        if inspect_line and non_posix.search(line):
+            print(f"{path}:{line_no}:{line}")
+PY
   if [[ -s "$_awk_violations" ]]; then
     count=$(wc -l < "$_awk_violations" | tr -d ' ')
     red "[FAIL] ${count} awk line(s) use non-POSIX regex (\\s \\d \\w \\b — breaks on BSD awk):"

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -187,8 +187,20 @@ if ! command -v cargo &>/dev/null; then
 fi
 echo "  Building vibeguard-runtime (Rust)..."
 if cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet 2>/dev/null; then
+  if ! _runtime_target_dir="$(
+    cargo metadata --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --no-deps --format-version=1 2>/dev/null \
+      | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+  )" || [[ -z "${_runtime_target_dir}" ]]; then
+    red "  ERROR: unable to resolve vibeguard-runtime Cargo target directory."
+    exit 2
+  fi
+  _runtime_binary="${_runtime_target_dir}/release/vibeguard-runtime"
+  if [[ ! -x "${_runtime_binary}" ]]; then
+    red "  ERROR: vibeguard-runtime build output not found at ${_runtime_binary}"
+    exit 2
+  fi
   mkdir -p "${_INSTALL_TMP}/bin"
-  cp "${REPO_DIR}/vibeguard-runtime/target/release/vibeguard-runtime" "${_INSTALL_TMP}/bin/vibeguard-runtime"
+  cp "${_runtime_binary}" "${_INSTALL_TMP}/bin/vibeguard-runtime"
   chmod +x "${_INSTALL_TMP}/bin/vibeguard-runtime"
   green "  vibeguard-runtime binary prepared"
 else

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -190,6 +190,8 @@ print(total)
   fi
   if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] hooks feature enabled in config.toml"
+  elif [[ "${codex_hooks_status}" == "LEGACY" ]]; then
+    yellow "[LEGACY] deprecated codex_hooks feature is enabled; run setup.sh to migrate to hooks"
   elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
     red "[BROKEN] ~/.codex/config.toml is malformed TOML"
   else
@@ -324,11 +326,13 @@ print_codex_status() {
     codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${config}" 2>/dev/null || true)"
   fi
   if [[ "${codex_hooks_status}" == "OK" ]]; then
-    green "[OK] codex_hooks feature enabled"
+    green "[OK] hooks feature enabled"
+  elif [[ "${codex_hooks_status}" == "LEGACY" ]]; then
+    yellow "[LEGACY] deprecated codex_hooks feature enabled"
   elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
     red "[BROKEN] ~/.codex/config.toml is malformed TOML"
   else
-    yellow "[MISSING] codex_hooks feature not enabled"
+    yellow "[MISSING] hooks feature not enabled"
   fi
 
   if _has_legacy_codex_mcp_config; then

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -12,6 +12,14 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 - Default verbosity: keep answers concise by default; use short paragraphs for simple tasks and expand only when the work is complex or the user asks for depth.
 - Formatting: use Markdown only when it helps; prefer prose first, flat bullets only for natural lists, and avoid decorative structure.
 
+## Operating Principles
+
+- Search before adding files, functions, rules, hooks, workflows, or tests.
+- Do not commit secrets, credentials, tokens, or private keys.
+- Do not use AI marker tags in commits, PRs, comments, generated files, or shipped text.
+- Do not force push unless the human explicitly authorizes the exact branch and reason.
+- Fail loudly on user-visible missing data, wrong output, malformed inputs, or broken validation.
+
 ## Constraints
 
 | ID | Rule |
@@ -38,6 +46,13 @@ Before completing any task:
 - TypeScript: `npx tsc --noEmit` then project test command
 - Go: `go build ./...` then `go test ./...`
 - Python: `pytest`
+
+## Routing
+
+Follow `workflows/references/routing-contract.md`:
+- `execute_direct`: clear, low-risk, local change with known verification.
+- `plan_first`: multi-file, architectural, migration, or ambiguous implementation path.
+- `clarify_first`: missing goal, context, constraints, or done-when would make execution unsafe.
 
 ## Architecture Layers
 

--- a/tests/hooks/test_pre_bash_guard.sh
+++ b/tests/hooks/test_pre_bash_guard.sh
@@ -72,6 +72,11 @@ assert_not_contains "$result" '"decision": "block"' "commit message with semicol
 result=$(echo '{"tool_input":{"command":"echo \"note && git restore .\"" }}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "echo string with && before restore mention not blocked"
 
+result=$(echo '{"tool_input":{"command":"printf x > notes.md"}}' | bash hooks/pre-bash-guard.sh)
+assert_contains "$result" '"hookSpecificOutput"' "non-standard markdown write emits schema-valid advisory context"
+assert_contains "$result" '"hookEventName": "PreToolUse"' "non-standard markdown advisory targets PreToolUse"
+assert_not_contains "$result" '"decision": "warn"' "non-standard markdown advisory does not emit invalid warn decision"
+
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -39,6 +39,171 @@ assert_not_contains() {
   fi
 }
 
+assert_codex_pretool_output_contract() {
+  local output="$1" desc="$2"
+  TOTAL=$((TOTAL + 1))
+  if CODEX_HOOK_OUTPUT="${output}" python3 - <<'PY'
+import json
+import os
+import sys
+
+try:
+    data = json.loads(os.environ["CODEX_HOOK_OUTPUT"])
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+allowed_top = {
+    "continue",
+    "stopReason",
+    "suppressOutput",
+    "systemMessage",
+    "decision",
+    "reason",
+    "hookSpecificOutput",
+}
+extra_top = sorted(set(data) - allowed_top)
+if extra_top:
+    print(f"unknown top-level fields: {extra_top}", file=sys.stderr)
+    raise SystemExit(1)
+if data.get("continue", True) is not True:
+    print("Codex PreToolUse does not support continue:false", file=sys.stderr)
+    raise SystemExit(1)
+if "stopReason" in data:
+    print("Codex PreToolUse does not support stopReason", file=sys.stderr)
+    raise SystemExit(1)
+if data.get("suppressOutput", False):
+    print("Codex PreToolUse does not support suppressOutput:true", file=sys.stderr)
+    raise SystemExit(1)
+
+decision = data.get("decision")
+if decision == "block":
+    if not str(data.get("reason", "")).strip():
+        print("Codex PreToolUse decision:block requires a non-empty reason", file=sys.stderr)
+        raise SystemExit(1)
+elif decision is not None:
+    print(f"unsupported VibeGuard PreToolUse top-level decision: {decision}", file=sys.stderr)
+    raise SystemExit(1)
+elif "reason" in data:
+    print("Codex PreToolUse reason requires decision:block", file=sys.stderr)
+    raise SystemExit(1)
+
+specific = data.get("hookSpecificOutput")
+if specific is None:
+    raise SystemExit(0)
+if not isinstance(specific, dict):
+    print("hookSpecificOutput must be an object", file=sys.stderr)
+    raise SystemExit(1)
+
+allowed_specific = {
+    "hookEventName",
+    "permissionDecision",
+    "permissionDecisionReason",
+    "updatedInput",
+    "additionalContext",
+}
+extra_specific = sorted(set(specific) - allowed_specific)
+if extra_specific:
+    print(f"unknown PreToolUse hookSpecificOutput fields: {extra_specific}", file=sys.stderr)
+    raise SystemExit(1)
+if specific.get("hookEventName") != "PreToolUse":
+    print("hookSpecificOutput.hookEventName must be PreToolUse", file=sys.stderr)
+    raise SystemExit(1)
+
+permission_decision = specific.get("permissionDecision")
+if permission_decision == "deny":
+    if not str(specific.get("permissionDecisionReason", "")).strip():
+        print("permissionDecision:deny requires permissionDecisionReason", file=sys.stderr)
+        raise SystemExit(1)
+elif permission_decision is not None:
+    print(f"unsupported VibeGuard PreToolUse permissionDecision: {permission_decision}", file=sys.stderr)
+    raise SystemExit(1)
+elif "permissionDecisionReason" in specific:
+    print("permissionDecisionReason requires permissionDecision", file=sys.stderr)
+    raise SystemExit(1)
+if "updatedInput" in specific:
+    print("VibeGuard Codex wrapper must not emit updatedInput on native PreToolUse", file=sys.stderr)
+    raise SystemExit(1)
+PY
+  then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_codex_posttool_output_contract() {
+  local output="$1" desc="$2"
+  TOTAL=$((TOTAL + 1))
+  if CODEX_HOOK_OUTPUT="${output}" python3 - <<'PY'
+import json
+import os
+import sys
+
+try:
+    data = json.loads(os.environ["CODEX_HOOK_OUTPUT"])
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+allowed_top = {
+    "continue",
+    "stopReason",
+    "suppressOutput",
+    "systemMessage",
+    "decision",
+    "reason",
+    "hookSpecificOutput",
+}
+extra_top = sorted(set(data) - allowed_top)
+if extra_top:
+    print(f"unknown top-level fields: {extra_top}", file=sys.stderr)
+    raise SystemExit(1)
+if data.get("suppressOutput", False):
+    print("Codex PostToolUse does not support suppressOutput:true", file=sys.stderr)
+    raise SystemExit(1)
+
+decision = data.get("decision")
+if decision == "block":
+    if not str(data.get("reason", "")).strip():
+        print("Codex PostToolUse decision:block requires a non-empty reason", file=sys.stderr)
+        raise SystemExit(1)
+elif decision is not None:
+    print(f"unsupported VibeGuard PostToolUse decision: {decision}", file=sys.stderr)
+    raise SystemExit(1)
+elif "reason" in data:
+    print("Codex PostToolUse reason requires decision:block", file=sys.stderr)
+    raise SystemExit(1)
+
+specific = data.get("hookSpecificOutput")
+if specific is None:
+    raise SystemExit(0)
+if not isinstance(specific, dict):
+    print("hookSpecificOutput must be an object", file=sys.stderr)
+    raise SystemExit(1)
+allowed_specific = {"hookEventName", "additionalContext", "updatedMCPToolOutput"}
+extra_specific = sorted(set(specific) - allowed_specific)
+if extra_specific:
+    print(f"unknown PostToolUse hookSpecificOutput fields: {extra_specific}", file=sys.stderr)
+    raise SystemExit(1)
+if specific.get("hookEventName") != "PostToolUse":
+    print("hookSpecificOutput.hookEventName must be PostToolUse", file=sys.stderr)
+    raise SystemExit(1)
+if "updatedMCPToolOutput" in specific:
+    print("VibeGuard Codex wrapper must not emit updatedMCPToolOutput", file=sys.stderr)
+    raise SystemExit(1)
+PY
+  then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 TMP_DIR="$(mktemp -d)"
 cleanup() {
   rm -rf "${TMP_DIR}"
@@ -81,6 +246,23 @@ rewrite_out="$(
 )"
 assert_contains "${rewrite_out}" '"systemMessage"' "run-hook-codex emits an explicit note for unsupported rewrites"
 assert_contains "${rewrite_out}" 'pnpm install' "run-hook-codex includes the suggested rewritten command"
+assert_codex_pretool_output_contract "${rewrite_out}" "rewrite advisory matches Codex PreToolUse output contract"
+
+header "run-hook-codex maps Claude PreToolUse blocks to Codex deny schema"
+cat > "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"block","reason":"force push denied"}\n'
+HOOK
+chmod +x "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh"
+
+pretool_block_out="$(
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"git push --force"}}' \
+    | HOME="${TMP_HOME}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${pretool_block_out}" '"permissionDecision": "deny"' "run-hook-codex maps Claude block to Codex permission deny"
+assert_contains "${pretool_block_out}" '"permissionDecisionReason": "force push denied"' "run-hook-codex preserves deny reason for Codex"
+assert_codex_pretool_output_contract "${pretool_block_out}" "mapped pretool block matches Codex PreToolUse output contract"
 
 header "run-hook-codex passes through pretool additional context"
 cat > "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
@@ -96,6 +278,7 @@ pretool_context_out="$(
 )"
 assert_contains "${pretool_context_out}" '"hookSpecificOutput"' "run-hook-codex passes through pretool hookSpecificOutput"
 assert_contains "${pretool_context_out}" 'advisory context' "run-hook-codex preserves pretool additional context"
+assert_codex_pretool_output_contract "${pretool_context_out}" "pretool additional context matches Codex PreToolUse output contract"
 
 header "run-hook-codex keeps pass-with-no-output silent"
 TMP_HOME_PASSING="${TMP_DIR}/home-passing"
@@ -147,6 +330,7 @@ set -e
 assert_contains "${failing_out}" '"permissionDecision": "deny"' "run-hook-codex emits a deny payload when the wrapped hook exits nonzero"
 assert_contains "${failing_out}" 'hook failed' "run-hook-codex explains wrapped hook failures"
 assert_not_contains "${failing_out}" '"permissionDecision":"allow"' "run-hook-codex does not convert wrapped hook failure into allow"
+assert_codex_pretool_output_contract "${failing_out}" "wrapped hook failure deny matches Codex PreToolUse output contract"
 TOTAL=$((TOTAL + 1))
 if [[ ${failing_rc} -eq 0 ]]; then
   green "run-hook-codex exits successfully when it emits a deny payload for wrapped hook failure"
@@ -216,6 +400,7 @@ invalid_json_rc=$?
 set -e
 assert_contains "${invalid_json_out}" '"permissionDecision": "deny"' "run-hook-codex emits a deny payload when pretool adaptation fails"
 assert_contains "${invalid_json_out}" 'invalid JSON' "run-hook-codex explains invalid pretool hook JSON"
+assert_codex_pretool_output_contract "${invalid_json_out}" "invalid JSON deny matches Codex PreToolUse output contract"
 TOTAL=$((TOTAL + 1))
 if [[ ${invalid_json_rc} -eq 0 ]]; then
   green "run-hook-codex exits successfully when it emits a deny payload on pretool adapter failure"
@@ -251,6 +436,7 @@ missing_hook_out="$(
     | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
 )"
 assert_contains "${missing_hook_out}" '"permissionDecision": "deny"' "missing PreToolUse hook fails closed"
+assert_codex_pretool_output_contract "${missing_hook_out}" "missing hook deny matches Codex PreToolUse output contract"
 assert_contains "$(cat "${DIAG_FILE}")" "missing-hook" "missing hook writes diagnostic event"
 
 cat > "${TMP_FAKE_REPO_DIAG}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
@@ -264,6 +450,7 @@ missing_adapter_out="$(
     | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_ADAPTER_PATH="${TMP_DIR}/missing-adapter.sh" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
 )"
 assert_contains "${missing_adapter_out}" '"permissionDecision": "deny"' "missing adapter fails closed for PreToolUse"
+assert_codex_pretool_output_contract "${missing_adapter_out}" "missing adapter deny matches Codex PreToolUse output contract"
 assert_contains "$(cat "${DIAG_FILE}")" "missing-adapter" "missing adapter writes diagnostic event"
 
 header "run-hook-codex adapts posttool block output"
@@ -285,6 +472,7 @@ posttool_out="$(
 )"
 assert_contains "${posttool_out}" '"decision": "block"' "run-hook-codex preserves posttool block decisions"
 assert_contains "${posttool_out}" '"additionalContext": "build failed"' "run-hook-codex maps posttool reason to additionalContext"
+assert_codex_posttool_output_contract "${posttool_out}" "posttool block matches Codex PostToolUse output contract"
 
 cat > "${TMP_FAKE_REPO_POSTTOOL}/hooks/vibeguard-post-build-check.sh" <<'HOOK'
 #!/usr/bin/env bash

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -82,6 +82,21 @@ rewrite_out="$(
 assert_contains "${rewrite_out}" '"systemMessage"' "run-hook-codex emits an explicit note for unsupported rewrites"
 assert_contains "${rewrite_out}" 'pnpm install' "run-hook-codex includes the suggested rewritten command"
 
+header "run-hook-codex passes through pretool additional context"
+cat > "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"advisory context"}}\n'
+HOOK
+chmod +x "${TMP_FAKE_REPO}/hooks/vibeguard-pre-bash-guard.sh"
+
+pretool_context_out="$(
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"printf x > notes.md"}}' \
+    | HOME="${TMP_HOME}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${pretool_context_out}" '"hookSpecificOutput"' "run-hook-codex passes through pretool hookSpecificOutput"
+assert_contains "${pretool_context_out}" 'advisory context' "run-hook-codex preserves pretool additional context"
+
 header "run-hook-codex keeps pass-with-no-output silent"
 TMP_HOME_PASSING="${TMP_DIR}/home-passing"
 TMP_FAKE_REPO_PASSING="${TMP_DIR}/fake-repo-passing"

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -170,7 +170,7 @@ header "codex config helper"
 CONFIG_FILE="${TMP_DIR}/config.toml"
 enable_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${enable_out}" "CHANGED" "enable-codex-hooks creates config when missing"
-assert_cmd "enable-codex-hooks writes codex_hooks = true" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+assert_cmd "enable-codex-hooks writes hooks = true" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
@@ -180,7 +180,7 @@ TOML
 enable_prefixed_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${enable_prefixed_out}" "CHANGED" "enable-codex-hooks adds canonical key when only prefixed keys exist"
 assert_cmd "enable-codex-hooks preserves prefixed feature keys" grep -Eq '^codex_hooks_beta[[:space:]]*=[[:space:]]*false$' "${CONFIG_FILE}"
-assert_cmd "enable-codex-hooks adds exact codex_hooks key" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+assert_cmd "enable-codex-hooks adds exact hooks key" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features] # user comment
@@ -189,7 +189,17 @@ TOML
 enable_commented_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${enable_commented_out}" "CHANGED" "enable-codex-hooks recognizes commented features table"
 assert_cmd "enable-codex-hooks does not append duplicate commented features table" bash -c "test \$(grep -Ec '^\\[features\\]' '${CONFIG_FILE}') -eq 1"
-assert_cmd "enable-codex-hooks adds exact key under commented features table" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+assert_cmd "enable-codex-hooks adds exact hooks key under commented features table" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
+
+cat > "${CONFIG_FILE}" <<'TOML'
+[features]
+codex_hooks = true
+foo = true
+TOML
+enable_legacy_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
+assert_contains "${enable_legacy_out}" "CHANGED" "enable-codex-hooks migrates legacy codex_hooks"
+assert_cmd "enable-codex-hooks removes deprecated codex_hooks key" bash -c "! grep -Eq '^codex_hooks[[:space:]]*=' '${CONFIG_FILE}'"
+assert_cmd "enable-codex-hooks writes hooks key during migration" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
@@ -215,21 +225,21 @@ assert_cmd "non-legacy tables remain after recursive cleanup" grep -Eq '^\[other
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
-codex_hooks = true
+hooks = true
 TOML
 check_ok_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${check_ok_out}" "OK" "check-codex-hooks accepts valid TOML with feature enabled"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
-hooks = true
+codex_hooks = true
 TOML
 check_legacy_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
-assert_contains "${check_legacy_out}" "MISSING" "check-codex-hooks rejects legacy hooks feature key"
+assert_contains "${check_legacy_out}" "LEGACY" "check-codex-hooks reports deprecated codex_hooks feature key"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
-codex_hooks = true
+hooks = true
 broken = [
 TOML
 check_invalid_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
@@ -238,7 +248,7 @@ assert_contains "${check_invalid_out}" "INVALID" "check-codex-hooks rejects malf
 python3 - <<'PY' "${CONFIG_FILE}"
 from pathlib import Path
 import sys
-Path(sys.argv[1]).write_bytes(b'[features]\ncodex_hooks = true\n\xff')
+Path(sys.argv[1]).write_bytes(b'[features]\nhooks = true\n\xff')
 PY
 check_invalid_utf8_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
 assert_contains "${check_invalid_utf8_out}" "INVALID" "check-codex-hooks rejects invalid UTF-8"

--- a/tests/test_prompt_contract.sh
+++ b/tests/test_prompt_contract.sh
@@ -84,7 +84,14 @@ assert_stderr_contains "missing Verification surfaces in stderr" \
 
 header "missing must-mention token"
 TARGET_NOFORCE="${WORK_DIR}/agents-no-force-push.md"
-sed 's/No force push/No rebase merge/' "$REAL_AGENTS" > "$TARGET_NOFORCE"
+python3 - <<'PY' "$REAL_AGENTS" "$TARGET_NOFORCE"
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+target.write_text(source.read_text(encoding="utf-8").replace("force push", "rebase merge"), encoding="utf-8")
+PY
 assert_cmd_fail "missing 'force push' token -> error" \
   run_validator --target "$TARGET_NOFORCE"
 assert_stderr_contains "missing force-push surfaces in stderr" \

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -549,7 +549,8 @@ state = {
 }
 (home / ".vibeguard/install-state.json").write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 PY
-install_out="$(bash "${REPO_DIR}/setup.sh" --yes)"
+CUSTOM_CARGO_TARGET_DIR="${TMP_HOME}/custom cargo target"
+install_out="$(CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
 assert_contains "${install_out}" "Removed retired VibeGuard skill link" "setup install removes tracked retired skill links"
 assert_cmd "setup install removes tracked retired Claude skill" test ! -L "${HOME}/.claude/skills/old-retired"
@@ -572,7 +573,8 @@ assert_cmd "post-guard-check is not enabled in the default installation" bash -c
 assert_cmd "skills-loader is not enabled in the default installation" bash -c "! grep -q 'skills-loader.sh' '${HOME}/.claude/settings.json'"
 assert_cmd "The default core profile does not enable full hooks" bash -c "python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target full-hooks >/dev/null 2>&1; test \$? -ne 0"
 assert_cmd "~/.codex/hooks.json exists after installation" test -f "${HOME}/.codex/hooks.json"
-assert_cmd "Enable codex_hooks feature after installation" grep -Eq '^codex_hooks[[:space:]]*=[[:space:]]*true$' "${HOME}/.codex/config.toml"
+assert_cmd "Enable hooks feature after installation" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${HOME}/.codex/config.toml"
+assert_cmd "Deprecated codex_hooks feature not written after installation" bash -c "! grep -Eq '^codex_hooks[[:space:]]*=' '${HOME}/.codex/config.toml'"
 assert_cmd "Clean legacy Codex MCP block after installation" bash -c "! grep -q '^\[mcp_servers\.vibeguard\]' '${HOME}/.codex/config.toml'"
 assert_cmd "Codex hooks are namespaced (vibeguard prefix)" bash -c "grep -q 'vibeguard-pre-bash-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-post-build-check.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-stop-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-learn-evaluator.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "Codex helper validates managed hooks" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${HOME}/.codex/hooks.json" --wrapper "${HOME}/.vibeguard/run-hook-codex.sh"

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -14,6 +14,14 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 STATUS_LIB="${REPO_DIR}/scripts/lib/status_report.sh"
 CHECK_SCRIPT="${REPO_DIR}/scripts/setup/check.sh"
 SETUP_SCRIPT="${REPO_DIR}/setup.sh"
+AWK_PORTABILITY_FIXTURE=""
+
+cleanup() {
+  if [[ -n "${AWK_PORTABILITY_FIXTURE}" ]]; then
+    rm -f "${AWK_PORTABILITY_FIXTURE}"
+  fi
+}
+trap cleanup EXIT
 
 PASS=0
 FAIL=0
@@ -241,6 +249,19 @@ default_out="$(bash "${SETUP_SCRIPT}" --check 2>&1 || true)"
 assert_contains "$default_out" "VibeGuard Installation Status" "default: legacy header preserved"
 assert_contains "$default_out" "Summary"        "default: summary block present"
 assert_contains "$default_out" "Verdict :"      "default: verdict line present"
+assert_contains "$default_out" "[OK] All awk blocks use POSIX-compatible regex" "default: Python heredoc regexes do not trip awk portability"
+assert_not_contains "$default_out" "check_dependency_changes.sh:147" "default: dependency Python regex not reported as awk"
+assert_not_contains "$default_out" "check_test_weakening.sh:118" "default: test weakening Python regex not reported as awk"
+
+AWK_PORTABILITY_FIXTURE="${REPO_DIR}/guards/universal/vg-test-non-posix-awk.sh"
+cat > "${AWK_PORTABILITY_FIXTURE}" <<'SH'
+#!/usr/bin/env bash
+awk '/\sbad/ { print }' "$1"
+SH
+awk_fixture_out="$(bash "${SETUP_SCRIPT}" --check 2>&1 || true)"
+assert_contains "$awk_fixture_out" "vg-test-non-posix-awk.sh" "check reports real non-POSIX awk regex"
+rm -f "${AWK_PORTABILITY_FIXTURE}"
+AWK_PORTABILITY_FIXTURE=""
 
 no_summary_out="$(bash "${SETUP_SCRIPT}" --check --no-summary 2>&1 || true)"
 assert_contains "$no_summary_out" "VibeGuard Installation Status" "no-summary: legacy header preserved"


### PR DESCRIPTION
## Summary

- migrate Codex setup/status from deprecated `[features].codex_hooks` to canonical `[features].hooks`, including legacy detection and migration
- emit schema-valid advisory context for non-blocking Claude/Codex PreToolUse hook warnings
- validate VibeGuard Codex wrapper output against the current OpenAI Codex hook output contract, not only Claude Code hook docs
- resolve the Cargo runtime binary from `cargo metadata` so custom `CARGO_TARGET_DIR` installs work
- repair prompt contract validation against the canonical AGENTS template and Bash 3.2 strict mode
- narrow setup-check awk portability scanning to actual awk contexts

Fixes #181
Fixes #183
Fixes #189
Fixes #190
Fixes #202

## Schema Sources

- Claude Code hook docs: `hookSpecificOutput.additionalContext` for advisory context and event-specific hook output
- OpenAI Codex source, refreshed from `openai/codex@origin/main` (`de9c5c0226`):
  - `codex-rs/hooks/src/schema.rs`
  - `codex-rs/hooks/src/engine/output_parser.rs`
- Local Codex CLI observed while validating: `codex-cli 0.130.0`

## Validation

- `bash -n scripts/setup/check.sh && bash -n scripts/setup/install.sh && bash -n scripts/ci/validate-prompt-contract.sh && bash -n hooks/pre-bash-guard.sh && bash -n hooks/_lib/codex_adapter.sh`
- `python3 -m py_compile scripts/lib/codex_config_toml.py scripts/lib/vibeguard_manifest.py`
- `git diff --check` and `git diff --cached --check`
- `bash scripts/ci/validate-prompt-contract.sh && bash scripts/ci/validate-prompt-contract.sh --strict`
- `cargo build --release --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_manifest_contract.sh`
- `bash tests/test_prompt_contract.sh`
- `bash tests/test_setup_check.sh`
- `bash tests/hooks/test_pre_bash_guard.sh`
- `bash tests/test_codex_runtime.sh` (`51/51`, including Codex PreToolUse/PostToolUse output contract assertions)
- `bash tests/test_setup.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/ci/validate-doc-paths.sh && bash scripts/ci/validate-doc-command-paths.sh`
- `bash tests/test_codex_status.sh`
- `bash scripts/ci/validate-hook-perf.sh`
- `bash scripts/codex-contract-check.sh`
