### PR TITLE
Add executable workflow contract schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
         shell: bash
         run: bash scripts/ci/validate-manifest-contract.sh
 
+      - name: Validate workflow contracts
+        shell: bash
+        run: bash scripts/ci/validate-workflow-contracts.sh
+
       # --- Cross-platform contract validation (Python-embedded shell scripts) ---
       # Uses Git Bash on Windows; Python 3 is available from setup-python above.
       - name: Validate doc paths
@@ -154,6 +158,10 @@ jobs:
       - name: Manifest contract regression tests
         shell: bash
         run: bash tests/test_manifest_contract.sh
+
+      - name: Workflow contract regression tests
+        shell: bash
+        run: bash tests/test_workflow_contracts.sh
 
       - name: Eval contract regression tests
         shell: bash
@@ -279,6 +287,9 @@ jobs:
       - name: Validate manifest contract
         run: bash scripts/ci/validate-manifest-contract.sh
 
+      - name: Validate workflow contracts
+        run: bash scripts/ci/validate-workflow-contracts.sh
+
       - name: Validate hooks manifest
         run: bash scripts/ci/validate-hooks-manifest.sh
 
@@ -293,6 +304,9 @@ jobs:
 
       - name: Manifest contract regression tests
         run: bash tests/test_manifest_contract.sh
+
+      - name: Workflow contract regression tests
+        run: bash tests/test_workflow_contracts.sh
 
       - name: Eval contract regression tests
         run: bash tests/test_eval_contract.sh

--- a/agents/dispatcher.md
+++ b/agents/dispatcher.md
@@ -17,7 +17,7 @@ Boundary:
 - This dispatcher only chooses the best role **within** the already chosen lifecycle.
 - If lifecycle and role routing disagree, lifecycle wins first and dispatcher refines inside that lane.
 
-Required upstream routing input:
+Required upstream routing input. The upstream `readiness` decision must be one of `execute_direct`, `plan_first`, or `clarify_first`:
 
 ```yaml
 mode: execute_direct | plan_first | clarify_first
@@ -33,10 +33,13 @@ handoff:
     - task_slice: <specific bounded outcome>
       allowed_files: [...]
       forbidden_files: [...]
+      read_only_files: [...]
       authority: readonly | propose_patch | write_owned_files | verify_only
       required_evidence: [...]
       blocker_conditions: [...]
       integration_owner: <single owner>
+      verification_owner: <owner>
+      handoff_artifacts: [...]
 ```
 
 Dispatcher rules:
@@ -45,7 +48,7 @@ Dispatcher rules:
 - If upstream `mode` is `clarify_first`, return clarification needs instead of dispatching execution.
 - If a handoff is present, consume its `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` as authoritative routing context.
 - Do not schedule delegated work when `lane_map` is missing or leaves the target lane without an owner.
