### PR TITLE
Add U-16 typical-size advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Most hooks trigger automatically during AI operations. `skills-loader` remains a
 | Scenario | Hook | Result |
 |----------|------|--------|
 | AI creates new `.py/.ts/.rs/.go/.js` file | `pre-write-guard` | **Warn by default** — search-first reminder; set `VIBEGUARD_WRITE_MODE=block` or `write_mode=block` to hard-block |
+| AI creates or edits production source above 400 lines | `pre-write-guard`, `pre-edit-guard`, `post-write-guard`, `post-edit-guard` | **Warn** — typical-size advisory; keep the current change localized and plan a later split if growth continues |
 | AI creates or edits production source above 800 lines | `pre-write-guard`, `pre-edit-guard` | **Block** — split the file before writing or patching |
 | AI runs `git push --force`, `rm -rf`, `reset --hard` | `pre-bash-guard` | **Block** — suggests safe alternatives |
 | AI edits non-existent file | `pre-edit-guard` | **Block** — must Read file first |
@@ -142,7 +143,7 @@ Most hooks trigger automatically during AI operations. `skills-loader` remains a
 | AI tries to finish with unverified changes | `stop-guard` | **Signal** — logs a Stop reminder; the Stop hook exits 0 to avoid feedback loops |
 | Session ends | `learn-evaluator` | **Evaluate** — collect metrics and detect correction signals |
 
-U-16 file-size enforcement applies to non-test source files with `.rs`, `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, or `.go` extensions. For Codex, `apply_patch Add File` and `apply_patch Update File` are both normalized before the file hook runs, so edits that would take a production source file past the 800-line limit are denied before mutation.
+U-16 file-size enforcement applies to non-test source files with `.rs`, `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, or `.go` extensions. The default typical-size advisory starts above 400 lines (`u16.warn_limit` / `VG_U16_WARN_LIMIT`), while the hard limit remains 800 lines (`u16.limit` / `VG_U16_LIMIT`). For Codex, `apply_patch Add File` and `apply_patch Update File` are both normalized before the file hook runs, so edits that would take a production source file past the hard limit are denied before mutation.
 
 ### Static Guards — Run Anytime
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -92,6 +92,7 @@ VibeGuard 现在明确分成两层：
 | 场景 | Hook | 结果 |
 |------|------|------|
 | AI 创建新的 `.py/.ts/.rs/.go/.js` 文件 | `pre-write-guard` | 默认 **告警**，提醒先搜索现有实现；设置 `VIBEGUARD_WRITE_MODE=block` 或 `write_mode=block` 后硬拦截 |
+| AI 创建或编辑超过 400 行的生产源码文件 | `pre-write-guard`、`pre-edit-guard`、`post-write-guard`、`post-edit-guard` | **告警**，提示已超过典型范围；当前改动保持局部，后续再规划拆分 |
 | AI 创建或编辑超过 800 行的生产源码文件 | `pre-write-guard`、`pre-edit-guard` | **拦截**，必须先拆分文件 |
 | AI 执行 `git push --force`、`rm -rf`、`git clean -fd`、批量 `git checkout/restore .` | `pre-bash-guard` | **拦截**，给出安全替代命令；如确实要清理本地改动，先运行 `python3 ~/vibeguard/scripts/authorized-discard.py --plan` 查看逐路径计划，再用确认短语执行 |
 | AI 编辑一个不存在的文件 | `pre-edit-guard` | **拦截**，要求先读取文件确认 |
@@ -104,7 +105,7 @@ VibeGuard 现在明确分成两层：
 | AI 想结束但还没有验证改动 | `stop-guard` | **信号**，记录 Stop 提醒；Stop hook 退出 0 以避免反馈循环 |
 | 会话结束 | `learn-evaluator` | **评估**，收集指标并识别纠错信号 |
 
-U-16 文件行数限制只覆盖非测试源码扩展名：`.rs`、`.ts`、`.tsx`、`.js`、`.jsx`、`.py`、`.go`。在 Codex 路径里，`apply_patch Add File` 和 `apply_patch Update File` 都会先被规范化再进入文件 hook；如果 patch 会让生产源码超过 800 行，会在写入前被 deny。
+U-16 文件行数限制只覆盖非测试源码扩展名：`.rs`、`.ts`、`.tsx`、`.js`、`.jsx`、`.py`、`.go`。默认 400 行以上触发典型范围告警（`u16.warn_limit` / `VG_U16_WARN_LIMIT`），800 行仍是硬上限（`u16.limit` / `VG_U16_LIMIT`）。在 Codex 路径里，`apply_patch Add File` 和 `apply_patch Update File` 都会先被规范化再进入文件 hook；如果 patch 会让生产源码超过硬上限，会在写入前被 deny。
 
 ### 3. 静态 Guards
 

--- a/hooks/_lib/config.sh
+++ b/hooks/_lib/config.sh
@@ -105,3 +105,15 @@ PY
 
   printf '%s' "$default_val"
 }
+
+vg_u16_warn_limit() {
+  local hard_limit="$1"
+  local warn_limit
+
+  warn_limit=$(vg_config_get_int VG_U16_WARN_LIMIT u16.warn_limit 400)
+  if [[ "$warn_limit" -ge "$hard_limit" ]]; then
+    printf '%s' "$hard_limit"
+  else
+    printf '%s' "$warn_limit"
+  fi
+}

