### PR TITLE
Scope narrow common rule loading

### DIFF
--- a/docs/how/memory-files.md
+++ b/docs/how/memory-files.md
@@ -36,14 +36,21 @@ VibeGuard installs native rule files under `common/`, `rust/`, `golang/`, `types
 ```text
 ~/.claude/rules/vibeguard/
 ├── common/
+│   ├── agent-harness-audit.md
 │   ├── coding-style.md
 │   ├── data-consistency.md
+│   ├── eval-validation.md
+│   ├── execution-pinning.md
 │   ├── fact-inference-separation.md
+│   ├── long-horizon-reliability.md
 │   ├── no-silent-degradation.md
 │   ├── publish-action-confirmation.md
 │   ├── security.md
+│   ├── vibe-coding-production.md
 │   └── workflow.md
-├── rust/quality.md
+├── rust/
+│   ├── quality.md
+│   └── struct-field-change-checklist.md
 ├── golang/quality.md
 ├── typescript/quality.md
 └── python/

--- a/rules/claude-rules/common/data-consistency.md
+++ b/rules/claude-rules/common/data-consistency.md
@@ -1,6 +1,14 @@
+---
+paths: **/*.rs,**/*.go,**/*.py,**/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/Cargo.toml,**/Cargo.lock,**/go.mod,**/go.sum,**/pyproject.toml,**/setup.py,**/package.json,**/package-lock.json,**/pnpm-lock.yaml,**/yarn.lock
+---
+
 # Cross-Entry Data Consistency Rules
 
 When multiple binaries in a monorepo or workspace share one data source, configuration must converge.
+
+## Applicability
+
+U-11 through U-14 apply when a project has multiple entry points, binaries, services, CLIs, workers, or UI/server surfaces that share persisted database or cache state. For a single-entry-point project, or a project with no persisted shared state, treat these rules as not applicable and do not create work solely to satisfy them.
 
 ## U-11: Inconsistent default DB/cache paths across binaries (high)
 Different entry points hardcode different data paths, which splits user data. Fix: make every entry point call the same shared `default_db_path()` helper in the core layer, and standardize environment-variable names.

--- a/rules/claude-rules/common/eval-validation.md
+++ b/rules/claude-rules/common/eval-validation.md
@@ -1,0 +1,48 @@
+---
+paths: **/evals/**,**/eval/**,**/evaluations/**,**/benchmarks/**,**/tests/eval*/**,**/*eval*.py,**/*eval*.ts,**/*eval*.tsx,**/*eval*.js,**/*eval*.rs,**/*eval*.go,**/pyproject.toml,**/package.json,**/Cargo.toml,**/go.mod
+---
+
+# Evaluation Validation Rules
+
+## Applicability
+
+W-18 applies when developing or reviewing eval harnesses, benchmark suites, agent-evaluation pipelines, or release gates that rely on model/agent evaluation results. For tasks that do not touch eval definitions, eval runners, benchmark fixtures, or eval-related dependencies, this rule is not part of the active task contract.
+
+## W-18: Evaluations must validate path, not only output (strict)
+Output-only evaluations miss systemic failures. An agent or pipeline can produce the correct final answer through the wrong tool, by skipping a required step, or with miscalibrated confidence; in production these all read as "passing" but degrade the moment the inputs shift.
+
+**Sources** (2026-04-27):
+- Confident AI, "Three Ways AI Systems Fail Even When Evals Pass" - names the three failure modes below
+- Microsoft Research, AgentRx (2026-04) - the same failure modes recur in the 9-class trajectory taxonomy
+- Anthropic Claude Code postmortem (2026-04-24) - quality degradation that no end-to-end eval caught, because the eval did not look at session-state behavior
+
+**The three failure modes that pass output-only evals**:
+
+| Mode | Description | What the eval saw | What was actually wrong |
+|------|-------------|-------------------|-------------------------|
+| Wrong tool, right answer | Used a search tool when a structured DB lookup was required | Correct value in response | Cached or pretrained knowledge, not the current source of truth |
+| Skipped required step | Answered without doing the mandatory retrieval / validation step | Correct answer | Bypassed the very check that the system was designed to enforce |
+| Miscalibrated confidence | Returned a wrong answer with high stated certainty | "Confident" output | No signal for downstream caller to fall back |
+
+**Required eval coverage (strict)**:
+
+Every eval suite that gates a release or guards a production agent must validate three axes, not one:
+
+1. **Tool selection** - assert that the trajectory used the expected tool (or a member of an allowed set) for each protected step. If the agent has no tools, this axis is vacuous and may be skipped, but the suite must say so explicitly.
+2. **Step adherence** - assert that the trajectory contains every mandatory step in the documented order. Examples: retrieval before answer, schema validation before write, permission check before mutation. A "skip step" must fail the eval even when the final output is correct.
+3. **Confidence calibration** - assert that stated confidence tracks correctness on the eval set. Concretely, expected calibration error (ECE) on the bucketed predictions must be reported alongside accuracy. An agent that is 90% confident on a sample where it is correct 50% of the time is a calibration failure even if accuracy is "fine".
+
+**Mechanical checks (agent execution rules)**:
+- When asked to "evaluate" a model, agent, or pipeline, first ask: does the suite log the trajectory (tool calls, ordered steps, stated confidence) or only the final output?
+- If only the final output is logged, the suite cannot satisfy W-18. The required fix is to record trajectory metadata, not to add more output-level cases.
+- When adding a new eval case, declare its target axis. A case that does not exercise tool selection, step adherence, or confidence calibration is an output-only case and must be balanced by cases on the other axes.
+- Reject pull requests that claim "evals pass" while the eval definition does not assert any of the three axes.
+
+**Anti-patterns**:
+- Reporting `pass@k` as the only quality metric for a tool-using agent.
+- Adding more end-to-end golden outputs to "harden" a regression that was actually a tool-selection or step-skip failure.
+- Reading model confidence directly without ever measuring how it correlates with correctness.
+- Marking a release green because output-level evals are stable, when the underlying trajectory shape has changed.
+
+**Downgrade path**:
+For pure text generation tasks with no tools and no required intermediate steps, axes 1 and 2 are vacuous and may be skipped if the eval suite explicitly states so. Axis 3 (calibration) is never optional whenever the model emits or implies a confidence value to a caller.

