### PR TITLE
Fix hook caller identity logging

### DIFF
--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -48,6 +48,12 @@ run-hook.sh (wrapper) run-hook-codex.sh (wrapper + format adaptation)
 Hooks are logged to events.jsonl using the following decision types:
 `pass` / `warn` / `block` / `gate` / `escalate` / `correction` / `complete`
 
+Each event keeps the backward-compatible `cli` / `agent` fields and may include
+caller identity fields: `client`, `client_variant`, `wrapper`,
+`source_config`, `hook_protocol_version`, and `caller_evidence`. Unknown or
+manual callers must be recorded as `client: "unknown"` instead of being
+silently attributed to Claude or Codex.
+
 ## Development specifications
 
 - All hooks must introduce shared functions in `source log.sh`

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -48,6 +48,24 @@ print(json.dumps({
 PY
 }
 
+codex_set_caller_identity() {
+  local event_name="$1"
+  export VIBEGUARD_WRAPPER="${VIBEGUARD_WRAPPER:-run-hook-codex.sh}"
+  export VIBEGUARD_SOURCE_CONFIG="${VIBEGUARD_SOURCE_CONFIG:-${HOME}/.codex/hooks.json}"
+  export VIBEGUARD_HOOK_PROTOCOL_VERSION="${VIBEGUARD_HOOK_PROTOCOL_VERSION:-codex-hooks-v1}"
+  if [[ -n "${event_name}" ]]; then
+    export VIBEGUARD_AGENT_TYPE="${VIBEGUARD_AGENT_TYPE:-codex}"
+    export VIBEGUARD_CLI="${VIBEGUARD_CLI:-codex}"
+    export VIBEGUARD_CLIENT="${VIBEGUARD_CLIENT:-codex}"
+    export VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-codex-cli-hooks}"
+    export VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-codex-hook-payload}"
+  else
+    export VIBEGUARD_CLIENT="${VIBEGUARD_CLIENT:-unknown}"
+    export VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-unknown}"
+    export VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-missing-codex-hook-payload}"
+  fi
+}
+
 codex_diag() {
   local hook_name="$1" event_name="$2" reason="$3" detail="${4:-}"
   local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"

--- a/hooks/_lib/log_session.sh
+++ b/hooks/_lib/log_session.sh
@@ -91,4 +91,36 @@ if [[ -z "${VIBEGUARD_CLI:-}" || -z "${VIBEGUARD_SESSION_ID:-}" ]]; then
   fi
 fi
 
+if [[ -z "${VIBEGUARD_CLIENT:-}" ]]; then
+  case "${VIBEGUARD_CLI:-unknown}" in
+    claude)
+      VIBEGUARD_CLIENT="claude"
+      VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-claude-code-hooks}"
+      VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-parent-process}"
+      ;;
+    codex)
+      VIBEGUARD_CLIENT="codex"
+      VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-codex-cli-hooks}"
+      VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-parent-process}"
+      ;;
+    *)
+      VIBEGUARD_CLIENT="unknown"
+      VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-unknown}"
+      VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-no-client-evidence}"
+      ;;
+  esac
+elif [[ -z "${VIBEGUARD_CLIENT_VARIANT:-}" ]]; then
+  case "${VIBEGUARD_CLIENT}" in
+    claude) VIBEGUARD_CLIENT_VARIANT="claude-code-hooks" ;;
+    codex) VIBEGUARD_CLIENT_VARIANT="codex-cli-hooks" ;;
+    *) VIBEGUARD_CLIENT_VARIANT="unknown" ;;
+  esac
+fi
+
+if [[ -z "${VIBEGUARD_CALLER_EVIDENCE:-}" ]]; then
+  VIBEGUARD_CALLER_EVIDENCE="explicit-client"
+fi
+
 export VIBEGUARD_CLI VIBEGUARD_SESSION_ID
+export VIBEGUARD_CLIENT VIBEGUARD_CLIENT_VARIANT VIBEGUARD_CALLER_EVIDENCE
+export VIBEGUARD_WRAPPER VIBEGUARD_SOURCE_CONFIG VIBEGUARD_HOOK_PROTOCOL_VERSION

--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -46,6 +46,27 @@ vg_log_clean_json_text() {
   fi
 }
 