--- a/hooks/_lib/post_edit_quality.sh
+++ b/hooks/_lib/post_edit_quality.sh
@@ -169,8 +169,10 @@ vg_post_edit_detect_u16_size() {
   local total limit dir exempt base_limit
   # Base U-16 limit resolved from env var > ~/.vibeguard/config.json > built-in 800.
   base_limit=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+  local warn_limit
+  warn_limit=$(vg_u16_warn_limit "$base_limit")
   total=$(wc -l < "$FILE_PATH" | tr -d ' ')
-  [[ "$total" -gt "$base_limit" ]] || return 0
+  [[ "$total" -gt "$warn_limit" ]] || return 0
 
   limit="$base_limit"
   dir="$FILE_PATH"
@@ -210,6 +212,10 @@ print(limit)
   if [[ "$total" -gt "$limit" ]]; then
     vg_post_edit_append_warning "[U-16] [review] [this-file] OBSERVATION: file has ${total} lines, exceeding ${limit}-line limit
 FIX: Split into focused submodules by responsibility; plan as a separate task
+DO NOT: Start splitting now — finish the current task first, then refactor"
+  elif [[ "$limit" -le "$base_limit" && "$total" -gt "$warn_limit" ]]; then
+    vg_post_edit_append_warning "[U-16] [advisory] [this-file] OBSERVATION: file has ${total} lines, exceeding the ${warn_limit}-line typical range while staying under the ${limit}-line hard limit
+FIX: Keep the current change localized; plan a split if this file keeps growing
 DO NOT: Start splitting now — finish the current task first, then refactor"
   fi
 }

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -20,8 +20,9 @@ INPUT=$(cat)
 
 if [[ -n "${_VIBEGUARD_RUNTIME:-}" ]]; then
   _VG_U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+  _VG_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_VG_U16_BASE_LIMIT")
   _VG_FAST_RESULT=$(printf '%s' "$INPUT" \
-    | "$_VIBEGUARD_RUNTIME" post-edit-fast-check "$_VG_U16_BASE_LIMIT" "$VIBEGUARD_SESSION_ID" "${VIBEGUARD_AGENT_TYPE:-}" "$VIBEGUARD_LOG_FILE" \
+    | "$_VIBEGUARD_RUNTIME" post-edit-fast-check "$_VG_U16_WARN_LIMIT" "$VIBEGUARD_SESSION_ID" "${VIBEGUARD_AGENT_TYPE:-}" "$VIBEGUARD_LOG_FILE" \
     2>/dev/null || true)
   _VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
   case "$_VG_FAST_STATUS" in
@@ -88,8 +89,9 @@ case "$FILE_PATH" in
     fi
     if [[ "$_VG_FAST_STATELESS" -eq 1 && -f "$FILE_PATH" ]]; then
       _VG_U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+      _VG_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_VG_U16_BASE_LIMIT")
       _VG_FILE_LINES=$(wc -l < "$FILE_PATH" | tr -d ' ')
-      [[ "${_VG_FILE_LINES:-0}" -gt "$_VG_U16_BASE_LIMIT" ]] && _VG_FAST_STATELESS=0
+      [[ "${_VG_FILE_LINES:-0}" -gt "$_VG_U16_WARN_LIMIT" ]] && _VG_FAST_STATELESS=0
     fi
     ;;
 esac

--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -16,9 +16,10 @@ INPUT=$(cat)
 
 if [[ -n "${_VIBEGUARD_RUNTIME:-}" ]]; then
   _VG_U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+  _VG_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_VG_U16_BASE_LIMIT")
   _VG_SCAN_MAX_FILES="${VG_SCAN_MAX_FILES:-5000}"
   _VG_FAST_RESULT=$(printf '%s' "$INPUT" \
-    | "$_VIBEGUARD_RUNTIME" post-write-fast-check "$_VG_U16_BASE_LIMIT" "$_VG_SCAN_MAX_FILES" "$VIBEGUARD_LOG_FILE" \
+    | "$_VIBEGUARD_RUNTIME" post-write-fast-check "$_VG_U16_WARN_LIMIT" "$_VG_SCAN_MAX_FILES" "$VIBEGUARD_LOG_FILE" \
     2>/dev/null || true)
   _VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
   case "$_VG_FAST_STATUS" in
@@ -309,13 +310,14 @@ fi
 # --- [U-16] File size guard: configurable limit with project exemptions ---
 # Base limit resolved from env var > ~/.vibeguard/config.json > built-in 800.
 _U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_U16_BASE_LIMIT")
 case "$FILE_PATH" in
   *.rs|*.ts|*.tsx|*.js|*.jsx|*.py|*.go)
     case "$FILE_PATH" in
       */tests/*|*_test.*|*.test.*|*.spec.*|*_test.rs|*/test_*) ;;
       *)
         _U16_TOTAL=$(echo "$CONTENT" | wc -l | tr -d ' ')
-        if [[ "$_U16_TOTAL" -gt "$_U16_BASE_LIMIT" ]]; then
+        if [[ "$_U16_TOTAL" -gt "$_U16_WARN_LIMIT" ]]; then
           _U16_LIMIT="$_U16_BASE_LIMIT"
           if [[ "$PROJECT_DIR" != "/" && -f "$PROJECT_DIR/CLAUDE.md" ]]; then
             _U16_EXEMPT=$(VG_CLAUDE_MD="$PROJECT_DIR/CLAUDE.md" VG_FILE_PATH="$FILE_PATH" python3 -c '
@@ -350,6 +352,12 @@ print(limit)
 ---
 }[U-16] [review] [this-file] OBSERVATION: file has ${_U16_TOTAL} lines, exceeding ${_U16_LIMIT}-line limit
 FIX: Split into focused submodules by responsibility; plan as a separate task
+DO NOT: Start splitting now — finish the current task first, then refactor"
+          elif [[ "$_U16_LIMIT" -le "$_U16_BASE_LIMIT" && "$_U16_TOTAL" -gt "$_U16_WARN_LIMIT" ]]; then
+            WARNINGS="${WARNINGS:+${WARNINGS}
+---
+}[U-16] [advisory] [this-file] OBSERVATION: file has ${_U16_TOTAL} lines, exceeding the ${_U16_WARN_LIMIT}-line typical range while staying under the ${_U16_LIMIT}-line hard limit
+FIX: Keep the current change localized; plan a split if this file keeps growing
 DO NOT: Start splitting now — finish the current task first, then refactor"
           fi
         fi

