### PR TITLE
Validate skill template format

### DIFF
--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -235,7 +235,7 @@ python3 scripts/skill_validate.py --format-only --proposed-skill path/to/SKILL.m
 python3 scripts/skill_validate.py --check-repo-format --repo-root .
 ```
 
-`--check-repo-format` scans both `skills/*/SKILL.md` and `workflows/*/SKILL.md`.
+`--check-repo-format` scans `skills/*/SKILL.md`, `workflows/*/SKILL.md`, and `templates/skill-template.md`.
 
 ## review output Schema
 

--- a/docs/how/learning-skill-generation.md
+++ b/docs/how/learning-skill-generation.md
@@ -270,7 +270,7 @@ Every generated skill must include:
 - `## Red Flags` with at least three specific anti-patterns or failure modes.
 - `## Checklist` with at least three `- [ ]` pre-delivery items.
 
-Run `bash scripts/ci/validate-skill-format.sh` before accepting the skill into this repository.
+Run `bash scripts/ci/validate-skill-format.sh` before accepting the skill into this repository; the gate also validates `templates/skill-template.md` so future skills do not start from a stale shape.
 
 ### Deduplication decision table
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -14,8 +14,8 @@ Reference notes for the utility scripts shipped with VibeGuard.
 | `log-capability-change.sh` | Extract a capability-change timeline from git history |
 | `authorized-discard.py` | Print and execute an explicit, confirmed Git cleanup plan for tracked, untracked, and selected ignored paths |
 | `live_truth.py` | Verify mutable claims such as latest, PR-ready, merged, running, deployed, and published with fresh facts/inferences/gaps |
-| `skill_validate.py` | Validate SKILL.md structure and score proposed skill changes with with/without repair and regression evidence |
-| `ci/validate-skill-format.py` | Validate VibeGuard skill/workflow SKILL.md structure (`When to Activate`, `Red Flags`, `Checklist`) |
+| `skill_validate.py` | Validate SKILL.md and template structure, then score proposed skill changes with with/without repair and regression evidence |
+| `ci/validate-skill-format.py` | Validate VibeGuard skill/workflow SKILL.md and template structure (`When to Activate`, `Red Flags`, `Checklist`) |
 
 ## GC / Metrics / Verification
 
@@ -39,7 +39,7 @@ Reference notes for the utility scripts shipped with VibeGuard.
 | `validate-doc-paths.sh` | Check backtick path references in markdown docs |
 | `validate-doc-command-paths.sh` | Check shell command paths and stale command aliases in user-facing docs |
 | `validate-no-personal-paths.sh` | Catch accidental personal absolute paths in tracked files |
-| `validate-skill-format.sh` | Check VibeGuard skill/workflow SKILL.md activation, red-flag, and checklist sections |
+| `validate-skill-format.sh` | Check VibeGuard skill/workflow SKILL.md and template activation, red-flag, and checklist sections |
 | `check-branch-protection.sh` | Verify branch protection settings |
 | `apply-branch-protection.sh` | Apply the expected branch protection policy |
 

