### PR TITLE
Document lint boundary for language rules

### DIFF
--- a/rules/go.md
+++ b/rules/go.md
@@ -4,6 +4,10 @@
 
 Reference index for scanning and repairing Go projects.
 
+## Linter Boundary
+
+These rules do not replace native linters. Treat lint-equivalent entries as agent reminders and review triage; use the verification command below for mechanical enforcement. Semantic/contextual entries remain useful when native linters lack project-level context.
+
 ## Scan checklist
 
 | ID | Rule | Severity | Summary |

--- a/rules/python.md
+++ b/rules/python.md
@@ -4,6 +4,10 @@
 
 Reference index for scanning and repairing Python projects.
 
+## Linter Boundary
+
+These rules do not replace native linters. Treat lint-equivalent entries as agent reminders and review triage; use the verification command below for mechanical enforcement. Semantic/contextual entries remain useful when native linters lack project-level context.
+
 ## Scan checklist
 
 | ID | Rule | Severity | Summary |

--- a/rules/rust.md
+++ b/rules/rust.md
@@ -4,6 +4,10 @@
 
 Reference index for scanning and repairing Rust projects.
 
+## Linter Boundary
+
+These rules do not replace native linters. Treat lint-equivalent entries as agent reminders and review triage; use the verification command below for mechanical enforcement. Semantic/contextual entries remain useful when native linters lack project-level context.
+
 ## Scan checklist
 
 | ID | Rule | Severity | Summary |

--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -4,6 +4,10 @@
 
 Reference index for scanning and repairing TypeScript projects.
 
+## Linter Boundary
+
+These rules do not replace native linters. Treat lint-equivalent entries as agent reminders and review triage; use the verification command below for mechanical enforcement. Semantic/contextual entries remain useful when native linters lack project-level context.
+
 ## Scan checklist
 
 | ID | Rule | Severity | Summary |

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -26,6 +26,14 @@ if ! grep -Fq "${expected_guideline}" docs/rule-reference.md; then
   exit 1
 fi
 
+expected_linter_boundary='These rules do not replace native linters. Treat lint-equivalent entries as agent reminders and review triage; use the verification command below for mechanical enforcement.'
+for generated_language_doc in rules/python.md rules/typescript.md rules/go.md rules/rust.md; do
+  if ! grep -Fq "${expected_linter_boundary}" "${generated_language_doc}"; then
+    echo "${generated_language_doc} must state the lint-vs-agent boundary" >&2
+    exit 1
+  fi
+done
+
 expected_u08='| U-08 | Do not skip verification steps | Strict | See W-03 and W-16 for canonical verification guidance. |'
 if ! grep -Fq "${expected_u08}" docs/rule-reference.md; then
   echo "docs/rule-reference.md must keep U-08 as a pointer to canonical W-03/W-16 guidance" >&2

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -292,6 +292,10 @@ def render_language_rules(title: str, intro: str, rule_list: list[Rule], verific
 
 {intro}
 
+## Linter Boundary
+
+These rules do not replace native linters. Treat lint-equivalent entries as agent reminders and review triage; use the verification command below for mechanical enforcement. Semantic/contextual entries remain useful when native linters lack project-level context.
+
 ## Scan checklist
 
 {make_table(["ID", "Rule", "Severity", "Summary"], rows_for(rule_list))}


### PR DESCRIPTION
## Summary
- add a generated Linter Boundary section to language rule docs
- clarify that VibeGuard language rules do not replace native linters
- frame lint-equivalent entries as agent reminders/review triage, with verification commands as the mechanical enforcement path
- pin the generated boundary text across language docs

Fixes #282
Follow-up to #242
Part of #266

## Validation
- python3 -m py_compile scripts/generate_rule_docs.py
- bash -n scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-rules.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/run-all.sh
- git diff --check
