### PR TITLE
Validate preflight routing contract

### DIFF
--- a/.claude/commands/vibeguard/preflight.md
+++ b/.claude/commands/vibeguard/preflight.md
@@ -12,16 +12,18 @@ tags: [vibeguard, preflight, constraints, prevention]
 - The constraint set guides all subsequent coding, eliminating the need to make architectural decisions during the implementation phase
 - Each constraint must be verifiable — either by writing a guard script or by writing a test assertion
 
-**Complexity Routing** (automatically determine process depth)
+**Routing**
 
-| Scale | Process | Action |
-|------|------|------|
-| 1-2 files | Direct implementation | Skip preflight and code directly |
-| 3-5 File | Lightweight preflight | Perform steps 1-5 below to generate a constraint set |
-| 6+ files | Complete planning | First `/vibeguard:interview` generates SPEC → then execute preflight |
+Follow the canonical router in `workflows/references/routing-contract.md` before starting preflight. The `readiness` decision has exactly three outputs:
 
-**Trigger Condition** (3+ file levels)
-- Changes involving 3+ files
+- `execute_direct`: skip preflight when the task is bounded, the next edit is clear, and verification can be owned immediately.
+- `plan_first`: run preflight when the task is well-specified but broad enough that a constraint set or planning handoff is needed before code changes.
+- `clarify_first`: ask for the missing scope, non-goals, decision boundaries, or delegation ownership before reading further or planning.
+
+File count can inform the routing decision as a secondary signal, but it is not the routing contract and must not replace `execute_direct`, `plan_first`, or `clarify_first`.
+
+**Trigger Condition**
+- Changes involving several file levels or cross-cutting areas
 - Added new entry point (binary/service/CLI subcommand)
 - Modify the data layer (database, cache, file storage)
 - Cross-module refactoring
@@ -56,7 +58,7 @@ tags: [vibeguard, preflight, constraints, prevention]
 3.5. **Reference Implementation Search (Skeleton Projects)**
    - Before implementing new functions, first search whether there are similar implementations inside and outside the project for reference.
    - **Search within the project**: Use Grep/Glob to search for keywords, function names, and pattern names to confirm that no existing implementations are missing
-   - **Search outside project** (only large changes to 6+ files):
+   - **Search outside project** (only for large cross-cutting changes):
      - Use WebSearch to search for "battle-tested" open source implementations (e.g. `"<feature> implementation" site:github.com`)
      - Evaluate the suitability of candidate implementations (license compatibility, dependencies, maintenance activity)
      - **Not copy**, but extract design decisions as input to constraint sets

--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -56,6 +56,11 @@
       "requires": ["routing_decision", "execution_handoff", "delegation_assignment", "lane_map", "verification_gate"]
     },
     {
+      "path": ".claude/commands/vibeguard/preflight.md",
+      "references": ["routing-contract.md"],
+      "requires": ["routing_decision"]
+    },
+    {
       "path": "workflows/fixflow/SKILL.md",
       "references": ["routing-contract.md", "delegation-contract.md"],
       "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -131,6 +131,30 @@ else
   red "routing schema accepts snake_case blocking_questions"
   FAIL=$((FAIL + 1))
 fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+registry = json.loads((repo / "schemas/workflow-contract-consumers.json").read_text(encoding="utf-8"))
+for consumer in registry["consumers"]:
+    if consumer.get("path") == ".claude/commands/vibeguard/preflight.md":
+        if "routing-contract.md" not in consumer.get("references", []):
+            raise SystemExit("preflight missing routing-contract.md reference")
+        if "routing_decision" not in consumer.get("requires", []):
+            raise SystemExit("preflight missing routing_decision requirement")
+        break
+else:
+    raise SystemExit("preflight command is not a workflow contract consumer")
+PY
+  green "preflight command is registered as a routing contract consumer"
+  PASS=$((PASS + 1))
+else
+  red "preflight command is registered as a routing contract consumer"
+  FAIL=$((FAIL + 1))
+fi
 
 header "consumer drift failures"
 HANDOFF_FIXTURE="${TMP_DIR}/handoff"


### PR DESCRIPTION
## Summary

- register `.claude/commands/vibeguard/preflight.md` as a workflow contract consumer
- replace preflight's local file-count routing table with the canonical `readiness` outputs from `workflows/references/routing-contract.md`
- add regression coverage that keeps the preflight command registered as a routing decision consumer

Closes #286
Follow-up from #266

## Verification

- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`