--- a/hooks/pre-edit-guard.sh
+++ b/hooks/pre-edit-guard.sh
@@ -13,9 +13,10 @@ INPUT=$(cat)
 
 # Base U-16 limit resolved from env var > ~/.vibeguard/config.json > built-in 800.
 _U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_U16_BASE_LIMIT")
 if [[ -n "${_VIBEGUARD_RUNTIME:-}" ]]; then
   _VG_FAST_RESULT=$(printf '%s' "$INPUT" \
-    | "$_VIBEGUARD_RUNTIME" pre-edit-check "$_U16_BASE_LIMIT" "$VIBEGUARD_LOG_FILE" \
+    | "$_VIBEGUARD_RUNTIME" pre-edit-check "$_U16_BASE_LIMIT" "$_U16_WARN_LIMIT" "$VIBEGUARD_LOG_FILE" \
     2>/dev/null || true)
   _VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
   case "$_VG_FAST_STATUS" in
@@ -37,7 +38,7 @@ vg_start_timer
 
 # Complete all checks directly in Python to avoid bash variable passing from destroying old_string
 # (<<<heredoc appends \n, $() swallows trailing newlines, echo escapes special characters)
-CHECK_RESULT=$(VG_U16_BASE_LIMIT="$_U16_BASE_LIMIT" python3 -c '
+CHECK_RESULT=$(VG_U16_BASE_LIMIT="$_U16_BASE_LIMIT" VG_U16_WARN_LIMIT="$_U16_WARN_LIMIT" python3 -c '
 import json, sys, os, re
 from pathlib import PurePath
 
@@ -145,8 +146,17 @@ if ext.lower() in SOURCE_EXTS and not is_test:
             break
         dir_path = os.path.dirname(dir_path)
 
+    warn_limit = int(os.environ.get("VG_U16_WARN_LIMIT", "400") or "400")
+    if limit > int(os.environ.get("VG_U16_BASE_LIMIT", "800") or "800"):
+        warn_limit = limit
+    else:
+        warn_limit = min(warn_limit, limit)
+
     if estimated > limit:
         print(f"U16_OVER_LIMIT:{estimated}:{limit}")
+        sys.exit(0)
+    if warn_limit < limit and estimated > warn_limit:
+        print(f"U16_OVER_TYPICAL:{estimated}:{warn_limit}:{limit}")
         sys.exit(0)
 
 print("OK")
@@ -223,6 +233,40 @@ if [[ "$DETAIL" == U16_OVER_LIMIT:* ]]; then
   _U16_LIM=$(echo "$DETAIL" | cut -d: -f3)
   vg_log "pre-edit-guard" "Edit" "block" "U-16 file size: ${_U16_EST} > ${_U16_LIM}" "$FILE_PATH"
   vg_json_output_kv decision block reason "VIBEGUARD [U-16] block: this edit would bring ${FILE_PATH##*/} to ~${_U16_EST} lines (limit: ${_U16_LIM}). Split the file into focused submodules before adding more code. Do NOT proceed with this edit."
+  exit 0
+fi
+
+if [[ "$DETAIL" == U16_OVER_TYPICAL:* ]]; then
+  _U16_EST=$(echo "$DETAIL" | cut -d: -f2)
+  _U16_WARN=$(echo "$DETAIL" | cut -d: -f3)
+  _U16_LIM=$(echo "$DETAIL" | cut -d: -f4)
+  vg_log "pre-edit-guard" "Edit" "warn" "U-16 file size advisory: ${_U16_EST} > ${_U16_WARN}" "$FILE_PATH"
+  VG_U16_FILE="${FILE_PATH##*/}" \
+  VG_U16_LINES="$_U16_EST" \
+  VG_U16_WARN="$_U16_WARN" \
+  VG_U16_LIMIT="$_U16_LIM" \
+  python3 - <<'PY'
+import json
+import os
+
+file_name = os.environ.get("VG_U16_FILE", "file")
+line_count = os.environ.get("VG_U16_LINES", "0")
+warn_limit = os.environ.get("VG_U16_WARN", "400")
+hard_limit = os.environ.get("VG_U16_LIMIT", "800")
+context = (
+    f"VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: this edit would leave {file_name} "
+    f"with {line_count} lines, exceeding the {warn_limit}-line typical range but staying "
+    f"under the {hard_limit}-line hard limit\n"
+    "SCOPE: keep the current change localized; plan a split if this file keeps growing\n"
+    "ACTION: NONE — advisory only, continue without acknowledgement"
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": context,
+    }
+}, ensure_ascii=False))
+PY
   exit 0
 fi
 

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -76,6 +76,10 @@ BLOCK_EOF
   exit 0
 fi
 
