### PR TITLE
Validate command output schema examples

### DIFF
--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -220,13 +220,23 @@ The text artifact emitted by `scripts/live_truth.py` uses these same sections so
     "unrelated_no_change": 2
   },
   "freshness_gaps": [],
+  "reasons": [
+    "repair count is greater than regression count with no regressions"
+  ],
+  "regression_justification": null,
+  "scored_against_agent": "claude-opus-4-7",
+  "scored_at": "2026-05-31",
   "scenarios": [
     {
       "scenario_id": "incident-1",
       "scenario_type": "target",
       "without_skill": "failure",
       "with_skill": "success",
-      "classification": "repair"
+      "classification": "repair",
+      "source": "baseline",
+      "scored_against_agent": "claude-opus-4-7",
+      "scored_at": "2026-05-31",
+      "notes": null
     }
   ]
 }

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -6,6 +6,12 @@ Canonical routing decisions and planning handoffs are defined in `workflows/refe
 
 Executable schema sources:
 
+- `schemas/command-preflight-output.schema.json`
+- `schemas/command-check-output.schema.json`
+- `schemas/command-live-truth-output.schema.json`
+- `schemas/command-skill-validate-output.schema.json`
+- `schemas/command-review-output.schema.json`
+- `schemas/command-learn-output.schema.json`
 - `schemas/workflow-routing-decision.schema.json`
 - `schemas/workflow-execution-handoff.schema.json`
 - `schemas/workflow-delegation-assignment.schema.json`
@@ -123,11 +129,11 @@ Delegation assignments are required before any child-agent write lane starts. Pa
 ```json
 {
   "command": "preflight",
-  "projectType": "rust | typescript | python | go",
+  "projectType": "rust",
   "constraints": [
     {
       "id": "C-01",
-      "category": "data_convergence | type_unique | interface_stable | error_handling | naming | guard_baseline",
+      "category": "data_convergence",
       "description": "Constraint description",
       "source": "source evidence",
       "verification": "verification method"
@@ -155,13 +161,13 @@ Delegation assignments are required before any child-agent write lane starts. Pa
 {
   "command": "check",
   "project": "project name",
-  "date": "ISO8601",
+  "date": "2026-05-31T00:00:00Z",
   "guardResults": [
     {
       "guardId": "RS-03",
       "name": "unwrap/expect",
       "count": 50,
-      "severity": "medium | high | pass",
+      "severity": "medium",
       "details": ["file:line description"]
     }
   ],
@@ -178,8 +184,8 @@ Delegation assignments are required before any child-agent write lane starts. Pa
 ```json
 {
   "command": "live_truth",
-  "claim_type": "latest | pr-ready | merged | running | deployed | published",
-  "verdict": "pass | fail | gap",
+  "claim_type": "latest",
+  "verdict": "gap",
   "facts": [
     {
       "key": "active_branch",
@@ -204,13 +210,14 @@ The text artifact emitted by `scripts/live_truth.py` uses these same sections so
   "command": "skill_validate",
   "skill_name": "demo-skill",
   "proposed_skill": "path/to/SKILL.md",
-  "decision_set": "baseline | held_out",
-  "verdict": "pass | fail | stale | needs_justification | advisory",
+  "decision_set": "baseline",
+  "verdict": "pass",
   "counts": {
     "repair": 1,
     "regression": 0,
     "no_change": 2,
-    "unrelated_regression": 0
+    "unrelated_regression": 0,
+    "unrelated_no_change": 2
   },
   "freshness_gaps": [],
   "scenarios": [
@@ -245,17 +252,17 @@ python3 scripts/skill_validate.py --check-repo-format --repo-root .
   "scope": "File or directory path",
   "findings": [
     {
-      "priority": "P0 | P1 | P2 | P3",
+      "priority": "P2",
       "file": "file_path:line",
       "issue": "Problem description",
       "suggestion": "Repair suggestion",
-      "ruleId": "RS-03 | U-11 | ..."
+      "ruleId": "U-11"
     }
   ],
   "passedItems": [
     "Confirm that there are no problems with the inspection items"
   ],
-  "verdict": "pass | warn | fail"
+  "verdict": "warn"
 }
 ```
 
@@ -272,7 +279,7 @@ python3 scripts/skill_validate.py --check-repo-format --repo-root .
   },
   "improvements": [
     {
-      "type": "new_guard | enhance_guard | new_hook | new_rule | claude_md",
+      "type": "enhance_guard",
       "target": "target file path",
       "description": "Improve description"
     }

--- a/schemas/command-check-output.schema.json
+++ b/schemas/command-check-output.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/command-check-output.schema.json",
+  "title": "VibeGuard Check Command Output",
+  "description": "Structured output contract for /vibeguard:check.",
+  "type": "object",
+  "required": ["command", "project", "date", "guardResults", "complianceScore", "baselineComparison"],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "const": "check"
+    },
+    "project": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+    },
+    "guardResults": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["guardId", "name", "count", "severity", "details"],
+        "additionalProperties": false,
+        "properties": {
+          "guardId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "count": {
+            "type": "integer"
+          },
+          "severity": {
+            "enum": ["low", "medium", "high", "pass"]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "complianceScore": {
+      "type": "number"
+    },
+    "baselineComparison": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["before", "after", "delta"],
+        "additionalProperties": false,
+        "properties": {
+          "before": {
+            "type": "number"
+          },
+          "after": {
+            "type": "number"
+          },
+          "delta": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/command-learn-output.schema.json
+++ b/schemas/command-learn-output.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/command-learn-output.schema.json",
+  "title": "VibeGuard Learn Command Output",
+  "description": "Structured output contract for /vibeguard:learn.",
+  "type": "object",
+  "required": ["command", "error", "rootCause", "improvements", "verification"],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "const": "learn"
+    },
+    "error": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rootCause": {
+      "type": "object",
+      "required": ["surface", "direct", "root"],
+      "additionalProperties": false,
+      "properties": {
+        "surface": {
+          "type": "string",
+          "minLength": 1
+        },
+        "direct": {
+          "type": "string",
+          "minLength": 1
+        },
+        "root": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "improvements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "target", "description"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["new_guard", "enhance_guard", "new_hook", "new_rule", "claude_md"]
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "required": ["newGuardPassed", "noRegression"],
+      "additionalProperties": false,
+      "properties": {
+        "newGuardPassed": {
+          "type": "boolean"
+        },
+        "noRegression": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/command-live-truth-output.schema.json
+++ b/schemas/command-live-truth-output.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/command-live-truth-output.schema.json",
+  "title": "VibeGuard Live Truth Command Output",
+  "description": "Structured output contract for scripts/live_truth.py artifacts.",
+  "type": "object",
+  "required": ["command", "claim_type", "verdict", "facts", "inferences", "unresolved_gaps"],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "const": "live_truth"
+    },
+    "claim_type": {
+      "enum": ["latest", "pr-ready", "merged", "running", "deployed", "published"]
+    },
+    "verdict": {
+      "enum": ["pass", "fail", "gap"]
+    },
+    "facts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "value"],
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": ["string", "number", "boolean", "null"]
+          }
+        }
+      }
+    },
+    "inferences": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "unresolved_gaps": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/schemas/command-preflight-output.schema.json
+++ b/schemas/command-preflight-output.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/command-preflight-output.schema.json",
+  "title": "VibeGuard Preflight Command Output",
+  "description": "Structured output contract for /vibeguard:preflight.",
+  "type": "object",
+  "required": ["command", "projectType", "constraints", "guardBaseline", "unclear"],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "const": "preflight"
+    },
+    "projectType": {
+      "enum": ["rust", "typescript", "python", "go", "unknown"]
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "category", "description", "source", "verification"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "enum": [
+              "data_convergence",
+              "type_unique",
+              "interface_stable",
+              "error_handling",
+              "naming",
+              "guard_baseline"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "verification": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "guardBaseline": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "unclear": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "question", "options"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1
+          },
+          "options": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/command-review-output.schema.json
+++ b/schemas/command-review-output.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/command-review-output.schema.json",
+  "title": "VibeGuard Review Command Output",
+  "description": "Structured output contract for /vibeguard:review.",
+  "type": "object",
+  "required": ["command", "scope", "findings", "passedItems", "verdict"],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "const": "review"
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["priority", "file", "issue", "suggestion", "ruleId"],
+        "additionalProperties": false,
+        "properties": {
+          "priority": {
+            "enum": ["P0", "P1", "P2", "P3"]
+          },
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "issue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "suggestion": {
+            "type": "string",
+            "minLength": 1
+          },
+          "ruleId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "passedItems": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "verdict": {
+      "enum": ["pass", "warn", "fail"]
+    }
+  }
+}

