### PR TITLE
Enforce runtime hook policy contract

### DIFF
--- a/hooks/_lib/config.sh
+++ b/hooks/_lib/config.sh
@@ -7,8 +7,9 @@
 #      ${VIBEGUARD_LOG_DIR:-$HOME/.vibeguard}/config.json.
 #   3. Caller-provided default.
 #
-# Config parse errors, missing keys, and wrong types fall through to the next
-# layer so a bad user edit cannot break hook execution.
+# Standalone helper reads stay permissive for non-critical tuning fields. The
+# wrapper policy gate validates malformed JSON before hooks execute, so parse
+# errors cannot silently weaken runtime enforcement.
 
 if [[ -n "${_VG_CONFIG_SH_LOADED:-}" ]]; then
   return 0

--- a/hooks/_lib/policy.py
+++ b/hooks/_lib/policy.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Runtime policy gate for VibeGuard hook wrappers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ALLOW = 0
+SKIP = 10
+POLICY_ERROR = 20
+CONFIG_PARSE_ERROR = 30
+
+
+class PolicyFailure(Exception):
+    def __init__(self, message: str, exit_code: int = POLICY_ERROR) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def _runtime_root() -> Path:
+    override = os.environ.get("VIBEGUARD_POLICY_ROOT")
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path, label: str) -> Any:
+    try:
+        with path.open(encoding="utf-8") as f:
+            return json.load(f)
+    except UnicodeDecodeError as exc:
+        raise PolicyFailure(
+            f"VibeGuard {label} invalid UTF-8: {path}: {exc}",
+            CONFIG_PARSE_ERROR,
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyFailure(
+            f"VibeGuard {label} invalid JSON: {path}: line {exc.lineno}, column {exc.colno}: {exc.msg}",
+            CONFIG_PARSE_ERROR,
+        ) from exc
+    except OSError as exc:
+        raise PolicyFailure(f"VibeGuard {label} cannot be read: {path}: {exc}") from exc
+
+
+def _project_config_path() -> Path | None:
+    configured = os.environ.get("VIBEGUARD_PROJECT_CONFIG", "")
+    if configured:
+        path = Path(configured)
+        return path if path.is_file() else None
+
+    cwd = Path.cwd().resolve()
+    try:
+        git_root = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cwd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).stdout.strip()
+    except OSError:
+        git_root = ""
+
+    if git_root:
+        candidate = Path(git_root) / ".vibeguard.json"
+        if candidate.is_file():
+            return candidate
+
+    candidate = cwd / ".vibeguard.json"
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def _validate_project_config(root: Path, path: Path) -> dict[str, Any]:
+    scripts_lib = root / "scripts" / "lib"
+    schema_path = root / "schemas" / "vibeguard-project.schema.json"
+    validator_path = scripts_lib / "project_config_validate.py"
+    if not schema_path.is_file():
+        raise PolicyFailure(f"VibeGuard policy error: project schema missing at {schema_path}")
+    if not validator_path.is_file():
+        raise PolicyFailure(f"VibeGuard policy error: project config validator missing at {validator_path}")
+
+    sys.path.insert(0, str(scripts_lib))
+    try:
+        import project_config_validate  # type: ignore[import-not-found]
+    except Exception as exc:
+        raise PolicyFailure(f"VibeGuard policy error: cannot load project config validator: {exc}") from exc
+
+    config = _load_json(path, "project config")
+    schema = _load_json(schema_path, "project schema")
+    errors = project_config_validate.validate(config, schema)
+    if errors:
+        lines = [f"VibeGuard project config invalid: {path}"]
+        lines.extend(f"  {error}" for error in errors)
+        raise PolicyFailure("\n".join(lines))
+    return config
+
+
+def _validate_user_config(path_text: str) -> None:
+    if not path_text:
+        return
+    path = Path(path_text)
+    if not path.is_file():
+        return
+    _load_json(path, "runtime config")
+
+
+def _load_manifest(root: Path) -> dict[str, Any]:
+    manifest_path = root / "hooks" / "manifest.json"
+    if not manifest_path.is_file():
+        raise PolicyFailure(f"VibeGuard policy error: hooks manifest missing at {manifest_path}")
+    manifest = _load_json(manifest_path, "hooks manifest")
+    if not isinstance(manifest, dict):
+        raise PolicyFailure(f"VibeGuard policy error: hooks manifest must be an object: {manifest_path}")
+    return manifest
+
+
+def _hook_entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    entries = manifest.get("hooks")
+    if not isinstance(entries, list):
+        raise PolicyFailure("VibeGuard policy error: hooks manifest must contain a hooks array")
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _script_names(entry: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    script = entry.get("script")
+    if isinstance(script, str):
+        names.add(script)
+
+    codex = entry.get("codex")
+    if isinstance(codex, dict):
+        codex_script = codex.get("script")
+        if isinstance(codex_script, str):
+            names.add(codex_script)
+        entries = codex.get("entries")
+        if isinstance(entries, list):
+            for codex_entry in entries:
+                if not isinstance(codex_entry, dict):
+                    continue
+                entry_script = codex_entry.get("script")
+                if isinstance(entry_script, str):
+                    names.add(entry_script)
+    return names
+
+
+def _canonical_hook(hook_name: str, manifest: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+    hook_file = Path(hook_name).name
+    hook_stem = hook_file[:-3] if hook_file.endswith(".sh") else hook_file
+    for entry in _hook_entries(manifest):
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        if hook_name == name or hook_file in _script_names(entry) or hook_stem == name:
+            return name, entry
+    return hook_stem.removeprefix("vibeguard-").replace("_", "-"), None
+
+
+def _profile_allows(profile: str | None, entry: dict[str, Any] | None) -> bool:
+    if not profile or entry is None:
+        return True
+    claude = entry.get("claude")
+    if not isinstance(claude, dict):
+        return True
+    profiles = claude.get("profiles")
+    if not isinstance(profiles, list):
+        return True
+    return profile in profiles
+
+
+def check_policy(hook_name: str, user_config: str) -> tuple[int, str]:
+    root = _runtime_root()
+    _validate_user_config(user_config)
+
+    project_config_file = _project_config_path()
+    if project_config_file is None:
+        return ALLOW, ""
+
+    config = _validate_project_config(root, project_config_file)
+    manifest = _load_manifest(root)
+    canonical_hook, manifest_entry = _canonical_hook(hook_name, manifest)
+
+    enforcement = config.get("enforcement", "block")
+    if enforcement == "off":
+        return SKIP, "VibeGuard policy skip: enforcement=off"
+
+    disabled_hooks = config.get("disabled_hooks", [])
+    if isinstance(disabled_hooks, list) and canonical_hook in disabled_hooks:
+        return SKIP, f"VibeGuard policy skip: disabled_hooks contains {canonical_hook}"
+
+    profile = config.get("profile")
+    if isinstance(profile, str) and not _profile_allows(profile, manifest_entry):
+        return SKIP, f"VibeGuard policy skip: profile={profile} excludes {canonical_hook}"
+
+    return ALLOW, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate runtime VibeGuard hook policy")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    check = subparsers.add_parser("check")
+    check.add_argument("hook_name")
+    check.add_argument("--user-config", default=os.environ.get("VIBEGUARD_USER_CONFIG_FILE", ""))
+    args = parser.parse_args()
+
+    if args.command == "check":
+        try:
+            status, message = check_policy(args.hook_name, args.user_config)
+        except PolicyFailure as exc:
+            print(str(exc), file=sys.stderr)
+            return exc.exit_code
+        if message:
+            print(message)
+        return status
+    return POLICY_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Shared runtime policy gate for VibeGuard hook wrappers.
+
+if [[ -n "${_VG_POLICY_SH_LOADED:-}" ]]; then
+  return 0
+fi
+_VG_POLICY_SH_LOADED=1
+
+_VG_POLICY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_VG_POLICY_PY="${_VG_POLICY_LIB_DIR}/policy.py"
+
+vg_policy_user_config_file() {
+  printf '%s' "${_VG_CONFIG_FILE:-${VIBEGUARD_CONFIG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/config.json}}"
+}
+
+vg_policy_check_hook() {
+  local hook_name="$1"
+  local output status
+
+  VG_POLICY_REASON=""
+  VG_POLICY_KIND=""
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    VG_POLICY_REASON="VibeGuard policy error: python3 is required for runtime policy checks."
+    VG_POLICY_KIND="policy_error"
+    return 20
+  fi
+  if [[ ! -f "${_VG_POLICY_PY}" ]]; then
+    VG_POLICY_REASON="VibeGuard policy error: policy helper missing at ${_VG_POLICY_PY}"
+    VG_POLICY_KIND="policy_error"
+    return 20
+  fi
+
+  status=0
+  output="$(
+    VIBEGUARD_USER_CONFIG_FILE="$(vg_policy_user_config_file)" \
+      python3 "${_VG_POLICY_PY}" check "${hook_name}" 2>&1
+  )" || status=$?
+
+  case "${status}" in
+    0)
+      return 0
+      ;;
+    10)
+      VG_POLICY_REASON="${output}"
+      VG_POLICY_KIND="policy_skip"
+      return 10
+      ;;
+    30)
+      VG_POLICY_REASON="${output}"
+      VG_POLICY_KIND="config_parse_error"
+      return 30
+      ;;
+    *)
+      VG_POLICY_REASON="${output:-VibeGuard policy error: unknown runtime policy failure.}"
+      VG_POLICY_KIND="policy_error"
+      return 20
+      ;;
+  esac
+}
+
+vg_policy_diag() {
+  local hook_name="$1" event_name="${2:-}" kind="$3" reason="$4"
+  local diag_file diag_dir
+  diag_file="${VIBEGUARD_POLICY_DIAG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/policy.jsonl}"
+  diag_dir="$(dirname "${diag_file}")"
+  mkdir -p "${diag_dir}" 2>/dev/null || return 0
+  VIBEGUARD_POLICY_DIAG_HOOK="${hook_name}" \
+    VIBEGUARD_POLICY_DIAG_EVENT="${event_name}" \
+    VIBEGUARD_POLICY_DIAG_KIND="${kind}" \
+    VIBEGUARD_POLICY_DIAG_REASON="${reason}" \
+    VIBEGUARD_POLICY_DIAG_WRAPPER="${VIBEGUARD_WRAPPER:-unknown}" \
+    python3 - <<'PY' >>"${diag_file}" 2>/dev/null || true
+import json
+import os
+from datetime import datetime, timezone
+
+print(json.dumps({
+    "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "wrapper": os.environ.get("VIBEGUARD_POLICY_DIAG_WRAPPER", ""),
+    "hook": os.environ.get("VIBEGUARD_POLICY_DIAG_HOOK", ""),
+    "event": os.environ.get("VIBEGUARD_POLICY_DIAG_EVENT", ""),
+    "kind": os.environ.get("VIBEGUARD_POLICY_DIAG_KIND", ""),
+    "reason": os.environ.get("VIBEGUARD_POLICY_DIAG_REASON", ""),
+}, ensure_ascii=False))
+PY
+}
+
+vg_policy_codex_error_output() {
+  local event_name="$1" reason="$2"
+  VIBEGUARD_POLICY_EVENT="${event_name}" VIBEGUARD_POLICY_REASON="${reason}" python3 - <<'PY'
+import json
+import os
+
+event = os.environ.get("VIBEGUARD_POLICY_EVENT", "")
+reason = os.environ.get("VIBEGUARD_POLICY_REASON", "")
+if event == "PreToolUse":
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+elif event == "PermissionRequest":
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {"behavior": "deny", "message": reason},
+        }
+    }
+elif event == "PostToolUse":
+    payload = {
+        "decision": "block",
+        "reason": reason,
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": reason,
+        },
+    }
+else:
+    payload = {"decision": "block", "reason": reason}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+}
+
+vg_policy_codex_gate() {
+  local hook_name="$1" event_name="$2" policy_status=0
+  vg_policy_check_hook "${hook_name}" || policy_status=$?
+  [[ ${policy_status} -eq 0 ]] && return 0
+
+  vg_policy_diag "${hook_name}" "${event_name}" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
+  if declare -F codex_diag >/dev/null 2>&1; then
+    codex_diag "${hook_name}" "${event_name}" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
+  fi
+  [[ ${policy_status} -eq 10 ]] && return 1
+  vg_policy_codex_error_output "${event_name}" "${VG_POLICY_REASON}"
+  return 1
+}

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -56,14 +56,10 @@ else
 fi
 
 RUNNER_PATH="${WRAPPER_DIR}/_lib/codex_runner.sh"