+_U16_SOURCE_NEW_LINES=""
+_U16_SOURCE_NEW_WARN=""
+_U16_SOURCE_NEW_LIMIT=""
+
 if [[ "$CHECK_STATUS" == "U16_WARN" || "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]]; then
   _CHECK_REST="${_CHECK_REST#*$'\n'}"
   _U16_LINES="${_CHECK_REST%%$'\n'*}"
@@ -85,14 +89,16 @@ if [[ "$CHECK_STATUS" == "U16_WARN" || "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" 
   _U16_LIM="${_CHECK_REST%%$'\n'*}"
   vg_log "pre-write-guard" "Write" "warn" "U-16 file size advisory: ${_U16_LINES} > ${_U16_WARN}" "$FILE_PATH"
   if [[ "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]]; then
-    vg_log "pre-write-guard" "Write" "warn" "New source file attempt" "$FILE_PATH"
-  fi
-  VG_U16_FILE="${FILE_PATH##*/}" \
-  VG_U16_LINES="$_U16_LINES" \
-  VG_U16_WARN="$_U16_WARN" \
-  VG_U16_LIMIT="$_U16_LIM" \
-  VG_U16_SOURCE_NEW="$([[ "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]] && printf 1 || printf 0)" \
-  python3 - <<'PY'
+    _U16_SOURCE_NEW_LINES="$_U16_LINES"
+    _U16_SOURCE_NEW_WARN="$_U16_WARN"
+    _U16_SOURCE_NEW_LIMIT="$_U16_LIM"
+    CHECK_STATUS="SOURCE_NEW"
+  else
+    VG_U16_FILE="${FILE_PATH##*/}" \
+    VG_U16_LINES="$_U16_LINES" \
+    VG_U16_WARN="$_U16_WARN" \
+    VG_U16_LIMIT="$_U16_LIM" \
+    python3 - <<'PY'
 import json
 import os
 
@@ -107,13 +113,6 @@ context = (
     "SCOPE: keep the current change localized; plan a split if this file keeps growing\n"
     "ACTION: NONE — advisory only, continue without acknowledgement"
 )
-if os.environ.get("VG_U16_SOURCE_NEW") == "1":
-    context += (
-        "\n---\n"
-        "VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\n"
-        "SCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\n"
-        "ACTION: NONE — advisory only, continue without acknowledgement"
-    )
 print(json.dumps({
     "hookSpecificOutput": {
         "hookEventName": "PreToolUse",
@@ -121,7 +120,8 @@ print(json.dumps({
     }
 }, ensure_ascii=False))
 PY
-  exit 0
+    exit 0
+  fi
 fi
 
 if [[ "$CHECK_STATUS" != "SOURCE_NEW" ]]; then
@@ -191,14 +191,39 @@ EOF
   if vg_cb_check "pre-write-guard"; then
     vg_log "pre-write-guard" "Write" "warn" "New source file reminder" "$FILE_PATH"
     vg_cb_record_block "pre-write-guard"
-    cat <<'EOF'
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "additionalContext": "VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\nSCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\nACTION: NONE — advisory only, continue without acknowledgement"
-  }
-}
-EOF
+    VG_U16_FILE="${FILE_PATH##*/}" \
+    VG_U16_LINES="$_U16_SOURCE_NEW_LINES" \
+    VG_U16_WARN="$_U16_SOURCE_NEW_WARN" \
+    VG_U16_LIMIT="$_U16_SOURCE_NEW_LIMIT" \
+    python3 - <<'PY'
+import json
+import os
+
+contexts = []
+line_count = os.environ.get("VG_U16_LINES", "")
+if line_count:
+    file_name = os.environ.get("VG_U16_FILE", "file")
+    warn_limit = os.environ.get("VG_U16_WARN", "400")
+    hard_limit = os.environ.get("VG_U16_LIMIT", "800")
+    contexts.append(
+        f"VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: writing {file_name} "
+        f"with {line_count} lines exceeds the {warn_limit}-line typical range but stays "
+        f"under the {hard_limit}-line hard limit\n"
+        "SCOPE: keep the current change localized; plan a split if this file keeps growing\n"
+        "ACTION: NONE — advisory only, continue without acknowledgement"
+    )
+contexts.append(
+    "VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\n"
+    "SCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\n"
+    "ACTION: NONE — advisory only, continue without acknowledgement"
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": "\n---\n".join(contexts),
+    }
+}, ensure_ascii=False))
+PY
   fi
   # Circuit OPEN: silent pass (vg_cb_check already logged the auto-pass).
 fi

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -23,7 +23,8 @@ _pass_and_exit() {
 INPUT=$(cat)
 
 _U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
-if ! CHECK_RESULT=$(printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" pre-write-check "$_U16_BASE_LIMIT" 2>/dev/null); then
+_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_U16_BASE_LIMIT")
+if ! CHECK_RESULT=$(printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" pre-write-check "$_U16_BASE_LIMIT" "$_U16_WARN_LIMIT" 2>/dev/null); then
   vg_log "pre-write-guard" "Write" "block" "vibeguard-runtime pre-write-check failed; fail-closed" ""
   vg_json_output_kv decision block reason "VIBEGUARD interception: runtime pre-write-check failed; fail-closed."
   exit 0
@@ -72,6 +73,54 @@ if [[ "$CHECK_STATUS" == "U16_BLOCK" ]]; then
   "reason": "VIBEGUARD [U-16] block: writing ${FILE_PATH##*/} with ${_U16_LINES} lines exceeds the ${_U16_LIM}-line limit. Split into focused submodules first. Do NOT proceed with this write."
 }
 BLOCK_EOF
+  exit 0
+fi
+
+if [[ "$CHECK_STATUS" == "U16_WARN" || "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]]; then
+  _CHECK_REST="${_CHECK_REST#*$'\n'}"
+  _U16_LINES="${_CHECK_REST%%$'\n'*}"
+  _CHECK_REST="${_CHECK_REST#*$'\n'}"
+  _U16_WARN="${_CHECK_REST%%$'\n'*}"
+  _CHECK_REST="${_CHECK_REST#*$'\n'}"
+  _U16_LIM="${_CHECK_REST%%$'\n'*}"
+  vg_log "pre-write-guard" "Write" "warn" "U-16 file size advisory: ${_U16_LINES} > ${_U16_WARN}" "$FILE_PATH"
+  if [[ "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]]; then
+    vg_log "pre-write-guard" "Write" "warn" "New source file attempt" "$FILE_PATH"
+  fi
+  VG_U16_FILE="${FILE_PATH##*/}" \
+  VG_U16_LINES="$_U16_LINES" \
+  VG_U16_WARN="$_U16_WARN" \
+  VG_U16_LIMIT="$_U16_LIM" \
+  VG_U16_SOURCE_NEW="$([[ "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]] && printf 1 || printf 0)" \
+  python3 - <<'PY'
+import json
+import os
+
+file_name = os.environ.get("VG_U16_FILE", "file")
+line_count = os.environ.get("VG_U16_LINES", "0")
+warn_limit = os.environ.get("VG_U16_WARN", "400")
+hard_limit = os.environ.get("VG_U16_LIMIT", "800")
+context = (
+    f"VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: writing {file_name} "
+    f"with {line_count} lines exceeds the {warn_limit}-line typical range but stays "
+    f"under the {hard_limit}-line hard limit\n"
+    "SCOPE: keep the current change localized; plan a split if this file keeps growing\n"
+    "ACTION: NONE — advisory only, continue without acknowledgement"
+)
+if os.environ.get("VG_U16_SOURCE_NEW") == "1":
+    context += (
+        "\n---\n"
+        "VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\n"
+        "SCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\n"
+        "ACTION: NONE — advisory only, continue without acknowledgement"
+    )
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": context,
+    }
+}, ensure_ascii=False))
+PY
   exit 0
 fi
 

