### PR TITLE
Promote W-19 doc hygiene rule to strict

### DIFF
--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -76,7 +76,7 @@ Canonical source of truth: `rules/claude-rules/`
 | W-16 | Verification commands must come from this session | Strict | When you say "fixed", "done", or "verified", you must cite command output produced in this session. |
 | W-17 | Fewer smarter gates beat more mechanical gates | Strict | When the user asks to add a new gate or rule, first ask whether an existing gate can absorb the new condition instead of creating one mor... |
 | W-18 | Evaluations must validate path, not only output | Strict | Output-only evaluations miss systemic failures. |
-| W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Medium | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
+| W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Strict | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
 | W-20 | Long tasks must pin runtime, tools, and rules | Strict | Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot... |
 
 ---

--- a/rules/claude-rules/common/workflow.md
+++ b/rules/claude-rules/common/workflow.md
@@ -312,13 +312,14 @@ Every eval suite that gates a release or guards a production agent must validate
 **Downgrade path**:
 For pure text generation tasks with no tools and no required intermediate steps, axes 1 and 2 are vacuous and may be skipped if the eval suite explicitly states so. Axis 3 (calibration) is never optional whenever the model emits or implies a confidence value to a caller.
 
-## W-19: AGENTS.md / CLAUDE.md sustainable size and pairing (medium)
+## W-19: AGENTS.md / CLAUDE.md sustainable size and pairing (strict)
 Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohibitions, or inline the full text of canonical vibeguard rules. Long instruction files trigger overexploration (agents read more surrounding docs and produce worse output) and warning cascades (agents over-validate against rules irrelevant to the current task).
 
-**Sources** (three-source convergence, 2026-04):
+**Sources** (four-source convergence, 2026-04 to 2026-05):
 - Augment Code, "A good AGENTS.md is a model upgrade. A bad one is worse than no docs at all." (AuggieBench measured 10-15% cross-metric drop on bloated docs).
 - Anthropic Claude Code Best Practices: a bloated `CLAUDE.md` causes Claude to ignore the instructions that actually matter.
 - Complement to U-32 (rule overload): U-32 sets the threshold (>30 rules per file), W-19 enforces it on the specific class of agent-instruction docs.
+- Alex Kim, "You've been doing harness engineering all along": independently re-derives W-19's shape from production practice by keeping root docs under roughly 150-200 lines, splitting detailed procedures into skills/reference files, encoding rules as checks, and requiring evidence instead of prose-only claims.
 
 **Detection thresholds**:
 

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -58,7 +58,7 @@ Reference index for VibeGuard rules that apply across languages, workflows, and 
 | W-16 | Verification commands must come from this session | Strict | When you say "fixed", "done", or "verified", you must cite command output produced in this session. |
 | W-17 | Fewer smarter gates beat more mechanical gates | Strict | When the user asks to add a new gate or rule, first ask whether an existing gate can absorb the new condition instead of creating one mor... |
 | W-18 | Evaluations must validate path, not only output | Strict | Output-only evaluations miss systemic failures. |
-| W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Medium | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
+| W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Strict | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
 | W-20 | Long tasks must pin runtime, tools, and rules | Strict | Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot... |
 
 ## FIX / SKIP / DEFER guidance


### PR DESCRIPTION
Summary
- promote W-19 from medium to strict, matching its existing strict fail thresholds
- add Alex Kim's harness-engineering article as a fourth convergence source
- regenerate the universal and rule reference indexes

Note
- this intentionally does not tighten the line-count thresholds from #224; it follows the conservative label/source update path.

Test plan
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-canonical-rule-language.sh
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash tests/test_manifest_contract.sh
- git diff --check

Closes #224