### PR TITLE
Make runtime failures visible by event

### DIFF
--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -48,6 +48,46 @@ print(json.dumps({
 PY
 }
 
+codex_visible_failure_raw() {
+  local event_name="$1" reason="$2"
+  CODEX_EVENT_NAME="${event_name}" CODEX_REASON="${reason}" python3 - <<'PY'
+import json
+import os
+
+event = os.environ.get("CODEX_EVENT_NAME", "")
+reason = os.environ.get("CODEX_REASON", "")
+if event == "PreToolUse":
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+elif event == "PermissionRequest":
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {"behavior": "deny", "message": reason},
+        }
+    }
+elif event == "PostToolUse":
+    payload = {
+        "decision": "block",
+        "reason": reason,
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": reason,
+        },
+    }
+elif event == "Stop":
+    payload = {"stopReason": reason}
+else:
+    payload = {"systemMessage": reason}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+}
+
 codex_set_caller_identity() {
   local event_name="$1"
   export VIBEGUARD_WRAPPER="${VIBEGUARD_WRAPPER:-run-hook-codex.sh}"

--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -36,11 +36,7 @@ codex_run_hook() {
     if [[ ${hook_exit} -ne 0 ]]; then
       codex_diag "${hook_name}" "${event_name}" "wrapped-hook-nonzero" "${hook_err:-${hook_output}}"
       rm -f "${normalized_file}" 2>/dev/null || true
-      if [[ "${event_name}" == "PreToolUse" ]]; then
-        codex_pretool_deny "VIBEGUARD hook failed: wrapped hook exited nonzero."
-      elif [[ "${event_name}" == "PermissionRequest" ]]; then
-        codex_permission_deny "VIBEGUARD hook failed: wrapped hook exited nonzero."
-      fi
+      codex_visible_failure_raw "${event_name}" "VIBEGUARD hook failed: wrapped hook exited nonzero."
       return 0
     fi
 
@@ -91,7 +87,9 @@ codex_run_hook() {
       posttool_output=$(codex_adapt_posttool "${hook_output}" 2>/dev/null) || posttool_status=$?
       if [[ ${posttool_status} -ne 0 ]]; then
         codex_diag "${hook_name}" "${event_name}" "posttool-adapter-failed" "${hook_output}"
-        continue
+        rm -f "${normalized_file}" 2>/dev/null || true
+        codex_visible_failure_raw "${event_name}" "VIBEGUARD hook failed: wrapped PostToolUse output could not be adapted."
+        return 0
       fi
       if [[ -n "${posttool_output}" ]]; then
         if [[ "${posttool_output}" == *'"decision": "block"'* || "${posttool_output}" == *'"decision":"block"'* ]]; then

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -118,8 +118,10 @@ elif event == "PostToolUse":
             "additionalContext": reason,
         },
     }
+elif event == "Stop":
+    payload = {"stopReason": reason}
 else:
-    payload = {"decision": "block", "reason": reason}
+    payload = {"systemMessage": reason}
 print(json.dumps(payload, ensure_ascii=False))
 PY
 }

--- a/hooks/_lib/timeout.sh
+++ b/hooks/_lib/timeout.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Shared timeout runner for hook-side subprocesses.
+
+if [[ -n "${_VG_TIMEOUT_SH_LOADED:-}" ]]; then
+  return 0
+fi
+_VG_TIMEOUT_SH_LOADED=1
+
+vg_run_with_timeout() {
+  local seconds="$1"
+  shift
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${seconds}" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${seconds}" "$@"
+    return $?
+  fi
+
+  python3 - "${seconds}" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout_seconds = float(sys.argv[1])
+command = sys.argv[2:]
+try:
+    completed = subprocess.run(command, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+raise SystemExit(completed.returncode)
+PY
+}

--- a/hooks/post-build-check.sh
+++ b/hooks/post-build-check.sh
@@ -11,16 +11,53 @@
 
 set -euo pipefail
 
-source "$(dirname "$0")/log.sh"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${HOOK_DIR}/log.sh"
+source "${HOOK_DIR}/_lib/timeout.sh"
 vg_start_timer
-VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "$0")/_lib" && pwd)}"
+VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-${HOOK_DIR}/_lib}"
+POST_BUILD_TIMEOUT="${VIBEGUARD_POST_BUILD_TIMEOUT:-30}"
 
 INPUT=$(cat)
