### PR TITLE
P1: align L1 enforcement docs with warn default

### DIFF
--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -10,7 +10,7 @@ Canonical source of truth: `rules/claude-rules/`
 
 | Layer | Enforcement | Mechanism |
 |-------|------------|-----------|
-| L1 | Search before create | `pre-write-guard.sh` hook (block) |
+| L1 | Search before create | `pre-write-guard.sh` hook (warn by default; block via `VIBEGUARD_WRITE_MODE=block` / `write_mode=block` or escalation) |
 | L2 | Naming conventions | `check_naming_convention.py` guard |
 | L3 | Quality baseline | `post-edit-guard.sh` hook (warn/escalate) |
 | L4 | Data integrity | Rules injection + guards |

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -7,3 +7,9 @@ REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 
 cd "$REPO_DIR"
 python3 scripts/generate_rule_docs.py --check
+
+expected_l1='| L1 | Search before create | `pre-write-guard.sh` hook (warn by default; block via `VIBEGUARD_WRITE_MODE=block` / `write_mode=block` or escalation) |'
+if ! grep -Fq "${expected_l1}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must describe L1 as warn-by-default with explicit block modes" >&2
+  exit 1
+fi

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -381,7 +381,7 @@ Canonical source of truth: `rules/claude-rules/`
 
 | Layer | Enforcement | Mechanism |
 |-------|------------|-----------|
-| L1 | Search before create | `pre-write-guard.sh` hook (block) |
+| L1 | Search before create | `pre-write-guard.sh` hook (warn by default; block via `VIBEGUARD_WRITE_MODE=block` / `write_mode=block` or escalation) |
 | L2 | Naming conventions | `check_naming_convention.py` guard |
 | L3 | Quality baseline | `post-edit-guard.sh` hook (warn/escalate) |
 | L4 | Data integrity | Rules injection + guards |


### PR DESCRIPTION
Closes #270
Refs #266

## Summary
- update generated rule reference to describe L1 as warn-by-default with explicit block modes and escalation
- update the rule docs generator so regenerated output keeps the same semantics
- add validation that rejects future generated docs claiming unconditional L1 block behavior

## Validation
- bash -n scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/verify/doc-freshness-check.sh --strict
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- git diff --check
