### PR TITLE
Add authorized discard workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,10 @@ jobs:
         shell: bash
         run: bash tests/test_rust_guards.sh
 
+      - name: Authorized discard regression tests
+        shell: bash
+        run: bash tests/test_authorized_discard.sh
+
       - name: Setup regression tests
         shell: bash
         run: bash tests/test_setup.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ VibeGuard adds **native rules + real-time hooks + static guards** to catch what 
 - Duplicate files and reinvented modules
 - Invented APIs, fake libraries, and hardcoded placeholder values
 - Dangerous shell/git commands (`rm -rf`, `push --force`, `reset --hard`)
+- Audited cleanup for intentional local discards, with exact path plans and confirmation gates
 - Analysis paralysis and unverified "I'm done" claims
 - Silent exception swallowing and `Any`-type abuse
 - AI-slop patterns flagged on every commit
@@ -72,6 +73,9 @@ AI:   → tries to create auth_service.py
 
       → runs `git push --force`
       ✗ VibeGuard denies — suggests `--force-with-lease`
+
+      → runs `git clean -fd`
+      ✗ VibeGuard denies — points to an authorized discard workflow with an exact deletion plan
 
       → keeps reading files without acting
       ⚠ VibeGuard escalates — force a concrete next step or report blocker

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -93,7 +93,7 @@ VibeGuard 现在明确分成两层：
 |------|------|------|
 | AI 创建新的 `.py/.ts/.rs/.go/.js` 文件 | `pre-write-guard` | 默认 **告警**，提醒先搜索现有实现；设置 `VIBEGUARD_WRITE_MODE=block` 或 `write_mode=block` 后硬拦截 |
 | AI 创建或编辑超过 800 行的生产源码文件 | `pre-write-guard`、`pre-edit-guard` | **拦截**，必须先拆分文件 |
-| AI 执行 `git push --force`、`rm -rf`、`reset --hard` | `pre-bash-guard` | **拦截**，给出安全替代命令 |
+| AI 执行 `git push --force`、`rm -rf`、`git clean -fd`、批量 `git checkout/restore .` | `pre-bash-guard` | **拦截**，给出安全替代命令；如确实要清理本地改动，先运行 `python3 ~/vibeguard/scripts/authorized-discard.py --plan` 查看逐路径计划，再用确认短语执行 |
 | AI 编辑一个不存在的文件 | `pre-edit-guard` | **拦截**，要求先读取文件确认 |
 | AI 编辑后引入 `unwrap()`、硬编码路径等问题 | `post-edit-guard` | **告警**，直接给修复建议 |
 | AI 编辑后留下 `console.log` / `print()` | `post-edit-guard` | **告警**，要求换成正式日志方案 |

--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -115,6 +115,11 @@ block() {
   exit 0
 }
 
+authorized_discard_hint() {
+  local root="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+  printf ' To perform an audited cleanup, run: python3 "%s/scripts/authorized-discard.py" --plan, then rerun with --confirm "discard listed changes" after reviewing the enumerated paths.' "$root"
+}
+
 # git reset --hard — Allow execution (users need to use it in scenarios such as rebase conflicts)
 
 # git checkout . / git restore . (discard all changes)
@@ -124,12 +129,12 @@ block() {
 # and shell redirections such as heredoc openers) without false-positives from separators
 # inside commit messages or string arguments.
 if echo "$COMMAND_STRIPPED_WITH_DOT" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||[<>]|$)'; then
-  block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding."
+  block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding.$(authorized_discard_hint)"
 fi
 
 # git clean -f (delete untracked files)
 if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+clean\s+.*-f'; then
