### PR TITLE
Point U-08 at W-03/W-16 verification guidance

### DIFF
--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -31,7 +31,7 @@ Canonical source of truth: `rules/claude-rules/`
 | U-05 | Do not delete code that merely looks unused without confirming first | Strict | It may be a work-in-progress feature. |
 | U-06 | Do not add dependencies for problems the standard library can solve | Strict | Use the standard library first. |
 | U-07 | Do not change code style while fixing behavior | Strict | Style-only edits should be a separate commit. |
-| U-08 | Do not skip verification steps | Strict | Every fix must independently pass lint and tests. |
+| U-08 | Do not skip verification steps | Strict | See W-03 and W-16 for canonical verification guidance. |
 | U-09 | Do not bundle unrelated fixes into one commit | Strict | Keep commits atomic so they are easy to review and revert. |
 | U-10 | Do not guess user intent | Strict | If the intent is unclear, mark it as DEFER or ask the user to clarify. |
 | U-11 | Inconsistent default DB/cache paths across binaries | High | Different entry points hardcode different data paths, which splits user data. |

--- a/rules/claude-rules/common/coding-style.md
+++ b/rules/claude-rules/common/coding-style.md
@@ -22,7 +22,7 @@ Use the standard library first. Avoid dependency bloat.
 Style-only edits should be a separate commit.
 
 ## U-08: Do not skip verification steps (strict)
-Every fix must independently pass lint and tests.
+See W-03 and W-16 for canonical verification guidance. U-08 keeps the compatibility-level principle: a fix is not complete until focused lint, test, or check evidence for the changed surface was produced in the current session.
 
 ## U-09: Do not bundle unrelated fixes into one commit (strict)
 Keep commits atomic so they are easy to review and revert.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -15,7 +15,7 @@ Reference index for VibeGuard rules that apply across languages, workflows, and 
 | U-05 | Do not delete code that merely looks unused without confirming first | Strict | It may be a work-in-progress feature. |
 | U-06 | Do not add dependencies for problems the standard library can solve | Strict | Use the standard library first. |
 | U-07 | Do not change code style while fixing behavior | Strict | Style-only edits should be a separate commit. |
-| U-08 | Do not skip verification steps | Strict | Every fix must independently pass lint and tests. |
+| U-08 | Do not skip verification steps | Strict | See W-03 and W-16 for canonical verification guidance. |
 | U-09 | Do not bundle unrelated fixes into one commit | Strict | Keep commits atomic so they are easy to review and revert. |
 | U-10 | Do not guess user intent | Strict | If the intent is unclear, mark it as DEFER or ask the user to clarify. |
 | U-11 | Inconsistent default DB/cache paths across binaries | High | Different entry points hardcode different data paths, which splits user data. |

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -14,6 +14,12 @@ if ! grep -Fq "${expected_l1}" docs/rule-reference.md; then
   exit 1
 fi
 
+expected_u08='| U-08 | Do not skip verification steps | Strict | See W-03 and W-16 for canonical verification guidance. |'
+if ! grep -Fq "${expected_u08}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must keep U-08 as a pointer to canonical W-03/W-16 guidance" >&2
+  exit 1
+fi
+
 expected_u17='| U-17 | Handle errors completely | Strict | See U-29 for canonical error-handling guidance. |'
 if ! grep -Fq "${expected_u17}" docs/rule-reference.md; then
   echo "docs/rule-reference.md must keep U-17 as a pointer to canonical U-29 guidance" >&2


### PR DESCRIPTION
## Summary
- keep U-08 as a stable compatibility rule ID
- rewrite U-08 as a compact pointer to W-03/W-16 canonical verification guidance
- regenerate public rule summaries and pin the generated U-08 row in generated-doc validation

Fixes #278
Follow-up to #242
Part of #266

## Validation
- bash -n scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/validate-canonical-rule-language.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check