-if [[ ! -f "${RUNNER_PATH}" && -f "${INSTALLED_DIR}/_lib/codex_runner.sh" ]]; then
-  RUNNER_PATH="${INSTALLED_DIR}/_lib/codex_runner.sh"
-fi
+[[ -f "${RUNNER_PATH}" || ! -f "${INSTALLED_DIR}/_lib/codex_runner.sh" ]] || RUNNER_PATH="${INSTALLED_DIR}/_lib/codex_runner.sh"
 
 NORMALIZER_PATH="${WRAPPER_DIR}/_lib/codex_apply_patch_adapter.py"
-if [[ ! -f "${NORMALIZER_PATH}" && -f "${INSTALLED_DIR}/_lib/codex_apply_patch_adapter.py" ]]; then
-  NORMALIZER_PATH="${INSTALLED_DIR}/_lib/codex_apply_patch_adapter.py"
-fi
+[[ -f "${NORMALIZER_PATH}" || ! -f "${INSTALLED_DIR}/_lib/codex_apply_patch_adapter.py" ]] || NORMALIZER_PATH="${INSTALLED_DIR}/_lib/codex_apply_patch_adapter.py"
 
 if [[ ! -d "$INSTALLED_DIR" ]]; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
@@ -89,6 +85,19 @@ if [[ ! -d "$INSTALLED_DIR" ]]; then
   fi
 fi
 