+
+post_build_log_skip() {
+  local reason="$1" file_path="${2:-}"
+  vg_log "post-build-check" "PostToolUse" "pass" "skip: ${reason}" "${file_path}"
+}
+
+post_build_filter_or_head() {
+  local pattern="$1" output="$2" filtered
+  filtered=$(printf '%s\n' "${output}" | grep -E "${pattern}" | head -10 || true)
+  if [[ -n "${filtered}" ]]; then
+    printf '%s\n' "${filtered}"
+  else
+    printf '%s\n' "${output}" | head -10
+  fi
+}
+
+post_build_run() {
+  local project_root="$1" label="$2" pattern="$3"
+  shift 3
+  local output status
+  status=0
+  if [[ -n "${project_root}" ]]; then
+    output=$(cd "${project_root}" && vg_run_with_timeout "${POST_BUILD_TIMEOUT}" "$@" 2>&1) || status=$?
+  else
+    output=$(vg_run_with_timeout "${POST_BUILD_TIMEOUT}" "$@" 2>&1) || status=$?
+  fi
+
+  if [[ ${status} -eq 124 ]]; then
+    printf '%s\n' "post-build-check timeout after ${POST_BUILD_TIMEOUT}s while running: ${label}"
+  elif [[ ${status} -ne 0 ]]; then
+    post_build_filter_or_head "${pattern}" "${output}"
+  fi
+}
 
 # Extract file_path from Edit or Write JSON
 FILE_PATH=$(echo "$INPUT" | vg_json_field "tool_input.file_path")
 
 if [[ -z "$FILE_PATH" ]]; then
+  post_build_log_skip "missing file_path" ""
   exit 0
 fi
 
@@ -38,7 +75,10 @@ EXT="${BASENAME##*.}"
 # Only handle languages that require build checks
 case "$EXT" in
   rs|ts|tsx|go|js|mjs|cjs) ;;
-  *) exit 0 ;;
+  *)
+    post_build_log_skip "unsupported extension .${EXT}" "${FILE_PATH}"
+    exit 0
+    ;;
 esac
 
 # Search upwards in the project root directory (find different markup files based on language)
@@ -60,30 +100,39 @@ PROJECT_ROOT=""
 
 case "$EXT" in
   rs)
-    PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "Cargo.toml") || exit 0
-    # cargo check, limit output
-    ERRORS=$(cd "$PROJECT_ROOT" && cargo check --message-format=short 2>&1 | grep -E "^error" | head -10) || true
+    if ! PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "Cargo.toml"); then
+      post_build_log_skip "missing Cargo.toml" "${FILE_PATH}"
+      exit 0
+    fi
+    ERRORS=$(post_build_run "$PROJECT_ROOT" "cargo check --message-format=short" "^error" cargo check --message-format=short)
     ;;
   ts|tsx)
-    PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "tsconfig.json") || exit 0
-    # tsc type check
-    ERRORS=$(cd "$PROJECT_ROOT" && npx tsc --noEmit 2>&1 | grep -E "error TS" | head -10) || true
+    if ! PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "tsconfig.json"); then
+      post_build_log_skip "missing tsconfig.json" "${FILE_PATH}"
+      exit 0
+    fi
+    ERRORS=$(post_build_run "$PROJECT_ROOT" "npx tsc --noEmit" "error TS" npx tsc --noEmit)
     ;;
   js|mjs|cjs)
     # JavaScript syntax check (does not depend on tsconfig)