--- a/rules/claude-rules/common/eval-validation.md
+++ b/rules/claude-rules/common/eval-validation.md
@@ -1,5 +1,5 @@
 ---
-paths: **/evals/**,**/eval/**,**/evaluations/**,**/benchmarks/**,**/tests/eval*/**,**/*eval*.py,**/*eval*.ts,**/*eval*.tsx,**/*eval*.js,**/*eval*.rs,**/*eval*.go,**/pyproject.toml,**/package.json,**/Cargo.toml,**/go.mod
+paths: evals/**,**/evals/**,eval/**,**/eval/**,evaluations/**,**/evaluations/**,benchmarks/**,**/benchmarks/**,tests/eval*/**,**/tests/eval*/**,*eval*.py,**/*eval*.py,*eval*.ts,**/*eval*.ts,*eval*.tsx,**/*eval*.tsx,*eval*.js,**/*eval*.js,*eval*.rs,**/*eval*.rs,*eval*.go,**/*eval*.go
 ---
 
 # Evaluation Validation Rules

--- a/rules/claude-rules/common/workflow.md
+++ b/rules/claude-rules/common/workflow.md
@@ -274,45 +274,6 @@ When using sub-agents, give each child only the minimum context required for its
 
 **Why**: the larger the context, the higher the hallucination risk. Isolated child agents stay more focused and more reliable.
 
-## W-18: Evaluations must validate path, not only output (strict)
-Output-only evaluations miss systemic failures. An agent or pipeline can produce the correct final answer through the wrong tool, by skipping a required step, or with miscalibrated confidence; in production these all read as "passing" but degrade the moment the inputs shift.
-
-**Sources** (2026-04-27):
-- Confident AI, "Three Ways AI Systems Fail Even When Evals Pass" — names the three failure modes below
-- Microsoft Research, AgentRx (2026-04) — the same failure modes recur in the 9-class trajectory taxonomy
-- Anthropic Claude Code postmortem (2026-04-24) — quality degradation that no end-to-end eval caught, because the eval did not look at session-state behavior
-
-**The three failure modes that pass output-only evals**:
-
-| Mode | Description | What the eval saw | What was actually wrong |
-|------|-------------|-------------------|-------------------------|
-| Wrong tool, right answer | Used a search tool when a structured DB lookup was required | Correct value in response | Cached or pretrained knowledge, not the current source of truth |
-| Skipped required step | Answered without doing the mandatory retrieval / validation step | Correct answer | Bypassed the very check that the system was designed to enforce |
-| Miscalibrated confidence | Returned a wrong answer with high stated certainty | "Confident" output | No signal for downstream caller to fall back |
-
-**Required eval coverage (strict)**:
-
-Every eval suite that gates a release or guards a production agent must validate three axes, not one:
-
-1. **Tool selection** — assert that the trajectory used the expected tool (or a member of an allowed set) for each protected step. If the agent has no tools, this axis is vacuous and may be skipped, but the suite must say so explicitly.
-2. **Step adherence** — assert that the trajectory contains every mandatory step in the documented order. Examples: retrieval before answer, schema validation before write, permission check before mutation. A "skip step" must fail the eval even when the final output is correct.
-3. **Confidence calibration** — assert that stated confidence tracks correctness on the eval set. Concretely, expected calibration error (ECE) on the bucketed predictions must be reported alongside accuracy. An agent that is 90% confident on a sample where it is correct 50% of the time is a calibration failure even if accuracy is "fine".
-
-**Mechanical checks (agent execution rules)**:
-- When asked to "evaluate" a model, agent, or pipeline, first ask: does the suite log the trajectory (tool calls, ordered steps, stated confidence) or only the final output?
-- If only the final output is logged, the suite cannot satisfy W-18. The required fix is to record trajectory metadata, not to add more output-level cases.
-- When adding a new eval case, declare its target axis. A case that does not exercise tool selection, step adherence, or confidence calibration is an output-only case and must be balanced by cases on the other axes.
-- Reject pull requests that claim "evals pass" while the eval definition does not assert any of the three axes.
-
-**Anti-patterns**:
-- Reporting `pass@k` as the only quality metric for a tool-using agent.
-- Adding more end-to-end golden outputs to "harden" a regression that was actually a tool-selection or step-skip failure.
-- Reading model confidence directly without ever measuring how it correlates with correctness.
-- Marking a release green because output-level evals are stable, when the underlying trajectory shape has changed.
-
-**Downgrade path**:
-For pure text generation tasks with no tools and no required intermediate steps, axes 1 and 2 are vacuous and may be skipped if the eval suite explicitly states so. Axis 3 (calibration) is never optional whenever the model emits or implies a confidence value to a caller.
-
 ## W-19: AGENTS.md / CLAUDE.md sustainable size and pairing (strict)
 Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohibitions, or inline the full text of canonical vibeguard rules. Long instruction files trigger overexploration (agents read more surrounding docs and produce worse output) and warning cascades (agents over-validate against rules irrelevant to the current task).
 

--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -10,6 +10,7 @@
         "rules/claude-rules/common/agent-harness-audit.md",
         "rules/claude-rules/common/coding-style.md",
         "rules/claude-rules/common/data-consistency.md",
+        "rules/claude-rules/common/eval-validation.md",
         "rules/claude-rules/common/execution-pinning.md",
         "rules/claude-rules/common/fact-inference-separation.md",
         "rules/claude-rules/common/long-horizon-reliability.md",

--- a/scripts/ci/validate-rules.sh
+++ b/scripts/ci/validate-rules.sh
@@ -39,6 +39,33 @@ for rule_file in "${RULES_DIR}"/*.md; do
   fi
 done
 
+echo
+echo "Checking canonical rule applicability boundaries..."
+DATA_CONSISTENCY_RULE="${RULES_DIR}/claude-rules/common/data-consistency.md"
+EVAL_VALIDATION_RULE="${RULES_DIR}/claude-rules/common/eval-validation.md"
+WORKFLOW_RULE="${RULES_DIR}/claude-rules/common/workflow.md"
+
+if grep -q '^paths:' "${DATA_CONSISTENCY_RULE}" && grep -q '^## Applicability' "${DATA_CONSISTENCY_RULE}"; then
+  echo "OK: data-consistency.md has path and applicability scope"
+else
+  echo "FAIL: data-consistency.md must declare paths and an Applicability section"
+  ((errors++))
+fi
+
+if [[ -f "${EVAL_VALIDATION_RULE}" ]] && grep -q '^paths:' "${EVAL_VALIDATION_RULE}" && grep -q '^## W-18:' "${EVAL_VALIDATION_RULE}" && grep -q '^## Applicability' "${EVAL_VALIDATION_RULE}"; then
+  echo "OK: eval-validation.md scopes W-18"
+else
+  echo "FAIL: eval-validation.md must exist with paths, W-18, and an Applicability section"
+  ((errors++))
+fi
+
+if grep -q '^## W-18:' "${WORKFLOW_RULE}"; then
+  echo "FAIL: W-18 must stay in eval-validation.md so workflow.md remains broadly scoped"
+  ((errors++))
+else
+  echo "OK: workflow.md does not carry W-18"
+fi
+
 # Check vibeguard-rules.md index file
 RULES_INDEX="${REPO_DIR}/claude-md/vibeguard-rules.md"
 if [[ -f "$RULES_INDEX" ]]; then

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -107,12 +107,20 @@ canonical_readme_ids="$(canonical_ids_for_task_path README.md)"
 assert_not_contains "${canonical_readme_ids}" "U-11" "data consistency rules stay unloaded for unrelated docs task"
 assert_not_contains "${canonical_readme_ids}" "W-18" "eval validation rule stays unloaded for unrelated docs task"
 
-canonical_eval_ids="$(canonical_ids_for_task_path evals/agent_eval.py)"
-assert_contains "${canonical_eval_ids}" "W-18" "eval validation rule activates for eval task path"
+canonical_eval_ids="$(canonical_ids_for_task_path evals/runner.py)"
+assert_contains "${canonical_eval_ids}" "W-18" "eval validation rule activates for eval directory task path"
+
+canonical_eval_manifest_ids="$(canonical_ids_for_task_path evals/package.json)"
+assert_contains "${canonical_eval_manifest_ids}" "W-18" "eval validation rule activates for eval-scoped dependency manifest"
 
 canonical_python_ids="$(canonical_ids_for_task_path src/main.py)"
 assert_contains "${canonical_python_ids}" "U-11" "data consistency rules activate for source task path"
 assert_not_contains "${canonical_python_ids}" "W-18" "eval validation rule stays scoped away from ordinary source path"
+
+for ordinary_manifest_path in package.json pyproject.toml Cargo.toml go.mod; do
+  ordinary_manifest_ids="$(canonical_ids_for_task_path "${ordinary_manifest_path}")"
+  assert_not_contains "${ordinary_manifest_ids}" "W-18" "eval validation rule stays scoped away from ordinary ${ordinary_manifest_path}"
+done
 
 GC_HOME="${TMP_ROOT}/home-gc"
 GC_REPO="${TMP_ROOT}/repo-gc"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -97,16 +97,22 @@ assert_contains "${path_json}" '"id": "PY-01"' "path-scoped rule activates for m
 no_path_json="$(python3 "${COUNTER}" --root "${PATH_REPO}" --home "${PATH_HOME}" --task-path README.md --json)"
 assert_not_contains "${no_path_json}" '"id": "PY-01"' "path-scoped rule stays unloaded for non-matching task path"
 
-canonical_readme_json="$(python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path README.md --json)"
-assert_not_contains "${canonical_readme_json}" '"id": "U-11"' "data consistency rules stay unloaded for unrelated docs task"
-assert_not_contains "${canonical_readme_json}" '"id": "W-18"' "eval validation rule stays unloaded for unrelated docs task"
+canonical_ids_for_task_path() {
+  local task_path="$1"
+  python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path "${task_path}" --json \
+    | python3 -c 'import json, sys; data = json.load(sys.stdin); print("\n".join(item["id"] for item in data.get("constraints", []) if item.get("id")))'
+}
 
-canonical_eval_json="$(python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path evals/agent_eval.py --json)"
-assert_contains "${canonical_eval_json}" '"id": "W-18"' "eval validation rule activates for eval task path"
+canonical_readme_ids="$(canonical_ids_for_task_path README.md)"
+assert_not_contains "${canonical_readme_ids}" "U-11" "data consistency rules stay unloaded for unrelated docs task"
+assert_not_contains "${canonical_readme_ids}" "W-18" "eval validation rule stays unloaded for unrelated docs task"
 
-canonical_python_json="$(python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path src/main.py --json)"
-assert_contains "${canonical_python_json}" '"id": "U-11"' "data consistency rules activate for source task path"
-assert_not_contains "${canonical_python_json}" '"id": "W-18"' "eval validation rule stays scoped away from ordinary source path"
+canonical_eval_ids="$(canonical_ids_for_task_path evals/agent_eval.py)"
+assert_contains "${canonical_eval_ids}" "W-18" "eval validation rule activates for eval task path"
+
+canonical_python_ids="$(canonical_ids_for_task_path src/main.py)"
+assert_contains "${canonical_python_ids}" "U-11" "data consistency rules activate for source task path"
+assert_not_contains "${canonical_python_ids}" "W-18" "eval validation rule stays scoped away from ordinary source path"
 
 GC_HOME="${TMP_ROOT}/home-gc"
 GC_REPO="${TMP_ROOT}/repo-gc"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -97,6 +97,17 @@ assert_contains "${path_json}" '"id": "PY-01"' "path-scoped rule activates for m
 no_path_json="$(python3 "${COUNTER}" --root "${PATH_REPO}" --home "${PATH_HOME}" --task-path README.md --json)"
 assert_not_contains "${no_path_json}" '"id": "PY-01"' "path-scoped rule stays unloaded for non-matching task path"
 
+canonical_readme_json="$(python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path README.md --json)"
+assert_not_contains "${canonical_readme_json}" '"id": "U-11"' "data consistency rules stay unloaded for unrelated docs task"
+assert_not_contains "${canonical_readme_json}" '"id": "W-18"' "eval validation rule stays unloaded for unrelated docs task"
+
+canonical_eval_json="$(python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path evals/agent_eval.py --json)"
+assert_contains "${canonical_eval_json}" '"id": "W-18"' "eval validation rule activates for eval task path"
+
+canonical_python_json="$(python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path src/main.py --json)"
+assert_contains "${canonical_python_json}" '"id": "U-11"' "data consistency rules activate for source task path"
+assert_not_contains "${canonical_python_json}" '"id": "W-18"' "eval validation rule stays scoped away from ordinary source path"
+
 GC_HOME="${TMP_ROOT}/home-gc"
 GC_REPO="${TMP_ROOT}/repo-gc"
 make_home "${GC_HOME}"

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -106,6 +106,7 @@ for module in manifest["modules"]:
 PY
 )"
 assert_contains "${common_paths_out}" "rules/claude-rules/common/agent-harness-audit.md" "rules-common installs W-30 rule file"
+assert_contains "${common_paths_out}" "rules/claude-rules/common/eval-validation.md" "rules-common installs scoped W-18 rule file"
 assert_contains "${common_paths_out}" "rules/claude-rules/common/long-horizon-reliability.md" "rules-common installs W-42 rule file"
 reference_rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source reference)"
 assert_contains "${reference_rules_out}" "TASTE-ANSI" "reference rule ids include TASTE-prefixed rules"


### PR DESCRIPTION
## Summary

Closes #284. Split #242 observation 5 into a focused loading/applicability cleanup.

- Add path frontmatter and an Applicability section to `rules/claude-rules/common/data-consistency.md` so U-11 through U-14 are not active for unrelated tasks when path filtering is available.
- Move W-18 out of broadly scoped `workflow.md` into new `rules/claude-rules/common/eval-validation.md` with eval-specific path frontmatter and applicability text.
- Update the install manifest and memory-file structure docs for the new common rule file.
- Add validation so W-18 stays scoped, data-consistency keeps an applicability boundary, and `count_active_constraints.py` proves these rules are excluded for unrelated docs tasks.

## Validation

- `python3 scripts/generate_rule_docs.py`
- `bash scripts/ci/validate-rules.sh`
- `bash tests/hooks/test_count_active_constraints.sh`
- `bash tests/test_manifest_contract.sh`
- `bash -n scripts/ci/validate-rules.sh && bash -n tests/hooks/test_count_active_constraints.sh && bash -n tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-generated-rule-docs.sh`
- `bash scripts/ci/validate-canonical-rule-language.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-manifest-contract.sh`
- `bash scripts/ci/validate-hook-behavior-docs.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_setup.sh`
- `git diff --check`