### PR TITLE
Fix auto-optimize compliance check path

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -37,7 +37,7 @@ Reference notes for the utility scripts shipped with VibeGuard.
 | `validate-hooks.sh` | Validate hook script presence and contract basics |
 | `validate-rules.sh` | Validate rule file format and ID uniqueness |
 | `validate-doc-paths.sh` | Check backtick path references in markdown docs |
-| `validate-doc-command-paths.sh` | Check `~/vibeguard/...` shell command paths in user-facing docs |
+| `validate-doc-command-paths.sh` | Check shell command paths and stale command aliases in user-facing docs |
 | `validate-no-personal-paths.sh` | Catch accidental personal absolute paths in tracked files |
 | `validate-skill-format.sh` | Check VibeGuard skill/workflow SKILL.md activation, red-flag, and checklist sections |
 | `check-branch-protection.sh` | Verify branch protection settings |

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -17,7 +17,7 @@ renamed_targets = [
     repo_root / "docs" / "README_CN.md",
     repo_root / "scripts" / "CLAUDE.md",
 ]
-renamed_targets.extend(sorted((repo_root / "workflows").glob("*.md")))
+renamed_targets.extend(sorted((repo_root / "workflows").rglob("*.md")))
 renamed_targets.extend(sorted((repo_root / ".claude" / "commands" / "vibeguard").glob("*.md")))
 
 renamed_command_paths = {

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# VibeGuard CI: validate shell command paths like ~/vibeguard/... in docs
+# VibeGuard CI: validate shell command paths in user-facing docs
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+REPO_DIR="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 python3 - "$REPO_DIR" <<'PY'
 import re
@@ -11,6 +11,18 @@ from pathlib import Path
 
 repo_root = Path(sys.argv[1]).resolve()
 targets = [repo_root / "README.md", repo_root / "docs" / "README_CN.md", repo_root / "CONTRIBUTING.md"]
+renamed_targets = [
+    repo_root / "README.md",
+    repo_root / "CONTRIBUTING.md",
+    repo_root / "docs" / "README_CN.md",
+    repo_root / "scripts" / "CLAUDE.md",
+]
+renamed_targets.extend(sorted((repo_root / "workflows").glob("*.md")))
+renamed_targets.extend(sorted((repo_root / ".claude" / "commands" / "vibeguard").glob("*.md")))
+
+renamed_command_paths = {
+    "scripts/compliance_check.sh": "scripts/verify/compliance_check.sh",
+}
 
 path_pattern = re.compile(r"~/vibeguard/([A-Za-z0-9_./-]+)")
 failures = []
@@ -30,6 +42,16 @@ for md_file in targets:
             ok = target.is_dir() if raw.endswith("/") else target.is_file()
             if not ok:
                 failures.append(f"{md_file.relative_to(repo_root)}:{idx} ~/vibeguard/{raw} (missing)")
+
+for md_file in renamed_targets:
+    if not md_file.exists():
+        continue
+    for idx, line in enumerate(md_file.read_text(encoding="utf-8").splitlines(), 1):
+        for old_path, new_path in renamed_command_paths.items():
+            if old_path in line:
+                failures.append(
+                    f"{md_file.relative_to(repo_root)}:{idx} stale command path {old_path}; use {new_path}"
+                )
 
 if failures:
     print("FAIL: broken shell command path references detected:")

--- a/scripts/verify/compliance_check.sh
+++ b/scripts/verify/compliance_check.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Check whether the current project complies with the VibeGuard anti-hallucination specification
 #
 # How to use:
-#   bash vibeguard/scripts/compliance_check.sh [project_dir]
-#   bash vibeguard/scripts/compliance_check.sh /path/to/my-project
+#   bash vibeguard/scripts/verify/compliance_check.sh [project_dir]
+#   bash vibeguard/scripts/verify/compliance_check.sh /path/to/my-project
 
 PROJECT_DIR="${1:-.}"
 VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -212,6 +212,17 @@ write_registry "${EXAMPLE_FIXTURE}" '"markdown_examples": [{"path": "docs/comman
 assert_fails_with "invalid command schema example fails schema validation" "maybe_later" \
   python3 "${HELPER}" --repo-dir "${EXAMPLE_FIXTURE}" --schema-dir "${EXAMPLE_FIXTURE}/schemas" --registry "${EXAMPLE_FIXTURE}/schemas/workflow-contract-consumers.json" validate
 
+header "workflow command path failures"
+COMMAND_PATH_FIXTURE="${TMP_DIR}/command-path"
+mkdir -p "${COMMAND_PATH_FIXTURE}/workflows"
+cat > "${COMMAND_PATH_FIXTURE}/workflows/auto-optimize.md" <<'MD'
+```bash
+bash "${VIBEGUARD_ROOT:-$(dirname "$0")/../..}/scripts/compliance_check.sh" /path/to/project
+```
+MD
+assert_fails_with "stale compliance check command path fails validation" "scripts/verify/compliance_check.sh" \
+  bash "${REPO_DIR}/scripts/ci/validate-doc-command-paths.sh" "${COMMAND_PATH_FIXTURE}"
+
 echo
 echo "=============================="
 printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -214,8 +214,8 @@ assert_fails_with "invalid command schema example fails schema validation" "mayb
 
 header "workflow command path failures"
 COMMAND_PATH_FIXTURE="${TMP_DIR}/command-path"
-mkdir -p "${COMMAND_PATH_FIXTURE}/workflows"
-cat > "${COMMAND_PATH_FIXTURE}/workflows/auto-optimize.md" <<'MD'
+mkdir -p "${COMMAND_PATH_FIXTURE}/workflows/auto-optimize"
+cat > "${COMMAND_PATH_FIXTURE}/workflows/auto-optimize/SKILL.md" <<'MD'
 ```bash
 bash "${VIBEGUARD_ROOT:-$(dirname "$0")/../..}/scripts/compliance_check.sh" /path/to/project
 ```

--- a/workflows/auto-optimize/SKILL.md
+++ b/workflows/auto-optimize/SKILL.md
@@ -205,7 +205,7 @@ cd "${AUTO_RUN_AGENT_DIR}"
 1. After all FIX are completed, run the full test suite
 2. **Run VibeGuard Compliance Check**:
    ```bash
-   bash "${VIBEGUARD_ROOT:-$(dirname "$0")/../..}/scripts/compliance_check.sh" /path/to/project
+   bash "${VIBEGUARD_ROOT:-$(dirname "$0")/../..}/scripts/verify/compliance_check.sh" /path/to/project
    ```
 3. Fix the problems found in the compliance check (if any)
 4. bump version（patch for fixes, minor for new features）


### PR DESCRIPTION
## Summary

- update Auto-Optimize's compliance check command to `scripts/verify/compliance_check.sh`
- fix the compliance check script's own usage examples
- teach doc command path validation to reject stale `scripts/compliance_check.sh` references in user-facing workflow/command docs
- add a workflow contract regression fixture proving the stale path is rejected

Closes #290
Follow-up from #266

## Verification

- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash scripts/ci/validate-skill-format.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash tests/test_skill_format.sh`
- `bash tests/test_manifest_contract.sh`
- `bash -n scripts/ci/validate-doc-command-paths.sh && bash -n scripts/verify/compliance_check.sh && bash -n tests/test_workflow_contracts.sh`
- `git diff --check`
