### PR TITLE
Fix stale hook registration checks

### DIFF
--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -37,6 +37,47 @@ MANAGED_MARKERS = LEGACY_MARKERS | all_managed_script_names(MANIFEST)
 _MANAGED_SCRIPT_NAMES: frozenset[str] = frozenset(spec["script"] for spec in MANAGED_SPECS)
 
 
+def _display_path(path: Path, home: Path) -> str:
+    try:
+        return "~/" + path.relative_to(home).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _expand_shell_path(token: str, home: Path) -> Path | None:
+    if token.startswith("~/"):
+        return home / token[2:]
+    if token.startswith("$HOME/"):
+        return home / token[len("$HOME/"):]
+    if token.startswith("${HOME}/"):
+        return home / token[len("${HOME}/"):]
+    if token.startswith("/"):
+        return Path(token)
+    return None
+
+
+def _hook_target_from_command(command: str, home: Path) -> Path | None:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+
+    for index, token in enumerate(parts):
+        path = _expand_shell_path(token, home)
+        if path is None:
+            continue
+        path_text = path.as_posix()
+        if "/.vibeguard/installed/hooks/" in path_text:
+            return path
+        if path_text.endswith("/.vibeguard/run-hook-codex.sh") and index + 1 < len(parts):
+            script_name = parts[index + 1]
+            if script_name and "/" not in script_name:
+                installed_dir = path.parent / "installed/hooks"
+                if installed_dir.exists():
+                    return installed_dir / script_name
+    return None
+
+
 def load_hooks(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
@@ -137,6 +178,109 @@ def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
     return changed
 
 
+def _iter_hook_commands(data: dict[str, Any]) -> list[tuple[str, str, str]]:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+
+    commands: list[tuple[str, str, str]] = []
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            matcher = entry.get("matcher")
+            matcher_text = matcher if isinstance(matcher, str) and matcher else "<none>"
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                continue
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str) and command:
+                    commands.append((str(event), matcher_text, command))
+    return commands
+
+
+def stale_hook_findings(path: Path, home: Path) -> list[dict[str, str]]:
+    data = load_hooks(path)
+    findings: list[dict[str, str]] = []
+    for event, matcher, command in _iter_hook_commands(data):
+        hook_target = _hook_target_from_command(command, home)
+        if hook_target is None or hook_target.exists():
+            continue
+        findings.append(
+            {
+                "client": "Codex",
+                "config": _display_path(path, home),
+                "event": event,
+                "matcher": matcher,
+                "command_path": str(hook_target),
+                "repair": "bash setup.sh --yes",
+            }
+        )
+    return findings
+
+
+def _prune_stale_installed_hook_entries(data: dict[str, Any], home: Path) -> bool:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+
+    changed = False
+    for event, entries in list(hooks.items()):
+        if not isinstance(entries, list):
+            continue
+
+        new_entries: list[Any] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                new_entries.append(entry)
+                continue
+
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                new_entries.append(entry)
+                continue
+
+            kept_hooks: list[Any] = []
+            removed_any = False
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    kept_hooks.append(hook)
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str):
+                    hook_target = _hook_target_from_command(command, home)
+                    if hook_target is not None and not hook_target.exists():
+                        removed_any = True
+                        changed = True
+                        continue
+                kept_hooks.append(hook)
+
+            if removed_any:
+                if kept_hooks:
+                    next_entry = dict(entry)
+                    next_entry["hooks"] = kept_hooks
+                    new_entries.append(next_entry)
+            else:
+                new_entries.append(entry)
+
+        if new_entries:
+            hooks[event] = new_entries
+        else:
+            hooks.pop(event, None)
+            changed = True
+
+    if not hooks:
+        data.pop("hooks", None)
+        changed = True
+
+    return changed
+
+
 def _build_entry(wrapper: str, spec: HookSpec) -> dict[str, Any]:
     hook: dict[str, Any] = {
         "type": "command",
@@ -198,6 +342,7 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
 
     _ensure_hooks_root(data)
     _prune_vibeguard_entries(data)
+    _prune_stale_installed_hook_entries(data, Path.home())
     hooks = _ensure_hooks_root(data)
 
     for spec in MANAGED_SPECS:
@@ -244,6 +389,19 @@ def cmd_remove_vibeguard(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_check_stale_hooks(args: argparse.Namespace) -> int:
+    hooks_path = Path(args.hooks_file)
+    if not hooks_path.exists():
+        return 0
+    findings = stale_hook_findings(hooks_path, Path.home())
+    for finding in findings:
+        print(
+            "stale {client} hook command: config={config} event={event} "
+            "matcher={matcher} command_path={command_path} repair={repair}".format(**finding)
+        )
+    return 1 if findings else 0
+
+
 def cmd_check_vibeguard(args: argparse.Namespace) -> int:
     hooks_path = Path(args.hooks_file)
     data = load_hooks(hooks_path)
@@ -282,6 +440,10 @@ def build_parser() -> argparse.ArgumentParser:
     check.add_argument("--hooks-file", required=True)
     check.add_argument("--wrapper", required=True)
     check.set_defaults(func=cmd_check_vibeguard)
+
+    stale = sub.add_parser("check-stale-hooks", help="Detect stale hook commands")
+    stale.add_argument("--hooks-file", required=True)
+    stale.set_defaults(func=cmd_check_stale_hooks)
 
     return parser
 

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -56,6 +56,150 @@ def _entry_contains(entry: Any, needle: str) -> bool:
         return False
 
 
+def _display_path(path: Path, home: Path) -> str:
+    try:
+        return "~/" + path.relative_to(home).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _expand_shell_path(token: str, home: Path) -> Path | None:
+    if token.startswith("~/"):
+        return home / token[2:]
+    if token.startswith("$HOME/"):
+        return home / token[len("$HOME/"):]
+    if token.startswith("${HOME}/"):
+        return home / token[len("${HOME}/"):]
+    if token.startswith("/"):
+        return Path(token)
+    return None
+
+
+def _hook_target_from_command(command: str, home: Path) -> Path | None:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+
+    for index, token in enumerate(parts):
+        path = _expand_shell_path(token, home)
+        if path is None:
+            continue
+        path_text = path.as_posix()
+        if "/.vibeguard/installed/hooks/" in path_text:
+            return path
+        if path_text.endswith("/.vibeguard/run-hook.sh") and index + 1 < len(parts):
+            script_name = parts[index + 1]
+            if script_name and "/" not in script_name:
+                installed_dir = path.parent / "installed/hooks"
+                if installed_dir.exists():
+                    return installed_dir / script_name
+    return None
+
+
+def _iter_hook_commands(data: dict[str, Any]) -> list[tuple[str, str, str]]:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+
+    commands: list[tuple[str, str, str]] = []
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            matcher = entry.get("matcher")
+            matcher_text = matcher if isinstance(matcher, str) and matcher else "<none>"
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                continue
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str) and command:
+                    commands.append((str(event), matcher_text, command))
+    return commands
+
+
+def stale_hook_findings(path: Path, home: Path) -> list[dict[str, str]]:
+    data = load_settings(path)
+    findings: list[dict[str, str]] = []
+    for event, matcher, command in _iter_hook_commands(data):
+        hook_target = _hook_target_from_command(command, home)
+        if hook_target is None or hook_target.exists():
+            continue
+        findings.append(
+            {
+                "client": "Claude",
+                "config": _display_path(path, home),
+                "event": event,
+                "matcher": matcher,
+                "command_path": str(hook_target),
+                "repair": "bash setup.sh --yes",
+            }
+        )
+    return findings
+
+
+def _remove_stale_installed_hook_entries(data: dict[str, Any], home: Path) -> bool:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+
+    changed = False
+    for event, entries in list(hooks.items()):
+        if not isinstance(entries, list):
+            continue
+
+        new_entries: list[Any] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                new_entries.append(entry)
+                continue
+
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                new_entries.append(entry)
+                continue
+
+            kept_hooks: list[Any] = []
+            removed_any = False
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    kept_hooks.append(hook)
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str):
+                    hook_target = _hook_target_from_command(command, home)
+                    if hook_target is not None and not hook_target.exists():
+                        removed_any = True
+                        changed = True
+                        continue
+                kept_hooks.append(hook)
+
+            if removed_any:
+                if kept_hooks:
+                    next_entry = dict(entry)
+                    next_entry["hooks"] = kept_hooks
+                    new_entries.append(next_entry)
+            else:
+                new_entries.append(entry)
+
+        if new_entries:
+            hooks[event] = new_entries
+        else:
+            hooks.pop(event, None)
+            changed = True
+
+    if not hooks:
+        data.pop("hooks", None)
+        changed = True
+
+    return changed
+
+
 def _has_hook_spec(data: dict[str, Any], spec: dict[str, Any]) -> bool:
     hooks = data.get("hooks", {})
     entries = hooks.get(spec["event"], []) if isinstance(hooks, dict) else []
