### PR TITLE
Harden setup config handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,10 @@ jobs:
         shell: bash
         run: bash tests/test_setup.sh
 
+      - name: Setup hardening regression tests
+        shell: bash
+        run: bash tests/test_setup_hardening.sh
+
       - name: Setup --check structured report tests
         shell: bash
         run: bash tests/test_setup_check.sh

--- a/scripts/ci/self-application/check-sec13-self-apply.sh
+++ b/scripts/ci/self-application/check-sec13-self-apply.sh
@@ -51,17 +51,27 @@ require(
     "settings.json diff confirmation",
 )
 require(
-    "scripts/setup/targets/claude-home.sh",
-    'confirm_high_context_write "~/.claude/CLAUDE.md"',
-    "CLAUDE.md diff confirmation",
+    "scripts/setup/lib.sh",
+    "inject_vibeguard_rules()",
+    "shared CLAUDE/AGENTS rule injection helper",
 )
+require(
+    "scripts/setup/lib.sh",
+    'confirm_high_context_write "${display_label}"',
+    "shared rule diff confirmation",
+)
+if (
+    'confirm_high_context_write "${display_label}"' not in (repo / "scripts/setup/lib.sh").read_text(encoding="utf-8")
+    or '"~/.claude/CLAUDE.md"' not in (repo / "scripts/setup/targets/claude-home.sh").read_text(encoding="utf-8")
+):
+    errors.append("scripts/setup/lib.sh + scripts/setup/targets/claude-home.sh: CLAUDE.md injection must route through shared confirmation helper")
 require(
     "scripts/setup/targets/claude-home.sh",
     "settings_upsert_diff",
     "settings diff computation before write",
 )
 require(
-    "scripts/setup/targets/claude-home.sh",
+    "scripts/setup/lib.sh",
     "diff-inject",
     "CLAUDE.md diff computation before write",
 )

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import argparse
 import re
-import tempfile
 from pathlib import Path
+
+from file_ops import write_text_atomic
 
 try:
     import tomllib
@@ -15,14 +16,6 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
         import tomli as tomllib
     except ModuleNotFoundError:  # pragma: no cover - pip vendor fallback
         from pip._vendor import tomli as tomllib
