### PR TITLE
Fix VibeGuard validation and hook drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
           fi
           echo "Installed: $(ast-grep --version)"
 
+      - name: Rust runtime checks
+        shell: bash
+        run: |
+          cargo check --manifest-path vibeguard-runtime/Cargo.toml
+          cargo test --manifest-path vibeguard-runtime/Cargo.toml
+
       # --- Shell-based validation ---
       # Skipped on Windows: these scripts check Unix file-permission bits ([ -x ])
       # which have no meaning on NTFS and would produce false-positive passes.

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -34,6 +34,17 @@ _CHECK_REST="${CHECK_RESULT#*$'\n'}"
 FILE_PATH="${_CHECK_REST%%$'\n'*}"
 [[ "$FILE_PATH" == "$CHECK_RESULT" ]] && FILE_PATH=""
 
+if [[ "$CHECK_STATUS" == "MALFORMED" ]]; then
+  vg_log "pre-write-guard" "Write" "block" "Malformed hook input" ""
+  cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "VIBEGUARD interception: malformed PreToolUse(Write) hook input. The write request could not be validated, so it was blocked instead of being treated as a safe skip."
+}
+EOF
+  exit 0
+fi
+
 if [[ "$CHECK_STATUS" == "PASS" || -z "$FILE_PATH" ]]; then
   _pass_and_exit
 fi

--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -7,13 +7,16 @@
       "kind": "rules",
       "description": "Common rules (U-series, W-series, SEC-series)",
       "paths": [
+        "rules/claude-rules/common/agent-harness-audit.md",
         "rules/claude-rules/common/coding-style.md",
         "rules/claude-rules/common/data-consistency.md",
         "rules/claude-rules/common/execution-pinning.md",
         "rules/claude-rules/common/fact-inference-separation.md",
+        "rules/claude-rules/common/long-horizon-reliability.md",
         "rules/claude-rules/common/no-silent-degradation.md",
         "rules/claude-rules/common/publish-action-confirmation.md",
         "rules/claude-rules/common/security.md",
+        "rules/claude-rules/common/vibe-coding-production.md",
         "rules/claude-rules/common/workflow.md"
       ],
       "target": "~/.claude/rules/vibeguard/common/",
@@ -26,7 +29,10 @@
       "id": "rules-rust",
       "kind": "rules",
       "description": "Rust-specific quality rules",
-      "paths": ["rules/claude-rules/rust/quality.md"],
+      "paths": [
+        "rules/claude-rules/rust/quality.md",
+        "rules/claude-rules/rust/struct-field-change-checklist.md"
+      ],
       "target": "~/.claude/rules/vibeguard/rust/",
       "defaultInstall": true,
       "languages": ["rust"],

--- a/scripts/ci/validate-no-personal-paths.sh
+++ b/scripts/ci/validate-no-personal-paths.sh
@@ -10,8 +10,8 @@ checked=0
 echo "Scanning for hardcoded personal paths..."
 
 # Patterns to detect (case-insensitive home directory references)
-# Excludes: .git/, node_modules/, dist/, .benchmarks/, *.jsonl, *.lock
-EXCLUDE_DIRS="--exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.benchmarks --exclude-dir=.vibeguard --exclude-dir=.pytest_cache --exclude-dir=worktrees --exclude-dir=target --exclude-dir=.claude --exclude-dir=__pycache__"
+# Excludes: .git/, node_modules/, dist/, .benchmarks/, local agent state, *.jsonl, *.lock
+EXCLUDE_DIRS="--exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.benchmarks --exclude-dir=.vibeguard --exclude-dir=.omx --exclude-dir=.pytest_cache --exclude-dir=worktrees --exclude-dir=target --exclude-dir=.claude --exclude-dir=__pycache__"
 EXCLUDE_FILES="--exclude=*.jsonl --exclude=*.lock --exclude=bun.lock --exclude=package-lock.json"
 
 # Pattern: /Users/<anything>/ or /home/<anything>/ (common home dir patterns)