-  block "Disable git clean -f (untracked files are permanently deleted and cannot be recovered). Alternatives: git clean -n (dry run preview) to see what will be deleted first; git stash --include-untracked to temporarily store untracked files; manually rm to specify files."
+  block "Disable git clean -f (untracked files are permanently deleted and cannot be recovered). Alternatives: git clean -n (dry run preview) to see what will be deleted first; git stash --include-untracked to temporarily store untracked files; manually rm to specify files.$(authorized_discard_hint)"
 fi
 
 # rm -rf dangerous path detection (covers rm -rf, rm -fr, rm -Rf, rm --recursive --force and other variants)

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -12,6 +12,7 @@ Reference notes for the utility scripts shipped with VibeGuard.
 | `project-init.sh` | Bootstrap another repository with detected languages, recommended constraints, and git hook wiring |
 | `constraint-recommender.py` | Generate an initial preflight constraint draft from project structure |
 | `log-capability-change.sh` | Extract a capability-change timeline from git history |
+| `authorized-discard.py` | Print and execute an explicit, confirmed Git cleanup plan for tracked, untracked, and selected ignored paths |
 
 ## GC / Metrics / Verification
 
@@ -54,6 +55,7 @@ Reference notes for the utility scripts shipped with VibeGuard.
 bash scripts/stats.sh
 bash scripts/hook-health.sh 24
 bash scripts/quality-grader.sh
+python3 scripts/authorized-discard.py --plan
 bash scripts/ci/validate-hooks-manifest.sh
 bash scripts/ci/validate-doc-paths.sh
 bash scripts/ci/validate-doc-command-paths.sh

