### PR TITLE
Add Codex hook status diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
         shell: bash
         run: bash tests/test_hook_health.sh
 
+      - name: Hook status regression tests
+        shell: bash
+        run: bash tests/test_hook_status.sh
+
       - name: Stats regression tests
         if: runner.os != 'Windows'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ that already require `codex app-server`.
 
 Codex hook command names are namespaced as `vibeguard-*.sh` to avoid collisions with other toolchains sharing `~/.codex/hooks.json`. Output format differences are handled by the `run-hook-codex.sh` wrapper (Claude Code `decision:block` -> Codex deny payloads). Codex sends `apply_patch` as a patch command, so the wrapper normalizes that payload into Edit/Write-shaped inputs before calling the existing VibeGuard file hooks. For `Update File` patches, the wrapper also passes the line delta so `pre-edit-guard.sh` can enforce U-16 before Codex mutates the file. When a hook suggests `updatedInput`, the Codex CLI wrapper cannot apply it automatically, so VibeGuard emits an explicit note with the suggested replacement command instead of silently dropping it.
 
+Hook status is a separate human diagnostics surface. Use `vibeguard-runtime hook-status --mode focused --log-file ~/.vibeguard/events.jsonl` to inspect recent `pass`, `skipped`, `slow`, `timeout`, and adapter-error states without adding successful hook summaries to the model context. Only actionable `warn` / `block` results should continue through `hookSpecificOutput.additionalContext`. See `docs/reference/codex-hook-status.md`.
+
 **MCP server status:** the legacy `mcp-server/` prototype is not installed by `setup.sh` and is not part of the supported runtime surface. Supported integrations are the Claude Code hooks, native Codex hooks, and the optional app-server wrapper below; any future MCP reintroduction must go through an explicit install path and hash/audit baseline.
 
 **Optional app-server wrapper** (advanced orchestrators only):

--- a/docs/reference/codex-hook-status.md
+++ b/docs/reference/codex-hook-status.md
@@ -1,0 +1,27 @@
+# Codex Hook Status
+
+VibeGuard keeps hook status separate from model-facing hook feedback.
+
+Use:
+
+```bash
+~/.vibeguard/installed/bin/vibeguard-runtime hook-status --mode focused --log-file ~/.vibeguard/events.jsonl
+```
+
+The command reads VibeGuard hook JSONL plus optional Codex wrapper diagnostics and reports recent hook results:
+
+- `pass` and `skipped`: visible to the human status surface only.
+- `slow`, `running`, `timeout`, and `adapter_error`: visible diagnostics for the user or UI integrations.
+- `warn`, `block`, `gate`, `escalate`, and `correction`: actionable model feedback; these are the states that should use `hookSpecificOutput.additionalContext`.
+
+`pass` / `skipped` summaries must not be emitted into `additionalContext` by default. They are useful for clearing stale UI states such as "Running 2 PostToolUse hooks", but they do not require model action and would add avoidable context noise.
+
+JSON mode is intended for UI polling:
+
+```bash
+~/.vibeguard/installed/bin/vibeguard-runtime hook-status --json --mode full --log-file ~/.vibeguard/events.jsonl
+```
+
+The JSON payload follows `schemas/hook-status.schema.json`. Each entry includes the hook name, event, matcher, normalized status, reason, duration, model-context flag, and log path.
+
+`setup.sh --check` also inspects `~/.codex/hooks.json` for non-Stop hook entries without `timeout`. VibeGuard-managed timeout drift is reported as broken install state. External hooks without timeout, such as an Orca bridge entry, are reported as warnings with the owning command so the user can add a timeout or consult that hook owner.

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -242,3 +242,49 @@ except OSError:
     pass
 PY
 }
+
+codex_hook_status_from_output() {
+  local hook_name="$1" event_name="$2" matcher="$3" hook_output="$4" detail="${5:-}" timeout_ms="${6:-}"
+  local parsed hook_status hook_reason
+  parsed=$(CODEX_HOOK_OUTPUT="${hook_output}" python3 - <<'PY' 2>/dev/null || true
+import json
+import os
+
+try:
+    data = json.loads(os.environ.get("CODEX_HOOK_OUTPUT", ""))
+except Exception:
+    print("hook_error\tinvalid-json")
+    raise SystemExit
+
+decision = data.get("decision", "pass")
+reason = data.get("reason", "")
+hook_specific = data.get("hookSpecificOutput")
+if not isinstance(reason, str):
+    reason = ""
+if not isinstance(decision, str):
+    decision = "pass"
+
+status = "pass"
+if decision in {"warn", "block", "gate", "escalate", "correction"}:
+    status = decision
+elif decision == "skip":
+    status = "skipped"
+elif isinstance(hook_specific, dict):
+    if hook_specific.get("permissionDecision") == "deny":
+        status = "block"
+    nested_decision = hook_specific.get("decision")
+    if isinstance(nested_decision, dict) and nested_decision.get("behavior") == "deny":
+        status = "block"
+
+reason = reason.replace("\t", " ").replace("\n", " ")[:300]
+print(f"{status}\t{reason}")
+PY
+)
+  hook_status="${parsed%%$'\t'*}"
+  hook_reason="${parsed#*$'\t'}"
+  if [[ "${hook_status}" == "${parsed}" ]]; then
+    hook_reason=""
+  fi
+  [[ -n "${hook_status}" ]] || hook_status="hook_error"
+  codex_hook_status "${hook_name}" "${event_name}" "${matcher}" "${hook_status}" "${hook_reason}" "${detail}" "${timeout_ms}"
+}

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -123,8 +123,9 @@ import os
 from pathlib import Path
 
 path = Path(os.environ["VIBEGUARD_DIAG_FILE"])
+ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 entry = {
-    "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "ts": ts,
     "cli": "codex",
     "hook": os.environ.get("VIBEGUARD_DIAG_HOOK", ""),
     "event": os.environ.get("VIBEGUARD_DIAG_EVENT", ""),
@@ -132,6 +133,107 @@ entry = {
     "detail": os.environ.get("VIBEGUARD_DIAG_DETAIL", "")[:300],
     "cwd": os.environ.get("VIBEGUARD_DIAG_CWD", ""),
 }
+with path.open("a", encoding="utf-8") as f:
+    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+try:
+    path.chmod(0o600)
+except OSError:
+    pass
+PY
+}
+
+codex_hook_timeout_ms() {
+  local hook_name="$1"
+  case "${hook_name}" in
+    *post-build-check*) printf '%s\n' "30000" ;;
+    *pre-*|*post-edit*|*post-write*) printf '%s\n' "10000" ;;
+    *) printf '%s\n' "" ;;
+  esac
+}
+
+codex_hook_status_detail() {
+  local input="$1"
+  CODEX_INPUT="${input}" python3 - <<'PY'
+import json
+import os
+
+try:
+    payload = json.loads(os.environ.get("CODEX_INPUT", ""))
+except Exception:
+    print("")
+    raise SystemExit
+
+tool_input = payload.get("tool_input")
+if not isinstance(tool_input, dict):
+    print("")
+    raise SystemExit
+
+for key in ("file_path", "command"):
+    value = tool_input.get(key)
+    if isinstance(value, str) and value:
+        print(value[:300])
+        raise SystemExit
+print("")
+PY
+}
+
+codex_hook_status_matcher() {
+  local input="$1"
+  CODEX_INPUT="${input}" python3 - <<'PY'
+import json
+import os
+
+try:
+    payload = json.loads(os.environ.get("CODEX_INPUT", ""))
+except Exception:
+    print("")
+    raise SystemExit
+
+tool_name = payload.get("tool_name")
+print(tool_name if isinstance(tool_name, str) else "")
+PY
+}
+
+codex_hook_status() {
+  local hook_name="$1" event_name="$2" matcher="$3" status="$4" reason="${5:-}" detail="${6:-}"
+  local timeout_ms="${7:-}"
+  local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
+  mkdir -p "$(dirname "${diag_file}")" 2>/dev/null || return 0
+  VIBEGUARD_DIAG_FILE="${diag_file}" \
+  VIBEGUARD_DIAG_HOOK="${hook_name}" \
+  VIBEGUARD_DIAG_EVENT="${event_name}" \
+  VIBEGUARD_DIAG_MATCHER="${matcher}" \
+  VIBEGUARD_DIAG_STATUS="${status}" \
+  VIBEGUARD_DIAG_REASON="${reason}" \
+  VIBEGUARD_DIAG_DETAIL="${detail}" \
+  VIBEGUARD_DIAG_TIMEOUT_MS="${timeout_ms}" \
+    python3 - <<'PY' 2>/dev/null || true
+import datetime
+import json
+import os
+from pathlib import Path
+
+def clean_hook(name: str) -> str:
+    if name.startswith("vibeguard-"):
+        name = name[len("vibeguard-"):]
+    if name.endswith(".sh"):
+        name = name[:-3]
+    return name
+
+path = Path(os.environ["VIBEGUARD_DIAG_FILE"])
+entry = {
+    "ts": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "cli": "codex",
+    "hook": clean_hook(os.environ.get("VIBEGUARD_DIAG_HOOK", "")),
+    "event": os.environ.get("VIBEGUARD_DIAG_EVENT", ""),
+    "matcher": os.environ.get("VIBEGUARD_DIAG_MATCHER", ""),
+    "status": os.environ.get("VIBEGUARD_DIAG_STATUS", ""),
+    "reason": os.environ.get("VIBEGUARD_DIAG_REASON", ""),
+    "detail": os.environ.get("VIBEGUARD_DIAG_DETAIL", "")[:300],
+}
+timeout_ms = os.environ.get("VIBEGUARD_DIAG_TIMEOUT_MS", "")
+if timeout_ms.isdigit():
+    entry["timeout_ms"] = int(timeout_ms)
 with path.open("a", encoding="utf-8") as f:
     f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 try:

--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -25,13 +25,19 @@ codex_run_hook() {
   while IFS= read -r normalized_input || [[ -n "${normalized_input:-}" ]]; do
     [[ -n "${normalized_input}" ]] || continue
 
+    hook_err_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-hook.XXXXXX")"
+    event_name=$(codex_event_name "${normalized_input}")
+    local hook_matcher hook_detail hook_timeout_ms
+    hook_matcher="$(codex_hook_status_matcher "${normalized_input}" 2>/dev/null || true)"
+    hook_detail="$(codex_hook_status_detail "${normalized_input}" 2>/dev/null || true)"
+    hook_timeout_ms="$(codex_hook_timeout_ms "${hook_name}" 2>/dev/null || true)"
+    codex_hook_status "${hook_name}" "${event_name}" "${hook_matcher}" "running" "" "${hook_detail}" "${hook_timeout_ms}"
+
     hook_output=""
     hook_exit=0
-    hook_err_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-hook.XXXXXX")"
     hook_output=$(printf '%s' "${normalized_input}" | bash "${hook_path}" "$@" 2>"${hook_err_file}") || hook_exit=$?
     hook_err="$(cat "${hook_err_file}" 2>/dev/null || true)"
     rm -f "${hook_err_file}" 2>/dev/null || true
-    event_name=$(codex_event_name "${normalized_input}")
 
     if [[ ${hook_exit} -ne 0 ]]; then
       codex_diag "${hook_name}" "${event_name}" "wrapped-hook-nonzero" "${hook_err:-${hook_output}}"
@@ -40,7 +46,10 @@ codex_run_hook() {
       return 0
     fi
 
-    [[ -n "${hook_output}" ]] || continue
+    if [[ -z "${hook_output}" ]]; then
+      codex_hook_status "${hook_name}" "${event_name}" "${hook_matcher}" "pass" "" "${hook_detail}" "${hook_timeout_ms}"
+      continue
+    fi
     if [[ "${VIBEGUARD_POLICY_ENFORCEMENT:-}" == "warn" ]] && declare -F vg_policy_downgrade_output >/dev/null 2>&1; then
       hook_output="$(vg_policy_downgrade_output "${hook_output}")"
     fi

--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -53,6 +53,7 @@ codex_run_hook() {
     if [[ "${VIBEGUARD_POLICY_ENFORCEMENT:-}" == "warn" ]] && declare -F vg_policy_downgrade_output >/dev/null 2>&1; then
       hook_output="$(vg_policy_downgrade_output "${hook_output}")"
     fi
+    codex_hook_status_from_output "${hook_name}" "${event_name}" "${hook_matcher}" "${hook_output}" "${hook_detail}" "${hook_timeout_ms}"
 
     if [[ "${event_name}" == "PreToolUse" ]]; then
       pretool_status=0

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -44,6 +44,10 @@ else
   codex_hook_status_detail() { printf '%s\n' ""; }
   codex_hook_status_matcher() { printf '%s\n' ""; }
   codex_hook_status() { return 0; }
+  codex_hook_status_from_output() { return 0; }
+fi
+if ! declare -F codex_hook_status_from_output >/dev/null 2>&1; then
+  codex_hook_status_from_output() { return 0; }
 fi
 
 INPUT=$(cat)

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -40,6 +40,10 @@ else
   }
   codex_set_caller_identity() { export VIBEGUARD_CLIENT="${VIBEGUARD_CLIENT:-unknown}" VIBEGUARD_CLIENT_VARIANT="${VIBEGUARD_CLIENT_VARIANT:-unknown}" VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-missing-codex-diag-helper}"; }
   codex_diag() { return 0; }
+  codex_hook_timeout_ms() { printf '%s\n' ""; }
+  codex_hook_status_detail() { printf '%s\n' ""; }
+  codex_hook_status_matcher() { printf '%s\n' ""; }
+  codex_hook_status() { return 0; }
 fi
 
 INPUT=$(cat)

--- a/schemas/hook-status.schema.json
+++ b/schemas/hook-status.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.dev/schemas/hook-status.schema.json",
+  "title": "VibeGuard Hook Status",
+  "type": "object",
+  "required": ["schema_version", "mode", "summary", "entries"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": 1 },
+    "mode": { "enum": ["minimal", "focused", "full"] },
+    "summary": {
+      "type": "object",
+      "required": ["event", "total", "complete", "running", "attention", "model_context_entries"],
+      "additionalProperties": false,
+      "properties": {
+        "event": { "type": "string" },
+        "total": { "type": "integer", "minimum": 0 },
+        "complete": { "type": "integer", "minimum": 0 },
+        "running": { "type": "integer", "minimum": 0 },
+        "attention": { "type": "integer", "minimum": 0 },
+        "model_context_entries": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "ts",
+          "session",
+          "source",
+          "hook",
+          "event",
+          "matcher",
+          "status",
+          "decision",
+          "reason",
+          "detail",
+          "duration_ms",
+          "elapsed_ms",
+          "timeout_ms",
+          "model_context",
+          "log_path"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "ts": { "type": "string" },
+          "session": { "type": "string" },
+          "source": { "enum": ["event_log", "codex_diag"] },
+          "hook": { "type": "string" },
+          "event": { "type": "string" },
+          "matcher": { "type": "string" },
+          "status": {
+            "enum": [
+              "pass",
+              "skipped",
+              "warn",
+              "block",
+              "gate",
+              "escalate",
+              "correction",
+              "complete",
+              "slow",
+              "timeout",
+              "running",
+              "adapter_error",
+              "hook_error",
+              "unknown"
+            ]
+          },
+          "decision": { "type": "string" },
+          "reason": { "type": "string" },
+          "detail": { "type": "string" },
+          "duration_ms": { "type": ["integer", "null"], "minimum": 0 },
+          "elapsed_ms": { "type": ["integer", "null"], "minimum": 0 },
+          "timeout_ms": { "type": ["integer", "null"], "minimum": 0 },
+          "model_context": { "type": "boolean" },
+          "log_path": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -184,12 +184,12 @@ def _prune_vibeguard_entries(data: dict[str, Any]) -> bool:
     return changed
 
 
-def _iter_hook_commands(data: dict[str, Any]) -> list[tuple[str, str, str]]:
+def _iter_hook_records(data: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
         return []
 
-    commands: list[tuple[str, str, str]] = []
+    records: list[tuple[str, str, dict[str, Any]]] = []
     for event, entries in hooks.items():
         if not isinstance(entries, list):
             continue
@@ -204,9 +204,16 @@ def _iter_hook_commands(data: dict[str, Any]) -> list[tuple[str, str, str]]:
             for hook in hook_entries:
                 if not isinstance(hook, dict):
                     continue
-                command = hook.get("command")
-                if isinstance(command, str) and command:
-                    commands.append((str(event), matcher_text, command))
+                records.append((str(event), matcher_text, hook))
+    return records
+
+
+def _iter_hook_commands(data: dict[str, Any]) -> list[tuple[str, str, str]]:
+    commands: list[tuple[str, str, str]] = []
+    for event, matcher, hook in _iter_hook_records(data):
+        command = hook.get("command")
+        if isinstance(command, str) and command:
+            commands.append((event, matcher, command))
     return commands
 
 
@@ -225,6 +232,38 @@ def stale_hook_findings(path: Path, home: Path) -> list[dict[str, str]]:
                 "matcher": matcher,
                 "command_path": str(hook_target),
                 "repair": "bash setup.sh --yes",
+            }
+        )
+    return findings
+
+
+def timeout_findings(path: Path, home: Path) -> list[dict[str, str]]:
+    data = load_hooks(path)
+    findings: list[dict[str, str]] = []
+    for event, matcher_text, hook in _iter_hook_records(data):
+        # VibeGuard's managed Stop entries intentionally have no timeout because
+        # Codex's Stop output surface is non-blocking and historically rejected
+        # spurious Stop timeouts in check-vibeguard.
+        if event == "Stop":
+            continue
+        command = hook.get("command")
+        if not isinstance(command, str) or not command:
+            continue
+        if isinstance(hook.get("timeout"), int) and hook["timeout"] > 0:
+            continue
+        matcher = None if matcher_text == "<none>" else matcher_text
+        identity = _identity_for_hook(event, matcher, hook)
+        managed_state = "managed" if identity.is_managed else "unmanaged"
+        repair = "bash setup.sh --yes" if identity.is_managed else "add timeout or consult hook owner"
+        findings.append(
+            {
+                "client": "Codex",
+                "config": _display_path(path, home),
+                "event": event,
+                "matcher": matcher_text,
+                "command": command,
+                "managed": managed_state,
+                "repair": repair,
             }
         )
     return findings
@@ -411,6 +450,19 @@ def cmd_check_stale_hooks(args: argparse.Namespace) -> int:
     return 1 if findings else 0
 
 
+def cmd_check_timeouts(args: argparse.Namespace) -> int:
+    hooks_path = Path(args.hooks_file)
+    if not hooks_path.exists():
+        return 0
+    findings = timeout_findings(hooks_path, Path.home())
+    for finding in findings:
+        print(
+            "{managed} {client} hook without timeout: config={config} event={event} "
+            "matcher={matcher} command={command} repair={repair}".format(**finding)
+        )
+    return 1 if findings else 0
+
+
 def cmd_check_vibeguard(args: argparse.Namespace) -> int:
     hooks_path = Path(args.hooks_file)
     data = load_hooks(hooks_path)
@@ -453,6 +505,10 @@ def build_parser() -> argparse.ArgumentParser:
     stale = sub.add_parser("check-stale-hooks", help="Detect stale hook commands")
     stale.add_argument("--hooks-file", required=True)
     stale.set_defaults(func=cmd_check_stale_hooks)
+
+    timeouts = sub.add_parser("check-timeouts", help="Detect hook entries without timeout")
+    timeouts.add_argument("--hooks-file", required=True)
+    timeouts.set_defaults(func=cmd_check_timeouts)
 
     return parser
 

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -243,16 +243,17 @@ def timeout_findings(path: Path, home: Path) -> list[dict[str, str]]:
     for event, matcher_text, hook in _iter_hook_records(data):
         # VibeGuard's managed Stop entries intentionally have no timeout because
         # Codex's Stop output surface is non-blocking and historically rejected
-        # spurious Stop timeouts in check-vibeguard.
-        if event == "Stop":
+        # spurious Stop timeouts in check-vibeguard. External Stop hooks are
+        # still reported so their owner can make an explicit timeout decision.
+        matcher = None if matcher_text == "<none>" else matcher_text
+        identity = _identity_for_hook(event, matcher, hook)
+        if event == "Stop" and identity.is_managed:
             continue
         command = hook.get("command")
         if not isinstance(command, str) or not command:
             continue
         if isinstance(hook.get("timeout"), int) and hook["timeout"] > 0:
             continue
-        matcher = None if matcher_text == "<none>" else matcher_text
-        identity = _identity_for_hook(event, matcher, hook)
         managed_state = "managed" if identity.is_managed else "unmanaged"
         repair = "bash setup.sh --yes" if identity.is_managed else "add timeout or consult hook owner"
         findings.append(

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -179,6 +179,20 @@ print(total)
         [[ -n "${line}" ]] && red "[BROKEN] ${line}"
       done <<< "${stale_hooks_report}"
     fi
+
+    local timeout_hooks_report
+    if timeout_hooks_report="$(python3 "${CODEX_HOOKS_HELPER}" check-timeouts --hooks-file "${CODEX_DIR}/hooks.json" 2>&1)"; then
+      :
+    else
+      while IFS= read -r line; do
+        [[ -n "${line}" ]] || continue
+        if [[ "${line}" == managed* ]]; then
+          red "[BROKEN] ${line}"
+        else
+          yellow "[WARN] ${line}"
+        fi
+      done <<< "${timeout_hooks_report}"
+    fi
   else
     yellow "[MISSING] Codex hooks.json not installed"
   fi

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -283,6 +283,7 @@ assert_codex_pretool_output_contract "${pretool_context_out}" "pretool additiona
 header "run-hook-codex keeps pass-with-no-output silent"
 TMP_HOME_PASSING="${TMP_DIR}/home-passing"
 TMP_FAKE_REPO_PASSING="${TMP_DIR}/fake-repo-passing"
+PASSING_DIAG_FILE="${TMP_DIR}/passing-codex-wrapper.jsonl"
 mkdir -p "${TMP_HOME_PASSING}/.vibeguard" "${TMP_FAKE_REPO_PASSING}/hooks"
 printf '%s' "${TMP_FAKE_REPO_PASSING}" > "${TMP_HOME_PASSING}/.vibeguard/repo-path"
 
@@ -295,7 +296,7 @@ chmod +x "${TMP_FAKE_REPO_PASSING}/hooks/vibeguard-pre-bash-guard.sh"
 
 passing_out="$({
   printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo ok"}}' \
-    | HOME="${TMP_HOME_PASSING}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+    | HOME="${TMP_HOME_PASSING}" VIBEGUARD_CODEX_DIAG_FILE="${PASSING_DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
 } 2>/dev/null)"
 TOTAL=$((TOTAL + 1))
 if [[ -z "${passing_out}" ]]; then
@@ -305,6 +306,8 @@ else
   red "run-hook-codex keeps empty pass responses silent"
   FAIL=$((FAIL + 1))
 fi
+assert_contains "$(cat "${PASSING_DIAG_FILE}")" '"status": "running"' "run-hook-codex writes running status for pass hooks"
+assert_contains "$(cat "${PASSING_DIAG_FILE}")" '"status": "pass"' "run-hook-codex writes pass status without stdout noise"
 
 header "run-hook-codex denies wrapped hook failures instead of passing silently"
 TMP_HOME_FAILING="${TMP_DIR}/home-failing"

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -473,6 +473,7 @@ assert_codex_posttool_output_contract "${missing_posttool_adapter_out}" "missing
 header "run-hook-codex adapts posttool block output"
 TMP_HOME_POSTTOOL="${TMP_DIR}/home-posttool"
 TMP_FAKE_REPO_POSTTOOL="${TMP_DIR}/fake-repo-posttool"
+POSTTOOL_DIAG_FILE="${TMP_DIR}/posttool-codex-wrapper.jsonl"
 mkdir -p "${TMP_HOME_POSTTOOL}/.vibeguard" "${TMP_FAKE_REPO_POSTTOOL}/hooks"
 printf '%s' "${TMP_FAKE_REPO_POSTTOOL}" > "${TMP_HOME_POSTTOOL}/.vibeguard/repo-path"
 
@@ -485,11 +486,13 @@ chmod +x "${TMP_FAKE_REPO_POSTTOOL}/hooks/vibeguard-post-build-check.sh"
 
 posttool_out="$(
   printf '{"hook_event_name":"PostToolUse","tool_input":{"file_path":"src/main.rs"}}' \
-    | HOME="${TMP_HOME_POSTTOOL}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-post-build-check.sh
+    | HOME="${TMP_HOME_POSTTOOL}" VIBEGUARD_CODEX_DIAG_FILE="${POSTTOOL_DIAG_FILE}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-post-build-check.sh
 )"
 assert_contains "${posttool_out}" '"decision": "block"' "run-hook-codex preserves posttool block decisions"
 assert_contains "${posttool_out}" '"additionalContext": "build failed"' "run-hook-codex maps posttool reason to additionalContext"
 assert_codex_posttool_output_contract "${posttool_out}" "posttool block matches Codex PostToolUse output contract"
+assert_contains "$(cat "${POSTTOOL_DIAG_FILE}")" '"status": "running"' "run-hook-codex writes running status before posttool output"
+assert_contains "$(cat "${POSTTOOL_DIAG_FILE}")" '"status": "block"' "run-hook-codex writes final status for posttool output"
 
 header "run-hook-codex passes native Codex hook output through"
 TMP_HOME_NATIVE="${TMP_DIR}/home-native"

--- a/tests/test_hook_status.sh
+++ b/tests/test_hook_status.sh
@@ -98,6 +98,15 @@ JSONL
 mixed_out="$("${RUNTIME}" hook-status --mode minimal --log-file "${TMP_DIR}/mixed-events.jsonl" --slow-ms 2000 2>&1)"
 assert_contains "$mixed_out" "PostToolUse checks  1/1 complete - 28ms" "minimal: summary counts only the displayed event"
 
+cat > "${TMP_DIR}/same-second-events.jsonl" <<'JSONL'
+{"ts":"2026-05-31T00:00:00Z","session":"s1","hook":"post-build-check","tool":"PostToolUse","decision":"warn","reason":"build warning","detail":"Edit src/foo.ts","duration_ms":44}
+JSONL
+cat > "${TMP_DIR}/same-second-diag.jsonl" <<'JSONL'
+{"ts":"2026-05-31T00:00:00Z","cli":"codex","hook":"post-build-check","event":"PostToolUse","matcher":"Bash","status":"running","detail":"Edit src/foo.ts","timeout_ms":30000}
+JSONL
+same_second_out="$("${RUNTIME}" hook-status --mode focused --log-file "${TMP_DIR}/same-second-events.jsonl" --diag-file "${TMP_DIR}/same-second-diag.jsonl" --slow-ms 2000 2>&1)"
+assert_not_contains "$same_second_out" "[running] post-build-check" "focused: same-second completion drops stale running status"
+
 header "json output"
 "${RUNTIME}" hook-status --json --mode full --log-file "${HOOK_LOG}" --diag-file "${DIAG_LOG}" --slow-ms 2000 > "${JSON_OUT}"
 assert_cmd "json: output parses" python3 -c "import json; json.load(open('${JSON_OUT}'))"

--- a/tests/test_hook_status.sh
+++ b/tests/test_hook_status.sh
@@ -69,6 +69,7 @@ cat > "${HOOK_LOG}" <<'JSONL'
 JSONL
 
 cat > "${DIAG_LOG}" <<'JSONL'
+{"ts":"2026-05-31T00:00:00Z","cli":"codex","hook":"post-build-check","event":"PostToolUse","matcher":"Bash","status":"running","detail":"Edit src/foo.ts","timeout_ms":30000}
 {"ts":"2026-05-31T00:00:07Z","cli":"codex","hook":"vibeguard-post-build-check.sh","event":"PostToolUse","reason":"posttool-adapter-failed","detail":"invalid json"}
 JSONL
 
@@ -84,10 +85,18 @@ assert_contains "$focused_out" "Last action: Edit src/foo.ts" "focused: timeout 
 assert_contains "$focused_out" "Log: ${HOOK_LOG}" "focused: timeout includes log path"
 assert_contains "$focused_out" "[skip] post-build-check PostToolUse(<none>) skipped - missing file_path - 28ms" "focused: skip result is visible"
 assert_contains "$focused_out" "[error] vibeguard-post-build-check.sh PostToolUse(<none>) adapter_error - posttool-adapter-failed" "focused: adapter error is visible"
+assert_not_contains "$focused_out" "[running] post-build-check" "focused: completed hooks drop stale running status"
 assert_not_contains "$focused_out" "additionalContext" "focused: pass/skip summaries do not inject model context"
 
 running_out="$("${RUNTIME}" hook-status --mode minimal --log-file "${RUNNING_LOG}" --slow-ms 2000 2>&1)"
 assert_contains "$running_out" "PostToolUse checks  1/2 running - 12s / 30s" "minimal: running state shows elapsed and timeout"
+
+cat > "${TMP_DIR}/mixed-events.jsonl" <<'JSONL'
+{"ts":"2026-05-31T00:00:01Z","session":"s1","hook":"pre-bash-guard","tool":"Bash","decision":"pass","reason":"","detail":"git status","duration_ms":18}
+{"ts":"2026-05-31T00:00:02Z","session":"s1","hook":"post-build-check","tool":"PostToolUse","decision":"pass","reason":"skip: missing file_path","detail":"","duration_ms":28}
+JSONL
+mixed_out="$("${RUNTIME}" hook-status --mode minimal --log-file "${TMP_DIR}/mixed-events.jsonl" --slow-ms 2000 2>&1)"
+assert_contains "$mixed_out" "PostToolUse checks  1/1 complete - 28ms" "minimal: summary counts only the displayed event"
 
 header "json output"
 "${RUNTIME}" hook-status --json --mode full --log-file "${HOOK_LOG}" --diag-file "${DIAG_LOG}" --slow-ms 2000 > "${JSON_OUT}"

--- a/tests/test_hook_status.sh
+++ b/tests/test_hook_status.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Regression tests for the hook-status runtime command and schema.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RUNTIME="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$output" | grep -qF -- "$expected"; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" forbidden="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$output" | grep -qF -- "$forbidden"; then
+    red "$desc (must not contain: $forbidden)"; FAIL=$((FAIL + 1))
+  else
+    green "$desc"; PASS=$((PASS + 1))
+  fi
+}
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (cmd: $*)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+header "build"
+assert_cmd "vibeguard-runtime builds" cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet
+
+HOOK_LOG="${TMP_DIR}/events.jsonl"
+DIAG_LOG="${TMP_DIR}/codex-wrapper.jsonl"
+RUNNING_LOG="${TMP_DIR}/running.jsonl"
+JSON_OUT="${TMP_DIR}/hook-status.json"
+
+cat > "${HOOK_LOG}" <<'JSONL'
+{"ts":"2026-05-31T00:00:01Z","session":"s1","hook":"pre-bash-guard","tool":"Bash","decision":"pass","reason":"","detail":"git status","duration_ms":18}
+{"ts":"2026-05-31T00:00:02Z","session":"s1","hook":"post-build-check","tool":"PostToolUse","decision":"pass","reason":"skip: missing file_path","detail":"","duration_ms":28}
+{"ts":"2026-05-31T00:00:03Z","session":"s1","hook":"post-edit-guard","tool":"Edit","decision":"warn","reason":"unwrap detected","detail":"src/main.rs","duration_ms":44}
+{"ts":"2026-05-31T00:00:04Z","session":"s1","hook":"pre-write-guard","tool":"Write","decision":"block","reason":"new source file without search","detail":"src/new.rs","duration_ms":20}
+{"ts":"2026-05-31T00:00:05Z","session":"s1","hook":"post-write-guard","tool":"Write","decision":"pass","reason":"","detail":"src/lib.rs","duration_ms":2500}
+{"ts":"2026-05-31T00:00:06Z","session":"s1","hook":"post-build-check","tool":"PostToolUse","decision":"warn","reason":"post-build-check timeout after 30s while running: npx tsc --noEmit","detail":"Edit src/foo.ts","duration_ms":30000}
+JSONL
+
+cat > "${DIAG_LOG}" <<'JSONL'
+{"ts":"2026-05-31T00:00:07Z","cli":"codex","hook":"vibeguard-post-build-check.sh","event":"PostToolUse","reason":"posttool-adapter-failed","detail":"invalid json"}
+JSONL
+
+cat > "${RUNNING_LOG}" <<'JSONL'
+{"ts":"2026-05-31T00:00:01Z","session":"s1","hook":"vibeguard-post-build-check.sh","event":"PostToolUse","matcher":"Bash","status":"running","reason":"npx tsc --noEmit","detail":"Edit src/foo.ts","elapsed_ms":12000,"timeout_ms":30000}
+{"ts":"2026-05-31T00:00:02Z","session":"s1","hook":"orca-bridge","event":"PostToolUse","matcher":"Bash","decision":"pass","reason":"skip: ORCA env absent","detail":"Edit src/foo.ts","duration_ms":3}
+JSONL
+
+header "human output"
+focused_out="$("${RUNTIME}" hook-status --mode focused --log-file "${HOOK_LOG}" --diag-file "${DIAG_LOG}" --slow-ms 2000 2>&1)"
+assert_contains "$focused_out" "PostToolUse hook timed out - post-build-check - 30s" "focused: timeout headline is visible"
+assert_contains "$focused_out" "Last action: Edit src/foo.ts" "focused: timeout includes last action"
+assert_contains "$focused_out" "Log: ${HOOK_LOG}" "focused: timeout includes log path"
+assert_contains "$focused_out" "[skip] post-build-check PostToolUse(<none>) skipped - missing file_path - 28ms" "focused: skip result is visible"
+assert_contains "$focused_out" "[error] vibeguard-post-build-check.sh PostToolUse(<none>) adapter_error - posttool-adapter-failed" "focused: adapter error is visible"
+assert_not_contains "$focused_out" "additionalContext" "focused: pass/skip summaries do not inject model context"
+
+running_out="$("${RUNTIME}" hook-status --mode minimal --log-file "${RUNNING_LOG}" --slow-ms 2000 2>&1)"
+assert_contains "$running_out" "PostToolUse checks  1/2 running - 12s / 30s" "minimal: running state shows elapsed and timeout"
+
+header "json output"
+"${RUNTIME}" hook-status --json --mode full --log-file "${HOOK_LOG}" --diag-file "${DIAG_LOG}" --slow-ms 2000 > "${JSON_OUT}"
+assert_cmd "json: output parses" python3 -c "import json; json.load(open('${JSON_OUT}'))"
+assert_cmd "json: statuses and model context contract" python3 - <<'PY' "${JSON_OUT}"
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+statuses = {entry["status"] for entry in data["entries"]}
+required = {"pass", "skipped", "warn", "block", "slow", "timeout", "adapter_error"}
+missing = required - statuses
+if missing:
+    raise SystemExit(f"missing statuses: {sorted(missing)}")
+for entry in data["entries"]:
+    if entry["status"] in {"pass", "skipped", "slow", "timeout", "adapter_error"} and entry["model_context"]:
+        raise SystemExit(f"{entry['status']} must not set model_context")
+    if entry["status"] in {"warn", "block"} and not entry["model_context"]:
+        raise SystemExit(f"{entry['status']} must set model_context")
+PY
+assert_cmd "schema: status enum covers accepted result states" python3 - <<'PY' "${REPO_DIR}/schemas/hook-status.schema.json"
+import json
+import sys
+
+schema = json.load(open(sys.argv[1], encoding="utf-8"))
+status_enum = set(schema["properties"]["entries"]["items"]["properties"]["status"]["enum"])
+required = {"pass", "skipped", "warn", "block", "slow", "timeout", "adapter_error"}
+missing = required - status_enum
+if missing:
+    raise SystemExit(f"schema missing statuses: {sorted(missing)}")
+PY
+
+printf '\n'
+if [[ "$FAIL" -eq 0 ]]; then
+  printf '\033[32mAll %d/%d tests passed\033[0m\n' "$PASS" "$TOTAL"
+  exit 0
+else
+  printf '\033[31m%d/%d tests failed\033[0m\n' "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -16,6 +16,7 @@ CHECK_SCRIPT="${REPO_DIR}/scripts/setup/check.sh"
 SETUP_SCRIPT="${REPO_DIR}/setup.sh"
 AWK_PORTABILITY_FIXTURE=""
 STALE_HOOK_HOME=""
+TIMEOUT_HOOK_HOME=""
 
 cleanup() {
   if [[ -n "${AWK_PORTABILITY_FIXTURE}" ]]; then
@@ -23,6 +24,9 @@ cleanup() {
   fi
   if [[ -n "${STALE_HOOK_HOME}" ]]; then
     rm -rf "${STALE_HOOK_HOME}"
+  fi
+  if [[ -n "${TIMEOUT_HOOK_HOME}" ]]; then
+    rm -rf "${TIMEOUT_HOOK_HOME}"
   fi
 }
 trap cleanup EXIT
@@ -368,6 +372,38 @@ assert_cmd "stale hook repair: Claude installed hook path removed" bash -c "! gr
 assert_cmd "stale hook repair: Codex installed hook path removed" bash -c "! grep -q '.vibeguard/installed/hooks/session-tagger.sh' '${STALE_HOOK_HOME}/.codex/hooks.json'"
 assert_cmd "stale hook repair: Claude stale check passes" env HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/settings_json.py" check-stale-hooks --settings-file "${STALE_HOOK_HOME}/.claude/settings.json"
 assert_cmd "stale hook repair: Codex stale check passes" env HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" check-stale-hooks --hooks-file "${STALE_HOOK_HOME}/.codex/hooks.json"
+
+# --- Codex hook timeout diagnostics ---
+header "codex hook timeout diagnostics"
+TIMEOUT_HOOK_HOME="$(mktemp -d)"
+mkdir -p "${TIMEOUT_HOOK_HOME}/.codex" "${TIMEOUT_HOOK_HOME}/.vibeguard/installed/hooks"
+cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${TIMEOUT_HOOK_HOME}/.vibeguard/run-hook-codex.sh"
+cat > "${TIMEOUT_HOOK_HOME}/.codex/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /tmp/orca/codex-bridge.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+timeout_helper_out="$(HOME="${TIMEOUT_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" check-timeouts --hooks-file "${TIMEOUT_HOOK_HOME}/.codex/hooks.json" 2>&1 || true)"
+assert_contains "$timeout_helper_out" "unmanaged Codex hook without timeout" "timeout helper: reports unmanaged hook"
+assert_contains "$timeout_helper_out" "event=PostToolUse matcher=Bash" "timeout helper: reports event and matcher"
+assert_contains "$timeout_helper_out" "command=node /tmp/orca/codex-bridge.js" "timeout helper: reports Orca bridge command"
+assert_contains "$timeout_helper_out" "repair=add timeout or consult hook owner" "timeout helper: reports repair direction"
+
+timeout_check_out="$(HOME="${TIMEOUT_HOOK_HOME}" bash "${SETUP_SCRIPT}" --check 2>&1 || true)"
+assert_contains "$timeout_check_out" "[WARN] unmanaged Codex hook without timeout" "setup --check: surfaces unmanaged hook without timeout"
 
 # --- Backwards-compat exit code contract ---
 header "exit code contract"

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -391,6 +391,16 @@ cat > "${TIMEOUT_HOOK_HOME}/.codex/hooks.json" <<'JSON'
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /tmp/orca/stop-bridge.js"
+          }
+        ]
+      }
     ]
   }
 }