+vg_log_json_escape() {
+  local text
+  text="$(vg_log_clean_json_text "$1")"
+  text="${text//\\/\\\\}"
+  text="${text//\"/\\\"}"
+  text="${text//$'\n'/\\n}"
+  text="${text//$'\r'/\\r}"
+  text="${text//$'\t'/\\t}"
+  text="${text//$'\b'/\\b}"
+  text="${text//$'\f'/\\f}"
+  printf '%s' "$text"
+}
+
+vg_log_append_string_field() {
+  local json="$1"
+  local field="$2"
+  local value="$3"
+  [[ -n "$value" ]] || { printf '%s' "$json"; return 0; }
+  printf '%s, "%s": "%s"' "$json" "$field" "$(vg_log_json_escape "$value")"
+}
+
 vg_log() {
   local hook="$1"
   local tool="$2"
@@ -88,21 +109,20 @@ vg_log() {
   # becomes ]8;;url\x07 with ESC-only stripping; the raw BEL makes JSONL invalid).
   # tr range: 0x00-0x07 (NUL-BEL), 0x0B (VT), 0x0E-0x1F (SO-US incl. ESC), 0x7F (DEL)
   local esc_reason esc_detail
-  esc_reason=$(vg_log_clean_json_text "$reason")
-  esc_detail=$(vg_log_clean_json_text "$detail")
-  esc_reason="${esc_reason//\\/\\\\}" esc_detail="${esc_detail//\\/\\\\}"
-  esc_reason="${esc_reason//\"/\\\"}" esc_detail="${esc_detail//\"/\\\"}"
-  esc_reason="${esc_reason//$'\n'/\\n}" esc_detail="${esc_detail//$'\n'/\\n}"
-  esc_reason="${esc_reason//$'\r'/\\r}" esc_detail="${esc_detail//$'\r'/\\r}"
-  esc_reason="${esc_reason//$'\t'/\\t}" esc_detail="${esc_detail//$'\t'/\\t}"
-  esc_reason="${esc_reason//$'\b'/\\b}" esc_detail="${esc_detail//$'\b'/\\b}"
-  esc_reason="${esc_reason//$'\f'/\\f}" esc_detail="${esc_detail//$'\f'/\\f}"
+  esc_reason=$(vg_log_json_escape "$reason")
+  esc_detail=$(vg_log_json_escape "$detail")
 
   local json
   json="{\"schema_version\": 1, \"ts\": \"${ts}\", \"session\": \"${VIBEGUARD_SESSION_ID}\", \"hook\": \"${hook}\", \"tool\": \"${tool}\", \"decision\": \"${decision}\", \"reason\": \"${esc_reason}\", \"detail\": \"${esc_detail}\""
   [[ -n "$duration_ms" ]] && json="${json}, \"duration_ms\": ${duration_ms}"
-  [[ -n "${VIBEGUARD_CLI:-}" ]] && json="${json}, \"cli\": \"${VIBEGUARD_CLI}\""
-  [[ -n "${VIBEGUARD_AGENT_TYPE:-}" ]] && json="${json}, \"agent\": \"${VIBEGUARD_AGENT_TYPE}\""
+  json="$(vg_log_append_string_field "$json" "cli" "${VIBEGUARD_CLI:-}")"
+  json="$(vg_log_append_string_field "$json" "agent" "${VIBEGUARD_AGENT_TYPE:-}")"
+  json="$(vg_log_append_string_field "$json" "client" "${VIBEGUARD_CLIENT:-}")"
+  json="$(vg_log_append_string_field "$json" "client_variant" "${VIBEGUARD_CLIENT_VARIANT:-}")"
+  json="$(vg_log_append_string_field "$json" "wrapper" "${VIBEGUARD_WRAPPER:-}")"
+  json="$(vg_log_append_string_field "$json" "source_config" "${VIBEGUARD_SOURCE_CONFIG:-}")"
+  json="$(vg_log_append_string_field "$json" "hook_protocol_version" "${VIBEGUARD_HOOK_PROTOCOL_VERSION:-}")"
+  json="$(vg_log_append_string_field "$json" "caller_evidence" "${VIBEGUARD_CALLER_EVIDENCE:-}")"
   json="${json}}"
 
   vg_private_log_file "$VIBEGUARD_LOG_FILE"

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-export VIBEGUARD_AGENT_TYPE="codex"
-export VIBEGUARD_CLI="codex"
-
 WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK_NAME="${1:?Usage: run-hook-codex.sh <hook-name>}"
 shift
@@ -35,11 +32,13 @@ else
   codex_raw_event_name() { [[ "$1" =~ \"hook_event_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]] && printf '%s\n' "${BASH_REMATCH[1]}"; }
   codex_pretool_deny_raw() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"VIBEGUARD install incomplete."}}\n'; }
   codex_permission_deny_raw() { printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"VIBEGUARD install incomplete."}}}\n'; }
+  codex_set_caller_identity() { export VIBEGUARD_CLIENT="${VIBEGUARD_CLIENT:-unknown}" VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-unknown}" VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-missing-codex-diag-helper}"; }
   codex_diag() { return 0; }
 fi
 
 INPUT=$(cat)
 EVENT_NAME=$(codex_raw_event_name "$INPUT")