-
-
-def _write_atomic(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8", dir=path.parent) as tmp:
-        tmp.write(content)
-        tmp_path = Path(tmp.name)
-    tmp_path.replace(path)
 
 
 def _table_name(line: str) -> str | None:
@@ -132,7 +125,7 @@ def cmd_enable_hooks(args: argparse.Namespace) -> int:
     old = path.read_text(encoding="utf-8") if path.exists() else ""
     new, changed = _ensure_hooks_enabled(old)
     if changed or not path.exists():
-        _write_atomic(path, new)
+        write_text_atomic(path, new)
         print("CHANGED")
     else:
         print("SKIP")
@@ -150,7 +143,7 @@ def cmd_remove_legacy_vibeguard_mcp(args: argparse.Namespace) -> int:
         print("SKIP")
         return 0
     if new:
-        _write_atomic(path, new)
+        write_text_atomic(path, new)
     else:
         path.unlink(missing_ok=True)
     print("CHANGED")

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -9,6 +9,8 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from file_ops import write_json_atomic
+from hook_config_model import hook_command_identity
 from hooks_manifest import all_managed_script_names, codex_specs, load_manifest
 
 
@@ -35,6 +37,10 @@ MANAGED_MARKERS = LEGACY_MARKERS | all_managed_script_names(MANIFEST)
 # unambiguous enough to identify VibeGuard entries without inspecting the
 # wrapper path, so removal works even when a non-standard wrapper is used.
 _MANAGED_SCRIPT_NAMES: frozenset[str] = frozenset(spec["script"] for spec in MANAGED_SPECS)
+_WRAPPER_NAMES: frozenset[str] = frozenset({"run-hook-codex.sh"})
+_STANDALONE_LEGACY_SCRIPTS: frozenset[str] = frozenset(
+    {"session-tagger.sh", "cognitive-reminder.sh", "post-guard-check.sh"}
+)
 
 
 def _display_path(path: Path, home: Path) -> str:
@@ -89,10 +95,7 @@ def load_hooks(path: Path) -> dict[str, Any]:
 
 
 def save_hooks(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    write_json_atomic(path, data)
 
 
 def _ensure_hooks_root(data: dict[str, Any]) -> dict[str, Any]:
@@ -103,21 +106,23 @@ def _ensure_hooks_root(data: dict[str, Any]) -> dict[str, Any]:
     return hooks
 
 
-def _is_vibeguard_command(command: str) -> bool:
+def _identity_for_hook(event: str, matcher: str | None, hook: dict[str, Any]) -> Any:
+    command = hook.get("command")
     if not isinstance(command, str):
-        return False
-    # Pure-legacy hooks that were never invoked via run-hook-codex.sh.
-    if any(marker in command for marker in ("session-tagger.sh", "cognitive-reminder.sh", "post-guard-check.sh")):
-        return True
-    # Namespaced vibeguard-* scripts are unambiguous regardless of wrapper path,
-    # so custom-wrapper installs are correctly detected during removal.
-    if any(script in command for script in _MANAGED_SCRIPT_NAMES):
-        return True
-    # Un-namespaced legacy markers still require the canonical wrapper name to
-    # avoid false positives against user scripts with similar short names.
-    if "run-hook-codex.sh" not in command:
-        return False
-    return any(marker in command for marker in MANAGED_MARKERS)
+        command = ""
+    timeout_value = hook.get("timeout")
+    timeout = timeout_value if isinstance(timeout_value, int) else None
+    return hook_command_identity(
+        platform="codex",
+        event=event,
+        matcher=matcher,
+        command=command,
+        timeout=timeout,
+        managed_scripts=_MANAGED_SCRIPT_NAMES,
+        legacy_scripts=MANAGED_MARKERS,
+        wrapper_names=_WRAPPER_NAMES,
+        standalone_legacy_scripts=_STANDALONE_LEGACY_SCRIPTS,
+    )
 
 
 def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
@@ -135,6 +140,8 @@ def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
             if not isinstance(entry, dict):
                 new_entries.append(entry)
                 continue
+            matcher_value = entry.get("matcher")
+            matcher = matcher_value if isinstance(matcher_value, str) and matcher_value else None
 
             hook_entries = entry.get("hooks")
             if not isinstance(hook_entries, list):
@@ -147,8 +154,7 @@ def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
                 if not isinstance(hook, dict):
                     kept_hooks.append(hook)
                     continue
-                command = str(hook.get("command", ""))
-                if _is_vibeguard_command(command):
+                if _identity_for_hook(str(event), matcher, hook).is_managed:
                     removed_any = True
                     changed = True
                     continue
@@ -318,6 +324,9 @@ def _has_entry(
             continue
         for hook in hook_entries:
             if not isinstance(hook, dict):
+                continue
+            identity = _identity_for_hook("", expected_matcher, hook)
+            if not identity.is_managed:
                 continue
             if hook.get("command") != expected_command:
                 continue

--- a/scripts/lib/file_ops.py
+++ b/scripts/lib/file_ops.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Shared durable file operations for setup/config helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def write_text_atomic(path: Path, content: str) -> None:
+    """Write text by replacing a same-directory temp file after fsync."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def write_json_atomic(path: Path, data: Any) -> None:
+    write_text_atomic(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/scripts/lib/hook_config_model.py
+++ b/scripts/lib/hook_config_model.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Typed hook config identity shared by Claude and Codex setup helpers."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class HookIdentity:
+    platform: str
+    event: str
+    matcher: str | None
+    command: str
+    script: str | None
+    wrapper: str | None
+    timeout: int | None
+    managed_id: str | None
+
+    @property
+    def is_managed(self) -> bool:
+        return self.managed_id is not None
+
+
+def _basename(token: str) -> str:
+    return Path(token).name
+
+
+def _script_id(script: str) -> str:
+    return script[:-3] if script.endswith(".sh") else script
+
+
+def _shell_invokes_wrapper(parts: list[str], index: int) -> bool:
+    if index < 2:
+        return False
+    shell = _basename(parts[index - 2])
+    wrapper = parts[index - 1]
+    return shell in {"bash", "sh", "zsh"} and not wrapper.startswith("-")
+
+
+def _looks_like_direct_script(parts: list[str], index: int) -> bool:
+    token = parts[index]
+    if "/" in token or token.startswith(("./", "../", "~/", "$HOME/", "${HOME}/")):
+        return True
+    if index > 0 and _basename(parts[index - 1]) in {"bash", "sh", "zsh"}:
+        return True
+    return index == 0 and token.endswith(".sh")
+
+
+def hook_command_identity(
+    *,
+    platform: str,
+    event: str,
+    matcher: str | None,
+    command: str,
+    timeout: int | None,
+    managed_scripts: Iterable[str],
+    legacy_scripts: Iterable[str] = (),
+    wrapper_names: Iterable[str] = (),
+    standalone_legacy_scripts: Iterable[str] = (),
+) -> HookIdentity:
+    managed_set = frozenset(managed_scripts)
+    legacy_set = frozenset(legacy_scripts)
+    all_known_scripts = managed_set | legacy_set
+    wrapper_set = frozenset(wrapper_names)
+    standalone_legacy_set = frozenset(standalone_legacy_scripts)
+
+    script: str | None = None
+    wrapper: str | None = None
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = []
+
+    for index, token in enumerate(parts):
+        token_base = _basename(token)
+        if token_base not in wrapper_set:
+            continue
+        wrapper = token_base
+        if index + 1 >= len(parts):
+            continue
+        next_script = _basename(parts[index + 1])
+        if next_script in all_known_scripts:
+            script = next_script
+            break
+
+    if script is None:
+        for index, token in enumerate(parts):
+            token_base = _basename(token)
+            if token_base in managed_set and (
+                _looks_like_direct_script(parts, index) or _shell_invokes_wrapper(parts, index)
+            ):
+                script = token_base
+                break
+            if token_base in standalone_legacy_set and _looks_like_direct_script(parts, index):
+                script = token_base
+                break
+
+    managed_id = _script_id(script) if script in all_known_scripts else None
+    return HookIdentity(
+        platform=platform,
+        event=event,
+        matcher=matcher,
+        command=command,
+        script=script,
+        wrapper=wrapper,
+        timeout=timeout,
+        managed_id=managed_id,
+    )
+
+
+def normalize_hook_entry(
+    *,
+    platform: str,
+    event: str,
+    entry: Any,
+    managed_scripts: Iterable[str],
+    legacy_scripts: Iterable[str] = (),
+    wrapper_names: Iterable[str] = (),
+    standalone_legacy_scripts: Iterable[str] = (),
+) -> list[HookIdentity]:
+    if not isinstance(entry, dict):
+        return []
+    matcher_value = entry.get("matcher")
+    matcher = matcher_value if isinstance(matcher_value, str) and matcher_value else None
+    hook_entries = entry.get("hooks")
+    if not isinstance(hook_entries, list):
+        return []
+
+    identities: list[HookIdentity] = []
+    for hook in hook_entries:
+        if not isinstance(hook, dict):
+            continue
+        command = hook.get("command")
+        if not isinstance(command, str) or not command:
+            continue
+        timeout_value = hook.get("timeout")
+        timeout = timeout_value if isinstance(timeout_value, int) else None
+        identities.append(
+            hook_command_identity(
+                platform=platform,
+                event=event,
+                matcher=matcher,
+                command=command,
+                timeout=timeout,
+                managed_scripts=managed_scripts,
+                legacy_scripts=legacy_scripts,
+                wrapper_names=wrapper_names,
+                standalone_legacy_scripts=standalone_legacy_scripts,
+            )
+        )
+    return identities

--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -24,6 +24,7 @@
 
 STATE_VERSION=1
 STATE_FILE="${HOME}/.vibeguard/install-state.json"
+INSTALL_STATE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Initialize or load state
 state_init() {
@@ -31,12 +32,15 @@ state_init() {
   local repo_dir
   repo_dir="$(cat "${HOME}/.vibeguard/repo-path" 2>/dev/null || true)"
 
-  python3 - "$STATE_FILE" "$STATE_VERSION" "$profile" "$languages" "$repo_dir" <<'PY'
+  python3 - "$INSTALL_STATE_LIB_DIR" "$STATE_FILE" "$STATE_VERSION" "$profile" "$languages" "$repo_dir" <<'PY'
 import datetime
-import json
 import sys
+from pathlib import Path
 
-state_file, state_version, profile, languages, repo_dir = sys.argv[1:6]
+lib_dir, state_file, state_version, profile, languages, repo_dir = sys.argv[1:7]
+sys.path.insert(0, lib_dir)
+from file_ops import write_json_atomic
+
 state = {
     'version': int(state_version),
     'installed_at': datetime.datetime.now().astimezone().isoformat(),
@@ -45,34 +49,29 @@ state = {
     'repo_dir': repo_dir,
     'files': {}
 }
-with open(state_file, 'w', encoding='utf-8') as f:
-    json.dump(state, f, indent=2)
-    f.write('\n')
+write_json_atomic(Path(state_file), state)
 PY
 }
 
 # Record a file installation
 state_record_file() {
   local dest="$1" source="$2" install_type="${3:-copy}"
-  local checksum=""
 
-  if [[ "$install_type" != "symlink" ]] && [[ -f "$dest" ]]; then
-    if command -v shasum &>/dev/null; then
-      checksum="sha256:$(shasum -a 256 "$dest" | cut -d' ' -f1)"
-    elif command -v sha256sum &>/dev/null; then
-      checksum="sha256:$(sha256sum "$dest" | cut -d' ' -f1)"
-    fi
-  fi
-
-  python3 - "$STATE_FILE" "$STATE_VERSION" "$dest" "$source" "$install_type" "$checksum" <<'PY'
+  python3 - "$INSTALL_STATE_LIB_DIR" "$STATE_FILE" "$STATE_VERSION" "$dest" "$source" "$install_type" <<'PY'
 import json
 import sys
+from pathlib import Path
 
-state_file, state_version, dest, source, install_type, checksum = sys.argv[1:7]
+lib_dir, state_file, state_version, dest, source, install_type = sys.argv[1:7]
+sys.path.insert(0, lib_dir)
+from file_ops import sha256_file, write_json_atomic
+
 expected_version = int(state_version)
+state_path = Path(state_file)
+dest_path = Path(dest)
 
 try:
-    with open(state_file, encoding='utf-8') as f:
+    with state_path.open(encoding='utf-8') as f:
         state = json.load(f)
 except (FileNotFoundError, json.JSONDecodeError):
     state = {'version': expected_version, 'files': {}}
@@ -82,13 +81,11 @@ if version != expected_version:
     raise SystemExit(f'unsupported install-state version: {version} (expected {expected_version})')
 
 entry = {'source': source, 'type': install_type}
-if checksum:
-    entry['checksum'] = checksum
+if install_type != 'symlink' and dest_path.is_file():
+    entry['checksum'] = 'sha256:' + sha256_file(dest_path)
 state.setdefault('files', {})[dest] = entry
 
-with open(state_file, 'w', encoding='utf-8') as f:
-    json.dump(state, f, indent=2)
-    f.write('\n')
+write_json_atomic(state_path, state)
 PY
 }
 
@@ -114,11 +111,14 @@ state_check_drift() {
     return 0
   fi
 
-  python3 - "$STATE_FILE" "$STATE_VERSION" 2>/dev/null <<'PY'
-import json, os, subprocess
+  python3 - "$INSTALL_STATE_LIB_DIR" "$STATE_FILE" "$STATE_VERSION" 2>/dev/null <<'PY'
+import json, os
 import sys
+from pathlib import Path
 
-state_file, state_version = sys.argv[1], int(sys.argv[2])
+lib_dir, state_file, state_version = sys.argv[1], sys.argv[2], int(sys.argv[3])
+sys.path.insert(0, lib_dir)
+from file_ops import sha256_file
 
 with open(state_file, encoding='utf-8') as f:
     state = json.load(f)
@@ -147,18 +147,10 @@ for dest, info in files.items():
             print(f'MISSING: {dest}')
             missing_count += 1
         elif 'checksum' in info:
-            try:
-                result = subprocess.run(
-                    ['shasum', '-a', '256', expanded],
-                    capture_output=True, text=True, timeout=5
-                )
-                if result.returncode == 0:
-                    actual = 'sha256:' + result.stdout.split()[0]
-                    if actual != info['checksum']:
-                        print(f'DRIFT: {dest} (checksum mismatch)')
-                        drift_count += 1
-            except (subprocess.TimeoutExpired, FileNotFoundError):
-                pass
+            actual = 'sha256:' + sha256_file(Path(expanded))
+            if actual != info['checksum']:
+                print(f'DRIFT: {dest} (checksum mismatch)')
+                drift_count += 1
 
 total = len(files)
 print(f'---')

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -11,10 +11,17 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from file_ops import write_json_atomic
+from hook_config_model import hook_command_identity, normalize_hook_entry
 from hooks_manifest import all_managed_script_names, claude_specs, load_manifest
 
 
 MANIFEST = load_manifest()
+MANAGED_SCRIPT_NAMES = all_managed_script_names(MANIFEST)
+LEGACY_SCRIPT_NAMES: frozenset[str] = frozenset(
+    {"post-guard-check.sh", "session-tagger.sh", "cognitive-reminder.sh"}
+)
+WRAPPER_NAMES: frozenset[str] = frozenset({"run-hook.sh"})
 
 
 def load_settings(path: Path) -> dict[str, Any]:
@@ -28,10 +35,7 @@ def load_settings(path: Path) -> dict[str, Any]:
 
 
 def save_settings(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    write_json_atomic(path, data)
 
 
 def render_settings(data: dict[str, Any]) -> str:
@@ -49,11 +53,39 @@ def unified_diff(path: Path, before: str, after: str) -> str:
     )
 
 
-def _entry_contains(entry: Any, needle: str) -> bool:
-    try:
-        return needle in json.dumps(entry, ensure_ascii=False)
-    except (TypeError, ValueError):
-        return False
+def _entry_identities(event: str, entry: Any) -> list[Any]:
+    return normalize_hook_entry(
+        platform="claude",
+        event=event,
+        entry=entry,
+        managed_scripts=MANAGED_SCRIPT_NAMES,
+        legacy_scripts=LEGACY_SCRIPT_NAMES,
+        wrapper_names=WRAPPER_NAMES,
+        standalone_legacy_scripts=LEGACY_SCRIPT_NAMES,
+    )
+
+
+def _hook_identity(event: str, matcher: str | None, hook: dict[str, Any]) -> Any:
+    command = hook.get("command")
+    if not isinstance(command, str):
+        command = ""
+    timeout_value = hook.get("timeout")
+    timeout = timeout_value if isinstance(timeout_value, int) else None
+    return hook_command_identity(
+        platform="claude",
+        event=event,
+        matcher=matcher,
+        command=command,
+        timeout=timeout,
+        managed_scripts=MANAGED_SCRIPT_NAMES,
+        legacy_scripts=LEGACY_SCRIPT_NAMES,
+        wrapper_names=WRAPPER_NAMES,
+        standalone_legacy_scripts=LEGACY_SCRIPT_NAMES,
+    )
+
+
+def _entry_has_script(event: str, entry: Any, scripts: set[str] | frozenset[str]) -> bool:
+    return any(identity.script in scripts for identity in _entry_identities(event, entry))
 
 
 def _display_path(path: Path, home: Path) -> str:
@@ -214,12 +246,8 @@ def _has_hook_spec(data: dict[str, Any], spec: dict[str, Any]) -> bool:
                 continue
         elif "matcher" in entry and entry.get("matcher") not in ("", None):
             continue
-        hook_entries = entry.get("hooks")
-        if not isinstance(hook_entries, list):
-            continue
-        for hook in hook_entries:
-            if isinstance(hook, dict) and spec["script"] in str(hook.get("command", "")):
-                return True
+        if any(identity.script == spec["script"] for identity in _entry_identities(str(spec["event"]), entry)):
+            return True
     return False
 
 
@@ -294,8 +322,6 @@ def _remove_legacy_hook_entries(data: dict[str, Any]) -> bool:
         return False
 
     changed = False
-    legacy_keys = ("post-guard-check", "session-tagger", "cognitive-reminder")
-
     for event in ("PreToolUse", "PostToolUse", "Stop", "SessionStart"):
         entries = hooks.get(event)
         if not isinstance(entries, list):
@@ -303,7 +329,7 @@ def _remove_legacy_hook_entries(data: dict[str, Any]) -> bool:
 
         filtered = [
             entry for entry in entries
-            if not any(_entry_contains(entry, key) for key in legacy_keys)
+            if not _entry_has_script(str(event), entry, LEGACY_SCRIPT_NAMES)
         ]
         if len(filtered) == len(entries):
             continue
@@ -325,7 +351,7 @@ def remove_hook(hooks: dict[str, Any], event: str, script_name: str, state: dict
     entries = hooks.get(event)
     if not isinstance(entries, list):
         return
-    filtered = [e for e in entries if not _entry_contains(e, script_name)]
+    filtered = [e for e in entries if not _entry_has_script(event, e, frozenset({script_name}))]
     if len(filtered) != len(entries):
         if filtered:
             hooks[event] = filtered
@@ -356,16 +382,12 @@ def upsert_hook(
     for entry in entries:
         if not isinstance(entry, dict):
             continue
+        identities = _entry_identities(event, entry)
         if matcher:
             if entry.get("matcher") != matcher:
                 continue
-        else:
-            hook_entries = entry.get("hooks", [])
-            if not any(
-                isinstance(h, dict) and script_name in str(h.get("command", ""))
-                for h in hook_entries
-            ):
-                continue
+        elif not any(identity.script == script_name for identity in identities):
+            continue
 
         hook_entries = entry.get("hooks")
         if not isinstance(hook_entries, list):
@@ -377,8 +399,11 @@ def upsert_hook(
         for hook in hook_entries:
             if not isinstance(hook, dict):
                 continue
+            matcher_value = entry.get("matcher")
+            entry_matcher = matcher_value if isinstance(matcher_value, str) and matcher_value else None
+            identity = _hook_identity(event, entry_matcher, hook)
             cmd = hook.get("command", "")
-            if script_name not in str(cmd):
+            if identity.script != script_name:
                 continue
             found = True
             if hook.get("type") != "command":
@@ -496,45 +521,21 @@ def cmd_remove_vibeguard(args: argparse.Namespace) -> int:
 
     hooks = data.get("hooks")
     if isinstance(hooks, dict):
-        if "PreToolUse" in hooks and isinstance(hooks["PreToolUse"], list):
-            original = hooks["PreToolUse"]
-            filtered = [
-                h for h in original
-                if not any(
-                    _entry_contains(h, key)
-                    for key in all_managed_script_names(MANIFEST)
-                )
-            ]
-            if len(filtered) != len(original):
-                if filtered:
-                    hooks["PreToolUse"] = filtered
-                else:
-                    hooks.pop("PreToolUse", None)
-                changed = True
-
-        if "PostToolUse" in hooks and isinstance(hooks["PostToolUse"], list):
-            original = hooks["PostToolUse"]
-            filtered = [
-                h for h in original
-                if not any(
-                    _entry_contains(h, key)
-                    for key in all_managed_script_names(MANIFEST) | {"post-guard-check.sh"}
-                )
-            ]
-            if len(filtered) != len(original):
-                if filtered:
-                    hooks["PostToolUse"] = filtered
-                else:
-                    hooks.pop("PostToolUse", None)
-                changed = True
-
-        for event in ("Stop", "SessionStart", "PreCompact", "UserPromptSubmit"):
+        event_scripts: dict[str, frozenset[str]] = {
+            "PreToolUse": frozenset(MANAGED_SCRIPT_NAMES),
+            "PostToolUse": frozenset(MANAGED_SCRIPT_NAMES | {"post-guard-check.sh"}),
+            "Stop": frozenset(MANAGED_SCRIPT_NAMES),
+            "SessionStart": frozenset(MANAGED_SCRIPT_NAMES),
+            "PreCompact": frozenset(MANAGED_SCRIPT_NAMES),
+            "UserPromptSubmit": frozenset(MANAGED_SCRIPT_NAMES),
+        }
+        for event, scripts in event_scripts.items():
             if event not in hooks or not isinstance(hooks[event], list):
                 continue
             original = hooks[event]
             filtered = [
                 h for h in original
-                if not any(_entry_contains(h, key) for key in all_managed_script_names(MANIFEST))
+                if not _entry_has_script(event, h, scripts)
             ]
             if len(filtered) != len(original):
                 if filtered:

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -127,6 +127,70 @@ cleanup_retired_manifest_skill_links() {
   done < <(state_list_tracked_symlinks_under "${dest_dir}")
 }
 
+install_manifest_skills() {
+  local target_uri="$1" dest_dir="$2" install_fn="$3"
+  local skill_links source_path skill
+
+  mkdir -p "${dest_dir}"
+  skill_links="$(manifest_skill_links_checked "${target_uri}")" || return 1
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    if [[ -d "${REPO_DIR}/${source_path}" ]]; then
+      "${install_fn}" "${REPO_DIR}/${source_path}" "${dest_dir}/${skill}" "${source_path}" "${skill}" || return 1
+    else
+      yellow "  SKIP ${skill} (source not found: ${source_path})"
+    fi
+  done <<< "${skill_links}"
+}
+
+install_context_profiles() {
+  local target_dir="$1" display_prefix="$2"
+  mkdir -p "${target_dir}"
+  local profile name
+  for profile in "${REPO_DIR}"/context-profiles/*.md; do
+    [[ -f "${profile}" ]] || continue
+    name=$(basename "${profile}")
+    cp "${profile}" "${target_dir}/${name}"
+    state_record_file "${target_dir}/${name}" "context-profiles/${name}" "copy"
+    green "  ${name} -> ${display_prefix}/${name}"
+  done
+}
+
+inject_vibeguard_rules() {
+  local target_file="$1" display_label="$2" state_source="$3"
+  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
+  local rules_diff rule_count result
+
+  rule_count=$(claude_rule_count_for_banner)
+  mkdir -p "$(dirname "${target_file}")"
+  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
+    red "  Failed to compute ${display_label} diff"
+    return 1
+  fi
+  if ! confirm_high_context_write "${display_label}" "${rules_diff}"; then
+    if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
+      echo
+      return 0
+    fi
+    return 1
+  fi
+  if [[ "${rules_diff}" == "SKIP" ]]; then
+    green "  ${display_label} already up to date"
+    echo
+    return 0
+  fi
+  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
+    if [[ -f "${target_file}" ]]; then
+      state_record_file "${target_file}" "${state_source}" "copy"
+    fi
+    green "  VibeGuard rules synced to ${display_label} (${result})"
+  else
+    red "  Failed to update ${display_label}"
+    return 1
+  fi
+  echo
+}
+
 confirm_high_context_write() {
   local label="$1"
   local diff_output="$2"

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -48,21 +48,16 @@ _remove_rule_subtree_if_safe() {
   rm -rf "${dest_dir}"
 }
 
+_install_claude_skill_link() {
+  local src="$1" dst="$2" source_path="$3" skill="$4"
+  safe_symlink "${src}" "${dst}"
+  state_record_file "${dst}" "${source_path}" "symlink"
+  green "  ${skill} -> ~/.claude/skills/${skill}"
+}
+
 install_claude_home_assets() {
   echo "Step 2: Install Claude Code skills"
-  mkdir -p "${CLAUDE_DIR}/skills"
-  local skill_links source_path skill
-  skill_links="$(manifest_skill_links_checked "~/.claude/skills/")" || return 1
-  while IFS=$'\t' read -r source_path skill; do
-    [[ -n "${source_path}" && -n "${skill}" ]] || continue
-    if [[ -d "${REPO_DIR}/${source_path}" ]]; then
-      safe_symlink "${REPO_DIR}/${source_path}" "${CLAUDE_DIR}/skills/${skill}"
-      state_record_file "${CLAUDE_DIR}/skills/${skill}" "${source_path}" "symlink"
-      green "  ${skill} -> ~/.claude/skills/${skill}"
-    else
-      yellow "  SKIP ${skill} (source not found: ${source_path})"
-    fi
-  done <<< "${skill_links}"
+  install_manifest_skills "~/.claude/skills/" "${CLAUDE_DIR}/skills" _install_claude_skill_link || return 1
   echo
 
   echo "Step 3: Install agents"
@@ -79,15 +74,7 @@ install_claude_home_assets() {
   echo
 
   echo "Step 4: Install context profiles"
-  mkdir -p "${CLAUDE_DIR}/context-profiles"
-  for profile in "${REPO_DIR}"/context-profiles/*.md; do
-    [[ -f "$profile" ]] || continue
-    local name
-    name=$(basename "$profile")
-    cp "$profile" "${CLAUDE_DIR}/context-profiles/${name}"
-    state_record_file "${CLAUDE_DIR}/context-profiles/${name}" "context-profiles/${name}" "copy"
-    green "  ${name} -> ~/.claude/context-profiles/${name}"
-  done
+  install_context_profiles "${CLAUDE_DIR}/context-profiles" "~/.claude/context-profiles"
   echo
 
   echo "Step 5: Install custom commands"
@@ -240,29 +227,7 @@ configure_claude_home_runtime() {
 
 inject_claude_home_rules() {
   echo "Step 10: Update VibeGuard rules in CLAUDE.md"
-  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
-  local rules_diff rule_count
-  rule_count=$(claude_rule_count_for_banner)
-  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${CLAUDE_DIR}/CLAUDE.md" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
-    red "  Failed to compute CLAUDE.md diff"
-    return 1
-  fi
-  if ! confirm_high_context_write "~/.claude/CLAUDE.md" "${rules_diff}"; then
-    if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
-      echo
-      return 0
-    fi
-    return 1
-  fi
-  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${CLAUDE_DIR}/CLAUDE.md" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
-    if [[ -f "${CLAUDE_DIR}/CLAUDE.md" ]]; then
-      state_record_file "${CLAUDE_DIR}/CLAUDE.md" "generated/CLAUDE.md" "copy"
-    fi
-    green "  VibeGuard rules synced to ~/.claude/CLAUDE.md (${result})"
-  else
-    red "  Failed to update CLAUDE.md"
-  fi
-  echo
+  inject_vibeguard_rules "${CLAUDE_DIR}/CLAUDE.md" "~/.claude/CLAUDE.md" "generated/CLAUDE.md"
 }
 
 check_claude_home_installation() {

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 
+_install_codex_manifest_skill() {
+  local src="$1" dst="$2" source_path="$3" skill="$4"
+  install_codex_skill_copy "${src}" "${dst}" "${source_path}"
+  green "  ${skill} copied to ~/.codex/skills/${skill}"
+}
+
 install_codex_home_assets() {
   echo "Step 6: Install Codex skills"
-  mkdir -p "${CODEX_DIR}/skills"
-  local skill_links source_path skill
-  skill_links="$(manifest_skill_links_checked "~/.codex/skills/")" || return 1
-  while IFS=$'\t' read -r source_path skill; do
-    [[ -n "${source_path}" && -n "${skill}" ]] || continue
-    if [[ -d "${REPO_DIR}/${source_path}" ]]; then
-      install_codex_skill_copy "${REPO_DIR}/${source_path}" "${CODEX_DIR}/skills/${skill}" "${source_path}"
-      green "  ${skill} copied to ~/.codex/skills/${skill}"
-    else
-      yellow "  SKIP ${skill} (source not found: ${source_path})"
-    fi
-  done <<< "${skill_links}"
+  install_manifest_skills "~/.codex/skills/" "${CODEX_DIR}/skills" _install_codex_manifest_skill || return 1
   echo
 
   echo "Step 6.5: Install Codex hooks"
@@ -112,37 +107,8 @@ codex_native_capability_summary() {
 
 inject_codex_home_rules() {
   echo "Step 10.1: Update VibeGuard rules in ~/.codex/AGENTS.md"
-  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
   local agents_md="${CODEX_DIR}/AGENTS.md"
-  local rules_diff rule_count
-  rule_count=$(claude_rule_count_for_banner)
-  mkdir -p "${CODEX_DIR}"
-  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${agents_md}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
-    red "  Failed to compute ~/.codex/AGENTS.md diff"
-    return 1
-  fi
-  if ! confirm_high_context_write "~/.codex/AGENTS.md" "${rules_diff}"; then
-    if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
-      echo
-      return 0
-    fi
-    return 1
-  fi
-  if [[ "${rules_diff}" == "SKIP" ]]; then
-    green "  ~/.codex/AGENTS.md already up to date"
-    echo
-    return 0
-  fi
-  local result
-  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${agents_md}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
-    if [[ -f "${agents_md}" ]]; then
-      state_record_file "${agents_md}" "generated/AGENTS.md" "copy"
-    fi
-    green "  VibeGuard rules synced to ~/.codex/AGENTS.md (${result})"
-  else
-    red "  Failed to update ~/.codex/AGENTS.md"
-  fi
-  echo
+  inject_vibeguard_rules "${agents_md}" "~/.codex/AGENTS.md" "generated/AGENTS.md"
 }
 
 configure_codex_home_runtime() {

--- a/tests/test_setup_hardening.sh
+++ b/tests/test_setup_hardening.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Focused setup hardening regression tests.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SETTINGS_HELPER="${REPO_DIR}/scripts/lib/settings_json.py"
+CODEX_HOOKS_HELPER="${REPO_DIR}/scripts/lib/codex_hooks_json.py"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red() { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header() { printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+export TMP_DIR
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+export PYTHONPATH="${REPO_DIR}/scripts/lib:${PYTHONPATH:-}"
+
+header "shared helper syntax"
+assert_cmd "file_ops.py syntax is correct" python3 -m py_compile "${REPO_DIR}/scripts/lib/file_ops.py"
+assert_cmd "hook_config_model.py syntax is correct" python3 -m py_compile "${REPO_DIR}/scripts/lib/hook_config_model.py"
+assert_cmd "shared setup primitives are declared" bash -c "
+  source '${REPO_DIR}/scripts/setup/lib.sh'
+  declare -F install_manifest_skills install_context_profiles inject_vibeguard_rules >/dev/null
+"
+assert_cmd "install-state uses Python hashlib instead of shell sha tools" bash -c "
+  ! grep -Eq 'shasum|sha256sum|subprocess\\.run' '${REPO_DIR}/scripts/lib/install-state.sh'
+"
+
+header "atomic writes and install-state hashing"
+assert_cmd "file_ops writes and hashes atomically" python3 - <<'PY'
+from pathlib import Path
+from file_ops import sha256_file, write_json_atomic, write_text_atomic
+
+root = Path(__import__("os").environ["TMP_DIR"])
+text_path = root / "nested" / "file.txt"
+json_path = root / "nested" / "data.json"
+write_text_atomic(text_path, "abc\n")
+write_json_atomic(json_path, {"ok": True})
+assert text_path.read_text(encoding="utf-8") == "abc\n"
+assert '"ok": true' in json_path.read_text(encoding="utf-8")
+assert sha256_file(text_path) == "edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb"
+PY
+
+INSTALL_STATE_HOME="${TMP_DIR}/install-state-home"
+INSTALL_STATE_DEST="${INSTALL_STATE_HOME}/tracked.txt"
+INSTALL_STATE_REPORT="${TMP_DIR}/install-state-report.txt"
+mkdir -p "${INSTALL_STATE_HOME}/.vibeguard"
+printf '%s' "${REPO_DIR}" > "${INSTALL_STATE_HOME}/.vibeguard/repo-path"
+printf 'tracked\n' > "${INSTALL_STATE_DEST}"
+assert_cmd "install-state records and detects drift with hashlib" env \
+  HOME="${INSTALL_STATE_HOME}" \
+  INSTALL_STATE_DEST="${INSTALL_STATE_DEST}" \
+  INSTALL_STATE_REPORT="${INSTALL_STATE_REPORT}" \
+  bash -c '
+    set -euo pipefail
+    source "$1"
+    state_init core python
+    state_record_file "${INSTALL_STATE_DEST}" generated/tracked.txt copy
+    state_check_drift > "${INSTALL_STATE_REPORT}"
+    grep -q "STATUS: CLEAN" "${INSTALL_STATE_REPORT}"
+    printf changed > "${INSTALL_STATE_DEST}"
+    state_check_drift > "${INSTALL_STATE_REPORT}"
+    grep -q "DRIFT:" "${INSTALL_STATE_REPORT}"
+  ' bash "${REPO_DIR}/scripts/lib/install-state.sh"
+
+header "typed hook config identity"
+CODEX_HOOKS="${TMP_DIR}/codex-hooks.json"
+CODEX_WRAPPER="${TMP_DIR}/custom-wrapper.sh"
+cat > "${CODEX_HOOKS}" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python /tmp/user_hook.py --label vibeguard-pre-bash-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${CODEX_HOOKS}" --wrapper "${CODEX_WRAPPER}" >/dev/null
+python3 "${CODEX_HOOKS_HELPER}" remove-vibeguard --hooks-file "${CODEX_HOOKS}" >/dev/null
+assert_cmd "Codex remove preserves user hook arguments mentioning managed names" python3 - <<'PY' "${CODEX_HOOKS}"
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+commands = [
+    hook["command"]
+    for entries in data.get("hooks", {}).values()
+    for entry in entries
+    for hook in entry.get("hooks", [])
+]
+assert "python /tmp/user_hook.py --label vibeguard-pre-bash-guard.sh" in commands
+assert all(not (command.startswith("bash ") and "vibeguard-" in command) for command in commands)
+PY
+
+CLAUDE_SETTINGS="${TMP_DIR}/claude-settings.json"
+cat > "${CLAUDE_SETTINGS}" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python /tmp/user_hook.py --label pre-bash-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+python3 "${SETTINGS_HELPER}" upsert-vibeguard --settings-file "${CLAUDE_SETTINGS}" --repo-dir "${REPO_DIR}" --profile core >/dev/null
+python3 "${SETTINGS_HELPER}" remove-vibeguard --settings-file "${CLAUDE_SETTINGS}" >/dev/null
+assert_cmd "Claude remove preserves user hook arguments mentioning managed names" python3 - <<'PY' "${CLAUDE_SETTINGS}"
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+commands = [
+    hook["command"]
+    for entries in data.get("hooks", {}).values()
+    for entry in entries
+    for hook in entry.get("hooks", [])
+]
+assert commands == ["python /tmp/user_hook.py --label pre-bash-guard.sh"]
+PY
+
+printf '\nSetup hardening tests: %s/%s passed\n' "${PASS}" "${TOTAL}"
+if [[ "${FAIL}" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add shared atomic write/hash helpers and use them for setup config and install-state writes
- normalize Claude/Codex hook entries through a typed hook identity model instead of raw substring matching
- share setup primitives for manifest skill installs, context profiles, and rule injection
- add focused setup hardening regression coverage and wire it into CI

## Test plan
- python3 -m py_compile scripts/lib/file_ops.py scripts/lib/hook_config_model.py scripts/lib/settings_json.py scripts/lib/codex_hooks_json.py scripts/lib/codex_config_toml.py
- bash -n scripts/lib/install-state.sh scripts/setup/lib.sh scripts/setup/targets/claude-home.sh scripts/setup/targets/codex-home.sh tests/test_setup_hardening.sh
- bash tests/test_setup_hardening.sh
- bash tests/test_setup.sh
- bash tests/test_setup_check.sh
- bash tests/test_codex_status.sh
- bash scripts/ci/validate-hooks-manifest.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-workflow-contracts.sh
- bash tests/test_manifest_contract.sh
- bash tests/test_workflow_contracts.sh
- bash scripts/ci/validate-guards.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash scripts/ci/self-application/run-all.sh
- bash tests/unit/run_all.sh
- bash tests/test_eval_contract.sh
- bash tests/test_behavior_eval.sh
- git diff --check
- git diff --cached --check

Closes #200