@@ -400,6 +410,8 @@ timeout_helper_out="$(HOME="${TIMEOUT_HOOK_HOME}" python3 "${REPO_DIR}/scripts/l
 assert_contains "$timeout_helper_out" "unmanaged Codex hook without timeout" "timeout helper: reports unmanaged hook"
 assert_contains "$timeout_helper_out" "event=PostToolUse matcher=Bash" "timeout helper: reports event and matcher"
 assert_contains "$timeout_helper_out" "command=node /tmp/orca/codex-bridge.js" "timeout helper: reports Orca bridge command"
+assert_contains "$timeout_helper_out" "event=Stop matcher=<none>" "timeout helper: reports unmanaged Stop hook"
+assert_contains "$timeout_helper_out" "command=node /tmp/orca/stop-bridge.js" "timeout helper: reports Stop bridge command"
 assert_contains "$timeout_helper_out" "repair=add timeout or consult hook owner" "timeout helper: reports repair direction"
 
 timeout_check_out="$(HOME="${TIMEOUT_HOOK_HOME}" bash "${SETUP_SCRIPT}" --check 2>&1 || true)"

--- a/vibeguard-runtime/src/event_schema.rs
+++ b/vibeguard-runtime/src/event_schema.rs
@@ -9,12 +9,20 @@ pub const SESSION_METRICS_SCHEMA_VERSION: u64 = 1;
 pub mod field {
     pub const TS: &str = "ts";
     pub const SESSION: &str = "session";
+    pub const EVENT: &str = "event";
     pub const HOOK: &str = "hook";
     pub const TOOL: &str = "tool";
+    pub const MATCHER: &str = "matcher";
     pub const DECISION: &str = "decision";
+    pub const STATUS: &str = "status";
     pub const REASON: &str = "reason";
     pub const DETAIL: &str = "detail";
     pub const DURATION_MS: &str = "duration_ms";
+    pub const ELAPSED_MS: &str = "elapsed_ms";
+    pub const TIMEOUT_MS: &str = "timeout_ms";
+    pub const LOG_PATH: &str = "log_path";
+    pub const MODEL_CONTEXT: &str = "model_context";
+    pub const SOURCE: &str = "source";
     pub const CLI: &str = "cli";
     pub const AGENT: &str = "agent";
     pub const CLIENT: &str = "client";
@@ -29,11 +37,30 @@ pub mod decision {
     pub const PASS: &str = "pass";
     pub const WARN: &str = "warn";
     pub const BLOCK: &str = "block";
+    pub const GATE: &str = "gate";
     pub const ESCALATE: &str = "escalate";
     pub const CORRECTION: &str = "correction";
+    pub const COMPLETE: &str = "complete";
 
     pub const NEGATIVE: [&str; 4] = [WARN, BLOCK, ESCALATE, CORRECTION];
     pub const RULE_REPEAT: [&str; 3] = [WARN, BLOCK, ESCALATE];
+}
+
+pub mod status {
+    pub const PASS: &str = super::decision::PASS;
+    pub const SKIPPED: &str = "skipped";
+    pub const WARN: &str = super::decision::WARN;
+    pub const BLOCK: &str = super::decision::BLOCK;
+    pub const GATE: &str = super::decision::GATE;
+    pub const ESCALATE: &str = super::decision::ESCALATE;
+    pub const CORRECTION: &str = super::decision::CORRECTION;
+    pub const COMPLETE: &str = super::decision::COMPLETE;
+    pub const SLOW: &str = "slow";
+    pub const TIMEOUT: &str = "timeout";
+    pub const RUNNING: &str = "running";
+    pub const ADAPTER_ERROR: &str = "adapter_error";
+    pub const HOOK_ERROR: &str = "hook_error";
+    pub const UNKNOWN: &str = super::UNKNOWN;
 }
 
 pub mod hook {

--- a/vibeguard-runtime/src/hook_status.rs
+++ b/vibeguard-runtime/src/hook_status.rs
@@ -10,6 +10,13 @@ use std::io::{self, BufRead, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
 use crate::event_schema::{UNKNOWN, decision, field, status, tool};
+use crate::time_utils::{now_unix_secs, parse_iso_ts};
+
+#[path = "hook_status_render.rs"]
+mod hook_status_render;
+#[cfg(test)]
+use hook_status_render::minimal_line;
+use hook_status_render::{render_human, render_json};
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -133,6 +140,7 @@ pub fn run(args: &[String]) -> Result {
     }
 
     entries.sort_by(|a, b| a.ts.cmp(&b.ts));
+    let entries = drop_stale_running(entries);
     let entries = latest_entries(entries, options.limit);
 
     if options.json {
@@ -363,6 +371,38 @@ fn normalize_diag_event(value: &Value, log_path: &str) -> HookStatusEntry {
     let reason = string_field(value, field::REASON);
     let hook_name = non_empty_or(string_field(value, field::HOOK), UNKNOWN);
     let event = non_empty_or(string_field(value, field::EVENT), UNKNOWN);
+    let explicit_status = string_field(value, field::STATUS);
+    if !explicit_status.is_empty() {
+        let duration_ms = numeric_field(value, field::DURATION_MS);
+        let normalized_status = normalize_status(
+            &explicit_status,
+            &string_field(value, field::DECISION),
+            &reason,
+            duration_ms,
+            DEFAULT_SLOW_MS,
+            false,
+        );
+        let elapsed_ms =
+            normalize_elapsed_ms(&normalized_status, &string_field(value, field::TS), value);
+        return HookStatusEntry {
+            ts: string_field(value, field::TS),
+            session: string_field(value, field::SESSION),
+            source: "codex_diag".to_string(),
+            hook: hook_name,
+            event,
+            matcher: non_empty_or(string_field(value, field::MATCHER), "<none>"),
+            status: normalized_status.clone(),
+            decision: string_field(value, field::DECISION),
+            reason: normalize_reason(&reason, &normalized_status),
+            detail: string_field(value, field::DETAIL),
+            duration_ms,
+            elapsed_ms,
+            timeout_ms: numeric_field(value, field::TIMEOUT_MS),
+            model_context: model_context_for_status(&normalized_status),
+            log_path: log_path.to_string(),
+        };
+    }
+
     let status_value = if is_adapter_error_reason(&reason) {
         status::ADAPTER_ERROR
     } else {
@@ -385,6 +425,17 @@ fn normalize_diag_event(value: &Value, log_path: &str) -> HookStatusEntry {
         timeout_ms: numeric_field(value, field::TIMEOUT_MS),
         model_context: false,
         log_path: log_path.to_string(),
+    }
+}
+
+fn normalize_elapsed_ms(normalized_status: &str, ts: &str, value: &Value) -> Option<u64> {
+    let explicit = numeric_field(value, field::ELAPSED_MS);
+    if normalized_status != status::RUNNING {
+        return explicit.or_else(|| numeric_field(value, field::DURATION_MS));
+    }
+    match explicit {
+        Some(ms) if ms > 0 => Some(ms),
+        _ => parse_iso_ts(ts).map(|started| now_unix_secs().saturating_sub(started) * 1_000),
     }
 }
 
@@ -553,196 +604,33 @@ fn latest_entries(mut entries: Vec<HookStatusEntry>, limit: usize) -> Vec<HookSt
     entries
 }
 
-fn render_json(entries: &[HookStatusEntry], mode: Mode) -> Result<String> {
-    let summary = summary_json(entries);
-    let mode_value = match mode {
-        Mode::Minimal => "minimal",
-        Mode::Focused => "focused",
-        Mode::Full => "full",
-    };
-    let payload = json!({
-        "schema_version": HOOK_STATUS_SCHEMA_VERSION,
-        "mode": mode_value,
-        "summary": summary,
-        "entries": entries.iter().map(HookStatusEntry::to_json).collect::<Vec<_>>(),
-    });
-    Ok(serde_json::to_string_pretty(&payload)?)
-}
-
-fn summary_json(entries: &[HookStatusEntry]) -> Value {
-    let total = entries.len();
-    let running = entries.iter().filter(|entry| entry.is_running()).count();
-    let attention = entries
-        .iter()
-        .filter(|entry| entry.is_attention_state())
-        .count();
-    let model_context = entries.iter().filter(|entry| entry.model_context).count();
-    let event = entries
-        .last()
-        .map(|entry| entry.event.as_str())
-        .unwrap_or(UNKNOWN);
-    json!({
-        "event": event,
-        "total": total,
-        "complete": total.saturating_sub(running),
-        "running": running,
-        "attention": attention,
-        "model_context_entries": model_context,
-    })
-}
-
-fn render_human(entries: &[HookStatusEntry], mode: Mode) -> String {
-    if entries.is_empty() {
-        return "No hook status events found.\n".to_string();
-    }
-
-    let mut out = String::new();
-    out.push_str(&minimal_line(entries));
-    out.push('\n');
-
-    if matches!(mode, Mode::Focused | Mode::Full) {
-        for entry in entries {
-            out.push_str(&format_entry_line(entry, mode));
-            out.push('\n');
+fn drop_stale_running(entries: Vec<HookStatusEntry>) -> Vec<HookStatusEntry> {
+    let mut kept = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        if entry.is_running()
+            && entries
+                .iter()
+                .skip(index + 1)
+                .any(|later| !later.is_running() && same_hook_event(entry, later))
+        {
+            continue;
         }
+        kept.push(entry.clone());
     }
-    out
+    kept
 }
 
-fn minimal_line(entries: &[HookStatusEntry]) -> String {
-    let event = entries
-        .last()
-        .map(|entry| entry.event.as_str())
-        .unwrap_or(UNKNOWN);
-    if let Some(entry) = entries
-        .iter()
-        .rev()
-        .find(|entry| entry.status == status::TIMEOUT)
-    {
-        return format!(
-            "{} hook timed out - {} - {}\nLast action: {}\nLog: {}\nSafe to interrupt: {}",
-            entry.event,
-            entry.hook,
-            format_duration(entry.display_duration_ms()),
-            non_empty_or(entry.detail.clone(), UNKNOWN),
-            non_empty_or(entry.log_path.clone(), UNKNOWN),
-            if entry.event == "PostToolUse" {
-                "yes, hook ran after the tool action"
-            } else {
-                "check the hook event before interrupting"
-            }
-        );
-    }
-    if let Some(entry) = entries
-        .iter()
-        .rev()
-        .find(|entry| entry.status == status::ADAPTER_ERROR)
-    {
-        return format!(
-            "{} hook adapter_error - {} - {}\nLast action: {}\nLog: {}",
-            entry.event,
-            entry.hook,
-            non_empty_or(entry.reason.clone(), UNKNOWN),
-            non_empty_or(entry.detail.clone(), UNKNOWN),
-            non_empty_or(entry.log_path.clone(), UNKNOWN)
-        );
-    }
-
-    let total = entries.len();
-    let running = entries.iter().filter(|entry| entry.is_running()).count();
-    if running > 0 {
-        let elapsed = entries
-            .iter()
-            .filter(|entry| entry.is_running())
-            .filter_map(HookStatusEntry::display_duration_ms)
-            .max();
-        let timeout = entries
-            .iter()
-            .filter(|entry| entry.is_running())
-            .filter_map(|entry| entry.timeout_ms)
-            .max();
-        return format!(
-            "{} checks  {}/{} running - {} / {}",
-            event,
-            running,
-            total,
-            format_duration(elapsed),
-            format_duration(timeout)
-        );
-    }
-
-    let total_duration = entries
-        .iter()
-        .filter_map(|entry| entry.duration_ms)
-        .sum::<u64>();
-    format!(
-        "{} checks  {}/{} complete - {}",
-        event,
-        total,
-        total,
-        format_duration(Some(total_duration))
-    )
+fn same_hook_event(left: &HookStatusEntry, right: &HookStatusEntry) -> bool {
+    left.event == right.event && canonical_hook_name(&left.hook) == canonical_hook_name(&right.hook)
 }
 
-fn format_entry_line(entry: &HookStatusEntry, mode: Mode) -> String {
-    let mut line = format!(
-        "[{}] {} {}({}) {}",
-        status_label(&entry.status),
-        entry.hook,
-        entry.event,
-        entry.matcher,
-        entry.status
-    );
-    if !entry.reason.is_empty() {
-        line.push_str(" - ");
-        line.push_str(&entry.reason);
-    }
-    if let Some(ms) = entry.display_duration_ms() {
-        line.push_str(" - ");
-        line.push_str(&format_duration(Some(ms)));
-    }
-    if entry.status == status::RUNNING {
-        if let Some(timeout_ms) = entry.timeout_ms {
-            line.push_str(" / ");
-            line.push_str(&format_duration(Some(timeout_ms)));
-        }
-    }
-    if matches!(mode, Mode::Full) {
-        line.push_str(&format!(
-            " - model_context={} - log={}",
-            entry.model_context,
-            non_empty_or(entry.log_path.clone(), UNKNOWN)
-        ));
-        if !entry.detail.is_empty() {
-            line.push_str(" - last_action=");
-            line.push_str(&entry.detail);
-        }
-    }
-    line
-}
-
-fn status_label(value: &str) -> &str {
-    match value {
-        status::PASS => "pass",
-        status::SKIPPED => "skip",
-        status::WARN => "warn",
-        status::BLOCK => "block",
-        status::SLOW => "slow",
-        status::TIMEOUT => "timeout",
-        status::RUNNING => "running",
-        status::ADAPTER_ERROR => "error",
-        status::HOOK_ERROR => "error",
-        _ => "info",
-    }
-}
-
-fn format_duration(ms: Option<u64>) -> String {
-    match ms {
-        None => "?".to_string(),
-        Some(value) if value < 1_000 => format!("{value}ms"),
-        Some(value) if value % 1_000 == 0 => format!("{}s", value / 1_000),
-        Some(value) => format!("{:.1}s", value as f64 / 1_000.0),
-    }
+fn canonical_hook_name(hook_name: &str) -> String {
+    hook_name
+        .strip_prefix("vibeguard-")
+        .unwrap_or(hook_name)
+        .strip_suffix(".sh")
+        .unwrap_or_else(|| hook_name.strip_prefix("vibeguard-").unwrap_or(hook_name))
+        .to_string()
 }
 
 #[cfg(test)]

--- a/vibeguard-runtime/src/hook_status.rs
+++ b/vibeguard-runtime/src/hook_status.rs
@@ -139,7 +139,10 @@ pub fn run(args: &[String]) -> Result {
         }
     }
 
-    entries.sort_by(|a, b| a.ts.cmp(&b.ts));
+    entries.sort_by(|a, b| {
+        a.ts.cmp(&b.ts)
+            .then_with(|| entry_sort_rank(a).cmp(&entry_sort_rank(b)))
+    });
     let entries = drop_stale_running(entries);
     let entries = latest_entries(entries, options.limit);
 
@@ -602,6 +605,10 @@ fn latest_entries(mut entries: Vec<HookStatusEntry>, limit: usize) -> Vec<HookSt
     }
     entries.drain(0..entries.len() - limit);
     entries
+}
+
+fn entry_sort_rank(entry: &HookStatusEntry) -> u8 {
+    if entry.is_running() { 0 } else { 1 }
 }
 
 fn drop_stale_running(entries: Vec<HookStatusEntry>) -> Vec<HookStatusEntry> {

--- a/vibeguard-runtime/src/hook_status.rs
+++ b/vibeguard-runtime/src/hook_status.rs
@@ -1,0 +1,750 @@
+//! Human-facing hook status summaries for Codex/Claude hook JSONL events.
+//!
+//! This command intentionally reports pass/skip/slow/timeout states outside the
+//! hook output contract, so successful hooks stay out of the model context.
+
+use serde_json::{Value, json};
+use std::env;
+use std::fs::File;
+use std::io::{self, BufRead, IsTerminal, Read};
+use std::path::{Path, PathBuf};
+
+use crate::event_schema::{UNKNOWN, decision, field, status, tool};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+const HOOK_STATUS_SCHEMA_VERSION: u64 = 1;
+const DEFAULT_LIMIT: usize = 20;
+const DEFAULT_SLOW_MS: u64 = 2_000;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Mode {
+    Minimal,
+    Focused,
+    Full,
+}
+
+#[derive(Debug)]
+struct Options {
+    mode: Mode,
+    json: bool,
+    limit: usize,
+    slow_ms: u64,
+    log_file: Option<PathBuf>,
+    diag_file: Option<PathBuf>,
+    session: Option<String>,
+    event: Option<String>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            mode: Mode::Minimal,
+            json: false,
+            limit: DEFAULT_LIMIT,
+            slow_ms: DEFAULT_SLOW_MS,
+            log_file: None,
+            diag_file: None,
+            session: None,
+            event: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HookStatusEntry {
+    ts: String,
+    session: String,
+    source: String,
+    hook: String,
+    event: String,
+    matcher: String,
+    status: String,
+    decision: String,
+    reason: String,
+    detail: String,
+    duration_ms: Option<u64>,
+    elapsed_ms: Option<u64>,
+    timeout_ms: Option<u64>,
+    model_context: bool,
+    log_path: String,
+}
+
+impl HookStatusEntry {
+    fn to_json(&self) -> Value {
+        json!({
+            field::TS: self.ts,
+            field::SESSION: self.session,
+            field::SOURCE: self.source,
+            field::HOOK: self.hook,
+            field::EVENT: self.event,
+            field::MATCHER: self.matcher,
+            field::STATUS: self.status,
+            field::DECISION: self.decision,
+            field::REASON: self.reason,
+            field::DETAIL: self.detail,
+            field::DURATION_MS: self.duration_ms,
+            field::ELAPSED_MS: self.elapsed_ms,
+            field::TIMEOUT_MS: self.timeout_ms,
+            field::MODEL_CONTEXT: self.model_context,
+            field::LOG_PATH: self.log_path,
+        })
+    }
+
+    fn is_running(&self) -> bool {
+        self.status == status::RUNNING
+    }
+
+    fn is_attention_state(&self) -> bool {
+        matches!(
+            self.status.as_str(),
+            status::WARN
+                | status::BLOCK
+                | status::GATE
+                | status::ESCALATE
+                | status::CORRECTION
+                | status::TIMEOUT
+                | status::ADAPTER_ERROR
+                | status::HOOK_ERROR
+        )
+    }
+
+    fn display_duration_ms(&self) -> Option<u64> {
+        self.elapsed_ms.or(self.duration_ms)
+    }
+}
+
+pub fn run(args: &[String]) -> Result {
+    let options = parse_args(args)?;
+    let (main_events, log_path) = read_main_events(&options)?;
+    let mut entries = Vec::new();
+    for event in main_events {
+        let entry = normalize_hook_event(&event, &log_path, options.slow_ms);
+        if entry_matches_filters(&entry, &options) {
+            entries.push(entry);
+        }
+    }
+
+    for diag_source in read_diag_events(&options)? {
+        let entry = normalize_diag_event(&diag_source.event, &diag_source.log_path);
+        if entry_matches_filters(&entry, &options) {
+            entries.push(entry);
+        }
+    }
+
+    entries.sort_by(|a, b| a.ts.cmp(&b.ts));
+    let entries = latest_entries(entries, options.limit);
+
+    if options.json {
+        println!("{}", render_json(&entries, options.mode)?);
+    } else {
+        print!("{}", render_human(&entries, options.mode));
+    }
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<Options> {
+    let mut options = Options::default();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => options.json = true,
+            "--mode" => {
+                index += 1;
+                let mode = args
+                    .get(index)
+                    .ok_or("--mode requires minimal|focused|full")?;
+                options.mode = parse_mode(mode)?;
+            }
+            "--limit" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or("--limit requires a positive integer")?;
+                options.limit = value.parse::<usize>()?;
+                if options.limit == 0 {
+                    return Err("--limit must be greater than 0".into());
+                }
+            }
+            "--slow-ms" => {
+                index += 1;
+                let value = args.get(index).ok_or("--slow-ms requires milliseconds")?;
+                options.slow_ms = value.parse::<u64>()?;
+            }
+            "--log-file" => {
+                index += 1;
+                let value = args.get(index).ok_or("--log-file requires a path")?;
+                options.log_file = Some(PathBuf::from(value));
+            }
+            "--diag-file" => {
+                index += 1;
+                let value = args.get(index).ok_or("--diag-file requires a path")?;
+                options.diag_file = Some(PathBuf::from(value));
+            }
+            "--session" => {
+                index += 1;
+                let value = args.get(index).ok_or("--session requires a value")?;
+                options.session = Some(value.to_string());
+            }
+            "--event" => {
+                index += 1;
+                let value = args.get(index).ok_or("--event requires a value")?;
+                options.event = Some(value.to_string());
+            }
+            "--help" | "-h" => {
+                return Err("Usage: vibeguard-runtime hook-status [--mode minimal|focused|full] [--json] [--limit N] [--slow-ms MS] [--log-file PATH] [--diag-file PATH] [--session ID] [--event EVENT]".into());
+            }
+            other => return Err(format!("unknown hook-status argument: {other}").into()),
+        }
+        index += 1;
+    }
+    Ok(options)
+}
+
+fn parse_mode(value: &str) -> Result<Mode> {
+    match value {
+        "minimal" => Ok(Mode::Minimal),
+        "focused" => Ok(Mode::Focused),
+        "full" => Ok(Mode::Full),
+        _ => Err("mode must be one of: minimal, focused, full".into()),
+    }
+}
+
+fn read_main_events(options: &Options) -> Result<(Vec<Value>, String)> {
+    if let Some(path) = &options.log_file {
+        return Ok((read_jsonl_file(path)?, display_path(path)));
+    }
+
+    let stdin_events = read_jsonl_from_stdin()?;
+    if !stdin_events.is_empty() {
+        return Ok((stdin_events, "stdin".to_string()));
+    }
+
+    if let Some(path) = default_event_log_path() {
+        if path.exists() {
+            return Ok((read_jsonl_file(&path)?, display_path(&path)));
+        }
+    }
+
+    Ok((Vec::new(), "stdin".to_string()))
+}
+
+struct DiagSource {
+    event: Value,
+    log_path: String,
+}
+
+fn read_diag_events(options: &Options) -> Result<Vec<DiagSource>> {
+    let path = if let Some(path) = &options.diag_file {
+        path.clone()
+    } else if let Ok(path) = env::var("VIBEGUARD_CODEX_DIAG_FILE") {
+        PathBuf::from(path)
+    } else {
+        match env::var("HOME") {
+            Ok(home) => PathBuf::from(home).join(".vibeguard/codex-wrapper.jsonl"),
+            Err(_) => return Ok(Vec::new()),
+        }
+    };
+
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let log_path = display_path(&path);
+    Ok(read_jsonl_file(&path)?
+        .into_iter()
+        .map(|event| DiagSource {
+            event,
+            log_path: log_path.clone(),
+        })
+        .collect())
+}
+
+fn read_jsonl_file(path: &Path) -> Result<Vec<Value>> {
+    let mut file = File::open(path)?;
+    let mut text = String::new();
+    file.read_to_string(&mut text)?;
+    Ok(read_jsonl_text(&text))
+}
+
+fn read_jsonl_from_stdin() -> Result<Vec<Value>> {
+    if io::stdin().is_terminal() {
+        return Ok(Vec::new());
+    }
+
+    let stdin = io::stdin();
+    let mut reader = io::BufReader::new(stdin.lock());
+    let mut lines = Vec::new();
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf)? {
+            0 => break,
+            _ => {
+                let line = String::from_utf8_lossy(&buf);
+                if let Ok(value) = serde_json::from_str::<Value>(line.trim()) {
+                    lines.push(value);
+                }
+            }
+        }
+    }
+    Ok(lines)
+}
+
+fn read_jsonl_text(text: &str) -> Vec<Value> {
+    text.lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
+        .collect()
+}
+
+fn default_event_log_path() -> Option<PathBuf> {
+    if let Ok(path) = env::var("VIBEGUARD_LOG_FILE") {
+        return Some(PathBuf::from(path));
+    }
+    env::var("HOME")
+        .ok()
+        .map(|home| PathBuf::from(home).join(".vibeguard/events.jsonl"))
+}
+
+fn display_path(path: &Path) -> String {
+    if let Ok(home) = env::var("HOME") {
+        let home_path = PathBuf::from(home);
+        if let Ok(stripped) = path.strip_prefix(&home_path) {
+            return format!("~/{}", stripped.to_string_lossy());
+        }
+    }
+    path.to_string_lossy().to_string()
+}
+
+fn normalize_hook_event(value: &Value, log_path: &str, slow_ms: u64) -> HookStatusEntry {
+    let reason = string_field(value, field::REASON);
+    let detail = string_field(value, field::DETAIL);
+    let decision_value = string_field(value, field::DECISION);
+    let duration_ms = numeric_field(value, field::DURATION_MS);
+    let elapsed_ms = numeric_field(value, field::ELAPSED_MS).or(duration_ms);
+    let timeout_ms = numeric_field(value, field::TIMEOUT_MS);
+    let hook_name = non_empty_or(string_field(value, field::HOOK), UNKNOWN);
+    let event = infer_event(value, &hook_name);
+    let matcher = infer_matcher(value);
+    let status_value = string_field(value, field::STATUS);
+    let normalized_status = normalize_status(
+        &status_value,
+        &decision_value,
+        &reason,
+        duration_ms,
+        slow_ms,
+        false,
+    );
+
+    HookStatusEntry {
+        ts: string_field(value, field::TS),
+        session: string_field(value, field::SESSION),
+        source: "event_log".to_string(),
+        hook: hook_name,
+        event,
+        matcher,
+        status: normalized_status.clone(),
+        decision: decision_value,
+        reason: normalize_reason(&reason, &normalized_status),
+        detail,
+        duration_ms,
+        elapsed_ms,
+        timeout_ms,
+        model_context: model_context_for_status(&normalized_status),
+        log_path: value
+            .get(field::LOG_PATH)
+            .and_then(Value::as_str)
+            .unwrap_or(log_path)
+            .to_string(),
+    }
+}
+
+fn normalize_diag_event(value: &Value, log_path: &str) -> HookStatusEntry {
+    let reason = string_field(value, field::REASON);
+    let hook_name = non_empty_or(string_field(value, field::HOOK), UNKNOWN);
+    let event = non_empty_or(string_field(value, field::EVENT), UNKNOWN);
+    let status_value = if is_adapter_error_reason(&reason) {
+        status::ADAPTER_ERROR
+    } else {
+        status::HOOK_ERROR
+    };
+
+    HookStatusEntry {
+        ts: string_field(value, field::TS),
+        session: string_field(value, field::SESSION),
+        source: "codex_diag".to_string(),
+        hook: hook_name,
+        event,
+        matcher: non_empty_or(string_field(value, field::MATCHER), "<none>"),
+        status: status_value.to_string(),
+        decision: String::new(),
+        reason,
+        detail: string_field(value, field::DETAIL),
+        duration_ms: numeric_field(value, field::DURATION_MS),
+        elapsed_ms: numeric_field(value, field::ELAPSED_MS),
+        timeout_ms: numeric_field(value, field::TIMEOUT_MS),
+        model_context: false,
+        log_path: log_path.to_string(),
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn numeric_field(value: &Value, key: &str) -> Option<u64> {
+    value
+        .get(key)
+        .and_then(|raw| raw.as_u64().or_else(|| raw.as_str()?.parse::<u64>().ok()))
+}
+
+fn non_empty_or(value: String, fallback: &str) -> String {
+    if value.is_empty() {
+        fallback.to_string()
+    } else {
+        value
+    }
+}
+
+fn infer_event(value: &Value, hook_name: &str) -> String {
+    for key in [field::EVENT, "hook_event_name", "hookEventName"] {
+        let candidate = string_field(value, key);
+        if !candidate.is_empty() {
+            return candidate;
+        }
+    }
+
+    let tool_value = string_field(value, field::TOOL);
+    match tool_value.as_str() {
+        "PreToolUse" | "PermissionRequest" | "PostToolUse" | "Stop" | "SessionStart" => tool_value,
+        _ if hook_name.contains("pre-") => "PreToolUse".to_string(),
+        _ if hook_name.contains("post-") => "PostToolUse".to_string(),
+        _ if hook_name.contains("stop-guard") || hook_name.contains("learn-evaluator") => {
+            "Stop".to_string()
+        }
+        _ => UNKNOWN.to_string(),
+    }
+}
+
+fn infer_matcher(value: &Value) -> String {
+    let matcher = string_field(value, field::MATCHER);
+    if !matcher.is_empty() {
+        return matcher;
+    }
+
+    match string_field(value, field::TOOL).as_str() {
+        tool::BASH | tool::EDIT | tool::WRITE | tool::READ | tool::GLOB | tool::GREP => {
+            string_field(value, field::TOOL)
+        }
+        _ => "<none>".to_string(),
+    }
+}
+
+fn normalize_status(
+    explicit_status: &str,
+    decision_value: &str,
+    reason: &str,
+    duration_ms: Option<u64>,
+    slow_ms: u64,
+    force_adapter_error: bool,
+) -> String {
+    if force_adapter_error {
+        return status::ADAPTER_ERROR.to_string();
+    }
+
+    let status_lower = explicit_status.to_ascii_lowercase();
+    let decision_lower = decision_value.to_ascii_lowercase();
+    let reason_lower = reason.to_ascii_lowercase();
+
+    if status_lower == status::RUNNING || decision_lower == status::RUNNING {
+        return status::RUNNING.to_string();
+    }
+    if status_lower == status::TIMEOUT || reason_lower.contains("timeout") {
+        return status::TIMEOUT.to_string();
+    }
+    if status_lower == status::ADAPTER_ERROR || is_adapter_error_reason(reason) {
+        return status::ADAPTER_ERROR.to_string();
+    }
+    if status_lower == status::HOOK_ERROR {
+        return status::HOOK_ERROR.to_string();
+    }
+    if reason_lower.starts_with("skip:")
+        || reason_lower.starts_with("skipped")
+        || reason_lower.contains(" skipped")
+    {
+        return status::SKIPPED.to_string();
+    }
+    if decision_lower == decision::PASS && duration_ms.is_some_and(|ms| ms >= slow_ms) {
+        return status::SLOW.to_string();
+    }
+
+    match decision_lower.as_str() {
+        decision::PASS => status::PASS,
+        decision::WARN => status::WARN,
+        decision::BLOCK => status::BLOCK,
+        decision::GATE => status::GATE,
+        decision::ESCALATE => status::ESCALATE,
+        decision::CORRECTION => status::CORRECTION,
+        decision::COMPLETE => status::COMPLETE,
+        "" => status::UNKNOWN,
+        _ => decision_lower.as_str(),
+    }
+    .to_string()
+}
+
+fn normalize_reason(reason: &str, normalized_status: &str) -> String {
+    if normalized_status == status::SKIPPED {
+        reason
+            .strip_prefix("skip:")
+            .or_else(|| reason.strip_prefix("skipped:"))
+            .unwrap_or(reason)
+            .trim()
+            .to_string()
+    } else {
+        reason.to_string()
+    }
+}
+
+fn is_adapter_error_reason(reason: &str) -> bool {
+    matches!(
+        reason,
+        "posttool-adapter-failed"
+            | "missing-adapter"
+            | "normalizer-failed"
+            | "missing-runner"
+            | "policy_error"
+            | "missing-repo-path"
+    )
+}
+
+fn model_context_for_status(normalized_status: &str) -> bool {
+    matches!(
+        normalized_status,
+        status::WARN | status::BLOCK | status::GATE | status::ESCALATE | status::CORRECTION
+    )
+}
+
+fn entry_matches_filters(entry: &HookStatusEntry, options: &Options) -> bool {
+    if let Some(session) = &options.session {
+        if !session.is_empty() && entry.source == "event_log" && entry.session != *session {
+            return false;
+        }
+    }
+
+    if let Some(event) = &options.event {
+        if &entry.event != event {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn latest_entries(mut entries: Vec<HookStatusEntry>, limit: usize) -> Vec<HookStatusEntry> {
+    if entries.len() <= limit {
+        return entries;
+    }
+    entries.drain(0..entries.len() - limit);
+    entries
+}
+
+fn render_json(entries: &[HookStatusEntry], mode: Mode) -> Result<String> {
+    let summary = summary_json(entries);
+    let mode_value = match mode {
+        Mode::Minimal => "minimal",
+        Mode::Focused => "focused",
+        Mode::Full => "full",
+    };
+    let payload = json!({
+        "schema_version": HOOK_STATUS_SCHEMA_VERSION,
+        "mode": mode_value,
+        "summary": summary,
+        "entries": entries.iter().map(HookStatusEntry::to_json).collect::<Vec<_>>(),
+    });
+    Ok(serde_json::to_string_pretty(&payload)?)
+}
+
+fn summary_json(entries: &[HookStatusEntry]) -> Value {
+    let total = entries.len();
+    let running = entries.iter().filter(|entry| entry.is_running()).count();
+    let attention = entries
+        .iter()
+        .filter(|entry| entry.is_attention_state())
+        .count();
+    let model_context = entries.iter().filter(|entry| entry.model_context).count();
+    let event = entries
+        .last()
+        .map(|entry| entry.event.as_str())
+        .unwrap_or(UNKNOWN);
+    json!({
+        "event": event,
+        "total": total,
+        "complete": total.saturating_sub(running),
+        "running": running,
+        "attention": attention,
+        "model_context_entries": model_context,
+    })
+}
+
+fn render_human(entries: &[HookStatusEntry], mode: Mode) -> String {
+    if entries.is_empty() {
+        return "No hook status events found.\n".to_string();
+    }
+
+    let mut out = String::new();
+    out.push_str(&minimal_line(entries));
+    out.push('\n');
+
+    if matches!(mode, Mode::Focused | Mode::Full) {
+        for entry in entries {
+            out.push_str(&format_entry_line(entry, mode));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn minimal_line(entries: &[HookStatusEntry]) -> String {
+    let event = entries
+        .last()
+        .map(|entry| entry.event.as_str())
+        .unwrap_or(UNKNOWN);
+    if let Some(entry) = entries
+        .iter()
+        .rev()
+        .find(|entry| entry.status == status::TIMEOUT)
+    {
+        return format!(
+            "{} hook timed out - {} - {}\nLast action: {}\nLog: {}\nSafe to interrupt: {}",
+            entry.event,
+            entry.hook,
+            format_duration(entry.display_duration_ms()),
+            non_empty_or(entry.detail.clone(), UNKNOWN),
+            non_empty_or(entry.log_path.clone(), UNKNOWN),
+            if entry.event == "PostToolUse" {
+                "yes, hook ran after the tool action"
+            } else {
+                "check the hook event before interrupting"
+            }
+        );
+    }
+    if let Some(entry) = entries
+        .iter()
+        .rev()
+        .find(|entry| entry.status == status::ADAPTER_ERROR)
+    {
+        return format!(
+            "{} hook adapter_error - {} - {}\nLast action: {}\nLog: {}",
+            entry.event,
+            entry.hook,
+            non_empty_or(entry.reason.clone(), UNKNOWN),
+            non_empty_or(entry.detail.clone(), UNKNOWN),
+            non_empty_or(entry.log_path.clone(), UNKNOWN)
+        );
+    }
+
+    let total = entries.len();
+    let running = entries.iter().filter(|entry| entry.is_running()).count();
+    if running > 0 {
+        let elapsed = entries
+            .iter()
+            .filter(|entry| entry.is_running())
+            .filter_map(HookStatusEntry::display_duration_ms)
+            .max();
+        let timeout = entries
+            .iter()
+            .filter(|entry| entry.is_running())
+            .filter_map(|entry| entry.timeout_ms)
+            .max();
+        return format!(
+            "{} checks  {}/{} running - {} / {}",
+            event,
+            running,
+            total,
+            format_duration(elapsed),
+            format_duration(timeout)
+        );
+    }
+
+    let total_duration = entries
+        .iter()
+        .filter_map(|entry| entry.duration_ms)
+        .sum::<u64>();
+    format!(
+        "{} checks  {}/{} complete - {}",
+        event,
+        total,
+        total,
+        format_duration(Some(total_duration))
+    )
+}
+
+fn format_entry_line(entry: &HookStatusEntry, mode: Mode) -> String {
+    let mut line = format!(
+        "[{}] {} {}({}) {}",
+        status_label(&entry.status),
+        entry.hook,
+        entry.event,
+        entry.matcher,
+        entry.status
+    );
+    if !entry.reason.is_empty() {
+        line.push_str(" - ");
+        line.push_str(&entry.reason);
+    }
+    if let Some(ms) = entry.display_duration_ms() {
+        line.push_str(" - ");
+        line.push_str(&format_duration(Some(ms)));
+    }
+    if entry.status == status::RUNNING {
+        if let Some(timeout_ms) = entry.timeout_ms {
+            line.push_str(" / ");
+            line.push_str(&format_duration(Some(timeout_ms)));
+        }
+    }
+    if matches!(mode, Mode::Full) {
+        line.push_str(&format!(
+            " - model_context={} - log={}",
+            entry.model_context,
+            non_empty_or(entry.log_path.clone(), UNKNOWN)
+        ));
+        if !entry.detail.is_empty() {
+            line.push_str(" - last_action=");
+            line.push_str(&entry.detail);
+        }
+    }
+    line
+}
+
+fn status_label(value: &str) -> &str {
+    match value {
+        status::PASS => "pass",
+        status::SKIPPED => "skip",
+        status::WARN => "warn",
+        status::BLOCK => "block",
+        status::SLOW => "slow",
+        status::TIMEOUT => "timeout",
+        status::RUNNING => "running",
+        status::ADAPTER_ERROR => "error",
+        status::HOOK_ERROR => "error",
+        _ => "info",
+    }
+}
+
+fn format_duration(ms: Option<u64>) -> String {
+    match ms {
+        None => "?".to_string(),
+        Some(value) if value < 1_000 => format!("{value}ms"),
+        Some(value) if value % 1_000 == 0 => format!("{}s", value / 1_000),
+        Some(value) => format!("{:.1}s", value as f64 / 1_000.0),
+    }
+}
+
+#[cfg(test)]
+#[path = "hook_status_tests.rs"]
+mod hook_status_tests;

--- a/vibeguard-runtime/src/hook_status.rs
+++ b/vibeguard-runtime/src/hook_status.rs
@@ -527,6 +527,18 @@ fn normalize_status(
     if status_lower == status::HOOK_ERROR {
         return status::HOOK_ERROR.to_string();
     }
+    match status_lower.as_str() {
+        status::PASS => return status::PASS.to_string(),
+        status::SKIPPED => return status::SKIPPED.to_string(),
+        status::WARN => return status::WARN.to_string(),
+        status::BLOCK => return status::BLOCK.to_string(),
+        status::GATE => return status::GATE.to_string(),
+        status::ESCALATE => return status::ESCALATE.to_string(),
+        status::CORRECTION => return status::CORRECTION.to_string(),
+        status::COMPLETE => return status::COMPLETE.to_string(),
+        status::SLOW => return status::SLOW.to_string(),
+        _ => {}
+    }
     if reason_lower.starts_with("skip:")
         || reason_lower.starts_with("skipped")
         || reason_lower.contains(" skipped")

--- a/vibeguard-runtime/src/hook_status_render.rs
+++ b/vibeguard-runtime/src/hook_status_render.rs
@@ -1,0 +1,271 @@
+use serde_json::{Value, json};
+
+use crate::event_schema::{UNKNOWN, status};
+
+use super::{HOOK_STATUS_SCHEMA_VERSION, HookStatusEntry, Mode, Result, non_empty_or};
+
+pub(super) fn render_json(entries: &[HookStatusEntry], mode: Mode) -> Result<String> {
+    let summary = summary_json(entries);
+    let mode_value = match mode {
+        Mode::Minimal => "minimal",
+        Mode::Focused => "focused",
+        Mode::Full => "full",
+    };
+    let payload = json!({
+        "schema_version": HOOK_STATUS_SCHEMA_VERSION,
+        "mode": mode_value,
+        "summary": summary,
+        "entries": entries.iter().map(HookStatusEntry::to_json).collect::<Vec<_>>(),
+    });
+    Ok(serde_json::to_string_pretty(&payload)?)
+}
+
+pub(super) fn render_human(entries: &[HookStatusEntry], mode: Mode) -> String {
+    if entries.is_empty() {
+        return "No hook status events found.\n".to_string();
+    }
+
+    let mut out = String::new();
+    out.push_str(&minimal_line(entries));
+    out.push('\n');
+
+    if matches!(mode, Mode::Focused | Mode::Full) {
+        for entry in entries {
+            out.push_str(&format_entry_line(entry, mode));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+pub(super) fn minimal_line(entries: &[HookStatusEntry]) -> String {
+    let summary_entries = summary_entries(entries);
+    let event = summary_entries
+        .last()
+        .map(|entry| entry.event.as_str())
+        .unwrap_or(UNKNOWN);
+    if let Some(entry) = summary_entries
+        .iter()
+        .rev()
+        .find(|entry| entry.status == status::TIMEOUT)
+    {
+        return format!(
+            "{} hook timed out - {} - {}\nLast action: {}\nLog: {}\nSafe to interrupt: {}",
+            entry.event,
+            entry.hook,
+            format_duration(entry.display_duration_ms()),
+            non_empty_or(entry.detail.clone(), UNKNOWN),
+            non_empty_or(entry.log_path.clone(), UNKNOWN),
+            if entry.event == "PostToolUse" {
+                "yes, hook ran after the tool action"
+            } else {
+                "check the hook event before interrupting"
+            }
+        );
+    }
+    if let Some(entry) = summary_entries
+        .iter()
+        .rev()
+        .find(|entry| entry.status == status::ADAPTER_ERROR)
+    {
+        return format!(
+            "{} hook adapter_error - {} - {}\nLast action: {}\nLog: {}",
+            entry.event,
+            entry.hook,
+            non_empty_or(entry.reason.clone(), UNKNOWN),
+            non_empty_or(entry.detail.clone(), UNKNOWN),
+            non_empty_or(entry.log_path.clone(), UNKNOWN)
+        );
+    }
+
+    let total = summary_entries.len();
+    let running = summary_entries
+        .iter()
+        .filter(|entry| entry.is_running())
+        .count();
+    if running > 0 {
+        let elapsed = summary_entries
+            .iter()
+            .filter(|entry| entry.is_running())
+            .filter_map(|entry| entry.display_duration_ms())
+            .max();
+        let timeout = summary_entries
+            .iter()
+            .filter(|entry| entry.is_running())
+            .filter_map(|entry| entry.timeout_ms)
+            .max();
+        return format!(
+            "{} checks  {}/{} running - {} / {}",
+            event,
+            running,
+            total,
+            format_duration(elapsed),
+            format_duration(timeout)
+        );
+    }
+
+    let total_duration = summary_entries
+        .iter()
+        .filter_map(|entry| entry.duration_ms)
+        .sum::<u64>();
+    format!(
+        "{} checks  {}/{} complete - {}",
+        event,
+        total,
+        total,
+        format_duration(Some(total_duration))
+    )
+}
+
+fn summary_json(entries: &[HookStatusEntry]) -> Value {
+    let summary_entries = summary_entries(entries);
+    let total = summary_entries.len();
+    let running = summary_entries
+        .iter()
+        .filter(|entry| entry.is_running())
+        .count();
+    let attention = summary_entries
+        .iter()
+        .filter(|entry| entry.is_attention_state())
+        .count();
+    let model_context = summary_entries
+        .iter()
+        .filter(|entry| entry.model_context)
+        .count();
+    let event = summary_entries
+        .last()
+        .map(|entry| entry.event.as_str())
+        .unwrap_or(UNKNOWN);
+    json!({
+        "event": event,
+        "total": total,
+        "complete": total.saturating_sub(running),
+        "running": running,
+        "attention": attention,
+        "model_context_entries": model_context,
+    })
+}
+
+fn summary_entries(entries: &[HookStatusEntry]) -> Vec<&HookStatusEntry> {
+    let Some(event) = entries.last().map(|entry| entry.event.as_str()) else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .filter(|entry| entry.event == event)
+        .collect::<Vec<_>>()
+}
+
+fn format_entry_line(entry: &HookStatusEntry, mode: Mode) -> String {
+    let mut line = format!(
+        "[{}] {} {}({}) {}",
+        status_label(&entry.status),
+        entry.hook,
+        entry.event,
+        entry.matcher,
+        entry.status
+    );
+    if !entry.reason.is_empty() {
+        line.push_str(" - ");
+        line.push_str(&entry.reason);
+    }
+    if let Some(ms) = entry.display_duration_ms() {
+        line.push_str(" - ");
+        line.push_str(&format_duration(Some(ms)));
+    }
+    if entry.status == status::RUNNING {
+        if let Some(timeout_ms) = entry.timeout_ms {
+            line.push_str(" / ");
+            line.push_str(&format_duration(Some(timeout_ms)));
+        }
+    }
+    if matches!(mode, Mode::Full) {
+        line.push_str(&format!(
+            " - model_context={} - log={}",
+            entry.model_context,
+            non_empty_or(entry.log_path.clone(), UNKNOWN)
+        ));
+        if !entry.detail.is_empty() {
+            line.push_str(" - last_action=");
+            line.push_str(&entry.detail);
+        }
+    }
+    line
+}
+
+fn status_label(value: &str) -> &str {
+    match value {
+        status::PASS => "pass",
+        status::SKIPPED => "skip",
+        status::WARN => "warn",
+        status::BLOCK => "block",
+        status::SLOW => "slow",
+        status::TIMEOUT => "timeout",
+        status::RUNNING => "running",
+        status::ADAPTER_ERROR => "error",
+        status::HOOK_ERROR => "error",
+        _ => "info",
+    }
+}
+
+fn format_duration(ms: Option<u64>) -> String {
+    match ms {
+        None => "?".to_string(),
+        Some(value) if value < 1_000 => format!("{value}ms"),
+        Some(value) if value % 1_000 == 0 => format!("{}s", value / 1_000),
+        Some(value) => format!("{:.1}s", value as f64 / 1_000.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(event: &str, status_value: &str, duration_ms: Option<u64>) -> HookStatusEntry {
+        HookStatusEntry {
+            ts: "2026-05-31T00:00:00Z".to_string(),
+            session: "s1".to_string(),
+            source: "event_log".to_string(),
+            hook: "post-build-check".to_string(),
+            event: event.to_string(),
+            matcher: "<none>".to_string(),
+            status: status_value.to_string(),
+            decision: status_value.to_string(),
+            reason: String::new(),
+            detail: String::new(),
+            duration_ms,
+            elapsed_ms: None,
+            timeout_ms: None,
+            model_context: status_value == status::WARN,
+            log_path: "events.jsonl".to_string(),
+        }
+    }
+
+    #[test]
+    fn minimal_summary_counts_only_last_event() {
+        let entries = vec![
+            entry("Bash", status::PASS, Some(18)),
+            entry("PostToolUse", status::SKIPPED, Some(28)),
+        ];
+        assert_eq!(
+            minimal_line(&entries),
+            "PostToolUse checks  1/1 complete - 28ms"
+        );
+    }
+
+    #[test]
+    fn json_summary_counts_only_last_event_but_keeps_entries() {
+        let entries = vec![
+            entry("Bash", status::PASS, Some(18)),
+            entry("Bash", status::WARN, Some(44)),
+            entry("PostToolUse", status::SKIPPED, Some(28)),
+        ];
+        let payload: Value = serde_json::from_str(&render_json(&entries, Mode::Full).unwrap())
+            .expect("hook-status JSON should parse");
+
+        assert_eq!(payload["summary"]["event"], "PostToolUse");
+        assert_eq!(payload["summary"]["total"], 1);
+        assert_eq!(payload["summary"]["attention"], 0);
+        assert_eq!(payload["entries"].as_array().unwrap().len(), 3);
+    }
+}

--- a/vibeguard-runtime/src/hook_status_tests.rs
+++ b/vibeguard-runtime/src/hook_status_tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+#[test]
+fn normalizes_skip_without_model_context() {
+    let event = json!({
+        "ts": "2026-05-31T00:00:00Z",
+        "hook": "post-build-check",
+        "tool": "PostToolUse",
+        "decision": "pass",
+        "reason": "skip: missing file_path",
+        "duration_ms": 28
+    });
+    let entry = normalize_hook_event(&event, "events.jsonl", DEFAULT_SLOW_MS);
+    assert_eq!(entry.status, status::SKIPPED);
+    assert_eq!(entry.reason, "missing file_path");
+    assert!(!entry.model_context);
+}
+
+#[test]
+fn warn_and_block_are_model_context() {
+    assert!(model_context_for_status(status::WARN));
+    assert!(model_context_for_status(status::BLOCK));
+    assert!(!model_context_for_status(status::PASS));
+    assert!(!model_context_for_status(status::SKIPPED));
+}
+
+#[test]
+fn pass_over_threshold_becomes_slow() {
+    assert_eq!(
+        normalize_status("", decision::PASS, "", Some(2_500), DEFAULT_SLOW_MS, false),
+        status::SLOW
+    );
+}
+
+#[test]
+fn timeout_reason_wins_over_warn_decision() {
+    assert_eq!(
+        normalize_status(
+            "",
+            decision::WARN,
+            "post-build-check timeout after 30s",
+            None,
+            DEFAULT_SLOW_MS,
+            false,
+        ),
+        status::TIMEOUT
+    );
+}
+
+#[test]
+fn diag_adapter_reason_becomes_adapter_error() {
+    let event = json!({
+        "ts": "2026-05-31T00:00:00Z",
+        "hook": "vibeguard-post-build-check.sh",
+        "event": "PostToolUse",
+        "reason": "posttool-adapter-failed",
+        "detail": "{}"
+    });
+    let entry = normalize_diag_event(&event, "codex-wrapper.jsonl");
+    assert_eq!(entry.status, status::ADAPTER_ERROR);
+    assert!(!entry.model_context);
+}
+
+#[test]
+fn running_summary_shows_elapsed_and_timeout() {
+    let running = json!({
+        "ts": "2026-05-31T00:00:00Z",
+        "hook": "vibeguard-post-build-check.sh",
+        "event": "PostToolUse",
+        "matcher": "Bash",
+        "status": "running",
+        "reason": "npx tsc --noEmit",
+        "detail": "Edit src/foo.ts",
+        "elapsed_ms": 12000,
+        "timeout_ms": 30000
+    });
+    let skipped = json!({
+        "ts": "2026-05-31T00:00:01Z",
+        "hook": "orca-bridge",
+        "event": "PostToolUse",
+        "matcher": "Bash",
+        "decision": "pass",
+        "reason": "skip: ORCA env absent",
+        "detail": "Edit src/foo.ts",
+        "duration_ms": 3
+    });
+    let entries = vec![
+        normalize_hook_event(&running, "events.jsonl", DEFAULT_SLOW_MS),
+        normalize_hook_event(&skipped, "events.jsonl", DEFAULT_SLOW_MS),
+    ];
+    assert_eq!(
+        minimal_line(&entries),
+        "PostToolUse checks  1/2 running - 12s / 30s"
+    );
+}

--- a/vibeguard-runtime/src/hook_status_tests.rs
+++ b/vibeguard-runtime/src/hook_status_tests.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use super::*;
 
 #[test]
@@ -59,6 +60,22 @@ fn diag_adapter_reason_becomes_adapter_error() {
     let entry = normalize_diag_event(&event, "codex-wrapper.jsonl");
     assert_eq!(entry.status, status::ADAPTER_ERROR);
     assert!(!entry.model_context);
+}
+
+#[test]
+fn diag_explicit_block_preserves_model_context() {
+    let event = json!({
+        "ts": "2026-05-31T00:00:00Z",
+        "hook": "post-build-check",
+        "event": "PostToolUse",
+        "status": "block",
+        "reason": "build failed",
+        "detail": "Edit src/main.rs"
+    });
+    let entry = normalize_diag_event(&event, "codex-wrapper.jsonl");
+    assert_eq!(entry.status, status::BLOCK);
+    assert_eq!(entry.reason, "build failed");
+    assert!(entry.model_context);
 }
 
 #[test]

--- a/vibeguard-runtime/src/hook_status_tests.rs
+++ b/vibeguard-runtime/src/hook_status_tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+#[test]
+fn normalizes_skip_without_model_context() {
+    let event = json!({
+        "ts": "2026-05-31T00:00:00Z",
+        "hook": "post-build-check",
+        "tool": "PostToolUse",
+        "decision": "pass",
+        "reason": "skip: missing file_path",
+        "duration_ms": 28
+    });
+    let entry = normalize_hook_event(&event, "events.jsonl", DEFAULT_SLOW_MS);
+    assert_eq!(entry.status, status::SKIPPED);
+    assert_eq!(entry.reason, "missing file_path");
+    assert!(!entry.model_context);
+}
+
+#[test]
+fn warn_and_block_are_model_context() {
+    assert!(model_context_for_status(status::WARN));
+    assert!(model_context_for_status(status::BLOCK));
+    assert!(!model_context_for_status(status::PASS));
+    assert!(!model_context_for_status(status::SKIPPED));
+}
+
+#[test]
+fn pass_over_threshold_becomes_slow() {
+    assert_eq!(
+        normalize_status("", decision::PASS, "", Some(2_500), DEFAULT_SLOW_MS, false),
+        status::SLOW
+    );
+}
+
+#[test]
+fn timeout_reason_wins_over_warn_decision() {
+    assert_eq!(
+        normalize_status(
+            "",
+            decision::WARN,
+            "post-build-check timeout after 30s",
+            None,
+            DEFAULT_SLOW_MS,
+            false,
+        ),
+        status::TIMEOUT
+    );
+}
+
+#[test]
+fn diag_adapter_reason_becomes_adapter_error() {
+    let event = json!({
+        "ts": "2026-05-31T00:00:00Z",
+        "hook": "vibeguard-post-build-check.sh",
+        "event": "PostToolUse",
+        "reason": "posttool-adapter-failed",
+        "detail": "{}"
+    });
+    let entry = normalize_diag_event(&event, "codex-wrapper.jsonl");
+    assert_eq!(entry.status, status::ADAPTER_ERROR);
+    assert!(!entry.model_context);
+}
+
+#[test]
+fn running_summary_shows_elapsed_and_timeout() {
+    let entries = vec![
+        HookStatusEntry {
+            ts: "2026-05-31T00:00:00Z".to_string(),
+            session: "s1".to_string(),
+            source: "event_log".to_string(),
+            hook: "vibeguard-post-build-check.sh".to_string(),
+            event: "PostToolUse".to_string(),
+            matcher: "Bash".to_string(),
+            status: status::RUNNING.to_string(),
+            decision: String::new(),
+            reason: "npx tsc --noEmit".to_string(),
+            detail: "Edit src/foo.ts".to_string(),
+            duration_ms: None,
+            elapsed_ms: Some(12_000),
+            timeout_ms: Some(30_000),
+            model_context: false,
+            log_path: "events.jsonl".to_string(),
+        },
+        HookStatusEntry {
+            ts: "2026-05-31T00:00:01Z".to_string(),
+            session: "s1".to_string(),
+            source: "event_log".to_string(),
+            hook: "orca-bridge".to_string(),
+            event: "PostToolUse".to_string(),
+            matcher: "Bash".to_string(),
+            status: status::SKIPPED.to_string(),
+            decision: decision::PASS.to_string(),
+            reason: "ORCA env absent".to_string(),
+            detail: "Edit src/foo.ts".to_string(),
+            duration_ms: Some(3),
+            elapsed_ms: Some(3),
+            timeout_ms: None,
+            model_context: false,
+            log_path: "events.jsonl".to_string(),
+        },
+    ];
+    assert_eq!(
+        minimal_line(&entries),
+        "PostToolUse checks  1/2 running - 12s / 30s"
+    );
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -7,6 +7,7 @@ mod hook_checks;
 mod hook_checks_common;
 mod hook_checks_history;
 mod hook_checks_scan;
+mod hook_status;
 mod json_field;
 mod log_query;
 mod pkg_rewrite;
@@ -69,6 +70,11 @@ static COMMANDS: &[Command] = &[
         name: "session-metrics",
         usage: "<session> <dir>  — emit session metrics and correction signals",
         handler: session_metrics::run,
+    },
+    Command {
+        name: "hook-status",
+        usage: "[--mode minimal|focused|full] [--json] [--log-file PATH] [--diag-file PATH]  — summarize hook pass/skip/warn/timeout status without adding model context",
+        handler: hook_status::run,
     },
     Command {
         name: "pre-write-check",


### PR DESCRIPTION
## Summary
- add `vibeguard-runtime hook-status` for human-readable and JSON hook status summaries without putting pass/skip results into model context
- add hook status schema, docs, CI coverage, and tests for pass/skipped/warn/block/slow/running/timeout/adapter_error states
- surface unmanaged Codex hook entries without timeout in `setup.sh --check` while preserving managed Stop timeout semantics

Fixes #257

## Validation
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_hook_status.sh`
- `bash tests/test_setup_check.sh`
- `bash tests/test_setup.sh`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/validate-doc-paths.sh && bash scripts/ci/validate-doc-command-paths.sh && bash scripts/ci/check-event-schema-literals.sh`
- `bash scripts/ci/validate-no-personal-paths.sh`
- `python3 -m json.tool schemas/hook-status.schema.json >/dev/null && python3 -m py_compile scripts/lib/codex_hooks_json.py`