+POLICY_PATH="${WRAPPER_DIR}/_lib/policy.sh"
+[[ -f "${POLICY_PATH}" ]] || POLICY_PATH="${INSTALLED_DIR}/_lib/policy.sh"
+[[ -f "${POLICY_PATH}" ]] || POLICY_PATH="$(dirname "${HOOK_PATH}")/_lib/policy.sh"
+if [[ ! -f "${POLICY_PATH}" ]]; then
+  codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "policy_error" "missing policy helper"
+  [[ "$EVENT_NAME" == "PreToolUse" ]] && codex_pretool_deny_raw "VIBEGUARD install incomplete: missing policy helper."
+  [[ "$EVENT_NAME" == "PermissionRequest" ]] && codex_permission_deny_raw "VIBEGUARD install incomplete: missing policy helper."
+  exit 0
+fi
+# shellcheck source=hooks/_lib/policy.sh
+source "${POLICY_PATH}"
+vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" || exit 0
+
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"
   if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
@@ -110,26 +119,14 @@ if [[ ! -f "${ADAPTER_PATH}" ]]; then
 fi
 
 source "${ADAPTER_PATH}"
-# Delegated adapter functions used by hooks/_lib/codex_runner.sh:
-# codex_event_name codex_pretool_deny codex_adapt_pretool codex_adapt_posttool
-if ! declare -F codex_permission_deny >/dev/null 2>&1; then
-  codex_permission_deny() {
-    codex_permission_deny_raw "$1"
-  }
-fi
-if ! declare -F codex_adapt_permission_request >/dev/null 2>&1; then
-  codex_adapt_permission_request() {
-    codex_permission_deny "VIBEGUARD install incomplete: missing PermissionRequest adapter."
-  }
-fi
+# Adapter delegates: codex_event_name codex_pretool_deny codex_adapt_pretool codex_adapt_posttool.
+if ! declare -F codex_permission_deny >/dev/null 2>&1; then codex_permission_deny() { codex_permission_deny_raw "$1"; }; fi
+if ! declare -F codex_adapt_permission_request >/dev/null 2>&1; then codex_adapt_permission_request() { codex_permission_deny "VIBEGUARD install incomplete: missing PermissionRequest adapter."; }; fi
 
 if [[ ! -f "${RUNNER_PATH}" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-runner" "${RUNNER_PATH}"
-  if [[ "${EVENT_NAME}" == "PreToolUse" ]]; then
-    codex_pretool_deny "VIBEGUARD install incomplete: missing Codex runner."
-  elif [[ "${EVENT_NAME}" == "PermissionRequest" ]]; then
-    codex_permission_deny "VIBEGUARD install incomplete: missing Codex runner."
-  fi
+  [[ "${EVENT_NAME}" == "PreToolUse" ]] && codex_pretool_deny "VIBEGUARD install incomplete: missing Codex runner."
+  [[ "${EVENT_NAME}" == "PermissionRequest" ]] && codex_permission_deny "VIBEGUARD install incomplete: missing Codex runner."
   exit 0
 fi
 

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -9,6 +9,7 @@
 
 set -euo pipefail
 
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export VIBEGUARD_WRAPPER="${VIBEGUARD_WRAPPER:-run-hook.sh}"
 export VIBEGUARD_SOURCE_CONFIG="${VIBEGUARD_SOURCE_CONFIG:-${HOME}/.claude/settings.json}"
 export VIBEGUARD_HOOK_PROTOCOL_VERSION="${VIBEGUARD_HOOK_PROTOCOL_VERSION:-claude-code-hooks-v1}"
@@ -33,6 +34,26 @@ fi
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   echo "ERROR: hook not found: ${HOOK_PATH}" >&2
+  exit 1
+fi
+
+POLICY_PATH="${WRAPPER_DIR}/_lib/policy.sh"
+[[ -f "${POLICY_PATH}" ]] || POLICY_PATH="${INSTALLED_DIR}/_lib/policy.sh"
+[[ -f "${POLICY_PATH}" ]] || POLICY_PATH="$(dirname "${HOOK_PATH}")/_lib/policy.sh"
+if [[ ! -f "${POLICY_PATH}" ]]; then
+  echo "ERROR: VibeGuard policy helper not found for ${HOOK_NAME}" >&2
+  exit 1
+fi
+# shellcheck source=hooks/_lib/policy.sh
+source "${POLICY_PATH}"
+policy_status=0
+vg_policy_check_hook "${HOOK_NAME}" || policy_status=$?
+if [[ ${policy_status} -eq 10 ]]; then
+  vg_policy_diag "${HOOK_NAME}" "Claude" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
+  exit 0
+elif [[ ${policy_status} -ne 0 ]]; then
+  vg_policy_diag "${HOOK_NAME}" "Claude" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
+  printf '%s\n' "${VG_POLICY_REASON}" >&2
   exit 1
 fi
 

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -172,6 +172,9 @@ _INSTALL_TMP=$(mktemp -d "${VIBEGUARD_HOME}/installed_tmp_XXXXXX")
 trap 'rm -rf "$_INSTALL_TMP"' EXIT
 cp -r "${REPO_DIR}/hooks" "${_INSTALL_TMP}/"
 cp -r "${REPO_DIR}/guards" "${_INSTALL_TMP}/"
+mkdir -p "${_INSTALL_TMP}/schemas" "${_INSTALL_TMP}/scripts/lib"
+cp "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${_INSTALL_TMP}/schemas/"
+cp "${REPO_DIR}/scripts/lib/project_config_validate.py" "${_INSTALL_TMP}/scripts/lib/"
 printf '%s' "$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')" > "${_INSTALL_TMP}/version"
 
 # Build vibeguard-runtime Rust binary before swapping the installed snapshot.

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Runtime policy enforcement for .vibeguard.json and ~/.vibeguard/config.json.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
+hook_test_init
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
+
+make_home() {
+  local home_dir="$1"
+  mkdir -p "${home_dir}/.vibeguard"
+  printf '%s' "${REPO_DIR}" > "${home_dir}/.vibeguard/repo-path"
+}
+
+make_project() {
+  local project_dir="$1" config_body="$2"
+  mkdir -p "${project_dir}"
+  printf '%s\n' "${config_body}" > "${project_dir}/.vibeguard.json"
+}
+
+assert_empty_success() {
+  local status="$1" output="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "${status}" -eq 0 && -z "${output}" ]]; then
+    green "${desc}"
+    PASS=$((PASS + 1))
+  else
+    red "${desc} (status=${status}, output=${output})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_claude_wrapper() {
+  local home_dir="$1" project_dir="$2" hook_name="$3" input="$4"
+  cd "${project_dir}"
+  printf '%s' "${input}" \
+    | HOME="${home_dir}" VIBEGUARD_LOG_DIR="${home_dir}/.vibeguard" \
+      bash "${REPO_DIR}/hooks/run-hook.sh" "${hook_name}"
+}
+
+run_codex_wrapper() {
+  local home_dir="$1" project_dir="$2" hook_name="$3" input="$4"
+  cd "${project_dir}"
+  printf '%s' "${input}" \
+    | HOME="${home_dir}" VIBEGUARD_LOG_DIR="${home_dir}/.vibeguard" \
+      bash "${REPO_DIR}/hooks/run-hook-codex.sh" "${hook_name}"
+}
+
+pretool_block_input='{"tool_input":{"command":"git push --force"}}'
+codex_pretool_input='{"hook_event_name":"PreToolUse","tool_input":{"command":"git push --force"}}'
+
+header "runtime policy — disabled hooks"
+disabled_home="${WORK_DIR}/home-disabled"
+disabled_project="${WORK_DIR}/project-disabled"
+make_home "${disabled_home}"
+make_project "${disabled_project}" '{"disabled_hooks":["pre-bash-guard"]}'
+
+set +e
+disabled_claude_out="$(run_claude_wrapper "${disabled_home}" "${disabled_project}" pre-bash-guard.sh "${pretool_block_input}" 2>&1)"
+disabled_claude_status=$?
+set -e
+assert_empty_success "${disabled_claude_status}" "${disabled_claude_out}" "Claude wrapper honors disabled_hooks before executing hook"
+
+set +e
+disabled_codex_out="$(run_codex_wrapper "${disabled_home}" "${disabled_project}" vibeguard-pre-bash-guard.sh "${codex_pretool_input}" 2>&1)"
+disabled_codex_status=$?
+set -e
+assert_empty_success "${disabled_codex_status}" "${disabled_codex_out}" "Codex wrapper honors disabled_hooks before executing hook"
+
+assert_contains "$(cat "${disabled_home}/.vibeguard/policy.jsonl")" "policy_skip" "runtime policy emits policy_skip telemetry"
+
+header "runtime policy — invalid project config"
+bad_project_home="${WORK_DIR}/home-bad-project"
+bad_project="${WORK_DIR}/project-bad"
+make_home "${bad_project_home}"
+make_project "${bad_project}" '{"disabled_hooks":["missing-hook"]}'
+
+set +e
+bad_project_claude_out="$(run_claude_wrapper "${bad_project_home}" "${bad_project}" pre-bash-guard.sh "${pretool_block_input}" 2>&1)"
+bad_project_claude_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${bad_project_claude_status}" -ne 0 ]]; then
+  green "Claude wrapper fails loudly on invalid .vibeguard.json"
+  PASS=$((PASS + 1))
+else
+  red "Claude wrapper fails loudly on invalid .vibeguard.json"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "${bad_project_claude_out}" "VibeGuard project config invalid" "Claude wrapper explains invalid .vibeguard.json"
+
+set +e
+bad_project_codex_out="$(run_codex_wrapper "${bad_project_home}" "${bad_project}" vibeguard-pre-bash-guard.sh "${codex_pretool_input}" 2>&1)"
+bad_project_codex_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${bad_project_codex_status}" -eq 0 ]]; then
+  green "Codex wrapper exits cleanly after emitting policy denial"
+  PASS=$((PASS + 1))
+else
+  red "Codex wrapper exits cleanly after emitting policy denial"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "${bad_project_codex_out}" '"permissionDecision": "deny"' "Codex wrapper denies invalid .vibeguard.json"
+assert_contains "${bad_project_codex_out}" "VibeGuard project config invalid" "Codex wrapper explains invalid .vibeguard.json"
+
+header "runtime policy — malformed user runtime config"
+bad_user_home="${WORK_DIR}/home-bad-user"
+bad_user_project="${WORK_DIR}/project-bad-user"
+bad_user_config="${WORK_DIR}/bad-config.json"
+make_home "${bad_user_home}"
+make_project "${bad_user_project}" '{}'
+printf '{"write_mode":' > "${bad_user_config}"
+
+set +e
+bad_user_claude_out="$(
+  cd "${bad_user_project}" && printf '%s' "${pretool_block_input}" \
+    | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
+      VIBEGUARD_CONFIG_FILE="${bad_user_config}" \
+      bash "${REPO_DIR}/hooks/run-hook.sh" pre-bash-guard.sh 2>&1
+)"
+bad_user_claude_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${bad_user_claude_status}" -ne 0 ]]; then
+  green "Claude wrapper fails loudly on malformed runtime config"
+  PASS=$((PASS + 1))
+else
+  red "Claude wrapper fails loudly on malformed runtime config"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "${bad_user_claude_out}" "VibeGuard runtime config invalid JSON" "Claude wrapper explains malformed runtime config"
+
+set +e
+bad_user_codex_out="$(
+  cd "${bad_user_project}" && printf '%s' "${codex_pretool_input}" \
+    | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
+      VIBEGUARD_CONFIG_FILE="${bad_user_config}" \
+      bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh 2>&1
+)"
+bad_user_codex_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${bad_user_codex_status}" -eq 0 ]]; then
+  green "Codex wrapper exits cleanly after malformed config denial"
+  PASS=$((PASS + 1))
+else
+  red "Codex wrapper exits cleanly after malformed config denial"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "${bad_user_codex_out}" '"permissionDecision": "deny"' "Codex wrapper denies malformed runtime config"
+assert_contains "${bad_user_codex_out}" "VibeGuard runtime config invalid JSON" "Codex wrapper explains malformed runtime config"
+assert_contains "$(cat "${bad_user_home}/.vibeguard/policy.jsonl")" "config_parse_error" "runtime policy emits config_parse_error telemetry"
+
+hook_test_finish

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -34,6 +34,7 @@ shards=(
   "tests/hooks/test_post_edit_w14.sh"
   "tests/hooks/test_post_edit_w15.sh"
   "tests/hooks/test_runtime_config.sh"
+  "tests/hooks/test_runtime_policy.sh"
   "tests/hooks/test_count_active_constraints.sh"
   "tests/hooks/test_u16_config.sh"
 )

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -563,6 +563,8 @@ assert_contains "${install_out}" "Removed retired VibeGuard skill link" "setup i
 assert_cmd "setup install removes tracked retired Claude skill" test ! -L "${HOME}/.claude/skills/old-retired"
 assert_cmd "setup install removes tracked retired Codex skill" test ! -L "${HOME}/.codex/skills/old-flow"
 assert_cmd "vibeguard-runtime binary installed after setup" test -x "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+assert_cmd "runtime policy project schema installed after setup" test -f "${HOME}/.vibeguard/installed/schemas/vibeguard-project.schema.json"
