### PR TITLE
Add skill validation evidence gate

### DIFF
--- a/.claude/commands/vibeguard/skill-validate.md
+++ b/.claude/commands/vibeguard/skill-validate.md
@@ -1,0 +1,56 @@
+---
+name: "VibeGuard: Skill Validate"
+description: "Gate proposed skills with with/without repair and regression evidence"
+category: VibeGuard
+tags: [vibeguard, skill, validation, eval]
+argument-hint: "--proposed-skill <SKILL.md> --baseline-trajectories <jsonl> [--held-out <jsonl>]"
+---
+
+**Core Concept**
+- A proposed skill is an intervention, not just documentation.
+- Accept it only after measuring `without_skill` vs `with_skill` on recorded scenarios.
+- Keep facts separate from judgment: repairs, regressions, stale evidence, and unrelated-task regressions are explicit.
+
+**Minimum JSONL Schema**
+
+Each nonblank line in the baseline or held-out file is one scenario:
+
+```json
+{
+  "scenario_id": "incident-1",
+  "scenario_type": "target | unrelated",
+  "without_skill": {"outcome": "success | failure"},
+  "with_skill": {"outcome": "success | failure"},
+  "scored_against_agent": "claude-opus-4-7",
+  "scored_at": "2026-05-18",
+  "notes": "optional human judgment notes"
+}
+```
+
+**Steps**
+
+1. Use `/vibeguard:learn` or a draft PR to propose a `SKILL.md`.
+2. Record 3-5 scenarios:
+   - At least one motivating incident the skill should repair.
+   - At least two unrelated tasks the skill should not affect.
+   - Optional held-out scenarios for the final verdict.
+3. Run:
+   ```bash
+   python3 ~/vibeguard/scripts/skill_validate.py \
+     --proposed-skill path/to/SKILL.md \
+     --baseline-trajectories path/to/baseline.jsonl \
+     --held-out path/to/held-out.jsonl \
+     --current-agent <agent-or-model-id>
+   ```
+4. Treat the verdict as the gate:
+   - `pass`: `repair > regression`, at least one repair, no regressions.
+   - `needs_justification`: repair beats regression but at least one regression needs a written trade-off.
+   - `advisory`: unrelated task regression exists; do not install as a hard instruction.
+   - `stale`: evidence was scored against a different or too-old agent/model.
+   - `fail`: no demonstrated repair, or regressions are greater than/equal to repairs.
+5. Attach the emitted artifact path from `.vibeguard/skill-validate/` to the PR or final answer.
+
+**Rules**
+- Do not accept a new or changed skill on senior judgment alone.
+- Do not hide regressions in summary prose; report the count and affected scenario IDs.
+- Docs-only typo fixes can opt out; changes to constraints or decision rules need this gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
         shell: bash
         run: bash tests/test_live_truth.sh
 
+      - name: Skill validation regression tests
+        shell: bash
+        run: bash tests/test_skill_validate.sh
+
       - name: Guard unit tests
         shell: bash
         run: bash tests/unit/run_all.sh

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path                # dea
 
 ## Slash Commands
 
-11 custom commands covering the full development lifecycle. Shortcuts: `/vg:pf` `/vg:gc` `/vg:ck` `/vg:lrn`.
+12 custom commands covering the full development lifecycle. Shortcuts: `/vg:pf` `/vg:gc` `/vg:ck` `/vg:lrn`.
 
 | Command | Purpose |
 |---------|---------|
@@ -196,6 +196,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path                # dea
 | `/vibeguard:cross-review` | Dual-model adversarial review (Claude + Codex) |
 | `/vibeguard:build-fix` | Build error resolution |
 | `/vibeguard:learn` | Generate guard rules from errors / extract Skills from discoveries |
+| `/vibeguard:skill-validate` | Gate proposed skills with repair/regression evidence before acceptance |
 | `/vibeguard:interview` | Deep requirements interview → SPEC.md |
 | `/vibeguard:exec-plan` | Long-running task execution plan, cross-session resume |
 | `/vibeguard:live-truth` | Fresh evidence gates for latest, PR-ready, merged, running, deployed, and published claims |

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -205,6 +205,7 @@ interview → preflight → coding → check → review → learn → stats
 | `/vibeguard:cross-review` | Dual model adversarial review (Claude + Codex) |
 | `/vibeguard:build-fix` | Build error fix |
 | `/vibeguard:learn` | Generate new guards from mistakes |