-- Do not schedule child-agent work when the matching delegation assignment is missing `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, `blocker_conditions`, or `integration_owner`.
+- Do not schedule child-agent work when the matching delegation assignment is missing `task_slice`, `allowed_files`, `forbidden_files`, `read_only_files`, `authority`, `required_evidence`, `blocker_conditions`, `integration_owner`, `verification_owner`, or `handoff_artifacts`.
 
 ## Scheduling rules
 

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -40,7 +40,7 @@ When readiness resolves to `execute_direct`, make the change directly without ov
 - Use child agents to keep the main context window clean only after the routing contract allows delegation
 - Follow `workflows/references/delegation-contract.md` for every child-agent assignment
 - Research, exploration, and parallel analysis can run in `readonly` mode before write ownership is clear
-- Write lanes require a task slice, allowed files, forbidden files, authority, required evidence, blockers, and a single integration owner
+- Write lanes require a task slice, allowed files, forbidden files, read-only files, authority, required evidence, blockers, a single integration owner, verification owner, and handoff artifacts
 - One focused task per sub-agent
 
 ### 4. Autonomous Execution

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -4,7 +4,17 @@ JSON Schema definition for structured communication between commands. Each comma
 
 Canonical routing decisions and planning handoffs are defined in `workflows/references/routing-contract.md`. Delegated work assignments are defined in `workflows/references/delegation-contract.md`.
 
+Executable schema sources:
+
+- `schemas/workflow-routing-decision.schema.json`
+- `schemas/workflow-execution-handoff.schema.json`
+- `schemas/workflow-delegation-assignment.schema.json`
+- `schemas/workflow-lane-map.schema.json`
+- `schemas/workflow-verification-gate.schema.json`
+
 ## routing decision Schema
+
+Allowed `readiness.decision` values are `execute_direct`, `plan_first`, and `clarify_first`.
 
 ```json
 {
@@ -17,11 +27,8 @@ Canonical routing decisions and planning handoffs are defined in `workflows/refe
     "execution_or_delegation_lane"
   ],
   "readiness": {
-    "decision": "execute_direct | plan_first | clarify_first",
-    "reason": "Short deterministic explanation",
-    "blockingQuestions": [
-      "Present only when decision = clarify_first"
-    ]
+    "decision": "execute_direct",
+    "reason": "Task is bounded, ownership is clear, and verification can run immediately"
   }
 }
 ```
@@ -31,15 +38,14 @@ Canonical routing decisions and planning handoffs are defined in `workflows/refe
 ```json
 {
   "command": "execution_handoff",
-  "mode": "fixflow | plan_flow_execution | execplan_execution | auto_optimize | custom",
+  "mode": "fixflow",
   "artifacts": [
-    "plan/task.md",
-    "SPEC.md"
+    "plan/task.md"
   ],
-  "runtime_pinning_snapshot": ".vibeguard/runtime-pinning.snapshot | null",
-  "verification_owner": "planner | executor | reviewer | named lane owner",
+  "runtime_pinning_snapshot": null,
+  "verification_owner": "executor",
   "stop_conditions": [
-    "Condition that must halt execution"
+    "Stop if a required check cannot run"
   ],
   "lane_map": {
     "implementation": "fixflow",
@@ -64,20 +70,20 @@ Required handoff keys:
   "command": "delegation_assignment",
   "task_slice": "Specific bounded outcome",
   "allowed_files": [
-    "Files or directories this worker may modify"
+    "src/owned-module"
   ],
   "forbidden_files": [
-    "Files or directories this worker must not modify"
+    "AGENTS.md"
   ],
   "read_only_files": [
-    "Files or directories this worker may inspect but not modify"
+    "workflows/references"
   ],
-  "authority": "readonly | propose_patch | write_owned_files | verify_only",
+  "authority": "write_owned_files",
   "required_evidence": [
-    "Commands, diffs, logs, or findings required for completion"
+    "Focused test output"
   ],
   "blocker_conditions": [
-    "Conditions that require stopping and escalating"
+    "Unexpected edits outside allowed_files"
   ],
   "integration_owner": "single named owner",
   "verification_owner": "owner who runs or accepts checks",
@@ -88,6 +94,29 @@ Required handoff keys:
 ```
 
 Delegation assignments are required before any child-agent write lane starts. Parallel work must serialize unless assignment file ownership is disjoint or isolated worktrees are explicitly used.
+
+## lane map ownership Schema
+
+```json
+{
+  "implementation": "fixflow",
+  "verification": "reviewer"
+}
+```
+
+## verification gate Schema
+
+```json
+{
+  "verification_owner": "executor",
+  "stop_conditions": [
+    "Stop if a required check cannot run"
+  ],
+  "required_checks": [
+    "bash tests/test_manifest_contract.sh"
+  ]
+}
+```
 
 ## preflight output Schema
 

--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "schema_files": {
+    "routing_decision": "workflow-routing-decision.schema.json",
+    "execution_handoff": "workflow-execution-handoff.schema.json",
+    "delegation_assignment": "workflow-delegation-assignment.schema.json",
+    "lane_map": "workflow-lane-map.schema.json",
+    "verification_gate": "workflow-verification-gate.schema.json"
+  },
+  "markdown_examples": [
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "routing decision Schema",
+      "schema": "routing_decision"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "execution handoff Schema",
+      "schema": "execution_handoff"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "delegation assignment Schema",
+      "schema": "delegation_assignment"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "lane map ownership Schema",
+      "schema": "lane_map"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "verification gate Schema",
+      "schema": "verification_gate"
+    }
+  ],
+  "consumers": [
+    {
+      "path": "workflows/references/routing-contract.md",
+      "references": ["delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/references/delegation-contract.md",
+      "references": ["routing-contract.md"],
+      "requires": ["delegation_assignment", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/references/delivery-base.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "delegation_assignment", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "agents/dispatcher.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "delegation_assignment", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/fixflow/SKILL.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/plan-flow/SKILL.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/plan-mode/SKILL.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/auto-optimize/SKILL.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "workflows/plan-flow/references/execplan-integration.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "delegation_assignment", "lane_map", "verification_gate"]
+    },
+    {
+      "path": "README.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": []
+    },
+    {
+      "path": "docs/CLAUDE.md.example",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": []
+    },
+    {
+      "path": "docs/openai-codex-best-practices.md",
+      "references": ["delegation-contract.md"],
+      "requires": []
+    },
+    {
+      "path": "docs/README_CN.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": []
+    },
+    {
+      "path": "claude-md/vibeguard-rules.md",
+      "references": ["routing-contract.md"],
+      "requires": []
+    },
+    {
+      "path": "templates/AGENTS.md",
+      "references": ["routing-contract.md"],
+      "requires": []
+    }
+  ],
+  "legacy_routing_markers": [
+    "1-2 files",
+    "3-5 files",
+    "6+ files",
+    "1-2 File",
+    "3-5 File",
+    "6+ Documentation",
+    "1-2 个文件",
+    "3-5 个文件",
+    "6 个及以上文件",
+    "1-2 file directly",
+    "3-5 `/vibeguard:preflight`"
+  ]
+}

--- a/schemas/workflow-delegation-assignment.schema.json
+++ b/schemas/workflow-delegation-assignment.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/workflow-delegation-assignment.schema.json",
+  "title": "VibeGuard Workflow Delegation Assignment",
+  "description": "Per-worker assignment contract for delegated workflow lanes.",
+  "type": "object",
+  "required": [
+    "task_slice",
+    "allowed_files",
+    "forbidden_files",
+    "read_only_files",
+    "authority",
+    "required_evidence",
+    "blocker_conditions",
+    "integration_owner",
+    "verification_owner",
+    "handoff_artifacts"
+  ],
+  "additionalProperties": false,
+  "x_markdown_tokens": [
+    "task_slice",
+    "allowed_files",
+    "forbidden_files",
+    "read_only_files",
+    "authority",
+    "required_evidence",
+    "blocker_conditions",
+    "integration_owner",
+    "verification_owner",
+    "handoff_artifacts"
+  ],
+  "properties": {
+    "command": {
+      "const": "delegation_assignment"
+    },
+    "task_slice": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_files": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "forbidden_files": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "read_only_files": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "authority": {
+      "enum": ["readonly", "propose_patch", "write_owned_files", "verify_only"]
+    },
+    "required_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "blocker_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "integration_owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verification_owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "handoff_artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/schemas/workflow-execution-handoff.schema.json
+++ b/schemas/workflow-execution-handoff.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/workflow-execution-handoff.schema.json",
+  "title": "VibeGuard Workflow Execution Handoff",
+  "description": "Shared planning-to-execution handoff payload.",
+  "type": "object",
+  "required": [
+    "mode",
+    "artifacts",
+    "runtime_pinning_snapshot",
+    "verification_owner",
+    "stop_conditions",
+    "lane_map"
+  ],
+  "additionalProperties": false,
+  "x_markdown_tokens": [
+    "mode",
+    "artifacts",
+    "runtime_pinning_snapshot",
+    "verification_owner",
+    "stop_conditions",
+    "lane_map"
+  ],
+  "properties": {
+    "command": {
+      "const": "execution_handoff"
+    },
+    "mode": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "runtime_pinning_snapshot": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "verification_owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stop_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "lane_map": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9_-]*$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/schemas/workflow-lane-map.schema.json
+++ b/schemas/workflow-lane-map.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/workflow-lane-map.schema.json",
+  "title": "VibeGuard Workflow Lane Map",
+  "description": "Ownership map for delegated or parallel workflow lanes.",
+  "type": "object",
+  "minProperties": 1,
+  "propertyNames": {
+    "pattern": "^[a-z][a-z0-9_-]*$"
+  },
+  "additionalProperties": {
+    "type": "string",
+    "minLength": 1
+  },
+  "x_markdown_tokens": ["lane_map"]
+}

--- a/schemas/workflow-routing-decision.schema.json
+++ b/schemas/workflow-routing-decision.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/workflow-routing-decision.schema.json",
+  "title": "VibeGuard Workflow Routing Decision",
+  "description": "Machine-readable contract for routing decisions before workflow execution.",
+  "type": "object",
+  "required": ["readiness"],
+  "additionalProperties": false,
+  "x_markdown_tokens": ["readiness", "execute_direct", "plan_first", "clarify_first"],
+  "properties": {
+    "command": {
+      "const": "routing_decision"
+    },
+    "precedence": {
+      "type": "array",
+      "minItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "user_override",
+          "risk_destructive_gate",
+          "ambiguity_gate",
+          "readiness_classifier",
+          "execution_or_delegation_lane"
+        ]
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "required": ["decision", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "decision": {
+          "enum": ["execute_direct", "plan_first", "clarify_first"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "blockingQuestions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/workflow-verification-gate.schema.json
+++ b/schemas/workflow-verification-gate.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/workflow-verification-gate.schema.json",
+  "title": "VibeGuard Workflow Verification Gate",
+  "description": "Verification ownership and stop-condition contract shared by workflow handoffs.",
+  "type": "object",
+  "required": ["verification_owner", "stop_conditions"],
+  "additionalProperties": false,
+  "x_markdown_tokens": ["verification_owner", "stop_conditions"],
+  "properties": {
+    "verification_owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stop_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/scripts/ci/validate-workflow-contracts.sh
+++ b/scripts/ci/validate-workflow-contracts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+python3 "${REPO_DIR}/scripts/lib/workflow_contracts.py" validate

--- a/scripts/lib/workflow_contracts.py
+++ b/scripts/lib/workflow_contracts.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Validate executable workflow contracts against their Markdown consumers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA_DIR = ROOT / "schemas"
+DEFAULT_REGISTRY = DEFAULT_SCHEMA_DIR / "workflow-contract-consumers.json"
+JSON_BLOCK_RE = re.compile(r"```json\s*(?P<body>.*?)\s*```", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ContractError:
+    category: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.category}: {self.message}"
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc.msg}") from exc
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "integer"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _type_matches(value: Any, expected: str) -> bool:
+    if expected == "null":
+        return value is None
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "object":
+        return isinstance(value, dict)
+    return False
+
+
+def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        allowed_types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(_type_matches(instance, item) for item in allowed_types):
+            errors.append(f"{path}: expected {allowed_types}, got {_type_name(instance)}")
+            return errors
+
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}, got {instance!r}")
+
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']}, got {instance!r}")
+
+    if isinstance(instance, str):
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and len(instance) < min_length:
+            errors.append(f"{path}: string shorter than minLength {min_length}")
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and not re.search(pattern, instance):
+            errors.append(f"{path}: string does not match pattern {pattern!r}")
+
+    if isinstance(instance, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(instance) < min_items:
+            errors.append(f"{path}: array shorter than minItems {min_items}")
+        if schema.get("uniqueItems") is True:
+            encoded = [json.dumps(item, sort_keys=True) for item in instance]
+            if len(encoded) != len(set(encoded)):
+                errors.append(f"{path}: array items must be unique")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(instance):
+                errors.extend(validate_instance(item, item_schema, f"{path}[{index}]"))
+
+    if isinstance(instance, dict):
+        min_properties = schema.get("minProperties")
+        if isinstance(min_properties, int) and len(instance) < min_properties:
+            errors.append(f"{path}: object has fewer than {min_properties} properties")
+
+        property_names = schema.get("propertyNames", {})
+        name_pattern = property_names.get("pattern") if isinstance(property_names, dict) else None
+        if isinstance(name_pattern, str):
+            for key in instance:
+                if not re.search(name_pattern, key):
+                    errors.append(f"{path}.{key}: property name does not match {name_pattern!r}")
+
+        required = schema.get("required", [])
+        if isinstance(required, list):
+            for key in required:
+                if key not in instance:
+                    errors.append(f"{path}: missing required property {key!r}")
+
+        properties = schema.get("properties", {})
+        additional = schema.get("additionalProperties", True)
+        if isinstance(properties, dict):
+            for key, value in instance.items():
+                child_path = f"{path}.{key}"
+                if key in properties and isinstance(properties[key], dict):
+                    errors.extend(validate_instance(value, properties[key], child_path))
+                elif additional is False:
+                    errors.append(f"{child_path}: additional property is not allowed")
+                elif isinstance(additional, dict):
+                    errors.extend(validate_instance(value, additional, child_path))
+
+    return errors
+
+
+def load_registry(registry_path: Path) -> dict[str, Any]:
+    registry = load_json(registry_path)
+    if not isinstance(registry, dict):
+        raise ValueError("workflow contract registry root must be an object")
+    if registry.get("schema_version") != 1:
+        raise ValueError("workflow contract registry schema_version must be 1")
+    return registry
+
+
+def load_schemas(schema_dir: Path, registry: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], list[ContractError]]:
+    errors: list[ContractError] = []
+    schemas: dict[str, dict[str, Any]] = {}
+    schema_files = registry.get("schema_files", {})
+    if not isinstance(schema_files, dict):
+        return {}, [ContractError("registry", "schema_files must be an object")]
+
+    for name, filename in sorted(schema_files.items()):
+        if not isinstance(name, str) or not isinstance(filename, str):
+            errors.append(ContractError("registry", "schema_files keys and values must be strings"))
+            continue
+        schema_path = schema_dir / filename
+        if not schema_path.is_file():
+            errors.append(ContractError("schema", f"{filename}: schema file is missing"))
+            continue
+        schema = load_json(schema_path)
+        if not isinstance(schema, dict):
+            errors.append(ContractError("schema", f"{filename}: schema root must be an object"))
+            continue
+        if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            errors.append(ContractError("schema", f"{filename}: unsupported $schema"))
+        if schema.get("type") != "object":
+            errors.append(ContractError("schema", f"{filename}: root type must be object"))
+        schemas[name] = schema
+
+    return schemas, errors
+
+
+def schema_tokens(schema: dict[str, Any]) -> list[str]:
+    tokens: set[str] = set()
+    required = schema.get("required", [])
+    if isinstance(required, list):
+        tokens.update(str(item) for item in required if item != "command")
+    extra = schema.get("x_markdown_tokens", [])
+    if isinstance(extra, list):
+        tokens.update(str(item) for item in extra)
+    return sorted(tokens)
+
+
+def _markdown_example(text: str, heading: str) -> tuple[str | None, str | None]:
+    heading_line = f"## {heading}"
+    lines = text.splitlines()
+    try:
+        start = lines.index(heading_line) + 1
+    except ValueError:
+        return None, f"missing heading {heading!r}"
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+    section = "\n".join(lines[start:end])
+    match = JSON_BLOCK_RE.search(section)
+    if not match:
+        return None, f"missing JSON example under heading {heading!r}"
+    return match.group("body"), None
+
+
+def collect_contract_errors(
+    repo_dir: Path = ROOT,
+    schema_dir: Path = DEFAULT_SCHEMA_DIR,
+    registry_path: Path = DEFAULT_REGISTRY,
+) -> list[ContractError]:
+    errors: list[ContractError] = []
+
+    try:
+        registry = load_registry(registry_path)
+    except ValueError as exc:
+        return [ContractError("registry", str(exc))]
+
+    try:
+        schemas, schema_errors = load_schemas(schema_dir, registry)
+    except ValueError as exc:
+        return [ContractError("schema", str(exc))]
+    errors.extend(schema_errors)
+
+    for example in registry.get("markdown_examples", []):
+        if not isinstance(example, dict):
+            errors.append(ContractError("registry", "markdown_examples entries must be objects"))
+            continue
+        schema_name = str(example.get("schema", ""))
+        schema = schemas.get(schema_name)
+        if schema is None:
+            errors.append(ContractError("registry", f"unknown markdown example schema {schema_name!r}"))
+            continue
+        path = repo_dir / str(example.get("path", ""))
+        heading = str(example.get("heading", ""))
+        if not path.is_file():
+            errors.append(ContractError("example", f"{path.relative_to(repo_dir)}: file is missing"))
+            continue
+        body, error = _markdown_example(path.read_text(encoding="utf-8"), heading)
+        if error is not None:
+            errors.append(ContractError("example", f"{path.relative_to(repo_dir)}: {error}"))
+            continue
+        try:
+            payload = json.loads(body or "")
+        except json.JSONDecodeError as exc:
+            errors.append(
+                ContractError(
+                    "example",
+                    f"{path.relative_to(repo_dir)}:{heading}: invalid JSON example: {exc.msg}",
+                )
+            )
+            continue
+        for message in validate_instance(payload, schema):
+            errors.append(ContractError("example", f"{path.relative_to(repo_dir)}:{heading}: {message}"))
+
+    legacy_markers = registry.get("legacy_routing_markers", [])
+    consumers = registry.get("consumers", [])
+    if not isinstance(consumers, list):
+        errors.append(ContractError("registry", "consumers must be a list"))
+        return errors
+
+    for consumer in consumers:
+        if not isinstance(consumer, dict):
+            errors.append(ContractError("registry", "consumer entries must be objects"))
+            continue
+        rel_path = str(consumer.get("path", ""))
+        path = repo_dir / rel_path
+        if not path.is_file():
+            errors.append(ContractError("consumer", f"{rel_path}: file is missing"))
+            continue
+        text = path.read_text(encoding="utf-8")
+
+        for reference in consumer.get("references", []):
+            if not isinstance(reference, str):
+                errors.append(ContractError("registry", f"{rel_path}: references must be strings"))
+                continue
+            if reference not in text:
+                errors.append(ContractError("consumer", f"{rel_path}: missing reference {reference!r}"))
+
+        for schema_name in consumer.get("requires", []):
+            if not isinstance(schema_name, str):
+                errors.append(ContractError("registry", f"{rel_path}: requires entries must be strings"))
+                continue
+            schema = schemas.get(schema_name)
+            if schema is None:
+                errors.append(ContractError("registry", f"{rel_path}: unknown required schema {schema_name!r}"))
+                continue
+            for token in schema_tokens(schema):
+                if token not in text:
+                    errors.append(
+                        ContractError(
+                            "consumer",
+                            f"{rel_path}: missing token {token!r} required by {schema_name}",
+                        )
+                    )
+
+        if isinstance(legacy_markers, list):
+            for marker in legacy_markers:
+                if isinstance(marker, str) and marker in text:
+                    errors.append(ContractError("consumer", f"{rel_path}: legacy routing marker {marker!r}"))
+
+    return errors
+
+
+def print_required(schema_name: str, schema_dir: Path, registry_path: Path) -> int:
+    registry = load_registry(registry_path)
+    schemas, errors = load_schemas(schema_dir, registry)
+    if errors:
+        for error in errors:
+            print(error.format(), file=sys.stderr)
+        return 1
+    schema = schemas.get(schema_name)
+    if schema is None:
+        print(f"unknown schema: {schema_name}", file=sys.stderr)
+        return 2
+    for token in schema_tokens(schema):
+        print(token)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate VibeGuard workflow contracts")
+    parser.add_argument("--repo-dir", type=Path, default=ROOT)
+    parser.add_argument("--schema-dir", type=Path, default=DEFAULT_SCHEMA_DIR)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("validate", help="Validate schemas, Markdown examples, and consumers")
+    required = sub.add_parser("list-required", help="List Markdown tokens required by a schema")
+    required.add_argument("schema_name")
+
+    args = parser.parse_args(argv)
+    repo_dir = args.repo_dir.resolve()
+    schema_dir = args.schema_dir.resolve()
+    registry = args.registry.resolve()
+
+    if args.command == "list-required":
+        return print_required(args.schema_name, schema_dir, registry)
+
+    errors = collect_contract_errors(repo_dir, schema_dir, registry)
+    if errors:
+        print("FAIL: workflow contract drift detected", file=sys.stderr)
+        for error in errors:
+            print(f"- {error.format()}", file=sys.stderr)
+        return 1
+    print("OK: workflow contracts validate")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/doc-freshness-check.sh
+++ b/scripts/verify/doc-freshness-check.sh
@@ -34,45 +34,13 @@ check_installed = sys.argv[3] == "true"
 
 sys.path.insert(0, str(repo_dir / "scripts" / "lib"))
 import vibeguard_manifest as manifest  # type: ignore
+import workflow_contracts  # type: ignore
 
 canonical_all = set(manifest.canonical_rule_ids("all"))
 documented_scope = {rule_id for rule_id in canonical_all if rule_id.startswith(("U-", "W-", "SEC-"))}
 reference_all = set(manifest.reference_rule_ids())
 documented_common = {rule_id for rule_id in reference_all if rule_id.startswith(("U-", "W-", "SEC-"))}
 mechanical = set(manifest.guard_rule_ids())
-
-routing_contract = repo_dir / "workflows" / "references" / "routing-contract.md"
-routing_text = routing_contract.read_text(encoding="utf-8") if routing_contract.is_file() else ""
-readiness_outputs = {"execute_direct", "plan_first", "clarify_first"}
-handoff_keys = {"mode", "artifacts", "verification_owner", "stop_conditions", "lane_map"}
-reference_surfaces = [
-    repo_dir / "README.md",
-    repo_dir / "agents" / "dispatcher.md",
-    repo_dir / "workflows" / "fixflow" / "SKILL.md",
-    repo_dir / "workflows" / "plan-flow" / "SKILL.md",
-    repo_dir / "workflows" / "plan-mode" / "SKILL.md",
-    repo_dir / "workflows" / "auto-optimize" / "SKILL.md",
-    repo_dir / "workflows" / "references" / "delivery-base.md",
-    repo_dir / "workflows" / "plan-flow" / "references" / "execplan-integration.md",
-    repo_dir / "docs" / "command-schemas.md",
-    repo_dir / "docs" / "CLAUDE.md.example",
-    repo_dir / "docs" / "README_CN.md",
-    repo_dir / "claude-md" / "vibeguard-rules.md",
-    repo_dir / "templates" / "AGENTS.md",
-]
-legacy_routing_markers = [
-    "1-2 files",
-    "3-5 files",
-    "6+ files",
-    "1-2 File",
-    "3-5 File",
-    "6+ Documentation",
-    "1-2 个文件",
-    "3-5 个文件",
-    "6 个及以上文件",
-    "1-2 file directly",
-    "3-5 `/vibeguard:preflight`",
-]
 
 installed_ids: set[str] = set()
 installed_source = "repo/rules/claude-rules (default)"
@@ -86,20 +54,13 @@ common_doc_extra = sorted(documented_common - documented_scope)
 mechanical_missing = sorted(canonical_all - mechanical)
 undocumented_mechanical = sorted(mechanical - canonical_all)
 installed_drift = sorted(canonical_all ^ installed_ids) if check_installed else []
+workflow_contract_drift = [
+    error.format()
+    for error in workflow_contracts.collect_contract_errors(repo_dir=repo_dir)
+]
 
 mechanical_covered = sorted(canonical_all & mechanical)
 coverage_rate = (len(mechanical_covered) / len(canonical_all) * 100) if canonical_all else 0.0
-
-missing_readiness = sorted(token for token in readiness_outputs if token not in routing_text)
-missing_handoff = sorted(token for token in handoff_keys if token not in routing_text)
-missing_references = []
-legacy_routing_files = []
-for surface in reference_surfaces:
-    text = surface.read_text(encoding="utf-8")
-    if "routing-contract.md" not in text:
-        missing_references.append(str(surface.relative_to(repo_dir)))
-    if any(marker in text for marker in legacy_routing_markers):
-        legacy_routing_files.append(str(surface.relative_to(repo_dir)))
 
 print(
     f"""
@@ -113,10 +74,7 @@ Missing mechanical coverage: {len(mechanical_missing)}
 Undocumented mechanical ids: {len(undocumented_mechanical)}
 Common doc drift (missing): {len(common_doc_missing)}
 Common doc drift (extra): {len(common_doc_extra)}
-Routing readiness drift: {len(missing_readiness)}
-Routing handoff drift: {len(missing_handoff)}
-Routing reference drift: {len(missing_references)}
-Legacy routing shortcuts: {len(legacy_routing_files)}
+Workflow contract drift: {len(workflow_contract_drift)}
 """.strip()
 )
 print()
@@ -132,10 +90,7 @@ print_group("Missing from docs/rule-reference.md (common scope)", common_doc_mis
 print_group("Extra in docs/rule-reference.md (not canonical)", common_doc_extra)
 print_group("Canonical rules without mechanical enforcement", mechanical_missing)
 print_group("Mechanical ids with no canonical rule definition", undocumented_mechanical)
-print_group("Missing readiness outputs in workflows/references/routing-contract.md", missing_readiness)
-print_group("Missing handoff keys in workflows/references/routing-contract.md", missing_handoff)
-print_group("Surfaces missing routing-contract reference", missing_references)
-print_group("Surfaces still using legacy routing shortcuts", legacy_routing_files)
+print_group("Workflow contract drift", workflow_contract_drift)
 
 if check_installed:
     print(f"Installed rule source: {installed_source}")
@@ -150,10 +105,7 @@ has_errors = bool(
     common_doc_missing
     or common_doc_extra
     or undocumented_mechanical
-    or missing_readiness
-    or missing_handoff
-    or missing_references
-    or legacy_routing_files
+    or workflow_contract_drift
 )
 has_warnings = bool(mechanical_missing or installed_drift)
 

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 MANIFEST_HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
 CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
+WORKFLOW_CONTRACT_HELPER="${REPO_DIR}/scripts/lib/workflow_contracts.py"
 
 PASS=0
 FAIL=0
@@ -76,6 +77,7 @@ trap cleanup EXIT
 header "helper syntax"
 assert_cmd "manifest helper syntax is correct" python3 -m py_compile "${MANIFEST_HELPER}"
 assert_cmd "codex config helper syntax is correct" python3 -m py_compile "${CODEX_CONFIG_HELPER}"
+assert_cmd "workflow contract helper syntax is correct" python3 -m py_compile "${WORKFLOW_CONTRACT_HELPER}"
 
 header "manifest contract"
 assert_cmd "manifest contract validates" python3 "${MANIFEST_HELPER}" validate
@@ -192,19 +194,12 @@ absolute_skill_validate_out="$(python3 "${MANIFEST_HELPER}" validate --manifest-
 assert_contains "${absolute_skill_validate_out}" "module absolute-skill-module: skill path must be repo-relative: /tmp/skill" "manifest validation reports absolute skill paths"
 assert_not_contains "${absolute_skill_validate_out}" "Traceback" "manifest validation reports absolute skill paths without traceback"
 
-header "routing contract"
-ROUTING_CONTRACT="${REPO_DIR}/workflows/references/routing-contract.md"
-DELEGATION_CONTRACT="${REPO_DIR}/workflows/references/delegation-contract.md"
-assert_cmd "canonical routing contract exists" test -f "${ROUTING_CONTRACT}"
-assert_cmd "routing contract includes execute_direct" grep -qF "execute_direct" "${ROUTING_CONTRACT}"
-assert_cmd "routing contract includes plan_first" grep -qF "plan_first" "${ROUTING_CONTRACT}"
-assert_cmd "routing contract includes clarify_first" grep -qF "clarify_first" "${ROUTING_CONTRACT}"
-assert_cmd "routing contract requires handoff fields" bash -c "for key in mode artifacts verification_owner stop_conditions lane_map; do grep -qF \"\$key\" '${ROUTING_CONTRACT}' || exit 1; done"
-assert_cmd "routing surfaces reference canonical contract" bash -c "for file in '${REPO_DIR}/README.md' '${REPO_DIR}/agents/dispatcher.md' '${REPO_DIR}/workflows/fixflow/SKILL.md' '${REPO_DIR}/workflows/plan-flow/SKILL.md' '${REPO_DIR}/workflows/plan-mode/SKILL.md' '${REPO_DIR}/workflows/auto-optimize/SKILL.md' '${REPO_DIR}/workflows/references/delivery-base.md' '${REPO_DIR}/workflows/plan-flow/references/execplan-integration.md' '${REPO_DIR}/docs/command-schemas.md' '${REPO_DIR}/docs/CLAUDE.md.example' '${REPO_DIR}/docs/README_CN.md' '${REPO_DIR}/claude-md/vibeguard-rules.md' '${REPO_DIR}/templates/AGENTS.md'; do grep -qF 'routing-contract.md' \"\$file\" || exit 1; done"
-assert_cmd "canonical delegation contract exists" test -f "${DELEGATION_CONTRACT}"
-assert_cmd "delegation contract defines assignment fields" bash -c "for key in task_slice allowed_files forbidden_files authority required_evidence blocker_conditions integration_owner; do grep -qF \"\$key\" '${DELEGATION_CONTRACT}' || exit 1; done"
-assert_cmd "delegation contract defines staged team pipeline" bash -c "for stage in solo delegate_readonly team_plan team_exec team_verify fix_loop; do grep -qF \"\$stage\" '${DELEGATION_CONTRACT}' || exit 1; done"
-assert_cmd "delegation consumers reference canonical contract" bash -c "for file in '${REPO_DIR}/README.md' '${REPO_DIR}/agents/dispatcher.md' '${REPO_DIR}/workflows/fixflow/SKILL.md' '${REPO_DIR}/workflows/plan-flow/SKILL.md' '${REPO_DIR}/workflows/plan-mode/SKILL.md' '${REPO_DIR}/workflows/auto-optimize/SKILL.md' '${REPO_DIR}/workflows/references/routing-contract.md' '${REPO_DIR}/workflows/references/delivery-base.md' '${REPO_DIR}/workflows/plan-flow/references/execplan-integration.md' '${REPO_DIR}/docs/command-schemas.md' '${REPO_DIR}/docs/CLAUDE.md.example' '${REPO_DIR}/docs/openai-codex-best-practices.md' '${REPO_DIR}/docs/README_CN.md'; do grep -qF 'delegation-contract.md' \"\$file\" || exit 1; done"
+header "workflow contracts"
+assert_cmd "workflow contracts validate from schema registry" python3 "${WORKFLOW_CONTRACT_HELPER}" validate
+handoff_required_out="$(python3 "${WORKFLOW_CONTRACT_HELPER}" list-required execution_handoff)"
+assert_contains "${handoff_required_out}" "runtime_pinning_snapshot" "execution handoff required keys come from schema"
+delegation_required_out="$(python3 "${WORKFLOW_CONTRACT_HELPER}" list-required delegation_assignment)"
+assert_contains "${delegation_required_out}" "handoff_artifacts" "delegation assignment required keys come from schema"
 
 header "codex config helper"
 CONFIG_FILE="${TMP_DIR}/config.toml"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# VibeGuard workflow contract schema regression tests
+#
+# Usage: bash tests/test_workflow_contracts.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="${REPO_DIR}/scripts/lib/workflow_contracts.py"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fails_with() {
+  local desc="$1" expected="$2"
+  shift 2
+  local output
+  local status
+  TOTAL=$((TOTAL + 1))
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [[ ${status} -eq 0 ]]; then
+    red "$desc (expected failure)"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if echo "$output" | grep -qF "$expected"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected output to contain: $expected)"
+    printf '%s\n' "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+copy_schemas() {
+  local target="$1"
+  mkdir -p "${target}/schemas"
+  cp "${REPO_DIR}"/schemas/workflow-*.schema.json "${target}/schemas/"
+}
+
+write_registry() {
+  local target="$1" body="$2"
+  cat > "${target}/schemas/workflow-contract-consumers.json" <<JSON
+{
+  "schema_version": 1,
+  "schema_files": {
+    "routing_decision": "workflow-routing-decision.schema.json",
+    "execution_handoff": "workflow-execution-handoff.schema.json",
+    "delegation_assignment": "workflow-delegation-assignment.schema.json",
+    "lane_map": "workflow-lane-map.schema.json",
+    "verification_gate": "workflow-verification-gate.schema.json"
+  },
+  ${body}
+}
+JSON
+}
+
+header "workflow contract validator"
+assert_cmd "workflow contract helper syntax is correct" python3 -m py_compile "${HELPER}"
+assert_cmd "workflow contracts validate" python3 "${HELPER}" validate
+required_out="$(python3 "${HELPER}" list-required execution_handoff)"
+assert_contains "${required_out}" "runtime_pinning_snapshot" "handoff required fields come from schema"
+
+header "consumer drift failures"
+HANDOFF_FIXTURE="${TMP_DIR}/handoff"
+copy_schemas "${HANDOFF_FIXTURE}"
+mkdir -p "${HANDOFF_FIXTURE}/agents"
+python3 - "${REPO_DIR}/agents/dispatcher.md" "${HANDOFF_FIXTURE}/agents/dispatcher.md" <<'PY'
+from pathlib import Path
+import sys
+source, target = map(Path, sys.argv[1:3])
+text = source.read_text(encoding="utf-8").replace("verification_owner", "verificationOwner")
+target.write_text(text, encoding="utf-8")
+PY
+write_registry "${HANDOFF_FIXTURE}" '"markdown_examples": [], "consumers": [{"path": "agents/dispatcher.md", "references": [], "requires": ["execution_handoff"]}], "legacy_routing_markers": []'
+assert_fails_with "renamed handoff field fails consumer validation" "verification_owner" \
+  python3 "${HELPER}" --repo-dir "${HANDOFF_FIXTURE}" --schema-dir "${HANDOFF_FIXTURE}/schemas" --registry "${HANDOFF_FIXTURE}/schemas/workflow-contract-consumers.json" validate
+
+DELEGATION_FIXTURE="${TMP_DIR}/delegation"
+copy_schemas "${DELEGATION_FIXTURE}"
+mkdir -p "${DELEGATION_FIXTURE}/workflows/references"
+python3 - "${REPO_DIR}/workflows/references/delegation-contract.md" "${DELEGATION_FIXTURE}/workflows/references/delegation-contract.md" <<'PY'
+from pathlib import Path
+import sys
+source, target = map(Path, sys.argv[1:3])
+text = source.read_text(encoding="utf-8").replace("handoff_artifacts", "handoffArtifacts")
+target.write_text(text, encoding="utf-8")
+PY
+write_registry "${DELEGATION_FIXTURE}" '"markdown_examples": [], "consumers": [{"path": "workflows/references/delegation-contract.md", "references": [], "requires": ["delegation_assignment"]}], "legacy_routing_markers": []'
+assert_fails_with "renamed delegation field fails consumer validation" "handoff_artifacts" \
+  python3 "${HELPER}" --repo-dir "${DELEGATION_FIXTURE}" --schema-dir "${DELEGATION_FIXTURE}/schemas" --registry "${DELEGATION_FIXTURE}/schemas/workflow-contract-consumers.json" validate
+
+header "markdown example failures"
+EXAMPLE_FIXTURE="${TMP_DIR}/example"
+copy_schemas "${EXAMPLE_FIXTURE}"
+mkdir -p "${EXAMPLE_FIXTURE}/docs"
+python3 - "${REPO_DIR}/docs/command-schemas.md" "${EXAMPLE_FIXTURE}/docs/command-schemas.md" <<'PY'
+from pathlib import Path
+import sys
+source, target = map(Path, sys.argv[1:3])
+text = source.read_text(encoding="utf-8").replace('"decision": "execute_direct"', '"decision": "maybe_later"', 1)
+target.write_text(text, encoding="utf-8")
+PY
+write_registry "${EXAMPLE_FIXTURE}" '"markdown_examples": [{"path": "docs/command-schemas.md", "heading": "routing decision Schema", "schema": "routing_decision"}], "consumers": [], "legacy_routing_markers": []'
+assert_fails_with "invalid command schema example fails schema validation" "maybe_later" \
+  python3 "${HELPER}" --repo-dir "${EXAMPLE_FIXTURE}" --schema-dir "${EXAMPLE_FIXTURE}/schemas" --registry "${EXAMPLE_FIXTURE}/schemas/workflow-contract-consumers.json" validate
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/workflows/references/delegation-contract.md
+++ b/workflows/references/delegation-contract.md
@@ -4,11 +4,17 @@ Canonical delegation contract for VibeGuard multi-agent work. Use this document 
 
 This contract extends the routing handoff in [`routing-contract.md`](routing-contract.md). The routing handoff decides whether delegation is allowed; this document defines how delegated work is assigned, executed, verified, and reintegrated.
 
+Executable schema sources:
+
+- `schemas/workflow-delegation-assignment.schema.json`
+- `schemas/workflow-lane-map.schema.json`
+- `schemas/workflow-verification-gate.schema.json`
+
 ## Roles
 
 | Role | Responsibility |
 |------|----------------|
-| `leader` | Owns scope, task slicing, `lane_map`, stop conditions, and final user handoff. |
+| `leader` | Owns scope, task slicing, `lane_map`, `stop_conditions`, and final user handoff. |
 | `worker` | Owns only the assigned task slice and allowed files. Reports evidence and blockers. |
 | `verification_owner` | Owns the required checks and decides whether evidence is sufficient. |
 | `integration_owner` | Single writer for shared outputs, conflict resolution, final diff shaping, and merge readiness. |

--- a/workflows/references/delivery-base.md
+++ b/workflows/references/delivery-base.md
@@ -6,8 +6,9 @@ Delivery step base shared by fixflow and optflow. Both reuse common processes by
 
 Before execution starts, consume the canonical router in [`workflows/references/routing-contract.md`](routing-contract.md).
 
-- Start direct execution only after upstream routing resolves to `execute_direct`, or after a planning workflow emits a handoff that preselects execution.
+- Start direct execution only after upstream `readiness` resolves to `execute_direct`, or after a planning workflow emits a handoff that preselects execution.
 - If upstream routing resolves to `clarify_first`, stop and clarify before building a plan or editing code.
+- If upstream `readiness` resolves to `plan_first`, wait for a planning handoff before editing.
 - Do not reinterpret the route locally with file-count shortcuts.
 - If execution delegates work, consume [`workflows/references/delegation-contract.md`](delegation-contract.md) before any child-agent or parallel write lane starts.
 
@@ -53,7 +54,7 @@ Delegated execution must use the assignment template in [`workflows/references/d
 Before starting delegated work:
 
 - name the `leader`, `verification_owner`, and single `integration_owner`
-- assign each child agent a `task_slice`, `allowed_files`, `forbidden_files`, `authority`, `required_evidence`, and `blocker_conditions`
+- assign each child agent a `task_slice`, `allowed_files`, `forbidden_files`, `read_only_files`, `authority`, `required_evidence`, `blocker_conditions`, `verification_owner`, and `handoff_artifacts`
 - serialize shared-file, high-context-file, generated-artifact, and security-sensitive work unless isolated worktrees or a single integration owner make the write boundary explicit
 
 Worker outputs are not complete until the `integration_owner` inspects them, merges shared outputs, and reruns the checks owned by `verification_owner`.

--- a/workflows/references/routing-contract.md
+++ b/workflows/references/routing-contract.md
@@ -4,6 +4,13 @@ Canonical routing contract for VibeGuard workflow selection. All workflow prompt
 
 Delegated execution is defined by [`delegation-contract.md`](delegation-contract.md). This routing contract decides whether delegation can start; the delegation contract defines assignments, parallelism, verification, and reintegration.
 
+Executable schema sources:
+
+- `schemas/workflow-routing-decision.schema.json`
+- `schemas/workflow-execution-handoff.schema.json`
+- `schemas/workflow-lane-map.schema.json`
+- `schemas/workflow-verification-gate.schema.json`
+
 ## Precedence
 
 Apply routing in this order:


### PR DESCRIPTION
## Summary

Adds executable workflow contract schemas for routing decisions, execution handoffs, delegation assignments, lane maps, and verification gates.

Fixes #199

## Changes

- Add workflow JSON schema files plus a schema/consumer registry.
- Add scripts/lib/workflow_contracts.py and CI wrapper to validate schemas, command-doc JSON examples, consumer references, required fields, and legacy routing shortcuts.
- Replace hard-coded routing/delegation grep checks in manifest tests with schema-driven checks.
- Add regression tests proving renamed handoff/delegation fields and invalid command examples fail validation.

## Test plan

- python3 -m py_compile scripts/lib/workflow_contracts.py
- bash scripts/ci/validate-workflow-contracts.sh
- bash tests/test_workflow_contracts.sh
- bash tests/test_manifest_contract.sh
- bash scripts/verify/doc-freshness-check.sh --strict
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-guards.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash tests/test_setup.sh
- bash scripts/ci/self-application/run-all.sh
- bash tests/test_eval_contract.sh
- bash tests/unit/run_all.sh
- git diff --check
- git diff --cached --check