--- a/schemas/command-skill-validate-output.schema.json
+++ b/schemas/command-skill-validate-output.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/command-skill-validate-output.schema.json",
+  "title": "VibeGuard Skill Validate Command Output",
+  "description": "Structured output contract for scripts/skill_validate.py evidence artifacts.",
+  "type": "object",
+  "required": [
+    "command",
+    "skill_name",
+    "proposed_skill",
+    "decision_set",
+    "verdict",
+    "counts",
+    "freshness_gaps",
+    "scenarios"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "const": "skill_validate"
+    },
+    "skill_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "proposed_skill": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decision_set": {
+      "enum": ["baseline", "held_out"]
+    },
+    "verdict": {
+      "enum": ["pass", "fail", "stale", "needs_justification", "advisory"]
+    },
+    "counts": {
+      "type": "object",
+      "required": ["repair", "regression", "no_change", "unrelated_regression", "unrelated_no_change"],
+      "additionalProperties": false,
+      "properties": {
+        "repair": {
+          "type": "integer"
+        },
+        "regression": {
+          "type": "integer"
+        },
+        "no_change": {
+          "type": "integer"
+        },
+        "unrelated_regression": {
+          "type": "integer"
+        },
+        "unrelated_no_change": {
+          "type": "integer"
+        }
+      }
+    },
+    "freshness_gaps": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scenario_id", "scenario_type", "without_skill", "with_skill", "classification"],
+        "additionalProperties": false,
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scenario_type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "without_skill": {
+            "enum": ["success", "failure"]
+          },
+          "with_skill": {
+            "enum": ["success", "failure"]
+          },
+          "classification": {
+            "enum": ["repair", "regression", "no_change"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/command-skill-validate-output.schema.json
+++ b/schemas/command-skill-validate-output.schema.json
@@ -62,6 +62,29 @@
         "minLength": 1
       }
     },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "regression_justification": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "scored_against_agent": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "scored_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+    },