-    command -v node >/dev/null 2>&1 || exit 0
+    if ! command -v node >/dev/null 2>&1; then
+      post_build_log_skip "missing node" "${FILE_PATH}"
+      exit 0
+    fi
     PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "package.json") || true
-    ERRORS=$(node --check "$FILE_PATH" 2>&1 | head -10) || true
+    ERRORS=$(post_build_run "" "node --check" "." node --check "$FILE_PATH")
     ;;
   go)
-    PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "go.mod") || exit 0
-    # go build check
-    ERRORS=$(cd "$PROJECT_ROOT" && go build ./... 2>&1 | head -10) || true
+    if ! PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "go.mod"); then
+      post_build_log_skip "missing go.mod" "${FILE_PATH}"
+      exit 0
+    fi
+    ERRORS=$(post_build_run "$PROJECT_ROOT" "go build ./..." "." go build ./...)
     ;;
 esac
 
 if [[ -z "$ERRORS" ]]; then
-  vg_log "post-build-check" "Edit" "pass" "" "$FILE_PATH"
+  vg_log "post-build-check" "PostToolUse" "pass" "" "$FILE_PATH"
   exit 0
 fi
 
@@ -106,7 +155,11 @@ if [[ "$CONSECUTIVE_FAILS" -ge 5 ]]; then
   WARNINGS="[U-25 ESCALATE] Continuous ${CONSECUTIVE_FAILS} build failures! You must fix the build errors before continuing editing. Recommendation: Run the complete build command to view all errors and locate the root cause and fix them at once. ${WARNINGS}"
 fi
 
-vg_log "post-build-check" "Edit" "$DECISION" "Build errors ${ERROR_COUNT}" "$FILE_PATH"
+if [[ "${ERRORS}" == post-build-check\ timeout* ]]; then
+  vg_log "post-build-check" "PostToolUse" "warn" "${ERRORS}" "$FILE_PATH"
+else
+  vg_log "post-build-check" "PostToolUse" "$DECISION" "Build errors ${ERROR_COUNT}" "$FILE_PATH"
+fi
 
 VG_WARNINGS="$WARNINGS" VG_DECISION="$DECISION" python3 -c '
 import json, os

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -32,6 +32,12 @@ else
   codex_raw_event_name() { [[ "$1" =~ \"hook_event_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]] && printf '%s\n' "${BASH_REMATCH[1]}"; }
   codex_pretool_deny_raw() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"VIBEGUARD install incomplete."}}\n'; }
   codex_permission_deny_raw() { printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"VIBEGUARD install incomplete."}}}\n'; }
+  codex_visible_failure_raw() {
+    [[ "$1" == "PreToolUse" ]] && { codex_pretool_deny_raw "$2"; return; }
+    [[ "$1" == "PermissionRequest" ]] && { codex_permission_deny_raw "$2"; return; }
+    [[ "$1" == "Stop" ]] && { printf '{"stopReason":"VIBEGUARD install incomplete."}\n'; return; }
+    printf '{"systemMessage":"VIBEGUARD install incomplete."}\n'
+  }
   codex_set_caller_identity() { export VIBEGUARD_CLIENT="${VIBEGUARD_CLIENT:-unknown}" VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-unknown}" VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-missing-codex-diag-helper}"; }
   codex_diag() { return 0; }
 fi
@@ -65,11 +71,7 @@ if [[ ! -d "$INSTALLED_DIR" ]]; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ ! -f "$REPO_PATH_FILE" ]]; then
     codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-repo-path" "${REPO_PATH_FILE}"
-    if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
-      codex_pretool_deny_raw "VIBEGUARD install incomplete: missing repo-path."
-    elif [[ "$EVENT_NAME" == "PermissionRequest" ]]; then
-      codex_permission_deny_raw "VIBEGUARD install incomplete: missing repo-path."
-    fi
+    codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD install incomplete: missing repo-path."
     exit 0
   fi
   REPO_DIR=$(<"$REPO_PATH_FILE")