@@ -268,6 +412,19 @@ def cmd_check(args: argparse.Namespace) -> int:
     return 1
 
 
+def cmd_check_stale_hooks(args: argparse.Namespace) -> int:
+    settings_path = Path(args.settings_file)
+    if not settings_path.exists():
+        return 0
+    findings = stale_hook_findings(settings_path, Path.home())
+    for finding in findings:
+        print(
+            "stale {client} hook command: config={config} event={event} "
+            "matcher={matcher} command_path={command_path} repair={repair}".format(**finding)
+        )
+    return 1 if findings else 0
+
+
 def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
     settings_path = Path(args.settings_file)
     before_text = settings_path.read_text(encoding="utf-8") if settings_path.exists() else ""
@@ -277,6 +434,8 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
     if _remove_legacy_mcp_server(data):
         state["changed"] = True
     if _remove_legacy_hook_entries(data):
+        state["changed"] = True
+    if _remove_stale_installed_hook_entries(data, Path.home()):
         state["changed"] = True
 
     hooks = data.setdefault("hooks", {})
@@ -404,6 +563,10 @@ def build_parser() -> argparse.ArgumentParser:
     check.add_argument("--settings-file", required=True)
     check.add_argument("--target", choices=["pre-hooks", "post-hooks", "full-hooks"], required=True)
     check.set_defaults(func=cmd_check)