+    "artifact_path": {
+      "type": "string",
+      "minLength": 1
+    },
     "scenarios": {
       "type": "array",
       "items": {
@@ -85,6 +108,21 @@
           },
           "classification": {
             "enum": ["repair", "regression", "no_change"]
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scored_against_agent": {
+            "type": ["string", "null"],
+            "minLength": 1
+          },
+          "scored_at": {
+            "type": ["string", "null"],
+            "minLength": 1
+          },
+          "notes": {
+            "type": ["string", "object", "null"]
           }
         }
       }

--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -1,6 +1,12 @@
 {
   "schema_version": 1,
   "schema_files": {
+    "check_output": "command-check-output.schema.json",
+    "learn_output": "command-learn-output.schema.json",
+    "live_truth_output": "command-live-truth-output.schema.json",
+    "preflight_output": "command-preflight-output.schema.json",
+    "review_output": "command-review-output.schema.json",
+    "skill_validate_output": "command-skill-validate-output.schema.json",
     "routing_decision": "workflow-routing-decision.schema.json",
     "execution_handoff": "workflow-execution-handoff.schema.json",
     "delegation_assignment": "workflow-delegation-assignment.schema.json",
@@ -32,6 +38,36 @@
       "path": "docs/command-schemas.md",
       "heading": "verification gate Schema",
       "schema": "verification_gate"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "preflight output Schema",
+      "schema": "preflight_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "check output Schema",
+      "schema": "check_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "live_truth output Schema",
+      "schema": "live_truth_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "skill_validate output Schema",
+      "schema": "skill_validate_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "review output Schema",
+      "schema": "review_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "learn output Schema",
+      "schema": "learn_output"
     }
   ],
   "consumers": [

--- a/scripts/lib/workflow_contracts.py
+++ b/scripts/lib/workflow_contracts.py
@@ -43,6 +43,8 @@ def _type_name(value: Any) -> str:
         return "string"
     if isinstance(value, int) and not isinstance(value, bool):
         return "integer"
+    if isinstance(value, float):
+        return "number"
     if isinstance(value, list):
         return "array"
     if isinstance(value, dict):
@@ -59,6 +61,8 @@ def _type_matches(value: Any, expected: str) -> bool:
         return isinstance(value, str)
     if expected == "integer":
         return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
     if expected == "array":
         return isinstance(value, list)
     if expected == "object":

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -75,7 +75,7 @@ trap cleanup EXIT
 copy_schemas() {
   local target="$1"
   mkdir -p "${target}/schemas"
-  cp "${REPO_DIR}"/schemas/workflow-*.schema.json "${target}/schemas/"
+  cp "${REPO_DIR}"/schemas/*.schema.json "${target}/schemas/"
 }
 
 write_registry() {
@@ -84,6 +84,12 @@ write_registry() {
 {
   "schema_version": 1,
   "schema_files": {
+    "check_output": "command-check-output.schema.json",
+    "learn_output": "command-learn-output.schema.json",
+    "live_truth_output": "command-live-truth-output.schema.json",
+    "preflight_output": "command-preflight-output.schema.json",
+    "review_output": "command-review-output.schema.json",
+    "skill_validate_output": "command-skill-validate-output.schema.json",
     "routing_decision": "workflow-routing-decision.schema.json",
     "execution_handoff": "workflow-execution-handoff.schema.json",
     "delegation_assignment": "workflow-delegation-assignment.schema.json",
@@ -160,11 +166,27 @@ for path, contract in expected.items():
     missing_requires = contract["requires"] - set(consumer.get("requires", []))
     if missing_requires:
         raise SystemExit(f"{path} missing requirements: {sorted(missing_requires)}")
+
+examples = {
+    (example.get("heading"), example.get("schema"))
+    for example in registry.get("markdown_examples", [])
+}
+expected_examples = {
+    ("preflight output Schema", "preflight_output"),
+    ("check output Schema", "check_output"),
+    ("live_truth output Schema", "live_truth_output"),
+    ("skill_validate output Schema", "skill_validate_output"),
+    ("review output Schema", "review_output"),
+    ("learn output Schema", "learn_output"),
+}
+missing_examples = expected_examples - examples
+if missing_examples:
+    raise SystemExit(f"command output schema examples missing from registry: {sorted(missing_examples)}")
 PY
-  green "command and workflow routing consumers stay registered"
+  green "command output examples and workflow consumers stay registered"
   PASS=$((PASS + 1))
 else
-  red "command and workflow routing consumers stay registered"
+  red "command output examples and workflow consumers stay registered"
   FAIL=$((FAIL + 1))
 fi
 
@@ -211,6 +233,20 @@ PY
 write_registry "${EXAMPLE_FIXTURE}" '"markdown_examples": [{"path": "docs/command-schemas.md", "heading": "routing decision Schema", "schema": "routing_decision"}], "consumers": [], "legacy_routing_markers": []'
 assert_fails_with "invalid command schema example fails schema validation" "maybe_later" \
   python3 "${HELPER}" --repo-dir "${EXAMPLE_FIXTURE}" --schema-dir "${EXAMPLE_FIXTURE}/schemas" --registry "${EXAMPLE_FIXTURE}/schemas/workflow-contract-consumers.json" validate
+
+COMMAND_EXAMPLE_FIXTURE="${TMP_DIR}/command-example"
+copy_schemas "${COMMAND_EXAMPLE_FIXTURE}"
+mkdir -p "${COMMAND_EXAMPLE_FIXTURE}/docs"
+python3 - "${REPO_DIR}/docs/command-schemas.md" "${COMMAND_EXAMPLE_FIXTURE}/docs/command-schemas.md" <<'PY'
+from pathlib import Path
+import sys
+source, target = map(Path, sys.argv[1:3])
+text = source.read_text(encoding="utf-8").replace('"claim_type": "latest"', '"claim_type": "laterish"', 1)
+target.write_text(text, encoding="utf-8")
+PY
+write_registry "${COMMAND_EXAMPLE_FIXTURE}" '"markdown_examples": [{"path": "docs/command-schemas.md", "heading": "live_truth output Schema", "schema": "live_truth_output"}], "consumers": [], "legacy_routing_markers": []'
+assert_fails_with "invalid live_truth command example fails schema validation" "laterish" \
+  python3 "${HELPER}" --repo-dir "${COMMAND_EXAMPLE_FIXTURE}" --schema-dir "${COMMAND_EXAMPLE_FIXTURE}/schemas" --registry "${COMMAND_EXAMPLE_FIXTURE}/schemas/workflow-contract-consumers.json" validate
 
 header "workflow command path failures"
 COMMAND_PATH_FIXTURE="${TMP_DIR}/command-path"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -139,6 +139,63 @@ else
 fi
 TOTAL=$((TOTAL + 1))
 if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+payload = {
+    "command": "skill_validate",
+    "skill_name": "demo-skill",
+    "proposed_skill": "/tmp/demo/SKILL.md",
+    "decision_set": "baseline",
+    "verdict": "pass",
+    "counts": {
+        "repair": 1,
+        "regression": 0,
+        "no_change": 2,
+        "unrelated_regression": 0,
+        "unrelated_no_change": 2,
+    },
+    "freshness_gaps": [],
+    "reasons": ["repair count is greater than regression count with no regressions"],
+    "regression_justification": None,
+    "scored_against_agent": "claude-opus-4-7",
+    "scored_at": "2026-05-31",
+    "artifact_path": ".vibeguard/skill-validate/demo-skill-2026-05-31.jsonl",
+    "scenarios": [
+        {
+            "scenario_id": "incident-1",
+            "scenario_type": "target",
+            "without_skill": "failure",
+            "with_skill": "success",
+            "classification": "repair",
+            "source": "baseline",
+            "scored_against_agent": "claude-opus-4-7",
+            "scored_at": "2026-05-31",
+            "notes": None,
+        }
+    ],
+}
+errors = module.validate_instance(payload, schema)
+if errors:
+    raise SystemExit("\n".join(errors))
+PY
+  green "skill_validate schema accepts persisted artifact fields"
+  PASS=$((PASS + 1))
+else
+  red "skill_validate schema accepts persisted artifact fields"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary

Fixes #294.

This makes the remaining command output examples in `docs/command-schemas.md` executable by adding JSON schemas and registering each markdown example with the existing contract validator.

## Changes

- Added executable schemas for `preflight`, `check`, `live_truth`, `skill_validate`, `review`, and `learn` command output examples.
- Registered the six command output headings in `schemas/workflow-contract-consumers.json` so markdown examples are validated.
- Converted placeholder enum examples such as `"pass | fail"` into concrete valid sample values.
- Added `number` support to the lightweight schema validator for fields such as `complianceScore`.
- Extended workflow contract regression tests to assert the command examples stay registered and that invalid command examples fail validation.

## Test plan

- `python3 -m py_compile scripts/lib/workflow_contracts.py`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`

Part of #266.