--- a/templates/vibeguard-config.README.md
+++ b/templates/vibeguard-config.README.md
@@ -12,6 +12,7 @@ Malformed JSON or wrong-typed values silently fall through to the next layer —
 
 | JSON path | Env var | Default | Effect |
 |-----------|---------|---------|--------|
+| `u16.warn_limit` | `VG_U16_WARN_LIMIT` | `400` | Source-file typical-size advisory threshold. Files over this and below `u16.limit` warn without blocking. |
 | `u16.limit` | `VG_U16_LIMIT` | `800` | Source-file line limit. Files over this trigger block on `Write`/`Edit` and warn after `PostToolUse`. Per-file `CLAUDE.md` exemptions (`U-16 exempt: \`pattern\` → N`) can raise it further per repo. |
 | `circuit_breaker.threshold` | `VG_CB_THRESHOLD` | `3` | Consecutive blocks before the hook circuit trips OPEN (silences batch advisories). |
 | `circuit_breaker.cooldown_seconds` | `VG_CB_COOLDOWN` | `300` | Seconds an OPEN circuit waits before HALF-OPEN. |
@@ -23,7 +24,7 @@ Malformed JSON or wrong-typed values silently fall through to the next layer —
 ```json
 {
   "version": 1,
-  "u16": { "limit": 1200 }
+  "u16": { "warn_limit": 600, "limit": 1200 }
 }
 ```
 