@@ -90,8 +92,7 @@ POLICY_PATH="${WRAPPER_DIR}/_lib/policy.sh"
 [[ -f "${POLICY_PATH}" ]] || POLICY_PATH="$(dirname "${HOOK_PATH}")/_lib/policy.sh"
 if [[ ! -f "${POLICY_PATH}" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "policy_error" "missing policy helper"
-  [[ "$EVENT_NAME" == "PreToolUse" ]] && codex_pretool_deny_raw "VIBEGUARD install incomplete: missing policy helper."
-  [[ "$EVENT_NAME" == "PermissionRequest" ]] && codex_permission_deny_raw "VIBEGUARD install incomplete: missing policy helper."
+  codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD install incomplete: missing policy helper."
   exit 0
 fi
 # shellcheck source=hooks/_lib/policy.sh
@@ -100,21 +101,13 @@ vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" || exit 0
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"
-  if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
-    codex_pretool_deny_raw "VIBEGUARD install incomplete: missing hook ${HOOK_NAME}."
-  elif [[ "$EVENT_NAME" == "PermissionRequest" ]]; then
-    codex_permission_deny_raw "VIBEGUARD install incomplete: missing hook ${HOOK_NAME}."
-  fi
+  codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD install incomplete: missing hook ${HOOK_NAME}."
   exit 0
 fi
 
 if [[ ! -f "${ADAPTER_PATH}" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-adapter" "${ADAPTER_PATH}"
-  if [[ "$EVENT_NAME" == "PreToolUse" ]]; then
-    codex_pretool_deny_raw "VIBEGUARD install incomplete: missing Codex adapter."
-  elif [[ "$EVENT_NAME" == "PermissionRequest" ]]; then
-    codex_permission_deny_raw "VIBEGUARD install incomplete: missing Codex adapter."
-  fi
+  codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD install incomplete: missing Codex adapter."
   exit 0
 fi
 
@@ -125,8 +118,7 @@ if ! declare -F codex_adapt_permission_request >/dev/null 2>&1; then codex_adapt
 
 if [[ ! -f "${RUNNER_PATH}" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-runner" "${RUNNER_PATH}"
-  [[ "${EVENT_NAME}" == "PreToolUse" ]] && codex_pretool_deny "VIBEGUARD install incomplete: missing Codex runner."
-  [[ "${EVENT_NAME}" == "PermissionRequest" ]] && codex_permission_deny "VIBEGUARD install incomplete: missing Codex runner."
+  codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD install incomplete: missing Codex runner."
   exit 0
 fi
 

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -250,3 +250,15 @@ status_exit_code() {
     printf '0\n'
   fi
 }
+
+# status_install_exit_code — echo 0|2 for install final verification.
+# WARN rows are allowed here because optional integrations can be degraded
+# without making the freshly written required runtime unusable.
+status_install_exit_code() {
+  local total_problems=$((_VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
+  if (( total_problems > 0 )); then
+    printf '2\n'
+  else
+    printf '0\n'
+  fi
+}

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -7,12 +7,14 @@
 #   bash setup.sh --check --quiet        # only show problem rows + summary
 #   bash setup.sh --check --json         # machine-readable JSON, no TTY output
 #   bash setup.sh --check --no-summary   # legacy behavior (no rollup, exit 0)
+#   bash setup.sh --check --install      # install final verification, fail on broken required state
 #
 # Exit code
 #   Default mode  : 0 always (backward compatible with pre-summary callers).
 #   --strict      : 0 healthy, 1 degraded (warn only), 2 broken (FAIL/BROKEN/MISSING).
 #   --json        : implies --strict (machine consumers want a real exit code).
 #   --no-summary  : 0 always.
+#   --install     : 0 healthy/degraded, 2 broken required state.
 
 set -uo pipefail
 
@@ -35,28 +37,32 @@ QUIET=0
 JSON=0
 STRICT=0
 WITH_SUMMARY=1
+INSTALL=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --quiet|-q)     QUIET=1; shift ;;
     --json)         JSON=1; shift ;;
     --strict)       STRICT=1; shift ;;
+    --install)      INSTALL=1; shift ;;
     --no-summary)   WITH_SUMMARY=0; shift ;;
     --help|-h)
       cat <<'USAGE'
-Usage: setup.sh --check [--quiet | --json | --strict | --no-summary]
+Usage: setup.sh --check [--quiet | --json | --strict | --install | --no-summary]
 
   --quiet        Suppress healthy [OK] rows; only print problems + summary.
   --strict       Reflect health in the exit code: 0 healthy, 1 degraded,
                  2 broken (FAIL/BROKEN/MISSING). Without --strict the exit
                  code is always 0 for backwards compatibility.
+  --install      Final install verification mode: exit 2 on broken required
+                 state, but allow WARN/INFO rows for optional integrations.
   --json         Emit a single-line JSON document (counts + events + verdict)
                  to stdout. Disables human-readable output. Implies --strict.
   --no-summary   Legacy mode: no rollup table, always exit 0.
                  Equivalent to the pre-summary behavior.
 
-Exit codes (--strict / --json only):
+Exit codes (--strict / --json / --install only):
   0  healthy
-  1  degraded (warnings only)
+  1  degraded (warnings only; --strict/--json)
   2  broken (FAIL/BROKEN/MISSING present)
 USAGE
       exit 0
@@ -80,6 +86,10 @@ if [[ "${JSON}" -eq 1 && "${QUIET}" -eq 1 ]]; then
 fi
 if [[ "${JSON}" -eq 1 && "${WITH_SUMMARY}" -eq 0 ]]; then
   red "ERROR: --json and --no-summary are mutually exclusive"
+  exit 64
+fi
+if [[ "${JSON}" -eq 1 && "${INSTALL}" -eq 1 ]]; then
+  red "ERROR: --json and --install are mutually exclusive"
   exit 64
 fi
 
@@ -309,6 +319,9 @@ if [[ "${WITH_SUMMARY}" -eq 1 ]]; then
   fi
   if [[ "${STRICT}" -eq 1 ]]; then
     exit "$(status_exit_code)"
+  fi
+  if [[ "${INSTALL}" -eq 1 ]]; then
+    exit "$(status_install_exit_code)"
   fi
   # Without --strict, preserve the original always-exit-0 contract so the
   # existing test_setup.sh harness, the install scripts, and external CI

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -320,7 +320,10 @@ inject_codex_home_rules
 # 11. Verification
 echo "Step 11: Verification"
 echo "=============================="
-bash "${SCRIPT_DIR}/check.sh"
+if ! bash "${SCRIPT_DIR}/check.sh" --install; then
+  red "ERROR: strict install verification failed. Run 'bash setup.sh --check --install' for details."
+  exit 2
+fi
 echo
 green "Setup complete! All components installed."
 echo

--- a/tests/hooks/test_post_build_check.sh
+++ b/tests/hooks/test_post_build_check.sh
@@ -15,6 +15,7 @@ assert_not_contains "$result" "VIBEGUARD" "Non-build language (.py) release"
 # .md files should be released
 result=$(echo '{"tool_input":{"file_path":"README.md"}}' | bash hooks/post-build-check.sh)
 assert_not_contains "$result" "VIBEGUARD" "Non-source files (.md) are allowed"
+assert_contains "$(grep -R "skip: unsupported extension .md" "$VIBEGUARD_LOG_DIR" 2>/dev/null || true)" "skip: unsupported extension .md" "Unsupported extension records skip telemetry"
 
 # Empty file_path is allowed
 result=$(echo '{"tool_input":{"file_path":""}}' | bash hooks/post-build-check.sh)
@@ -41,6 +42,32 @@ EOF
 result=$(echo "{\"tool_input\":{\"file_path\":\"$tmp_js_ok/good.js\"}}" | bash hooks/post-build-check.sh)
 assert_not_contains "$result" "VIBEGUARD" "JavaScript syntax is correct"
 rm -rf "$tmp_js_ok"
+
+# Missing language markers should be logged instead of silent-only exits
+tmp_rs_no_marker="$(mktemp -d)"
+cat >"$tmp_rs_no_marker/main.rs" <<'EOF'
+fn main() {}
+EOF
+result=$(echo "{\"tool_input\":{\"file_path\":\"$tmp_rs_no_marker/main.rs\"}}" | bash hooks/post-build-check.sh)
+assert_not_contains "$result" "VIBEGUARD" "Rust file without Cargo.toml is skipped"
+assert_contains "$(grep -R "skip: missing Cargo.toml" "$VIBEGUARD_LOG_DIR" 2>/dev/null || true)" "skip: missing Cargo.toml" "Missing Cargo.toml records skip telemetry"
+rm -rf "$tmp_rs_no_marker"
+
+# Build commands must be bounded by a hook-level timeout
+tmp_js_timeout="$(mktemp -d)"
+mkdir -p "$tmp_js_timeout/bin"
+cat >"$tmp_js_timeout/bin/node" <<'EOF'
+#!/usr/bin/env bash
+sleep 5
+EOF
+chmod +x "$tmp_js_timeout/bin/node"
+cat >"$tmp_js_timeout/slow.js" <<'EOF'
+const value = 1;
+EOF
+result=$(PATH="$tmp_js_timeout/bin:$PATH" VIBEGUARD_POST_BUILD_TIMEOUT=1 bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp_js_timeout/slow.js\"}}' | bash hooks/post-build-check.sh")
+assert_contains "$result" "timeout after 1s" "Post-build check reports timeout visibly"
+assert_contains "$(grep -R "post-build-check timeout after 1s" "$VIBEGUARD_LOG_DIR" 2>/dev/null || true)" "post-build-check timeout after 1s" "Post-build timeout records telemetry"
+rm -rf "$tmp_js_timeout"
 
 # =========================================================
 

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -340,7 +340,7 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-header "run-hook-codex keeps best-effort stop hooks non-blocking"
+header "run-hook-codex surfaces failed stop hooks without shell failure"
 TMP_HOME_STOP_FAILING="${TMP_DIR}/home-stop-failing"
 TMP_FAKE_REPO_STOP_FAILING="${TMP_DIR}/fake-repo-stop-failing"
 mkdir -p "${TMP_HOME_STOP_FAILING}/.vibeguard" "${TMP_FAKE_REPO_STOP_FAILING}/hooks"
@@ -363,20 +363,14 @@ stop_rc=$?
 set -e
 TOTAL=$((TOTAL + 1))
 if [[ ${stop_rc} -eq 0 ]]; then
-  green "run-hook-codex swallows nonzero exits for best-effort stop hooks"
+  green "run-hook-codex exits successfully after reporting failed stop hooks"
   PASS=$((PASS + 1))
 else
-  red "run-hook-codex swallows nonzero exits for best-effort stop hooks"
+  red "run-hook-codex exits successfully after reporting failed stop hooks"
   FAIL=$((FAIL + 1))
 fi
-TOTAL=$((TOTAL + 1))
-if [[ -z "${stop_out}" ]]; then
-  green "run-hook-codex keeps failed best-effort stop hooks silent"
-  PASS=$((PASS + 1))
-else
-  red "run-hook-codex keeps failed best-effort stop hooks silent"
-  FAIL=$((FAIL + 1))
-fi
+assert_contains "${stop_out}" '"stopReason"' "run-hook-codex emits visible Stop feedback on wrapped hook failure"
+assert_contains "${stop_out}" 'wrapped hook exited nonzero' "run-hook-codex explains failed Stop hook"
 
 header "run-hook-codex denies invalid pretool adapter output on any adapter failure"
 TMP_HOME_INVALID_JSON="${TMP_DIR}/home-invalid-json"
@@ -452,6 +446,26 @@ missing_adapter_out="$(
 assert_contains "${missing_adapter_out}" '"permissionDecision": "deny"' "missing adapter fails closed for PreToolUse"
 assert_codex_pretool_output_contract "${missing_adapter_out}" "missing adapter deny matches Codex PreToolUse output contract"
 assert_contains "$(cat "${DIAG_FILE}")" "missing-adapter" "missing adapter writes diagnostic event"
+
+missing_posttool_hook_out="$(
+  printf '{"hook_event_name":"PostToolUse","tool_input":{"file_path":"src/main.ts"}}' \
+    | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-post-edit-guard.sh
+)"
+assert_contains "${missing_posttool_hook_out}" '"decision": "block"' "missing PostToolUse hook emits visible feedback"
+assert_codex_posttool_output_contract "${missing_posttool_hook_out}" "missing PostToolUse hook output matches Codex contract"
+
+cat > "${TMP_FAKE_REPO_DIAG}/hooks/vibeguard-post-edit-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+HOOK
+chmod +x "${TMP_FAKE_REPO_DIAG}/hooks/vibeguard-post-edit-guard.sh"
+missing_posttool_adapter_out="$(
+  printf '{"hook_event_name":"PostToolUse","tool_input":{"file_path":"src/main.ts"}}' \
+    | HOME="${TMP_HOME_DIAG}" VIBEGUARD_CODEX_ADAPTER_PATH="${TMP_DIR}/missing-adapter.sh" VIBEGUARD_CODEX_DIAG_FILE="${DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-post-edit-guard.sh
+)"
+assert_contains "${missing_posttool_adapter_out}" '"decision": "block"' "missing PostToolUse adapter emits visible feedback"
+assert_codex_posttool_output_contract "${missing_posttool_adapter_out}" "missing PostToolUse adapter output matches Codex contract"
 
 header "run-hook-codex adapts posttool block output"
 TMP_HOME_POSTTOOL="${TMP_DIR}/home-posttool"