+
+    stale = sub.add_parser("check-stale-hooks", help="Detect stale hook commands")
+    stale.add_argument("--settings-file", required=True)
+    stale.set_defaults(func=cmd_check_stale_hooks)
 
     upsert = sub.add_parser("upsert-vibeguard", help="Upsert VibeGuard hooks config")
     upsert.add_argument("--settings-file", required=True)

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -25,6 +25,12 @@ settings_check() {
   python3 "${SETTINGS_HELPER}" check --settings-file "${settings_file}" --target "${target}" >/dev/null 2>&1
 }
 
+settings_stale_hooks_report() {
+  local settings_file="$1"
+  [[ -f "${settings_file}" ]] || return 0
+  python3 "${SETTINGS_HELPER}" check-stale-hooks --settings-file "${settings_file}"
+}
+
 settings_upsert() {
   local settings_file="$1" profile="$2"
   local args=(upsert-vibeguard --settings-file "${settings_file}" --repo-dir "${REPO_DIR}" --profile "${profile}")

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -357,6 +357,15 @@ check_claude_home_installation() {
   else
     yellow "[INFO] Full profile hooks not configured (current install may be core profile)"
   fi
+
+  local stale_hooks_report
+  if stale_hooks_report="$(settings_stale_hooks_report "${SETTINGS_FILE}" 2>&1)"; then
+    :
+  else
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && red "[BROKEN] ${line}"
+    done <<< "${stale_hooks_report}"
+  fi
 }
 
 clean_claude_home_installation() {

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -204,6 +204,15 @@ print(total)
     else
       yellow "[MISSING] VibeGuard hooks not fully configured in ~/.codex/hooks.json"
     fi
+
+    local stale_hooks_report
+    if stale_hooks_report="$(python3 "${CODEX_HOOKS_HELPER}" check-stale-hooks --hooks-file "${CODEX_DIR}/hooks.json" 2>&1)"; then
+      :
+    else
+      while IFS= read -r line; do
+        [[ -n "${line}" ]] && red "[BROKEN] ${line}"
+      done <<< "${stale_hooks_report}"
+    fi
   else
     yellow "[MISSING] Codex hooks.json not installed"
   fi

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -15,10 +15,14 @@ STATUS_LIB="${REPO_DIR}/scripts/lib/status_report.sh"
 CHECK_SCRIPT="${REPO_DIR}/scripts/setup/check.sh"
 SETUP_SCRIPT="${REPO_DIR}/setup.sh"
 AWK_PORTABILITY_FIXTURE=""
+STALE_HOOK_HOME=""
 
 cleanup() {
   if [[ -n "${AWK_PORTABILITY_FIXTURE}" ]]; then
     rm -f "${AWK_PORTABILITY_FIXTURE}"
+  fi
+  if [[ -n "${STALE_HOOK_HOME}" ]]; then
+    rm -rf "${STALE_HOOK_HOME}"
   fi
 }
 trap cleanup EXIT
@@ -285,6 +289,68 @@ else
 fi
 assert_json_path "$json_full_out" 'd["schema_version"]' "1" "json end-to-end: schema_version=1"
 assert_json_path "$json_full_out" 'd["verdict"] in ("healthy","degraded","broken")' "True" "json end-to-end: verdict in expected set"
+
+# --- Stale hook registry detection ---
+header "stale hook registry detection"
+STALE_HOOK_HOME="$(mktemp -d)"
+mkdir -p "${STALE_HOOK_HOME}/.claude" "${STALE_HOOK_HOME}/.codex" "${STALE_HOOK_HOME}/.vibeguard/installed/hooks"
+cp "${REPO_DIR}/hooks/run-hook.sh" "${STALE_HOOK_HOME}/.vibeguard/run-hook.sh"
+cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${STALE_HOOK_HOME}/.vibeguard/run-hook-codex.sh"
+cp -R "${REPO_DIR}/hooks/." "${STALE_HOOK_HOME}/.vibeguard/installed/hooks/"
+cat > "${STALE_HOOK_HOME}/.claude/settings.json" <<JSON
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${STALE_HOOK_HOME}/.vibeguard/installed/hooks/session-tagger.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+cat > "${STALE_HOOK_HOME}/.codex/hooks.json" <<JSON
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${STALE_HOOK_HOME}/.vibeguard/installed/hooks/session-tagger.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+stale_check_out="$(HOME="${STALE_HOOK_HOME}" bash "${SETUP_SCRIPT}" --check --strict 2>&1)"
+stale_check_rc=$?
+assert_eq "$stale_check_rc" "2" "stale hook check: strict mode exits broken"
+assert_contains "$stale_check_out" "stale Claude hook command" "stale hook check: reports Claude stale command"
+assert_contains "$stale_check_out" "config=~/.claude/settings.json event=Stop matcher=<none>" "stale hook check: names Claude config/event/matcher"
+assert_contains "$stale_check_out" "command_path=${STALE_HOOK_HOME}/.vibeguard/installed/hooks/session-tagger.sh" "stale hook check: names missing installed hook path"
+assert_contains "$stale_check_out" "stale Codex hook command" "stale hook check: reports Codex stale command"
+assert_contains "$stale_check_out" "config=~/.codex/hooks.json event=Stop matcher=<none>" "stale hook check: names Codex config/event/matcher"
+assert_contains "$stale_check_out" "repair=bash setup.sh --yes" "stale hook check: names repair action"
+
+HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/settings_json.py" upsert-vibeguard \
+  --settings-file "${STALE_HOOK_HOME}/.claude/settings.json" \
+  --repo-dir "${REPO_DIR}" \
+  --profile core >/dev/null
+HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" upsert-vibeguard \
+  --hooks-file "${STALE_HOOK_HOME}/.codex/hooks.json" \
+  --wrapper "${STALE_HOOK_HOME}/.vibeguard/run-hook-codex.sh" >/dev/null
+assert_cmd "stale hook repair: Claude installed hook path removed" bash -c "! grep -q '.vibeguard/installed/hooks/session-tagger.sh' '${STALE_HOOK_HOME}/.claude/settings.json'"
+assert_cmd "stale hook repair: Codex installed hook path removed" bash -c "! grep -q '.vibeguard/installed/hooks/session-tagger.sh' '${STALE_HOOK_HOME}/.codex/hooks.json'"
+assert_cmd "stale hook repair: Claude stale check passes" env HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/settings_json.py" check-stale-hooks --settings-file "${STALE_HOOK_HOME}/.claude/settings.json"
+assert_cmd "stale hook repair: Codex stale check passes" env HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" check-stale-hooks --hooks-file "${STALE_HOOK_HOME}/.codex/hooks.json"
 
 # --- Backwards-compat exit code contract ---
 header "exit code contract"


### PR DESCRIPTION
## Summary
- detect stale Claude and Codex hook commands that point at missing ~/.vibeguard/installed/hooks scripts
- surface actionable setup --check diagnostics with client config, event, matcher, command path, and repair action
- remove stale installed-hook entries during setup repair/upsert and cover the scenario in setup --check tests

Fixes #188

## Tests
- bash tests/test_setup_check.sh
- bash tests/test_setup.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check