+codex_set_caller_identity "${EVENT_NAME}"
 
 if [[ "${HOOK_NAME}" != vibeguard-* ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "non-namespaced-hook" "${HOOK_NAME}"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -9,6 +9,11 @@
 
 set -euo pipefail
 
+export VIBEGUARD_WRAPPER="${VIBEGUARD_WRAPPER:-run-hook.sh}"
+export VIBEGUARD_SOURCE_CONFIG="${VIBEGUARD_SOURCE_CONFIG:-${HOME}/.claude/settings.json}"
+export VIBEGUARD_HOOK_PROTOCOL_VERSION="${VIBEGUARD_HOOK_PROTOCOL_VERSION:-claude-code-hooks-v1}"
+export VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-wrapper-and-parent-process}"
+
 HOOK_NAME="${1:?Usage: run-hook.sh <hook-name>}"
 shift
 

--- a/scripts/hook-health.sh
+++ b/scripts/hook-health.sh
@@ -48,6 +48,7 @@ events.sort(key=lambda e: e["_parsed_ts"])
 total = len(events)
 by_decision = Counter(e.get("decision", "unknown") for e in events)
 by_cli = Counter(e.get("cli", "unknown") for e in events)
+by_client = Counter(e.get("client", e.get("cli", "unknown")) for e in events)
 pass_count = by_decision.get("pass", 0)
 risk_count = total - pass_count
 risk_rate = (risk_count / total * 100) if total else 0.0
@@ -70,6 +71,9 @@ print(f"  correction: {by_decision.get('correction', 0)}")
 print("CLI distribution:")
 for cli, count in by_cli.most_common():
     print(f"  {cli}: {count}")
+print("Client distribution:")
+for client, count in by_client.most_common():
+    print(f"  {client}: {count}")
 
 non_pass_events = [e for e in events if e.get("decision") != "pass"]
 if non_pass_events:
@@ -85,13 +89,14 @@ if non_pass_events:
         hook = event.get("hook", "unknown")
         decision = event.get("decision", "unknown")
         cli = event.get("cli", "unknown")
+        client = event.get("client", cli)
         reason = (event.get("reason") or "").replace("\n", " ").strip()
         detail = (event.get("detail") or "").replace("\n", " ").strip()
         if len(reason) > 100:
             reason = reason[:97] + "..."
         if len(detail) > 100:
             detail = detail[:97] + "..."
-        print(f"  {i}. {ts} | {hook} | {decision} | cli={cli} | session={session}")
+        print(f"  {i}. {ts} | {hook} | {decision} | cli={cli} | client={client} | session={session}")
         if reason:
             print(f"     reason: {reason}")
         if detail:

--- a/tests/hooks/test_log_timer.sh
+++ b/tests/hooks/test_log_timer.sh
@@ -22,6 +22,70 @@ rm -rf "$_timer_log"
 assert_contains "$_timer_result" '"duration_ms":' "vg_start_timer: duration_ms field written to events.jsonl"
 assert_contains "$_timer_result" '"schema_version": 1' "vg_log: events.jsonl includes schema_version"
 
+header "log.sh — caller identity fields"
+
+_manual_log=$(mktemp -d)
+_manual_result=$(
+  export VIBEGUARD_LOG_DIR="$_manual_log"
+  export VIBEGUARD_SESSION_ID="manual-session"
+  unset VIBEGUARD_CLI VIBEGUARD_CLIENT VIBEGUARD_CLIENT_VARIANT VIBEGUARD_CALLER_EVIDENCE
+  source hooks/log.sh
+  vg_log "manual-hook" "Tool" "pass" "" ""
+  cat "$VIBEGUARD_LOG_FILE"
+)
+rm -rf "$_manual_log"
+assert_contains "$_manual_result" '"cli": "unknown"' "manual caller: legacy cli field is unknown"
+assert_contains "$_manual_result" '"client": "unknown"' "manual caller: client field is unknown"
+assert_contains "$_manual_result" '"client_variant": "unknown"' "manual caller: client_variant field is unknown"
+assert_contains "$_manual_result" '"caller_evidence": "no-client-evidence"' "manual caller: evidence explains unknown attribution"
+
+_conflict_log=$(mktemp -d)
+_conflict_result=$(
+  export VIBEGUARD_LOG_DIR="$_conflict_log"
+  export VIBEGUARD_SESSION_ID="conflict-session"
+  export VIBEGUARD_CLI="codex"
+  export VIBEGUARD_CLIENT="claude"
+  export VIBEGUARD_CLIENT_VARIANT="claude-code-hooks"
+  export VIBEGUARD_CALLER_EVIDENCE="explicit-test"
+  source hooks/log.sh
+  vg_log "conflict-hook" "Tool" "pass" "" ""
+  cat "$VIBEGUARD_LOG_FILE"
+)
+rm -rf "$_conflict_log"
+assert_contains "$_conflict_result" '"cli": "codex"' "conflicting signals: legacy cli is preserved"
+assert_contains "$_conflict_result" '"client": "claude"' "conflicting signals: explicit client is preserved"
+assert_contains "$_conflict_result" '"caller_evidence": "explicit-test"' "conflicting signals: evidence is preserved"
+
+_claude_home=$(mktemp -d)
+_claude_log=$(mktemp -d)
+mkdir -p "$_claude_home/.vibeguard"
+printf '%s' "$PWD" > "$_claude_home/.vibeguard/repo-path"
+printf '%s\n' '{"tool_input":{"command":"echo hello"}}' \
+  | HOME="$_claude_home" VIBEGUARD_LOG_DIR="$_claude_log" VIBEGUARD_CLI="claude" bash hooks/run-hook.sh pre-bash-guard.sh >/dev/null 2>&1 || true
+_claude_result=$(cat "$_claude_log/events.jsonl" 2>/dev/null || true)
+assert_contains "$_claude_result" '"client": "claude"' "Claude wrapper: client is inferred from caller CLI"
+assert_contains "$_claude_result" '"client_variant": "claude-code-hooks"' "Claude wrapper: client_variant is recorded"
+assert_contains "$_claude_result" '"wrapper": "run-hook.sh"' "Claude wrapper: wrapper is recorded"
+assert_contains "$_claude_result" "\"source_config\": \"$_claude_home/.claude/settings.json\"" "Claude wrapper: source_config is recorded"
+assert_contains "$_claude_result" '"hook_protocol_version": "claude-code-hooks-v1"' "Claude wrapper: hook protocol is recorded"
+rm -rf "$_claude_home" "$_claude_log"
+
+_codex_home=$(mktemp -d)
+_codex_log=$(mktemp -d)
+mkdir -p "$_codex_home/.vibeguard"
+printf '%s' "$PWD" > "$_codex_home/.vibeguard/repo-path"
+printf '%s\n' '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo hello"}}' \
+  | HOME="$_codex_home" VIBEGUARD_LOG_DIR="$_codex_log" bash hooks/run-hook-codex.sh vibeguard-pre-bash-guard.sh >/dev/null 2>&1 || true
+_codex_result=$(cat "$_codex_log/events.jsonl" 2>/dev/null || true)
+assert_contains "$_codex_result" '"cli": "codex"' "Codex wrapper: legacy cli remains compatible"
+assert_contains "$_codex_result" '"client": "codex"' "Codex wrapper: client is recorded from hook payload"
+assert_contains "$_codex_result" '"client_variant": "codex-cli-hooks"' "Codex wrapper: client_variant is recorded"
+assert_contains "$_codex_result" '"wrapper": "run-hook-codex.sh"' "Codex wrapper: wrapper is recorded"
+assert_contains "$_codex_result" "\"source_config\": \"$_codex_home/.codex/hooks.json\"" "Codex wrapper: source_config is recorded"
+assert_contains "$_codex_result" '"hook_protocol_version": "codex-hooks-v1"' "Codex wrapper: hook protocol is recorded"
+assert_contains "$_codex_result" '"caller_evidence": "codex-hook-payload"' "Codex wrapper: evidence records payload-based attribution"
+rm -rf "$_codex_home" "$_codex_log"
+
 # Extract duration_ms value and verify it's a positive integer >= 1
 _dur=$(echo "$_timer_result" | python3 -c "import sys,json; e=json.loads(sys.stdin.read()); print(e.get('duration_ms','missing'))" 2>/dev/null || echo "missing")
 TOTAL=$((TOTAL + 1))

--- a/tests/test_hook_health.sh
+++ b/tests/test_hook_health.sh
@@ -69,6 +69,8 @@ events = [
         "decision": "pass",
         "reason": "",
         "detail": "cargo check",
+        "cli": "claude",
+        "client": "claude",
     },
     {
         "ts": (now - timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
@@ -78,6 +80,8 @@ events = [
         "decision": "gate",
         "reason": "uncommitted source changes",
         "detail": "src/main.rs",
+        "cli": "codex",
+        "client": "codex",
     },
     {
         "ts": (now - timedelta(hours=3)).isoformat().replace("+00:00", "Z"),
@@ -119,9 +123,12 @@ assert_contains "${health_out}" "Total triggers: 4" "Filter out events within 24
 assert_contains "${health_out}" "Pass: 1" "Pass statistics are correct"
 assert_contains "${health_out}" "Risk (non-pass): 3" "Risk statistics are correct"
 assert_contains "${health_out}" "Risk rate: 75.0%" "Risk rate calculation is correct"
+assert_contains "${health_out}" "Client distribution:" "Output client distribution"
+assert_contains "${health_out}" "claude: 1" "Client distribution includes Claude"
+assert_contains "${health_out}" "codex: 1" "Client distribution includes Codex"
 assert_contains "${health_out}" "Risk Hook Top 5:" "Output risk hook ranking"
 assert_contains "${health_out}" "Top 10 recent risk events:" "Output the latest risk events"
-assert_contains "${health_out}" "stop-guard | gate" "Risk event contains gate"
+assert_contains "${health_out}" "stop-guard | gate | cli=codex | client=codex" "Risk event contains caller split"
 
 header "Malformed UTF-8 and broken JSON lines are tolerated"
 python3 - "${TMP_DIR}/log/events-malformed.jsonl" <<'PY'

--- a/vibeguard-runtime/src/codex_app_server_core.rs
+++ b/vibeguard-runtime/src/codex_app_server_core.rs
@@ -329,6 +329,21 @@ pub fn hook_env(thread_id: Option<&str>, thread: Option<&ThreadState>) -> HashMa
     let mut env = HashMap::from([
         ("VIBEGUARD_CLI".into(), "codex".into()),
         ("VIBEGUARD_AGENT_TYPE".into(), "codex".into()),
+        ("VIBEGUARD_CLIENT".into(), "codex".into()),
+        ("VIBEGUARD_CLIENT_VARIANT".into(), "codex-app-server".into()),
+        (
+            "VIBEGUARD_WRAPPER".into(),
+            "codex-app-server-wrapper".into(),
+        ),
+        ("VIBEGUARD_SOURCE_CONFIG".into(), "codex app-server".into()),
+        (
+            "VIBEGUARD_HOOK_PROTOCOL_VERSION".into(),
+            "codex-app-server-jsonrpc-v1".into(),
+        ),
+        (
+            "VIBEGUARD_CALLER_EVIDENCE".into(),
+            "codex-app-server-wrapper".into(),
+        ),
     ]);
     if let Some(thread) = thread {
         if let Some(session_id) = &thread.session_id {
@@ -567,6 +582,38 @@ mod tests {
         assert_eq!(value["file_change_guard"], true);
         assert_eq!(value["post_turn_feedback"], true);
         assert_eq!(value["analysis_paralysis_guard"], true);
+    }
+
+    #[test]
+    fn hook_env_records_codex_app_server_caller_identity() {
+        let env = hook_env(None, None);
+
+        assert_eq!(env.get("VIBEGUARD_CLI").map(String::as_str), Some("codex"));
+        assert_eq!(
+            env.get("VIBEGUARD_AGENT_TYPE").map(String::as_str),
+            Some("codex")
+        );
+        assert_eq!(
+            env.get("VIBEGUARD_CLIENT").map(String::as_str),
+            Some("codex")
+        );
+        assert_eq!(
+            env.get("VIBEGUARD_CLIENT_VARIANT").map(String::as_str),
+            Some("codex-app-server")
+        );
+        assert_eq!(
+            env.get("VIBEGUARD_WRAPPER").map(String::as_str),
+            Some("codex-app-server-wrapper")
+        );
+        assert_eq!(
+            env.get("VIBEGUARD_HOOK_PROTOCOL_VERSION")
+                .map(String::as_str),
+            Some("codex-app-server-jsonrpc-v1")
+        );
+        assert_eq!(
+            env.get("VIBEGUARD_CALLER_EVIDENCE").map(String::as_str),
+            Some("codex-app-server-wrapper")
+        );
     }
 
     #[test]

--- a/vibeguard-runtime/src/event_schema.rs
+++ b/vibeguard-runtime/src/event_schema.rs
@@ -15,6 +15,14 @@ pub mod field {
     pub const REASON: &str = "reason";
     pub const DETAIL: &str = "detail";
     pub const DURATION_MS: &str = "duration_ms";
+    pub const CLI: &str = "cli";
+    pub const AGENT: &str = "agent";
+    pub const CLIENT: &str = "client";
+    pub const CLIENT_VARIANT: &str = "client_variant";
+    pub const WRAPPER: &str = "wrapper";
+    pub const SOURCE_CONFIG: &str = "source_config";
+    pub const HOOK_PROTOCOL_VERSION: &str = "hook_protocol_version";
+    pub const CALLER_EVIDENCE: &str = "caller_evidence";
 }
 
 pub mod decision {

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -286,8 +286,6 @@ pub(crate) fn write_log_event(
     detail: &str,
 ) -> io::Result<()> {
     let session = env::var("VIBEGUARD_SESSION_ID").unwrap_or_else(|_| "unknown".to_string());
-    let cli = env::var("VIBEGUARD_CLI").ok();
-    let agent = env::var("VIBEGUARD_AGENT_TYPE").ok();
     let ts = format_unix_secs_utc(now_unix_secs());
     let mut event = serde_json::json!({
         "schema_version": 1,
@@ -299,11 +297,33 @@ pub(crate) fn write_log_event(
         "reason": reason,
         "detail": detail,
     });
-    if let Some(cli) = cli.filter(|s| !s.is_empty()) {
-        event["cli"] = serde_json::Value::String(cli);
-    }
-    if let Some(agent) = agent.filter(|s| !s.is_empty()) {
-        event["agent"] = serde_json::Value::String(agent);
+    for (env_name, field_name) in [
+        ("VIBEGUARD_CLI", crate::event_schema::field::CLI),
+        ("VIBEGUARD_AGENT_TYPE", crate::event_schema::field::AGENT),
+        ("VIBEGUARD_CLIENT", crate::event_schema::field::CLIENT),
+        (
+            "VIBEGUARD_CLIENT_VARIANT",
+            crate::event_schema::field::CLIENT_VARIANT,
+        ),
+        ("VIBEGUARD_WRAPPER", crate::event_schema::field::WRAPPER),
+        (
+            "VIBEGUARD_SOURCE_CONFIG",
+            crate::event_schema::field::SOURCE_CONFIG,
+        ),
+        (
+            "VIBEGUARD_HOOK_PROTOCOL_VERSION",
+            crate::event_schema::field::HOOK_PROTOCOL_VERSION,
+        ),
+        (
+            "VIBEGUARD_CALLER_EVIDENCE",
+            crate::event_schema::field::CALLER_EVIDENCE,
+        ),
+    ] {
+        if let Ok(value) = env::var(env_name) {
+            if !value.is_empty() {
+                event[field_name] = serde_json::Value::String(value);
+            }
+        }
     }
     let line = serde_json::to_string(&event).unwrap_or_else(|_| "{}".to_string());
     append_jsonl(Path::new(log_file), &line)?;


### PR DESCRIPTION
## Summary
- record structured caller identity fields in shell and Rust hook logs while preserving legacy cli/agent fields
- mark unknown/manual callers as unknown instead of silently attributing them to Claude or Codex
- add client distribution to hook-health output and cover Claude, Codex, unknown/manual, conflicting signals, and Codex app-server identity

Fixes #187

## Verification
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/hooks/test_log_timer.sh
- bash tests/test_hook_health.sh
- bash tests/test_codex_runtime.sh
- bash tests/test_hooks.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check