+| `/vibeguard:skill-validate` | Gate proposed skills with repair/regression evidence |
 | `/vibeguard:exec-plan` | Long-term task execution plan (cross-session recovery) |
 | `/vibeguard:live-truth` | Fresh evidence gates for mutable claims |
 | `/vibeguard:gc` | Garbage collection (log archiving + worktree cleaning + rule budget + code garbage scanning) |

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -148,7 +148,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 
 ## Slash Commands
 
-仓库内置了 11 个自定义命令，覆盖从需求澄清到验证复盘的完整流程：
+仓库内置了 12 个自定义命令，覆盖从需求澄清到验证复盘的完整流程：
 
 | 命令 | 作用 |
 |------|------|
@@ -158,6 +158,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 | `/vibeguard:cross-review` | Claude + Codex 双模型对抗式审查 |
 | `/vibeguard:build-fix` | 构建错误修复 |
 | `/vibeguard:learn` | 从错误中生成 guard/rule，或提炼 Skill |
+| `/vibeguard:skill-validate` | 用 repair/regression 证据门验证新 Skill 是否值得接受 |
 | `/vibeguard:interview` | 深度需求访谈，输出 SPEC.md |
 | `/vibeguard:exec-plan` | 长任务执行计划，支持跨会话恢复 |
 | `/vibeguard:live-truth` | 为 latest、PR ready、merged、running、deployed、published 等可变状态声明提供新鲜证据门 |

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -168,6 +168,36 @@ Delegation assignments are required before any child-agent write lane starts. Pa
 
 The text artifact emitted by `scripts/live_truth.py` uses these same sections so final answers and PR comments do not mix facts with assumptions.
 