@@ -560,14 +574,9 @@ bad_posttool_out="$({
   printf '{"hook_event_name":"PostToolUse","tool_input":{"command":"cargo check"}}' \
     | HOME="${TMP_HOME_POSTTOOL}" VIBEGUARD_CODEX_DIAG_FILE="${posttool_bad_diag}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-post-build-check.sh
 } 2>/dev/null)"
-TOTAL=$((TOTAL + 1))
-if [[ -z "${bad_posttool_out}" ]]; then
-  green "invalid PostToolUse hook output stays stdout-silent"
-  PASS=$((PASS + 1))
-else
-  red "invalid PostToolUse hook output stays stdout-silent"
-  FAIL=$((FAIL + 1))
-fi
+assert_contains "${bad_posttool_out}" '"decision": "block"' "invalid PostToolUse hook output emits visible feedback"
+assert_contains "${bad_posttool_out}" 'could not be adapted' "invalid PostToolUse hook output explains adapter failure"
+assert_codex_posttool_output_contract "${bad_posttool_out}" "invalid PostToolUse failure output matches Codex contract"
 assert_contains "$(cat "${posttool_bad_diag}")" "posttool-adapter-failed" "invalid PostToolUse output writes diagnostic event"
 
 header "run-hook-codex adapts PermissionRequest decisions"

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -228,6 +228,7 @@ help_rc=$?
 assert_eq "$help_rc" "0" "check --help: exit 0"
 assert_contains "$help_out" "Usage: setup.sh --check" "check --help: prints usage"
 assert_contains "$help_out" "Exit codes"             "check --help: documents exit codes"