--- a/templates/vibeguard-config.json.example
+++ b/templates/vibeguard-config.json.example
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "u16": {
+    "warn_limit": 400,
     "limit": 800
   },
   "circuit_breaker": {

--- a/tests/hooks/test_u16_config.sh
+++ b/tests/hooks/test_u16_config.sh
@@ -11,6 +11,7 @@ hook_test_init
 # --- Fixture setup ---------------------------------------------------------
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
+export VG_CB_THRESHOLD=999
 
 # 850-line python source (over default 800)
 big_py_content=$(python3 -c 'print("\n".join(f"x = {i}" for i in range(850)))')
@@ -94,6 +95,13 @@ result=$(run_pre_write_medium)
 assert_not_contains "$result" '"decision": "block"' "default 400/800: 450-line write is advisory only"
 assert_contains "$result" "[U-16]" "default 400/800: 450-line write emits U-16 advisory"
 assert_contains "$result" "400-line typical range" "write advisory cites typical threshold"
+assert_contains "$result" "[L1]" "450-line new source write still includes search-first advisory"
+
+export VIBEGUARD_WRITE_MODE=block
+result=$(run_pre_write_medium)
+assert_contains "$result" '"decision": "block"' "write_mode=block still blocks 450-line new source writes"
+assert_contains "$result" "[L1] [block]" "write_mode=block block reason stays L1 search-first"
+unset VIBEGUARD_WRITE_MODE
 
 export VG_U16_WARN_LIMIT=600
 result=$(run_pre_write_medium)

--- a/tests/hooks/test_u16_config.sh
+++ b/tests/hooks/test_u16_config.sh
@@ -14,6 +14,7 @@ trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
 
 # 850-line python source (over default 800)
 big_py_content=$(python3 -c 'print("\n".join(f"x = {i}" for i in range(850)))')
+medium_py_content=$(python3 -c 'print("\n".join(f"x = {i}" for i in range(450)))')
 
 # tool_input.content envelope for Write hooks
 write_input_file="$WORK_DIR/write_input.json"
@@ -21,6 +22,13 @@ python3 > "$write_input_file" <<PY
 import json
 content = "\n".join(f"x = {i}" for i in range(850))
 print(json.dumps({"tool_input": {"file_path": "$REPO_DIR/__vg_u16_cfg_subj.py", "content": content}}))
+PY
+
+medium_write_input_file="$WORK_DIR/medium_write_input.json"
+python3 > "$medium_write_input_file" <<PY
+import json
+content = "\n".join(f"x = {i}" for i in range(450))
+print(json.dumps({"tool_input": {"file_path": "$REPO_DIR/__vg_u16_typical_subj.py", "content": content}}))
 PY
 
 # Real on-disk file for Edit hook (needs to actually exist)
@@ -36,30 +44,66 @@ print(json.dumps({"tool_input": {
 }}))
 PY
 
+medium_edit_target="$WORK_DIR/medium_edit_target.py"
+printf '%s\n' "$medium_py_content" > "$medium_edit_target"
+medium_edit_input_file="$WORK_DIR/medium_edit_input.json"
+python3 > "$medium_edit_input_file" <<PY
+import json
+print(json.dumps({"tool_input": {
+    "file_path": "$medium_edit_target",
+    "old_string": "x = 449",
+    "new_string": "x = 449\nx = 450"
+}}))
+PY
+
 # --- Helpers ---------------------------------------------------------------
 run_pre_write() {
   bash hooks/pre-write-guard.sh < "$write_input_file"
 }
+run_pre_write_medium() {
+  bash hooks/pre-write-guard.sh < "$medium_write_input_file"
+}
 run_pre_edit() {
   bash hooks/pre-edit-guard.sh < "$edit_input_file"
 }
+run_pre_edit_medium() {
+  bash hooks/pre-edit-guard.sh < "$medium_edit_input_file"
+}
 run_post_write() {
   bash hooks/post-write-guard.sh < "$write_input_file" 2>/dev/null
+}
+run_post_write_medium() {
+  bash hooks/post-write-guard.sh < "$medium_write_input_file" 2>/dev/null
+}
+run_post_edit_medium() {
+  bash hooks/post-edit-guard.sh < "$medium_edit_input_file" 2>/dev/null
 }
 
 # --- pre-write-guard -------------------------------------------------------
 header "U-16 layered config — pre-write-guard"
 
 unset VG_U16_LIMIT
+unset VG_U16_WARN_LIMIT
 unset VIBEGUARD_CONFIG_FILE
 result=$(run_pre_write)
 assert_contains "$result" '"decision": "block"' "default 800: 850-line write blocks"
 assert_contains "$result" "850 lines" "block reason cites actual line count"
 assert_contains "$result" "800-line" "block reason cites resolved limit"
 
+result=$(run_pre_write_medium)
+assert_not_contains "$result" '"decision": "block"' "default 400/800: 450-line write is advisory only"
+assert_contains "$result" "[U-16]" "default 400/800: 450-line write emits U-16 advisory"
+assert_contains "$result" "400-line typical range" "write advisory cites typical threshold"
+
+export VG_U16_WARN_LIMIT=600
+result=$(run_pre_write_medium)
+assert_not_contains "$result" "[U-16]" "VG_U16_WARN_LIMIT=600: 450-line write has no U-16 advisory"
+unset VG_U16_WARN_LIMIT
+
 export VG_U16_LIMIT=1000
 result=$(run_pre_write)
 assert_not_contains "$result" '"decision": "block"' "VG_U16_LIMIT=1000 raises limit, no block"
+assert_contains "$result" "[U-16]" "VG_U16_LIMIT=1000 still emits typical-range advisory"
 unset VG_U16_LIMIT
 
 cfg_file="$WORK_DIR/cfg.json"
@@ -67,6 +111,11 @@ echo '{"u16":{"limit":1500}}' > "$cfg_file"
 export VIBEGUARD_CONFIG_FILE="$cfg_file"
 result=$(run_pre_write)
 assert_not_contains "$result" '"decision": "block"' "JSON u16.limit=1500 raises limit, no block"
+assert_contains "$result" "[U-16]" "JSON u16.limit=1500 still emits typical-range advisory"
+
+echo '{"u16":{"limit":1500,"warn_limit":900}}' > "$cfg_file"
+result=$(run_pre_write)
+assert_not_contains "$result" "[U-16]" "JSON u16.warn_limit=900 suppresses advisory for 850-line write"
 
 export VG_U16_LIMIT=500
 result=$(run_pre_write)
@@ -83,10 +132,20 @@ unset VIBEGUARD_CONFIG_FILE
 # --- pre-edit-guard --------------------------------------------------------
 header "U-16 layered config — pre-edit-guard"
 
-unset VG_U16_LIMIT VIBEGUARD_CONFIG_FILE
+unset VG_U16_LIMIT VG_U16_WARN_LIMIT VIBEGUARD_CONFIG_FILE
 result=$(run_pre_edit)
 assert_contains "$result" '"decision": "block"' "default 800: edit pushing to 851 blocks"
 assert_contains "$result" "limit: 800" "block reason cites resolved limit"
+
+result=$(run_pre_edit_medium)
+assert_not_contains "$result" '"decision": "block"' "default 400/800: edit to 451 lines is advisory only"
+assert_contains "$result" "[U-16]" "default 400/800: edit to 451 lines emits U-16 advisory"
+assert_contains "$result" "400-line typical range" "edit advisory cites typical threshold"
+
+export VG_U16_WARN_LIMIT=600
+result=$(run_pre_edit_medium)
+assert_not_contains "$result" "[U-16]" "VG_U16_WARN_LIMIT=600: edit to 451 lines has no U-16 advisory"
+unset VG_U16_WARN_LIMIT
 
 export VG_U16_LIMIT=2000
 result=$(run_pre_edit)
@@ -102,30 +161,52 @@ export VG_U16_LIMIT=600
 result=$(run_pre_edit)
 assert_contains "$result" '"decision": "block"' "env=600 beats JSON=2000, blocks"
 assert_contains "$result" "limit: 600" "block reason reflects env override"
-unset VG_U16_LIMIT VIBEGUARD_CONFIG_FILE
+unset VG_U16_LIMIT VG_U16_WARN_LIMIT VIBEGUARD_CONFIG_FILE
 
 # --- post-write-guard ------------------------------------------------------
 header "U-16 layered config — post-write-guard"
 
-unset VG_U16_LIMIT VIBEGUARD_CONFIG_FILE
+unset VG_U16_LIMIT VG_U16_WARN_LIMIT VIBEGUARD_CONFIG_FILE
 result=$(run_post_write)
 assert_contains "$result" "[U-16]" "default 800: 850-line write emits U-16 warn"
 assert_contains "$result" "exceeding 800-line limit" "warn cites resolved limit"
 
+result=$(run_post_write_medium)
+assert_contains "$result" "[U-16]" "default 400/800: 450-line post-write emits U-16 advisory"
+assert_contains "$result" "400-line typical range" "post-write advisory cites typical threshold"
+
 export VG_U16_LIMIT=1000
 result=$(run_post_write)
-assert_not_contains "$result" "[U-16]" "VG_U16_LIMIT=1000: silent (no U-16 warn)"
+assert_contains "$result" "400-line typical range" "VG_U16_LIMIT=1000: 850-line write emits advisory, not hard-limit warning"
+assert_not_contains "$result" "exceeding 1000-line limit" "VG_U16_LIMIT=1000: no hard-limit warning"
 unset VG_U16_LIMIT
 
 echo '{"u16":{"limit":1500}}' > "$cfg_file"
 export VIBEGUARD_CONFIG_FILE="$cfg_file"
 result=$(run_post_write)
-assert_not_contains "$result" "[U-16]" "JSON u16.limit=1500: silent"
+assert_contains "$result" "400-line typical range" "JSON u16.limit=1500: 850-line write emits advisory"
+
+echo '{"u16":{"limit":1500,"warn_limit":900}}' > "$cfg_file"
+result=$(run_post_write)
+assert_not_contains "$result" "[U-16]" "JSON u16.warn_limit=900: 850-line post-write is silent"
 
 export VG_U16_LIMIT=600
 result=$(run_post_write)
 assert_contains "$result" "exceeding 600-line limit" "env=600 wins, warn at 600"
-unset VG_U16_LIMIT VIBEGUARD_CONFIG_FILE
+unset VG_U16_LIMIT VG_U16_WARN_LIMIT VIBEGUARD_CONFIG_FILE
+
+# --- post-edit-guard -------------------------------------------------------
+header "U-16 layered config — post-edit-guard"
+
+unset VG_U16_LIMIT VG_U16_WARN_LIMIT VIBEGUARD_CONFIG_FILE
+result=$(run_post_edit_medium)
+assert_contains "$result" "[U-16]" "default 400/800: 450-line post-edit emits U-16 advisory"
+assert_contains "$result" "400-line typical range" "post-edit advisory cites typical threshold"
+
+export VG_U16_WARN_LIMIT=600
+result=$(run_post_edit_medium)
+assert_not_contains "$result" "[U-16]" "VG_U16_WARN_LIMIT=600: 450-line post-edit is silent"
+unset VG_U16_WARN_LIMIT
 
 # --- config.sh helper unit checks -----------------------------------------
 header "vg_config_get_int — unit"
@@ -139,10 +220,14 @@ got=$(vg_config_get_int VG_TEST_X u16.limit 800)
 [[ "$got" == "800" ]] && green "missing config falls back to default" || { red "missing config (got: $got)"; FAIL=$((FAIL+1)); }
 TOTAL=$((TOTAL+1)); PASS=$((PASS+1))
 
-echo '{"u16":{"limit":1234}}' > "$WORK_DIR/cfg.json"
+echo '{"u16":{"limit":1234,"warn_limit":456}}' > "$WORK_DIR/cfg.json"
 _VG_CONFIG_FILE="$WORK_DIR/cfg.json"
 got=$(vg_config_get_int VG_TEST_X u16.limit 800)
 [[ "$got" == "1234" ]] && green "JSON read returns int" || { red "JSON int (got: $got)"; FAIL=$((FAIL+1)); }
+TOTAL=$((TOTAL+1)); PASS=$((PASS+1))
+
+got=$(vg_config_get_int VG_TEST_WARN u16.warn_limit 400)
+[[ "$got" == "456" ]] && green "JSON read returns U-16 warn_limit" || { red "JSON warn_limit (got: $got)"; FAIL=$((FAIL+1)); }
 TOTAL=$((TOTAL+1)); PASS=$((PASS+1))
 
 VG_TEST_X=999

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -73,6 +73,7 @@ from pathlib import Path
 data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 checks = [
     data.get("write_mode") == "warn",
+    data.get("u16", {}).get("warn_limit") == 400,
     data.get("u16", {}).get("limit") == 800,
     data.get("circuit_breaker", {}).get("threshold") == 3,
     data.get("circuit_breaker", {}).get("cooldown_seconds") == 300,

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -26,6 +26,10 @@ pub fn pre_write_check(args: &[String]) -> Result {
         .first()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(800);
+    let warn_limit = args
+        .get(1)
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(400);
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
         println!("MALFORMED");
@@ -46,7 +50,8 @@ pub fn pre_write_check(args: &[String]) -> Result {
 
     let content = nested_str(&data, "tool_input.content").unwrap_or_default();
     let line_count = count_lines(&content);
-    if is_source_path(&file_path) && !is_test_path(&file_path) && line_count > base_limit {
+    let mut u16_advisory = None;
+    if is_source_path(&file_path) && !is_test_path(&file_path) {
         let limit = project_u16_limit(&file_path, base_limit);
         if line_count > limit {
             println!("U16_BLOCK");
@@ -55,9 +60,21 @@ pub fn pre_write_check(args: &[String]) -> Result {
             println!("{limit}");
             return Ok(());
         }
+        let advisory_limit = u16_advisory_limit(base_limit, limit, warn_limit);
+        if advisory_limit < limit && line_count > advisory_limit {
+            u16_advisory = Some((line_count, advisory_limit, limit));
+        }
     }
 
     if Path::new(&file_path).exists() {
+        if let Some((line_count, advisory_limit, limit)) = u16_advisory {
+            println!("U16_WARN");
+            println!("{file_path}");
+            println!("{line_count}");
+            println!("{advisory_limit}");
+            println!("{limit}");
+            return Ok(());
+        }
         println!("EXISTS");
         println!("{file_path}");
         return Ok(());
@@ -69,6 +86,15 @@ pub fn pre_write_check(args: &[String]) -> Result {
         return Ok(());
     }
 
+    if let Some((line_count, advisory_limit, limit)) = u16_advisory {
+        println!("U16_WARN_SOURCE_NEW");
+        println!("{file_path}");
+        println!("{line_count}");
+        println!("{advisory_limit}");
+        println!("{limit}");
+        return Ok(());
+    }
+
     println!("SOURCE_NEW");
     println!("{file_path}");
     Ok(())
@@ -76,11 +102,17 @@ pub fn pre_write_check(args: &[String]) -> Result {
 
 pub fn pre_edit_check(args: &[String]) -> Result {
     if args.len() < 2 {
-        return Err("Usage: vibeguard-runtime pre-edit-check <base-limit> <log-file>".into());
+        return Err(
+            "Usage: vibeguard-runtime pre-edit-check <base-limit> [warn-limit] <log-file>".into(),
+        );
     }
 
     let base_limit = args[0].parse::<usize>().unwrap_or(800);
-    let log_file = &args[1];
+    let (warn_limit, log_file) = if args.len() >= 3 {
+        (args[1].parse::<usize>().unwrap_or(400), &args[2])
+    } else {
+        (400, &args[1])
+    };
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
         write_pre_edit_block(
@@ -184,6 +216,38 @@ pub fn pre_edit_check(args: &[String]) -> Result {
                             .unwrap_or(&file_path)
                     ),
                 )?;
+                return Ok(());
+            }
+            let advisory_limit = u16_advisory_limit(base_limit, limit, warn_limit);
+            if advisory_limit < limit && estimated > advisory_limit {
+                if write_log_event(
+                    log_file,
+                    "pre-edit-guard",
+                    "Edit",
+                    "warn",
+                    &format!("U-16 file size advisory: {estimated} > {advisory_limit}"),
+                    &file_path,
+                )
+                .is_err()
+                {
+                    println!("FALLBACK");
+                    return Ok(());
+                }
+                println!("FAST_OUTPUT");
+                println!(
+                    "{}",
+                    hook_context_json(
+                        "PreToolUse",
+                        &u16_advisory_context(
+                            &file_path,
+                            estimated,
+                            advisory_limit,
+                            limit,
+                            "this edit would leave",
+                            false,
+                        )
+                    )
+                );
                 return Ok(());
             }
         }
@@ -306,6 +370,44 @@ fn missing_file_candidates(file_path: &str, stem: &str) -> MissingFileCandidates
 fn decision_block_json(reason: &str) -> String {
     let escaped = serde_json::to_string(reason).unwrap_or_else(|_| "\"\"".to_string());
     format!("{{ \"decision\": \"block\", \"reason\": {escaped} }}")
+}
+
+fn hook_context_json(event_name: &str, context: &str) -> String {
+    let escaped = serde_json::to_string(context).unwrap_or_else(|_| "\"\"".to_string());
+    format!(
+        "{{\"hookSpecificOutput\":{{\"hookEventName\":\"{event_name}\",\"additionalContext\":{escaped}}}}}"
+    )
+}
+
+fn u16_advisory_limit(base_limit: usize, hard_limit: usize, warn_limit: usize) -> usize {
+    if hard_limit > base_limit {
+        hard_limit
+    } else {
+        warn_limit.min(hard_limit)
+    }
+}
+
+fn u16_advisory_context(
+    file_path: &str,
+    line_count: usize,
+    warn_limit: usize,
+    hard_limit: usize,
+    action: &str,
+    include_search: bool,
+) -> String {
+    let file_name = Path::new(file_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(file_path);
+    let mut context = format!(
+        "VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: {action} {file_name} with {line_count} lines exceeds the {warn_limit}-line typical range but stays under the {hard_limit}-line hard limit\nSCOPE: keep the current change localized; plan a split if this file keeps growing\nACTION: NONE — advisory only, continue without acknowledgement"
+    );
+    if include_search {
+        context.push_str(
+            "\n---\nVIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\nSCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\nACTION: NONE — advisory only, continue without acknowledgement",
+        );
+    }
+    context
 }
 
 pub fn post_edit_fast_check(args: &[String]) -> Result {

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -78,12 +78,12 @@ static COMMANDS: &[Command] = &[
     },
     Command {
         name: "pre-write-check",
-        usage: "<base-limit>  — classify PreToolUse(Write) input for hooks",
+        usage: "<base-limit> [warn-limit]  — classify PreToolUse(Write) input for hooks",
         handler: hook_checks::pre_write_check,
     },
     Command {
         name: "pre-edit-check",
-        usage: "<base-limit> <log-file>  — classify and handle PreToolUse(Edit) input for hooks",
+        usage: "<base-limit> [warn-limit] <log-file>  — classify and handle PreToolUse(Edit) input for hooks",
         handler: hook_checks::pre_edit_check,
     },
     Command {


### PR DESCRIPTION
## Summary
- add a configurable `u16.warn_limit` / `VG_U16_WARN_LIMIT` defaulting to 400 lines
- surface non-blocking U-16 advisories in pre-write, pre-edit, post-write, and post-edit flows while keeping the 800-line hard limit behavior
- update config templates/docs and expand U-16 hook coverage for warn/hard thresholds

Fixes #246

## Validation
- `bash -n hooks/pre-write-guard.sh hooks/pre-edit-guard.sh hooks/post-write-guard.sh hooks/post-edit-guard.sh hooks/_lib/post_edit_quality.sh hooks/_lib/config.sh tests/hooks/test_u16_config.sh tests/test_setup.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo build --release --manifest-path vibeguard-runtime/Cargo.toml --quiet`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/hooks/test_u16_config.sh`
- `bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash tests/test_setup.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-no-personal-paths.sh`
- `bash scripts/ci/check-event-schema-literals.sh`
- `git diff --check`