--- a/scripts/ci/validate-skill-format.py
+++ b/scripts/ci/validate-skill-format.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate VibeGuard-owned SKILL.md structure."""
+"""Validate VibeGuard-owned SKILL.md and skill template structure."""
 
 from __future__ import annotations
 
@@ -27,6 +27,9 @@ def default_skill_paths(repo_dir: Path) -> list[Path]:
     for root in (repo_dir / "skills", repo_dir / "workflows"):
         if root.is_dir():
             paths.extend(sorted(root.glob("*/SKILL.md")))
+    template = repo_dir / "templates" / "skill-template.md"
+    if template.is_file():
+        paths.append(template)
     return paths
 
 
@@ -106,11 +109,14 @@ def validate_skill(path: Path) -> list[str]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Validate VibeGuard skill and workflow SKILL.md files.")
+    parser = argparse.ArgumentParser(description="Validate VibeGuard skill, workflow, and skill template files.")
     parser.add_argument(
         "paths",
         nargs="*",
-        help="Specific SKILL.md files to validate. Defaults to skills/*/SKILL.md and workflows/*/SKILL.md.",
+        help=(
+            "Specific SKILL.md files to validate. Defaults to skills/*/SKILL.md, "
+            "workflows/*/SKILL.md, and templates/skill-template.md."
+        ),
     )
     parser.add_argument(
         "--repo-dir",

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 OUTCOMES = {"success", "failure"}
 DEFAULT_OUTPUT_DIR = ".vibeguard/skill-validate"
-FORMAT_PATH_PATTERNS = ("skills/*/SKILL.md", "workflows/*/SKILL.md")
+FORMAT_PATH_PATTERNS = ("skills/*/SKILL.md", "workflows/*/SKILL.md", "templates/skill-template.md")
 FORMAT_REQUIRED_SECTIONS = ("## When to Activate", "## Red Flags", "## Checklist")
 FORMAT_LIST_SECTIONS = ("## Red Flags", "## Checklist")
 
@@ -408,7 +408,7 @@ def build_parser() -> argparse.ArgumentParser:
     format_group.add_argument(
         "--check-repo-format",
         action="store_true",
-        help="Validate skills/*/SKILL.md and workflows/*/SKILL.md under --repo-root.",
+        help="Validate skills/*/SKILL.md, workflows/*/SKILL.md, and templates/skill-template.md under --repo-root.",
     )
     parser.add_argument("--repo-root", default=".", help="Repository root for --check-repo-format")
     return parser

--- a/templates/skill-template.md
+++ b/templates/skill-template.md
@@ -28,17 +28,19 @@ date: YYYY-MM-DD
 
 [Failure patterns or anti-patterns this Skill should help catch:]
 
-- [Specific warning sign 1]
-- [Specific warning sign 2]
-- [Anti-pattern that means this Skill may be misapplied]
+- Source search was skipped before adding a new skill, rule, hook, workflow, or test.
+- Activation cues are generic and do not name a concrete error, symptom, or scenario.
+- Verification is described as intent instead of a runnable command or observable result.
 
 ## Checklist
 
 [Pre-delivery checks before claiming the Skill was applied correctly:]
 
-- [Required check 1]
-- [Required check 2]
-- [Verification or regression check]
+- [ ] Activation conditions match this task; otherwise do not use this skill.
+- [ ] Existing files, rules, hooks, or workflows were searched before adding a new one.
+- [ ] The solution steps are concrete and testable.
+- [ ] Verification commands or manual checks are listed with expected results.
+- [ ] Red flags name real failure modes, not generic advice.
 
 ## Solution
 
@@ -67,22 +69,6 @@ date: YYYY-MM-DD
 1. [Verification Step 1]
 2. [Verification Step 2]
 3. [Expected results]
-
-## Red Flags
-
-[List concrete anti-patterns that indicate the skill is being misapplied or the work is drifting.]
-
-- **[Red flag 1]** - [Why this causes a production or delivery failure]
-- **[Red flag 2]** - [Why this causes a production or delivery failure]
-- **[Red flag 3]** - [Why this causes a production or delivery failure]
-
-## Checklist
-
-- [ ] [Activation conditions match this task; otherwise do not use this skill]
-- [ ] [Existing files, rules, hooks, or workflows were searched before adding a new one]
-- [ ] [The solution steps are concrete and testable]
-- [ ] [Verification commands or manual checks are listed with expected results]
-- [ ] [Red flags name real failure modes, not generic advice]
 
 ## Example
 

--- a/tests/test_skill_format.sh
+++ b/tests/test_skill_format.sh
@@ -78,8 +78,12 @@ header "syntax"
 assert_cmd "validate-skill-format.py syntax is valid" python3 -m py_compile "${VALIDATOR}"
 
 header "repository coverage"
-assert_cmd "repository skills and workflows pass format validation" \
+assert_cmd "repository skills, workflows, and template pass format validation" \
   bash "${REPO_DIR}/scripts/ci/validate-skill-format.sh"
+repo_format_out="$(python3 "${VALIDATOR}" --repo-dir "${REPO_DIR}")"
+assert_contains "${repo_format_out}" "templates/skill-template.md" "repository format coverage includes skill template"
+assert_cmd "skill template passes direct format validation" \
+  python3 "${VALIDATOR}" "${REPO_DIR}/templates/skill-template.md"
 
 header "single-file validation"
 VALID_SKILL="${TMP_DIR}/skills/demo/SKILL.md"

--- a/tests/test_skill_validate.sh
+++ b/tests/test_skill_validate.sh
@@ -74,6 +74,8 @@ assert_cmd "skill_validate.py syntax is valid" python3 -m py_compile "${SKILL_VA
 header "format gate"
 assert_cmd "format-only accepts shaped skill" \
   python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${SKILL_DIR}/SKILL.md"
+assert_cmd "format-only accepts repository skill template" \
+  python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${REPO_DIR}/templates/skill-template.md" --no-persist
 
 MARKDOWN_LINK_DIR="${TMP_DIR}/markdown-link"
 mkdir -p "${MARKDOWN_LINK_DIR}"
@@ -181,7 +183,28 @@ coverage_out="$(
 )"
 assert_contains "${coverage_out}" "workflows/bad/SKILL.md: missing required section: ## Checklist" "repo format gate covers workflows"
 
-assert_cmd "repo skill and workflow format gate passes" \
+TEMPLATE_COVERAGE_REPO="${TMP_DIR}/template-coverage-repo"
+mkdir -p "${TEMPLATE_COVERAGE_REPO}/templates"
+cat > "${TEMPLATE_COVERAGE_REPO}/templates/skill-template.md" <<'MD'
+---
+name: bad-template
+description: Use when testing template coverage.
+---
+
+# Bad Template
+
+## When to Activate
+
+- Validate template coverage.
+MD
+template_coverage_out="$(
+  python3 "${SKILL_VALIDATE}" \
+    --check-repo-format \
+    --repo-root "${TEMPLATE_COVERAGE_REPO}" 2>&1 || true
+)"
+assert_contains "${template_coverage_out}" "templates/skill-template.md: missing required section: ## Red Flags" "repo format gate covers skill template"
+
+assert_cmd "repo skill, workflow, and template format gate passes" \
   python3 "${SKILL_VALIDATE}" --check-repo-format --repo-root "${REPO_DIR}"
 
 header "passing repair evidence"


### PR DESCRIPTION
## Summary

Fixes #292.

This aligns the reusable skill template with the repository skill format gates and makes the template part of default repository format coverage.

## Changes

- Updated `templates/skill-template.md` so its `## Checklist` uses real checkbox items accepted by both validators.
- Consolidated duplicate `## Red Flags` / `## Checklist` sections in the template.
- Included `templates/skill-template.md` in both `validate-skill-format.py` and `skill_validate.py --check-repo-format` coverage.
- Added regression tests proving direct template validation and repo-level template coverage.
- Updated the related docs for the expanded format gate surface.

## Test plan

- `python3 scripts/ci/validate-skill-format.py templates/skill-template.md`
- `python3 scripts/skill_validate.py --format-only --proposed-skill templates/skill-template.md --no-persist`
- `bash tests/test_skill_format.sh`
- `bash tests/test_skill_validate.sh`
- `bash scripts/ci/validate-skill-format.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`

Part of #266.
