### PR TITLE
Fix Codex app-server EOF drain race

### DIFF
--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -706,6 +706,9 @@ cat > "${TMP_DIR}/child-rewrite.sh" <<'CHILD'
 #!/usr/bin/env bash
 IFS= read -r _thread_start
 IFS= read -r _turn_start
+# Exercise the wrapper's EOF drain path: CI can be slow enough that a final
+# approval request arrives after the parent stdin has already closed.
+sleep 0.4
 printf '{"id":"req-1","method":"item/commandExecution/requestApproval","params":{"threadId":"thread/alpha","command":"npm install"}}\n'
 IFS= read -r response
 printf '%s\n' "$response"

--- a/vibeguard-runtime/src/codex_app_server.rs
+++ b/vibeguard-runtime/src/codex_app_server.rs
@@ -197,12 +197,9 @@ fn run_proxy(strategy: Box<dyn GateStrategy>, codex_command: &str) -> Result<(),
     });
 
     let _ = t_in.join();
-    // Client EOF may be the shutdown signal. Give the child one short drain
-    // window for responses triggered by the final input, then propagate EOF.
-    if stdout_done_rx
-        .recv_timeout(Duration::from_millis(250))
-        .is_err()
-    {
+    // Client EOF may be the shutdown signal. Give the child a drain window for
+    // responses triggered by the final input, then propagate EOF.
+    if stdout_done_rx.recv_timeout(Duration::from_secs(2)).is_err() {
         close_child_stdin(&child_stdin);
     }
     let _ = t_out.join();


### PR DESCRIPTION
## Summary
- extend the app-server wrapper EOF drain window so final approval responses are not dropped on slower runners
- make the regression test exercise a delayed final approval request

## Root cause
The main push CI for #240 failed on Ubuntu because the wrapper closed child stdin after a fixed 250ms drain. The hook had already produced the corrected command, but the response could be dropped before the child read it.

## Validation
- cargo fmt
- cargo check
- cargo test
- bash tests/test_codex_runtime.sh
- git diff --check