+assert_cmd "runtime policy project validator installed after setup" test -f "${HOME}/.vibeguard/installed/scripts/lib/project_config_validate.py"
 assert_contains "${install_out}" "~/.vibeguard/config.json present (preserved)" "setup preserves seeded runtime config during install"
 assert_cmd "~/.claude/skills/vibeguard exists after installation" test -L "${HOME}/.claude/skills/vibeguard"
 assert_cmd "~/.codex/skills/vibeguard is copied after installation" bash -c "test -d '${HOME}/.codex/skills/vibeguard' && test ! -L '${HOME}/.codex/skills/vibeguard'"


### PR DESCRIPTION
## Summary
- add a shared runtime policy gate for Claude and Codex hook wrappers
- validate project/user config before hook execution and honor disabled_hooks/profile/enforcement skips
- install the project schema/validator into the runtime snapshot and cover policy behavior in hook/setup tests

Closes #195

## Test plan
- python3 -m py_compile hooks/_lib/policy.py scripts/lib/project_config_validate.py
- bash tests/hooks/test_runtime_policy.sh
- bash tests/test_codex_runtime.sh
- bash tests/test_hooks.sh
- bash tests/test_setup.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/self-application/run-all.sh
- bash tests/test_setup_check.sh
- bash scripts/ci/validate-manifest-contract.sh
- git diff --check
- git diff --cached --check