### PR TITLE
Add W-30 agent harness audit rule

### DIFF
--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -78,6 +78,7 @@ Canonical source of truth: `rules/claude-rules/`
 | W-18 | Evaluations must validate path, not only output | Strict | Output-only evaluations miss systemic failures. |
 | W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Strict | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
 | W-20 | Long tasks must pin runtime, tools, and rules | Strict | Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot... |
+| W-30 | Harness audits must measure boundary, fidelity, and stability | Strict | Agent harness evaluation must audit the trajectory, not only final task completion. |
 | W-37 | Agent learning must draw from successful and failed trajectories | Strict | An agent memory or experience layer that feeds future inference must learn from both successful and failed trajectories. |
 | W-38 | Tool-need recognition and tool-call execution are separate metrics | Strict | Tool-use evals must distinguish whether an agent recognized that a tool was needed from whether it actually called the tool. |
 | W-42 | Long-horizon artifact workflows must measure fidelity at checkpoints | Strict | Agent workflows that repeatedly modify and hand off the same artifact must measure semantic fidelity at fixed checkpoints. |

--- a/rules/claude-rules/common/agent-harness-audit.md
+++ b/rules/claude-rules/common/agent-harness-audit.md
@@ -1,0 +1,30 @@
+# Agent Harness Audit Rules
+
+## W-30: Harness audits must measure boundary, fidelity, and stability (strict)
+Agent harness evaluation must audit the trajectory, not only final task completion. A harness can finish the requested task while violating resource boundaries, silently deviating from its declared plan, or accumulating failures as the trajectory gets longer.
+
+**Sources** (2026-05):
+- arXiv:2605.14271, "Auditing Agent Harness Safety" — evaluates agent harnesses across tasks, domains, frameworks, and frontier models, and defines boundary compliance, execution fidelity, and system stability as separate audit axes.
+- W-18 baseline: output-only evaluation misses tool, step, and confidence failures.
+- W-14 baseline: parallel agents need explicit ownership; W-30 extends that concern to information flow and resource boundaries.
+- W-12 baseline: an eval that ignores trajectory violations is a weakened safety gate.
+
+**Required audit axes (strict)**:
+1. **Boundary compliance** — every tool call, file access, network access, credential use, and resource-consuming action must be checked against the agent's declared permission scope.
+2. **Execution fidelity** — every intermediate action must match the declared plan or a logged replan event. Silent plan deviations are fidelity violations even if the final answer is correct.
+3. **System stability** — violations must be reported over trajectory length so the suite can show whether failures stay isolated or accumulate as the run gets longer.
+4. **Information flow** — multi-agent harnesses must log inter-agent transfers: sender, receiver, payload class, authorization basis, and redaction status when sensitive data may be present.
+
+**Mechanical checks (agent execution rules)**:
+- Reject agent harness eval reports that claim safety or readiness without all applicable audit axes.
+- Per-step logs must include at least: declared scope, declared plan step or replan id, actual action, resource touched, tool result status, and violation classification.
+- Multi-agent harnesses must include an information-flow log before they can claim W-14-style isolation or safe delegation.
+- If violation counts grow with trajectory length, the release must treat that as a stability failure even when short runs pass.
+
+**Downgrade path**:
+For pure text generation with no tools, no resource access, and no required intermediate steps, boundary compliance and execution fidelity are vacuous if the eval suite says so explicitly. Any harness that runs more than 5 turns, delegates to another agent, or touches external resources must still report system stability or explain why no trajectory state exists.
+
+**Anti-patterns**:
+- Reporting only task success while hiding per-step tool or file access.
+- Calling a multi-agent run safe because each individual agent stayed in scope, while the information passed between agents was never audited.
+- Treating one short successful run as evidence that longer trajectories remain stable.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -60,6 +60,7 @@ Reference index for VibeGuard rules that apply across languages, workflows, and 
 | W-18 | Evaluations must validate path, not only output | Strict | Output-only evaluations miss systemic failures. |
 | W-19 | AGENTS.md / CLAUDE.md sustainable size and pairing | Strict | Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi... |
 | W-20 | Long tasks must pin runtime, tools, and rules | Strict | Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot... |
+| W-30 | Harness audits must measure boundary, fidelity, and stability | Strict | Agent harness evaluation must audit the trajectory, not only final task completion. |
 | W-37 | Agent learning must draw from successful and failed trajectories | Strict | An agent memory or experience layer that feeds future inference must learn from both successful and failed trajectories. |
 | W-38 | Tool-need recognition and tool-call execution are separate metrics | Strict | Tool-use evals must distinguish whether an agent recognized that a tool was needed from whether it actually called the tool. |
 | W-42 | Long-horizon artifact workflows must measure fidelity at checkpoints | Strict | Agent workflows that repeatedly modify and hand off the same artifact must measure semantic fidelity at fixed checkpoints. |


### PR DESCRIPTION
## Summary
Add W-30, requiring agent harness audits to measure boundary compliance, execution fidelity, and system stability.

Closes #206

## Changes
- Add a dedicated agent harness audit rule file for W-30.
- Regenerate the universal rule index and rule reference.

## Test plan
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-canonical-rule-language.sh
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash tests/test_manifest_contract.sh
- git diff --check