+assert_contains "$help_out" "--install"              "check --help: documents install verification mode"
 
 # Unknown flag should exit 64 (sysexits.h EX_USAGE).
 err_out="$(bash "${SETUP_SCRIPT}" --check --bogus 2>&1)"
@@ -244,6 +245,10 @@ assert_contains "$conf_out" "mutually exclusive" "check --json --quiet: error me
 conf_out2="$(bash "${SETUP_SCRIPT}" --check --json --no-summary 2>&1)"
 conf_rc2=$?
 assert_eq "$conf_rc2" "64" "check --json --no-summary: rejected with exit 64"
+
+conf_out3="$(bash "${SETUP_SCRIPT}" --check --json --install 2>&1)"
+conf_rc3=$?
+assert_eq "$conf_rc3" "64" "check --json --install: rejected with exit 64"
 
 # --- End-to-end check ---
 header "check.sh end-to-end"
@@ -340,6 +345,11 @@ assert_contains "$stale_check_out" "stale Codex hook command" "stale hook check:
 assert_contains "$stale_check_out" "config=~/.codex/hooks.json event=Stop matcher=<none>" "stale hook check: names Codex config/event/matcher"
 assert_contains "$stale_check_out" "repair=bash setup.sh --yes" "stale hook check: names repair action"
 