--- a/scripts/ci/validate-precision-thresholds.sh
+++ b/scripts/ci/validate-precision-thresholds.sh
@@ -6,6 +6,8 @@ MIN_PRECISION="${MIN_PRECISION:-75}"
 MIN_RECALL="${MIN_RECALL:-75}"
 MIN_F1="${MIN_F1:-75}"
 
+cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet
+
 CSV_OUTPUT="$(bash "${REPO_DIR}/tests/run_precision.sh" --all --csv)"
 
 VG_PRECISION_CSV="${CSV_OUTPUT}" python3 - "$MIN_PRECISION" "$MIN_RECALL" "$MIN_F1" <<'PY'

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -180,6 +180,36 @@ def _validate_paths(manifest: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_rule_paths(manifest: dict[str, Any]) -> list[str]:
+    modules = manifest.get("modules", [])
+    if not isinstance(modules, list):
+        return []
+
+    actual: set[str] = set()
+    for module in modules:
+        if not isinstance(module, dict) or module.get("kind") != "rules":
+            continue
+        paths = module.get("paths", [])
+        if not isinstance(paths, list):
+            continue
+        for path in paths:
+            if isinstance(path, str):
+                actual.add(path.rstrip("/"))
+
+    expected = {
+        path.relative_to(ROOT).as_posix()
+        for path in sorted(CANONICAL_RULES_DIR.rglob("*.md"))
+    }
+    if actual == expected:
+        return []
+
+    return [
+        "rule install path drift: "
+        f"manifest_missing={sorted(expected - actual)} "
+        f"manifest_extra={sorted(actual - expected)}"
+    ]
+
+
 def _validate_profiles(manifest: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     modules = set(_module_ids(manifest))
@@ -466,6 +496,7 @@ def validate_contract(
     if len(module_ids) != len(set(module_ids)):
         errors.append("duplicate module ids detected in manifest")
     errors.extend(_validate_paths(manifest))
+    errors.extend(_validate_rule_paths(manifest))
     errors.extend(_validate_profiles(manifest))
     errors.extend(_validate_project_schema(manifest, project_schema, hooks_manifest))
     errors.extend(_validate_hook_install_targets(manifest, hooks_manifest))

--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -22,6 +22,12 @@ assert_not_contains "$runtime_missing_stdout" '"decision": "pass"' "missing runt
 rm -rf "$runtime_missing_dir"
 unset runtime_missing_dir runtime_missing_stdout runtime_missing_rc runtime_missing_stderr
 
+header "pre-write-guard.sh — malformed input fails closed"
+
+result=$(printf '%s' '{"tool_input":' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "Malformed Write hook JSON fails closed"
+assert_contains "$result" "malformed PreToolUse(Write)" "Malformed Write hook input explains validation failure"
+
 header "pre-write-guard.sh — search first and then write"
 # =========================================================
 

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -6,8 +6,7 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
-if [[ -f "vibeguard-runtime/Cargo.toml" ]] \
-    && [[ ! -x "vibeguard-runtime/target/release/vibeguard-runtime" ]]; then
+if [[ -f "vibeguard-runtime/Cargo.toml" ]]; then
   if ! command -v cargo >/dev/null 2>&1; then
     echo "tests/test_hooks.sh requires cargo to build vibeguard-runtime" >&2
     exit 2

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -156,6 +156,29 @@ bad_hooks_manifest_out="$(python3 "${MANIFEST_HELPER}" validate --hooks-manifest
 assert_contains "${bad_hooks_manifest_out}" "hook install target drift for hooks-pre" "manifest validation detects hook install target drift"
 assert_not_contains "${bad_hooks_manifest_out}" "Traceback" "hook install target drift reports without traceback"
 
+BAD_RULE_PATHS_MANIFEST="${TMP_DIR}/bad-rule-paths-install-modules.json"
+python3 - "${REPO_DIR}/schemas/install-modules.json" "${BAD_RULE_PATHS_MANIFEST}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+for module in data["modules"]:
+    if module.get("id") == "rules-common":
+        module["paths"] = [
+            path for path in module["paths"]
+            if path != "rules/claude-rules/common/agent-harness-audit.md"
+        ]
+        break
+target.write_text(json.dumps(data), encoding="utf-8")
+PY
+bad_rule_paths_validate_out="$(python3 "${MANIFEST_HELPER}" validate --manifest-file "${BAD_RULE_PATHS_MANIFEST}" 2>&1 || true)"
+assert_contains "${bad_rule_paths_validate_out}" "rule install path drift" "manifest validation detects missing canonical rule paths"
+assert_contains "${bad_rule_paths_validate_out}" "rules/claude-rules/common/agent-harness-audit.md" "manifest rule drift reports the missing rule path"
+assert_not_contains "${bad_rule_paths_validate_out}" "Traceback" "manifest rule drift reports without traceback"
+
 ESCAPING_SKILL_PATH_MANIFEST="${TMP_DIR}/escaping-skill-path-install-modules.json"
 cat > "${ESCAPING_SKILL_PATH_MANIFEST}" <<'JSON'
 {

--- a/tests/test_no_personal_paths.sh
+++ b/tests/test_no_personal_paths.sh
@@ -61,6 +61,11 @@ chmod +x "${FAKE_REPO}/scripts/ci/validate-no-personal-paths.sh"
 printf 'gitdir: /Users/alice/project/.git/worktrees/repo\n' > "${FAKE_REPO}/.git"
 assert_cmd "linked-worktree .git file is ignored" bash "${FAKE_REPO}/scripts/ci/validate-no-personal-paths.sh"
 
+header "local agent state"
+mkdir -p "${FAKE_REPO}/.omx/state"
+printf '{"path": "/Users/alice/project/cache"}\n' > "${FAKE_REPO}/.omx/state/local.json"
+assert_cmd "ignored local .omx state is not scanned" bash "${FAKE_REPO}/scripts/ci/validate-no-personal-paths.sh"
+
 header "real source leak"
 printf 'command: /Users/alice/project/run.sh\n' > "${FAKE_REPO}/leak.txt"
 assert_fails_with "ordinary file with personal path still fails" "leak.txt" \

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -28,7 +28,7 @@ pub fn pre_write_check(args: &[String]) -> Result {
         .unwrap_or(800);
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
-        println!("PASS");
+        println!("MALFORMED");
         return Ok(());
     };
 


### PR DESCRIPTION
## Summary

Refs #266.

This PR addresses the first focused P1 slice from the VibeGuard audit:

- fail-close malformed `PreToolUse(Write)` input instead of silently passing
- make hook tests rebuild the Rust release runtime instead of reusing a stale binary
- make precision threshold validation self-contained by building the release runtime first
- add explicit `cargo check` and `cargo test` for `vibeguard-runtime` in CI
- make `schemas/install-modules.json` include all canonical native rule files
- add manifest validation that fails when canonical rule files drift from install modules
- ignore local `.omx` agent state in personal-path validation while keeping real source leaks blocked

## Validation

- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `python3 -m json.tool schemas/install-modules.json >/dev/null`
- `python3 scripts/lib/vibeguard_manifest.py validate`
- `bash tests/hooks/test_pre_write_guard.sh`
- `bash tests/test_manifest_contract.sh`
- `bash tests/test_no_personal_paths.sh`
- `bash scripts/ci/validate-precision-thresholds.sh`
- `bash scripts/ci/validate-no-personal-paths.sh`
- `bash scripts/ci/validate-manifest-contract.sh`
- `bash scripts/local-contract-check.sh --quick`
- `bash scripts/ci/validate-generated-rule-docs.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-hooks.sh`
- `bash tests/test_hooks.sh`
