### PR TITLE
Register optflow routing contract

### DIFF
--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -66,6 +66,11 @@
       "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]
     },
     {
+      "path": "workflows/optflow/SKILL.md",
+      "references": ["routing-contract.md", "delegation-contract.md"],
+      "requires": ["routing_decision", "execution_handoff", "lane_map", "verification_gate"]
+    },
+    {
       "path": "workflows/plan-flow/SKILL.md",
       "references": ["routing-contract.md", "delegation-contract.md"],
       "requires": ["execution_handoff", "lane_map", "verification_gate"]

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -139,20 +139,32 @@ from pathlib import Path
 
 repo = Path(sys.argv[1])
 registry = json.loads((repo / "schemas/workflow-contract-consumers.json").read_text(encoding="utf-8"))
-for consumer in registry["consumers"]:
-    if consumer.get("path") == ".claude/commands/vibeguard/preflight.md":
-        if "routing-contract.md" not in consumer.get("references", []):
-            raise SystemExit("preflight missing routing-contract.md reference")
-        if "routing_decision" not in consumer.get("requires", []):
-            raise SystemExit("preflight missing routing_decision requirement")
-        break
-else:
-    raise SystemExit("preflight command is not a workflow contract consumer")
+consumers = {consumer.get("path"): consumer for consumer in registry["consumers"]}
+expected = {
+    ".claude/commands/vibeguard/preflight.md": {
+        "references": {"routing-contract.md"},
+        "requires": {"routing_decision"},
+    },
+    "workflows/optflow/SKILL.md": {
+        "references": {"routing-contract.md", "delegation-contract.md"},
+        "requires": {"routing_decision", "execution_handoff", "lane_map", "verification_gate"},
+    },
+}
+for path, contract in expected.items():
+    consumer = consumers.get(path)
+    if consumer is None:
+        raise SystemExit(f"{path} is not a workflow contract consumer")
+    missing_references = contract["references"] - set(consumer.get("references", []))
+    if missing_references:
+        raise SystemExit(f"{path} missing references: {sorted(missing_references)}")
+    missing_requires = contract["requires"] - set(consumer.get("requires", []))
+    if missing_requires:
+        raise SystemExit(f"{path} missing requirements: {sorted(missing_requires)}")
 PY
-  green "preflight command is registered as a routing contract consumer"
+  green "command and workflow routing consumers stay registered"
   PASS=$((PASS + 1))
 else
-  red "preflight command is registered as a routing contract consumer"
+  red "command and workflow routing consumers stay registered"
   FAIL=$((FAIL + 1))
 fi
 

--- a/workflows/optflow/SKILL.md
+++ b/workflows/optflow/SKILL.md
@@ -33,6 +33,33 @@ Trigger this skill when the user asks for one or more of:
 - [ ] Prioritize by impact, effort, risk, and confidence.
 - [ ] Verify each selected optimization with the smallest command that proves the claimed gain.
 
+## Routing Contract Integration
+
+Optflow follows the canonical router in [`workflows/references/routing-contract.md`](../references/routing-contract.md).
+
+Optflow can start discovery or execution only when either condition is true:
+
+- upstream readiness resolved to `execute_direct`
+- a planning workflow already emitted a handoff that preselects Optflow
+
+Optflow must not start execution when either condition is true:
+
+- upstream readiness resolved to `clarify_first`
+- upstream readiness resolved to `plan_first` and no execution handoff exists yet
+
+When Optflow receives a planning handoff, it must honor:
+
+- `mode`
+- `artifacts`
+- `runtime_pinning_snapshot`
+- `verification_owner`
+- `stop_conditions`
+- `lane_map`
+
+If `lane_map` does not assign Optflow-owned work clearly, stop and clarify before editing.
+
+If Optflow delegates any task to a child agent or parallel worker, it must use [`workflows/references/delegation-contract.md`](../references/delegation-contract.md) and keep a single integration owner for shared outputs.
+
 ## Workflow
 
 ### 0. Discover Optimization Backlog


### PR DESCRIPTION
## Summary

- add explicit routing-contract integration to `workflows/optflow/SKILL.md`
- register Optflow as a workflow contract consumer with routing, handoff, lane-map, and verification-gate requirements
- extend workflow contract regression coverage so preflight and optflow cannot silently drop out of the registry

Closes #288
Follow-up from #266

## Verification

- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`