+stale_install_check_out="$(HOME="${STALE_HOOK_HOME}" bash "${SETUP_SCRIPT}" --check --install 2>&1)"
+stale_install_check_rc=$?
+assert_eq "$stale_install_check_rc" "2" "install check: broken required state exits 2"
+assert_contains "$stale_install_check_out" "stale Codex hook command" "install check: reports broken required hook state"
+
 HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/settings_json.py" upsert-vibeguard \
   --settings-file "${STALE_HOOK_HOME}/.claude/settings.json" \
   --repo-dir "${REPO_DIR}" \
@@ -365,7 +375,7 @@ bash "${SETUP_SCRIPT}" --check --no-summary >/dev/null 2>&1
 no_sum_rc=$?
 assert_eq "$no_sum_rc" "0" "no-summary mode: exit 0 (compat)"
 
-# --strict and --json should reflect the verdict in the exit code.
+# --strict, --install, and --json should reflect the verdict in the exit code.
 # We can only assert that the result is one of {0, 1, 2}.
 bash "${SETUP_SCRIPT}" --check --strict >/dev/null 2>&1
 strict_rc=$?
@@ -374,6 +384,15 @@ if [[ "$strict_rc" == "0" || "$strict_rc" == "1" || "$strict_rc" == "2" ]]; then
   green "strict mode: exit code in {0,1,2} (got ${strict_rc})"; PASS=$((PASS + 1))
 else
   red "strict mode: unexpected exit code ${strict_rc}"; FAIL=$((FAIL + 1))
+fi
+
+bash "${SETUP_SCRIPT}" --check --install >/dev/null 2>&1
+install_rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$install_rc" == "0" || "$install_rc" == "2" ]]; then
+  green "install mode: exit code in {0,2} (got ${install_rc})"; PASS=$((PASS + 1))
+else
+  red "install mode: unexpected exit code ${install_rc}"; FAIL=$((FAIL + 1))
 fi
 
 bash "${SETUP_SCRIPT}" --check --json >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- add an install verification mode and make setup fail after broken required health checks
- surface Codex Stop/PostToolUse wrapper failures visibly while preserving diagnostics
- add shared hook timeout runner and post-build skip/timeout telemetry

## Validation
- bash tests/hooks/test_post_build_check.sh
- bash tests/test_codex_runtime.sh
- bash tests/test_setup_check.sh
- bash tests/test_hooks.sh
- bash tests/test_setup.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash scripts/ci/validate-hooks-manifest.sh
- bash scripts/ci/self-application/run-all.sh
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- git diff --check
- git diff --cached --check

Closes #196