### PR TITLE
Point U-17 and U-23 at U-29 canonical guidance

### DIFF
--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -40,13 +40,13 @@ Canonical source of truth: `rules/claude-rules/`
 | U-14 | CLI default path uses a different base directory than GUI/server | Medium | Different entry points use different base directories. |
 | U-15 | Prefer immutability | Guideline | Create new objects instead of mutating existing ones. |
 | U-16 | Keep file size under control | Guideline | 200-400 lines is typical, 800 lines is the hard ceiling. |
-| U-17 | Handle errors completely | Strict | Cover error paths thoroughly. |
+| U-17 | Handle errors completely | Strict | See U-29 for canonical error-handling guidance. |
 | U-18 | Validate inputs | Guideline | Validate all user input at system boundaries. |
 | U-19 | Use the Repository pattern | Guideline | Encapsulate data access in a Repository layer. |
 | U-20 | Keep API response shapes consistent | Guideline | Use a standard envelope such as `{ data, error, meta }`. |
 | U-21 | Commit messages must follow the Lore protocol | Strict | Record why the change exists, not just what changed. |
 | U-22 | Test coverage | Strict | New code must reach at least 80% line coverage. |
-| U-23 | No silent degradation | Strict | Unsupported strategies or configurations must fail explicitly or be marked as DEFER. |
+| U-23 | No silent degradation | Strict | See U-29 for canonical no-silent-degradation guidance. |
 | U-24 | No aliases | Strict | Do not keep function, type, command, or directory aliases. |
 | U-25 | Fix build failures first | Strict | When a build failure is detected, you must fix the build before continuing any other edits. |
 | U-26 | Declaration-execution completeness | Strict | When you declare framework components such as configs, traits, persistence layers, or state containers, you must also finish the startup... |

--- a/rules/claude-rules/common/coding-style.md
+++ b/rules/claude-rules/common/coding-style.md
@@ -37,7 +37,7 @@ Create new objects instead of mutating existing ones. Treat function parameters 
 200-400 lines is typical, 800 lines is the hard ceiling. Files above 800 lines must be split.
 
 ## U-17: Handle errors completely (strict)
-Cover error paths thoroughly. Do not swallow exceptions silently. Provide user-friendly error messages.
+See U-29 for canonical error-handling guidance. U-17 keeps the compatibility-level principle: do not swallow exception or error paths; surface user-visible failures at error level or raise.
 
 ## U-18: Validate inputs (guideline)
 Validate all user input at system boundaries. Internal code can trust framework guarantees.
@@ -61,7 +61,7 @@ New code must reach at least 80% line coverage. Critical paths require 100% cove
 - If you refactor hook or module interfaces, update every test mock that depends on the module shape as well (see TS-14).
 
 ## U-23: No silent degradation (strict)
-Unsupported strategies or configurations must fail explicitly or be marked as DEFER. Do not silently fall back to a default strategy.
+See U-29 for canonical no-silent-degradation guidance. Unsupported strategies or configurations must fail explicitly or be marked as DEFER; do not invent default fallback semantics.
 
 ## U-24: No aliases (strict)
 Do not keep function, type, command, or directory aliases. If you find the old name, replace it everywhere and delete the alias.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -24,13 +24,13 @@ Reference index for VibeGuard rules that apply across languages, workflows, and 
 | U-14 | CLI default path uses a different base directory than GUI/server | Medium | Different entry points use different base directories. |
 | U-15 | Prefer immutability | Guideline | Create new objects instead of mutating existing ones. |
 | U-16 | Keep file size under control | Guideline | 200-400 lines is typical, 800 lines is the hard ceiling. |
-| U-17 | Handle errors completely | Strict | Cover error paths thoroughly. |
+| U-17 | Handle errors completely | Strict | See U-29 for canonical error-handling guidance. |
 | U-18 | Validate inputs | Guideline | Validate all user input at system boundaries. |
 | U-19 | Use the Repository pattern | Guideline | Encapsulate data access in a Repository layer. |
 | U-20 | Keep API response shapes consistent | Guideline | Use a standard envelope such as `{ data, error, meta }`. |
 | U-21 | Commit messages must follow the Lore protocol | Strict | Record why the change exists, not just what changed. |
 | U-22 | Test coverage | Strict | New code must reach at least 80% line coverage. |
-| U-23 | No silent degradation | Strict | Unsupported strategies or configurations must fail explicitly or be marked as DEFER. |
+| U-23 | No silent degradation | Strict | See U-29 for canonical no-silent-degradation guidance. |
 | U-24 | No aliases | Strict | Do not keep function, type, command, or directory aliases. |
 | U-25 | Fix build failures first | Strict | When a build failure is detected, you must fix the build before continuing any other edits. |
 | U-26 | Declaration-execution completeness | Strict | When you declare framework components such as configs, traits, persistence layers, or state containers, you must also finish the startup... |

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -13,3 +13,15 @@ if ! grep -Fq "${expected_l1}" docs/rule-reference.md; then
   echo "docs/rule-reference.md must describe L1 as warn-by-default with explicit block modes" >&2
   exit 1
 fi
+
+expected_u17='| U-17 | Handle errors completely | Strict | See U-29 for canonical error-handling guidance. |'
+if ! grep -Fq "${expected_u17}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must keep U-17 as a pointer to canonical U-29 guidance" >&2
+  exit 1
+fi
+
+expected_u23='| U-23 | No silent degradation | Strict | See U-29 for canonical no-silent-degradation guidance. |'
+if ! grep -Fq "${expected_u23}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must keep U-23 as a pointer to canonical U-29 guidance" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- keep U-17 and U-23 as stable compatibility rule IDs
- rewrite their bodies as compact pointers to U-29 canonical error-handling / no-silent-degradation guidance
- regenerate public rule summaries and pin the generated U-17/U-23 rows in the generated-doc validation script

Fixes #276
Follow-up to #242
Part of #266

## Validation
- bash -n scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/validate-canonical-rule-language.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/run-all.sh
- bash scripts/ci/validate-no-personal-paths.sh
- git diff --check