+## skill_validate output Schema
+
+```json
+{
+  "command": "skill_validate",
+  "skill_name": "demo-skill",
+  "proposed_skill": "path/to/SKILL.md",
+  "decision_set": "baseline | held_out",
+  "verdict": "pass | fail | stale | needs_justification | advisory",
+  "counts": {
+    "repair": 1,
+    "regression": 0,
+    "no_change": 2,
+    "unrelated_regression": 0
+  },
+  "freshness_gaps": [],
+  "scenarios": [
+    {
+      "scenario_id": "incident-1",
+      "scenario_type": "target",
+      "without_skill": "failure",
+      "with_skill": "success",
+      "classification": "repair"
+    }
+  ]
+}
+```
+
+`scripts/skill_validate.py` appends this artifact as JSONL under `.vibeguard/skill-validate/` unless `--no-persist` is used.
+
 ## review output Schema
 
 ```json

--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -190,7 +190,7 @@
     {
       "id": "commands",
       "kind": "commands",
-      "description": "VibeGuard slash commands (11 commands)",
+      "description": "VibeGuard slash commands (12 commands)",
       "paths": [".claude/commands/vibeguard/"],
       "target": "~/.claude/commands/",
       "defaultInstall": true,

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -14,6 +14,7 @@ Reference notes for the utility scripts shipped with VibeGuard.
 | `log-capability-change.sh` | Extract a capability-change timeline from git history |
 | `authorized-discard.py` | Print and execute an explicit, confirmed Git cleanup plan for tracked, untracked, and selected ignored paths |
 | `live_truth.py` | Verify mutable claims such as latest, PR-ready, merged, running, deployed, and published with fresh facts/inferences/gaps |
+| `skill_validate.py` | Score proposed skill changes with with/without repair and regression evidence |
 
 ## GC / Metrics / Verification
 
@@ -58,6 +59,7 @@ bash scripts/hook-health.sh 24
 bash scripts/quality-grader.sh
 python3 scripts/authorized-discard.py --plan
 python3 scripts/live_truth.py checklist
+python3 scripts/skill_validate.py --proposed-skill path/to/SKILL.md --baseline-trajectories path/to/baseline.jsonl
 bash scripts/ci/validate-hooks-manifest.sh
 bash scripts/ci/validate-doc-paths.sh
 bash scripts/ci/validate-doc-command-paths.sh

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Score proposed skill changes with repair/regression evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+
+
+OUTCOMES = {"success", "failure"}
+DEFAULT_OUTPUT_DIR = ".vibeguard/skill-validate"
+
+
+class SkillValidateError(Exception):
+    """Raised for invalid validation inputs."""
+
+
+def read_jsonl(path: Path, source_name: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise SkillValidateError(f"cannot read {source_name} file {path}: {exc}") from exc
+    for index, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SkillValidateError(f"{path}:{index}: invalid JSON: {exc}") from exc
+        if not isinstance(value, dict):
+            raise SkillValidateError(f"{path}:{index}: each JSONL line must be an object")
+        value["_source"] = source_name
+        value["_line"] = index
+        records.append(value)
+    if not records:
+        raise SkillValidateError(f"{source_name} file has no records: {path}")
+    return records
+
+
+def outcome_from(value: object, field_name: str, record_id: str) -> str:
+    raw = value
+    if isinstance(value, dict):
+        raw = value.get("outcome")
+    if not isinstance(raw, str):
+        raise SkillValidateError(f"{record_id}: {field_name} must contain an outcome string")
+    outcome = raw.strip().lower()
+    if outcome not in OUTCOMES:
+        raise SkillValidateError(f"{record_id}: {field_name} outcome must be success or failure")
+    return outcome
+
+
+def record_id(record: dict[str, object]) -> str:
+    scenario_id = record.get("scenario_id") or record.get("id")
+    source = record.get("_source", "records")
+    line = record.get("_line", "?")
+    return str(scenario_id or f"{source}:{line}")
+
+
+def parse_date(value: object, record_label: str) -> dt.date | None:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise SkillValidateError(f"{record_label}: scored_at must be an ISO date string")
+    try:
+        return dt.date.fromisoformat(value[:10])
+    except ValueError as exc:
+        raise SkillValidateError(f"{record_label}: scored_at must start with YYYY-MM-DD") from exc
+
+
+def classify_record(record: dict[str, object]) -> dict[str, object]:
+    label = record_id(record)
+    without = outcome_from(
+        record.get("without_skill", record.get("baseline")),
+        "without_skill",
+        label,
+    )
+    with_skill = outcome_from(
+        record.get("with_skill", record.get("intervention")),
+        "with_skill",
+        label,
+    )
+    if without == "failure" and with_skill == "success":
+        classification = "repair"
+    elif without == "success" and with_skill == "failure":
+        classification = "regression"
+    else:
+        classification = "no_change"
+    scenario_type = str(record.get("scenario_type") or "target").strip().lower()
+    return {
+        "scenario_id": label,
+        "scenario_type": scenario_type,
+        "without_skill": without,
+        "with_skill": with_skill,
+        "classification": classification,
+        "source": record.get("_source", "records"),
+        "scored_against_agent": record.get("scored_against_agent"),
+        "scored_at": record.get("scored_at"),
+        "notes": record.get("notes"),
+    }
+
+
+def freshness_gaps(
+    records: list[dict[str, object]],
+    current_agent: str | None,
+    as_of: dt.date,
+    max_age_days: int | None,
+) -> list[str]:
+    gaps: list[str] = []
+    for record in records:
+        label = record_id(record)
+        scored_agent = record.get("scored_against_agent")
+        if current_agent:
+            if not scored_agent:
+                gaps.append(f"{label}: missing scored_against_agent")
+            elif str(scored_agent) != current_agent:
+                gaps.append(f"{label}: scored against {scored_agent}, not {current_agent}")
+        scored_at = parse_date(record.get("scored_at"), label)
+        if max_age_days is not None:
+            if scored_at is None:
+                gaps.append(f"{label}: missing scored_at")
+            elif (as_of - scored_at).days > max_age_days:
+                gaps.append(f"{label}: scored_at is older than {max_age_days} days")
+    return gaps
+
+
+def count_classifications(classified: list[dict[str, object]]) -> dict[str, int]:
+    counts = {"repair": 0, "regression": 0, "no_change": 0, "unrelated_regression": 0}
+    for item in classified:
+        classification = str(item["classification"])
+        counts[classification] += 1
+        if classification == "regression" and item.get("scenario_type") == "unrelated":
+            counts["unrelated_regression"] += 1
+    return counts
+
+
+def extract_skill_name(path: Path) -> str:
+    if not path.is_file():
+        raise SkillValidateError(f"proposed skill does not exist: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillValidateError(f"cannot read proposed skill {path}: {exc}") from exc
+    if not text.lstrip().startswith("---"):
+        raise SkillValidateError("proposed skill must have YAML frontmatter")
+    match = re.search(r"(?m)^name:\s*['\"]?([^'\"\n]+)['\"]?\s*$", text)
+    if match:
+        return match.group(1).strip()
+    if path.parent.name:
+        return path.parent.name
+    raise SkillValidateError("cannot infer skill name")
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip().lower()).strip("-")
+    return slug or "skill"
+
+
+def determine_verdict(
+    counts: dict[str, int],
+    stale_gaps: list[str],
+    allow_stale: bool,
+    regression_justification: str | None,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    repairs = counts["repair"]
+    regressions = counts["regression"]
+    unrelated_regressions = counts["unrelated_regression"]
+
+    if stale_gaps and not allow_stale:
+        return ("stale", ["freshness evidence is stale or incomplete"])
+    if repairs == 0:
+        return ("fail", ["repair count is zero"])
+    if repairs <= regressions:
+        return ("fail", ["repair count is not greater than regression count"])
+    if unrelated_regressions > 0:
+        return ("advisory", ["unrelated task regression requires advisory-only treatment"])
+    if regressions > 0 and not regression_justification:
+        return ("needs_justification", ["regression count is nonzero and no justification was provided"])
+    if regressions > 0:
+        reasons.append("accepted with written regression justification")
+    else:
+        reasons.append("repair count is greater than regression count with no regressions")
+    return ("pass", reasons)
+
+
+def write_artifact(artifact: dict[str, object], output_dir: Path, skill_name: str, as_of: dt.date) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{slugify(skill_name)}-{as_of.isoformat()}.jsonl"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(artifact, sort_keys=True) + "\n")
+    return path
+
+
+def print_report(artifact: dict[str, object], artifact_path: Path | None) -> None:
+    counts = artifact["counts"]
+    print(f"SKILL-VALIDATE {artifact['skill_name']}")
+    print(f"verdict: {artifact['verdict']}")
+    print(f"decision_set: {artifact['decision_set']}")
+    print(f"artifact: {artifact_path if artifact_path else 'not written'}")
+    print("counts:")
+    for key in ("repair", "regression", "no_change", "unrelated_regression"):
+        print(f"- {key}: {counts[key]}")
+    print("reasons:")
+    for reason in artifact["reasons"]:
+        print(f"- {reason}")
+    print("freshness_gaps:")
+    gaps = artifact["freshness_gaps"]
+    if gaps:
+        for gap in gaps:
+            print(f"- {gap}")
+    else:
+        print("- none")
+    print("scenarios:")
+    for item in artifact["scenarios"]:
+        print(
+            "- {scenario_id}: {classification} ({without_skill} -> {with_skill}, {scenario_type})".format(
+                **item,
+            )
+        )
+
+
+def build_artifact(args: argparse.Namespace) -> tuple[dict[str, object], Path | None]:
+    proposed_skill = Path(args.proposed_skill).resolve()
+    skill_name = extract_skill_name(proposed_skill)
+    as_of = dt.date.fromisoformat(args.as_of) if args.as_of else dt.date.today()
+    baseline_records = read_jsonl(Path(args.baseline_trajectories), "baseline")
+    held_out_records = read_jsonl(Path(args.held_out), "held_out") if args.held_out else []
+    decision_records = held_out_records or baseline_records
+    decision_set = "held_out" if held_out_records else "baseline"
+
+    stale_gaps = freshness_gaps(
+        decision_records,
+        args.current_agent,
+        as_of,
+        args.max_age_days,
+    )
+    classified = [classify_record(record) for record in decision_records]
+    counts = count_classifications(classified)
+    verdict, reasons = determine_verdict(
+        counts,
+        stale_gaps,
+        args.allow_stale,
+        args.regression_justification,
+    )
+    artifact: dict[str, object] = {
+        "command": "skill_validate",
+        "skill_name": skill_name,
+        "proposed_skill": str(proposed_skill),
+        "decision_set": decision_set,
+        "verdict": verdict,
+        "counts": counts,
+        "freshness_gaps": stale_gaps,
+        "reasons": reasons,
+        "regression_justification": args.regression_justification,
+        "scored_against_agent": args.current_agent,
+        "scored_at": as_of.isoformat(),
+        "scenarios": classified,
+    }
+    artifact_path = None
+    if not args.no_persist:
+        artifact_path = write_artifact(artifact, Path(args.output_dir), skill_name, as_of)
+        artifact["artifact_path"] = str(artifact_path)
+    return artifact, artifact_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Score proposed skills with with/without repair and regression evidence.",
+    )
+    parser.add_argument("--proposed-skill", required=True, help="Path to draft SKILL.md")
+    parser.add_argument("--baseline-trajectories", required=True, help="JSONL with paired without/with outcomes")
+    parser.add_argument("--held-out", help="Optional held-out JSONL used for the final verdict")
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Directory for verdict JSONL artifacts")
+    parser.add_argument("--no-persist", action="store_true", help="Print only; do not write an artifact")
+    parser.add_argument("--current-agent", help="Expected agent/model identifier for freshness checks")
+    parser.add_argument("--max-age-days", type=int, default=90, help="Mark records stale after N days")
+    parser.add_argument("--as-of", help="Evaluation date, YYYY-MM-DD; defaults to today")
+    parser.add_argument("--allow-stale", action="store_true", help="Report stale gaps without failing the verdict")
+    parser.add_argument("--regression-justification", help="Required when regression count is nonzero")
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        artifact, artifact_path = build_artifact(args)
+    except SkillValidateError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    print_report(artifact, artifact_path)
+    return 0 if artifact["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_skill_validate.sh
+++ b/tests/test_skill_validate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# VibeGuard skill validation regression tests
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_VALIDATE="${REPO_DIR}/scripts/skill_validate.py"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF -- "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+SKILL_DIR="${TMP_DIR}/demo-skill"
+mkdir -p "${SKILL_DIR}"
+cat > "${SKILL_DIR}/SKILL.md" <<'MD'
+---
+name: demo-skill
+description: Use when validating a proposed skill change.
+---
+
+# Demo Skill
+MD
+
+header "syntax"
+assert_cmd "skill_validate.py syntax is valid" python3 -m py_compile "${SKILL_VALIDATE}"
+
+header "passing repair evidence"
+PASSING_JSONL="${TMP_DIR}/passing.jsonl"
+cat > "${PASSING_JSONL}" <<'JSONL'
+{"scenario_id":"incident-1","scenario_type":"target","without_skill":{"outcome":"failure"},"with_skill":{"outcome":"success"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+{"scenario_id":"unrelated-1","scenario_type":"unrelated","without_skill":{"outcome":"success"},"with_skill":{"outcome":"success"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+JSONL
+passing_out="$(
+  python3 "${SKILL_VALIDATE}" \
+    --proposed-skill "${SKILL_DIR}/SKILL.md" \
+    --baseline-trajectories "${PASSING_JSONL}" \
+    --output-dir "${TMP_DIR}/artifacts" \
+    --current-agent claude-opus-4-7 \
+    --as-of 2026-05-18
+)"
+assert_contains "${passing_out}" "verdict: pass" "pass verdict when repair beats regression"
+assert_contains "${passing_out}" "repair: 1" "pass output records repair count"
+assert_cmd "pass verdict writes an artifact" test -f "${TMP_DIR}/artifacts/demo-skill-2026-05-18.jsonl"
+
+header "regression needs justification"
+REGRESSION_JSONL="${TMP_DIR}/regression.jsonl"
+cat > "${REGRESSION_JSONL}" <<'JSONL'
+{"scenario_id":"incident-1","scenario_type":"target","without_skill":{"outcome":"failure"},"with_skill":{"outcome":"success"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+{"scenario_id":"incident-2","scenario_type":"target","without_skill":{"outcome":"failure"},"with_skill":{"outcome":"success"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+{"scenario_id":"adjacent-1","scenario_type":"target","without_skill":{"outcome":"success"},"with_skill":{"outcome":"failure"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+JSONL
+regression_out="$(
+  python3 "${SKILL_VALIDATE}" \
+    --proposed-skill "${SKILL_DIR}/SKILL.md" \
+    --baseline-trajectories "${REGRESSION_JSONL}" \
+    --no-persist \
+    --current-agent claude-opus-4-7 \
+    --as-of 2026-05-18 2>&1 || true
+)"
+assert_contains "${regression_out}" "verdict: needs_justification" "regression without justification blocks acceptance"
+assert_contains "${regression_out}" "regression: 1" "regression output records regression count"
+
+header "unrelated regression becomes advisory"
+UNRELATED_JSONL="${TMP_DIR}/unrelated.jsonl"
+cat > "${UNRELATED_JSONL}" <<'JSONL'
+{"scenario_id":"incident-1","scenario_type":"target","without_skill":{"outcome":"failure"},"with_skill":{"outcome":"success"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+{"scenario_id":"incident-2","scenario_type":"target","without_skill":{"outcome":"failure"},"with_skill":{"outcome":"success"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+{"scenario_id":"unrelated-1","scenario_type":"unrelated","without_skill":{"outcome":"success"},"with_skill":{"outcome":"failure"},"scored_against_agent":"claude-opus-4-7","scored_at":"2026-05-18"}
+JSONL
+unrelated_out="$(
+  python3 "${SKILL_VALIDATE}" \
+    --proposed-skill "${SKILL_DIR}/SKILL.md" \
+    --baseline-trajectories "${UNRELATED_JSONL}" \
+    --no-persist \
+    --current-agent claude-opus-4-7 \
+    --regression-justification "target repair is worth advisory rollout" \
+    --as-of 2026-05-18 2>&1 || true
+)"
+assert_contains "${unrelated_out}" "verdict: advisory" "unrelated regression downgrades the skill"
+assert_contains "${unrelated_out}" "unrelated_regression: 1" "unrelated regression count is explicit"
+
+header "stale evidence blocks verdict"
+STALE_JSONL="${TMP_DIR}/stale.jsonl"
+cat > "${STALE_JSONL}" <<'JSONL'
+{"scenario_id":"incident-1","scenario_type":"target","without_skill":{"outcome":"failure"},"with_skill":{"outcome":"success"},"scored_against_agent":"older-agent","scored_at":"2026-01-01"}
+JSONL
+stale_out="$(
+  python3 "${SKILL_VALIDATE}" \
+    --proposed-skill "${SKILL_DIR}/SKILL.md" \
+    --baseline-trajectories "${STALE_JSONL}" \
+    --no-persist \
+    --current-agent claude-opus-4-7 \
+    --as-of 2026-05-18 2>&1 || true
+)"
+assert_contains "${stale_out}" "verdict: stale" "stale evidence blocks acceptance"
+assert_contains "${stale_out}" "scored against older-agent, not claude-opus-4-7" "stale output names agent mismatch"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add /vibeguard:skill-validate command docs for evidence-gating proposed skills
- add scripts/skill_validate.py to score repair, regression, stale evidence, and unrelated-task regressions
- add regression tests and wire them into CI

Fixes #192

## Verification
- python3 -m py_compile scripts/skill_validate.py
- bash -n tests/test_skill_validate.sh
- bash tests/test_skill_validate.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash tests/test_manifest_contract.sh
- bash tests/test_setup_check.sh
- bash scripts/ci/self-application/run-all.sh
- bash tests/test_setup.sh
- git diff --check
- git diff --cached --check