### PR TITLE
Document rule severity semantics

### DIFF
--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -20,6 +20,19 @@ Canonical source of truth: `rules/claude-rules/`
 
 ---
 
+## Severity Semantics
+
+Severity labels describe the agent/reviewer contract. They do not, by themselves, promise that every rule is hook-blocked.
+
+| Severity | Meaning |
+|----------|---------|
+| Critical | Security or data-loss risk that should block until fixed or explicitly accepted. |
+| High / Medium / Low | Risk-ranked findings for guard outputs and review triage. |
+| Strict | Non-negotiable agent/reviewer rule. If enforcement is not mechanical, violations still need a fix, explicit DEFER, or documented downgrade path. |
+| Guideline | Preferred pattern; follow when it helps the current task without expanding scope. |
+
+---
+
 ## Common Rules (U-series)
 
 | ID | Name | Severity | Summary |

--- a/rules/CLAUDE.md
+++ b/rules/CLAUDE.md
@@ -24,7 +24,7 @@ VibeGuard rule files define inspection standards for each language and domain.
 ## Each rule contains
 
 1. ID and name
-2. Severity (high/medium/low)
+2. Severity (critical/strict/high/medium/low/guideline)
 3. Description of inspection items
 4. Repair mode (specific code repair method)
 5. FIX/SKIP judgment matrix

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -20,6 +20,12 @@ if ! grep -Fq "${expected_strict}" docs/rule-reference.md; then
   exit 1
 fi
 
+expected_guideline='| Guideline | Preferred pattern; follow when it helps the current task without expanding scope. |'
+if ! grep -Fq "${expected_guideline}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must define Guideline as a preferred pattern, not a required block" >&2
+  exit 1
+fi
+
 expected_u08='| U-08 | Do not skip verification steps | Strict | See W-03 and W-16 for canonical verification guidance. |'
 if ! grep -Fq "${expected_u08}" docs/rule-reference.md; then
   echo "docs/rule-reference.md must keep U-08 as a pointer to canonical W-03/W-16 guidance" >&2

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -14,6 +14,12 @@ if ! grep -Fq "${expected_l1}" docs/rule-reference.md; then
   exit 1
 fi
 
+expected_strict='| Strict | Non-negotiable agent/reviewer rule. If enforcement is not mechanical, violations still need a fix, explicit DEFER, or documented downgrade path. |'
+if ! grep -Fq "${expected_strict}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must define Strict as an agent/reviewer contract, not automatic hook blocking" >&2
+  exit 1
+fi
+
 expected_u08='| U-08 | Do not skip verification steps | Strict | See W-03 and W-16 for canonical verification guidance. |'
 if ! grep -Fq "${expected_u08}" docs/rule-reference.md; then
   echo "docs/rule-reference.md must keep U-08 as a pointer to canonical W-03/W-16 guidance" >&2

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -391,6 +391,19 @@ Canonical source of truth: `rules/claude-rules/`
 
 ---
 
+## Severity Semantics
+
+Severity labels describe the agent/reviewer contract. They do not, by themselves, promise that every rule is hook-blocked.
+
+| Severity | Meaning |
+|----------|---------|
+| Critical | Security or data-loss risk that should block until fixed or explicitly accepted. |
+| High / Medium / Low | Risk-ranked findings for guard outputs and review triage. |
+| Strict | Non-negotiable agent/reviewer rule. If enforcement is not mechanical, violations still need a fix, explicit DEFER, or documented downgrade path. |
+| Guideline | Preferred pattern; follow when it helps the current task without expanding scope. |
+
+---
+
 ## Common Rules (U-series)
 
 {make_table(["ID", "Name", "Severity", "Summary"], rows_for(common, ["U"]))}


### PR DESCRIPTION
## Summary
- add generated severity semantics to the public rule reference
- clarify that Strict is an agent/reviewer contract, not a promise of automatic hook blocking
- pin the Strict wording in generated-doc validation
- update rules/CLAUDE.md so it lists all supported severity labels

Fixes #280
Follow-up to #242
Part of #266

## Validation
- python3 -m py_compile scripts/generate_rule_docs.py
- bash -n scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/validate-canonical-rule-language.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-no-personal-paths.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check