--- a/scripts/authorized-discard.py
+++ b/scripts/authorized-discard.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Safely discard enumerated Git changes after explicit authorization."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from datetime import datetime, timezone
+import shutil
+import subprocess
+import sys
+
+
+CONFIRM_PHRASE = "discard listed changes"
+CONFIRM_TOKEN = "discard-listed-changes"
+IGNORED_CONFIRM_PHRASE = "discard ignored secret-like files"
+IGNORED_CONFIRM_TOKEN = "discard-ignored-secret-like-files"
+
+
+def run_git(repo: Path | None, args: list[str], check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    cmd = ["git"]
+    if repo is not None:
+        cmd.extend(["-C", str(repo)])
+    cmd.extend(args)
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if check and proc.returncode != 0:
+        err = proc.stderr.decode("utf-8", "replace").strip()
+        raise RuntimeError(err or f"git {' '.join(args)} failed")
+    return proc
+
+
+def git_paths(repo: Path, args: list[str]) -> list[str]:
+    out = run_git(repo, args).stdout
+    return sorted({os.fsdecode(part) for part in out.split(b"\0") if part})
+
+
+def repo_root() -> Path:
+    proc = run_git(None, ["rev-parse", "--show-toplevel"], check=False)
+    if proc.returncode != 0:
+        raise RuntimeError("not inside a Git work tree")
+    return Path(proc.stdout.decode("utf-8", "replace").strip()).resolve()
+
+
+def has_head(repo: Path) -> bool:
+    return run_git(repo, ["rev-parse", "--verify", "HEAD"], check=False).returncode == 0
+
+
+def path_in_head(repo: Path, path: str) -> bool:
+    return run_git(repo, ["cat-file", "-e", f"HEAD:{path}"], check=False).returncode == 0
+
+
+def is_secret_like(path: str) -> bool:
+    lower = path.lower()
+    name = Path(path).name.lower()
+    if name == ".env" or name.startswith(".env."):
+        return True
+    if name in {"id_rsa", "id_ed25519", "known_hosts"}:
+        return True
+    if name.endswith((".pem", ".p12", ".pfx", ".key")):
+        return True
+    return any(marker in lower for marker in ("secret", "token", "credential", "private_key", "api_key"))
+
+
+def build_plan(repo: Path, include_ignored: bool) -> dict[str, list[str]]:
+    if has_head(repo):
+        changed = git_paths(repo, ["diff", "--name-only", "-z", "HEAD", "--"])
+    else:
+        changed = git_paths(repo, ["diff", "--cached", "--name-only", "-z", "--"])
+
+    tracked_restore = [path for path in changed if path_in_head(repo, path)]
+    tracked_remove = [path for path in changed if path not in tracked_restore]
+    untracked_delete = git_paths(repo, ["ls-files", "--others", "--exclude-standard", "-z"])
+    ignored = git_paths(repo, ["ls-files", "--others", "-i", "--exclude-standard", "-z"])
+    ignored_secret = [path for path in ignored if is_secret_like(path)]
+    ignored_non_secret = [path for path in ignored if path not in ignored_secret]
+
+    return {
+        "tracked_restore": tracked_restore,
+        "tracked_remove": tracked_remove,
+        "untracked_delete": untracked_delete,
+        "ignored_delete": ignored_non_secret if include_ignored else [],
+        "ignored_secret": ignored_secret if include_ignored else [],
+        "ignored_skipped": ignored if not include_ignored else [],
+    }
+
+
+def section(title: str, paths: list[str]) -> None:
+    print(f"{title}:")
+    if not paths:
+        print("  (none)")
+        return
+    for path in paths:
+        print(f"  {path}")
+
+
+def print_plan(repo: Path, plan: dict[str, list[str]], include_ignored: bool) -> None:
+    print("VibeGuard authorized discard plan")
+    print(f"Repository: {repo}")
+    section("Tracked paths to restore from HEAD", plan["tracked_restore"])
+    section("Tracked paths added to the index to remove", plan["tracked_remove"])
+    section("Untracked paths to delete", plan["untracked_delete"])
+    if include_ignored:
+        section("Ignored paths to delete", plan["ignored_delete"])
+        section("Ignored secret-like paths requiring separate confirmation", plan["ignored_secret"])
+    else:
+        section("Ignored paths not touched", plan["ignored_skipped"])
+    print("No changes have been made by this plan output.")
+
+
+def confirmed(value: str | None, env_name: str, phrase: str, token: str) -> bool:
+    env_value = os.environ.get(env_name)
+    return value in {phrase, token} or env_value in {phrase, token}
+
+
+def total_selected(plan: dict[str, list[str]]) -> int:
+    keys = ["tracked_restore", "tracked_remove", "untracked_delete", "ignored_delete", "ignored_secret"]
+    return sum(len(plan[key]) for key in keys)
+
+
+def checked_target(repo: Path, path: str) -> Path:
+    target = repo / path
+    resolved_repo = repo.resolve()
+    resolved_target = target.resolve(strict=False)
+    try:
+        resolved_target.relative_to(resolved_repo)
+    except ValueError as exc:
+        raise RuntimeError(f"refusing path outside repository: {path}") from exc
+    return target
+
+
+def remove_path(repo: Path, path: str) -> None:
+    target = checked_target(repo, path)
+    if not target.exists() and not target.is_symlink():
+        return
+    if target.is_dir() and not target.is_symlink():
+        shutil.rmtree(target)
+    else:
+        target.unlink()
+
+    parent = target.parent
+    while parent != repo and parent.exists():
+        try:
+            parent.rmdir()
+        except OSError:
+            break
+        parent = parent.parent
+
+
+def apply_plan(repo: Path, plan: dict[str, list[str]]) -> None:
+    for path in plan["tracked_restore"]:
+        run_git(repo, ["restore", "--staged", "--worktree", "--source=HEAD", "--", path])
+    for path in plan["tracked_remove"]:
+        run_git(repo, ["rm", "--cached", "-r", "--ignore-unmatch", "--", path])
+        remove_path(repo, path)
+    for path in plan["untracked_delete"] + plan["ignored_delete"] + plan["ignored_secret"]:
+        remove_path(repo, path)
+
+
+def log_file(repo: Path) -> Path:
+    explicit = os.environ.get("VIBEGUARD_LOG_FILE")
+    if explicit:
+        return Path(explicit)
+    base = Path(os.environ.get("VIBEGUARD_LOG_DIR", str(Path.home() / ".vibeguard")))
+    digest = hashlib.sha256(str(repo).encode("utf-8")).hexdigest()[:8]
+    project_dir = base / "projects" / digest
+    project_dir.mkdir(parents=True, exist_ok=True)
+    mapping = project_dir / ".project-root"
+    try:
+        mapping.write_text(str(repo), encoding="utf-8")
+    except OSError:
+        pass
+    return project_dir / "events.jsonl"
+
+
+def append_log(repo: Path, plan: dict[str, list[str]]) -> None:
+    counts = {key: len(value) for key, value in plan.items() if key != "ignored_skipped"}
+    event = {
+        "schema_version": 1,
+        "ts": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "session": os.environ.get("VIBEGUARD_SESSION_ID", "unknown"),
+        "hook": "authorized-discard",
+        "tool": "Git",
+        "decision": "complete",
+        "reason": "authorized destructive cleanup",
+        "detail": " ".join(f"{key}={value}" for key, value in sorted(counts.items())),
+    }
+    path = log_file(repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    with os.fdopen(fd, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Safely discard enumerated Git changes.")
+    parser.add_argument("--plan", action="store_true", help="Print the discard plan and exit.")
+    parser.add_argument("--include-ignored", action="store_true", help="Also consider ignored files.")
+    parser.add_argument("--confirm", help=f'Execute only when set to "{CONFIRM_PHRASE}".')
+    parser.add_argument(
+        "--confirm-ignored",
+        help=f'Allow ignored secret-like files only when set to "{IGNORED_CONFIRM_PHRASE}".',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo = repo_root()
+        plan = build_plan(repo, args.include_ignored)
+        print_plan(repo, plan, args.include_ignored)
+        if args.plan:
+            return 0
+        if total_selected(plan) == 0 and not plan["ignored_secret"]:
+            print("Nothing selected to discard.")
+            return 0
+        if plan["ignored_secret"] and not confirmed(
+            args.confirm_ignored,
+            "VIBEGUARD_AUTHORIZED_DISCARD_IGNORED",
+            IGNORED_CONFIRM_PHRASE,
+            IGNORED_CONFIRM_TOKEN,
+        ):
+            print(
+                f'Refusing ignored secret-like paths. Re-run with --confirm-ignored "{IGNORED_CONFIRM_PHRASE}" '
+                f"or VIBEGUARD_AUTHORIZED_DISCARD_IGNORED={IGNORED_CONFIRM_TOKEN}.",
+                file=sys.stderr,
+            )
+            return 4
+        if not confirmed(args.confirm, "VIBEGUARD_AUTHORIZED_DISCARD", CONFIRM_PHRASE, CONFIRM_TOKEN):
+            print(
+                f'Re-run with --confirm "{CONFIRM_PHRASE}" or '
+                f"VIBEGUARD_AUTHORIZED_DISCARD={CONFIRM_TOKEN}.",
+                file=sys.stderr,
+            )
+            return 3
+        apply_plan(repo, plan)
+        append_log(repo, plan)
+        print("Authorized discard complete.")
+        return 0
+    except RuntimeError as exc:
+        print(f"VIBEGUARD authorized discard error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hooks/test_pre_bash_guard.sh
+++ b/tests/hooks/test_pre_bash_guard.sh
@@ -23,6 +23,7 @@ assert_not_contains "$result" '"decision": "block"' "Release git reset --hard (p
 # git checkout . should be intercepted
 result=$(echo '{"tool_input":{"command":"git checkout ."}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Intercept git checkout ."
+assert_contains "$result" "authorized-discard.py" "git checkout . block points to authorized discard workflow"
 
 # git checkout "." (quoted dot) should be intercepted
 result=$(echo '{"tool_input":{"command":"git checkout \".\"" }}' | bash hooks/pre-bash-guard.sh)
@@ -80,6 +81,7 @@ assert_not_contains "$result" '"decision": "warn"' "non-standard markdown adviso
 # git clean -f should be intercepted
 result=$(echo '{"tool_input":{"command":"git clean -fd"}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "intercept git clean -f"
+assert_contains "$result" "authorized-discard.py" "git clean -f block points to authorized discard workflow"
 
 # rm -rf / should be intercepted
 result=$(echo '{"tool_input":{"command":"rm -rf /"}}' | bash hooks/pre-bash-guard.sh)

--- a/tests/test_authorized_discard.sh
+++ b/tests/test_authorized_discard.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_DIR}/scripts/authorized-discard.py"
+TMP_DIR=""
+
+cleanup() {
+  if [[ -n "${TMP_DIR}" ]]; then
+    rm -rf "${TMP_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red() { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header() { printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$output" | grep -qF -- "$expected"; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$actual" == "$expected" ]]; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (expected '${expected}', got '${actual}')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (cmd: $*)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd_fail() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    red "$desc (unexpected success)"; FAIL=$((FAIL + 1))
+  else
+    green "$desc"; PASS=$((PASS + 1))
+  fi
+}
+
+make_repo() {
+  local name="$1"
+  local repo="${TMP_DIR}/${name}"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.name "VibeGuard Test"
+  git -C "$repo" config user.email "test@vibeguard.local"
+  printf 'base\n' > "${repo}/tracked.txt"
+  git -C "$repo" add tracked.txt
+  git -C "$repo" commit -q -m "base"
+  printf '%s\n' "$repo"
+}
+
+TMP_DIR="$(mktemp -d)"
+
+header "tracked-only cleanup"
+tracked_repo="$(make_repo tracked)"
+printf 'changed\n' > "${tracked_repo}/tracked.txt"
+tracked_plan="$(cd "$tracked_repo" && python3 "$SCRIPT" --plan)"
+assert_contains "$tracked_plan" "Tracked paths to restore from HEAD:" "tracked plan names restore section"
+assert_contains "$tracked_plan" "tracked.txt" "tracked plan enumerates modified file"
+assert_eq "$(cat "${tracked_repo}/tracked.txt")" "changed" "plan mode does not change tracked file"
+tracked_log="${TMP_DIR}/tracked-events.jsonl"
+tracked_run="$(cd "$tracked_repo" && VIBEGUARD_LOG_FILE="$tracked_log" python3 "$SCRIPT" --confirm "discard listed changes")"
+assert_contains "$tracked_run" "Authorized discard complete." "tracked cleanup completes"
+assert_eq "$(cat "${tracked_repo}/tracked.txt")" "base" "tracked file restored to HEAD"
+assert_eq "$(git -C "$tracked_repo" status --porcelain)" "" "tracked cleanup leaves clean status"
+assert_contains "$(cat "$tracked_log")" '"hook": "authorized-discard"' "tracked cleanup writes audit log"
+
+header "untracked-only cleanup"
+untracked_repo="$(make_repo untracked)"
+mkdir -p "${untracked_repo}/scratch"
+printf 'temp\n' > "${untracked_repo}/scratch/tmp.txt"
+untracked_plan="$(cd "$untracked_repo" && python3 "$SCRIPT" --plan)"
+assert_contains "$untracked_plan" "scratch/tmp.txt" "untracked plan enumerates file"
+untracked_run="$(cd "$untracked_repo" && VIBEGUARD_AUTHORIZED_DISCARD=discard-listed-changes python3 "$SCRIPT")"
+assert_contains "$untracked_run" "Authorized discard complete." "env token authorizes untracked cleanup"
+assert_cmd "untracked file removed" test ! -e "${untracked_repo}/scratch/tmp.txt"
+assert_cmd "empty untracked parent pruned" test ! -d "${untracked_repo}/scratch"
+
+header "mixed tracked and untracked cleanup"
+mixed_repo="$(make_repo mixed)"
+printf 'changed\n' > "${mixed_repo}/tracked.txt"
+printf 'new\n' > "${mixed_repo}/new.txt"
+mixed_run="$(cd "$mixed_repo" && python3 "$SCRIPT" --confirm "discard listed changes")"
+assert_contains "$mixed_run" "Authorized discard complete." "mixed cleanup completes"
+assert_eq "$(cat "${mixed_repo}/tracked.txt")" "base" "mixed cleanup restores tracked file"
+assert_cmd "mixed cleanup deletes untracked file" test ! -e "${mixed_repo}/new.txt"
+assert_eq "$(git -C "$mixed_repo" status --porcelain)" "" "mixed cleanup leaves clean status"
+
+header "ignored file handling"
+ignored_repo="$(make_repo ignored)"
+printf '.env\nignored.txt\n' > "${ignored_repo}/.gitignore"
+git -C "$ignored_repo" add .gitignore
+git -C "$ignored_repo" commit -q -m "ignore fixtures"
+printf 'SECRET=1\n' > "${ignored_repo}/.env"
+printf 'cache\n' > "${ignored_repo}/ignored.txt"
+ignored_plan="$(cd "$ignored_repo" && python3 "$SCRIPT" --plan)"
+assert_contains "$ignored_plan" "Ignored paths not touched:" "default plan reports ignored paths as skipped"
+assert_contains "$ignored_plan" ".env" "default plan names ignored secret-like file"
+assert_cmd "default cleanup keeps ignored secret-like file" bash -c "cd '$ignored_repo' && python3 '$SCRIPT' --confirm 'discard listed changes' >/dev/null && test -e .env"
+ignored_refuse="$(cd "$ignored_repo" && python3 "$SCRIPT" --include-ignored --confirm "discard listed changes" 2>&1)"
+ignored_refuse_rc=$?
+assert_eq "$ignored_refuse_rc" "4" "ignored secret-like cleanup needs separate confirmation"
+assert_contains "$ignored_refuse" "Refusing ignored secret-like paths" "ignored refusal explains blocker"
+assert_cmd "refusal keeps ignored non-secret file" test -e "${ignored_repo}/ignored.txt"
+assert_cmd "refusal keeps ignored secret-like file" test -e "${ignored_repo}/.env"
+ignored_run="$(cd "$ignored_repo" && python3 "$SCRIPT" --include-ignored --confirm "discard listed changes" --confirm-ignored "discard ignored secret-like files")"
+assert_contains "$ignored_run" "Authorized discard complete." "second confirmation allows ignored cleanup"
+assert_cmd "ignored non-secret file removed" test ! -e "${ignored_repo}/ignored.txt"
+assert_cmd "ignored secret-like file removed" test ! -e "${ignored_repo}/.env"
+
+header "outside repository"
+outside_dir="${TMP_DIR}/outside"
+mkdir -p "$outside_dir"
+outside_out="$(cd "$outside_dir" && python3 "$SCRIPT" --plan 2>&1)"
+outside_rc=$?
+assert_eq "$outside_rc" "2" "outside repo exits nonzero"
+assert_contains "$outside_out" "not inside a Git work tree" "outside repo error is explicit"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/authorized-discard.py` to print and execute an explicit Git cleanup plan after confirmation
- require a second confirmation before deleting ignored secret-like paths
- point destructive `git checkout/restore .` and `git clean -f` blocks to the audited workflow
- document the workflow and run it in CI

Fixes #185

## Verification
- python3 -m py_compile scripts/authorized-discard.py
- bash -n tests/test_authorized_discard.sh hooks/pre-bash-guard.sh tests/hooks/test_pre_bash_guard.sh
- bash tests/test_authorized_discard.sh
- bash tests/hooks/test_pre_bash_guard.sh
- bash tests/test_hooks.sh
- bash tests/test_setup.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check