### PR TITLE
Count non-numeric rule IDs in rule banners

### DIFF
--- a/scripts/lib/claude_md.py
+++ b/scripts/lib/claude_md.py
@@ -9,7 +9,10 @@ from typing import Optional
 START = "<!-- vibeguard-start -->"
 END = "<!-- vibeguard-end -->"
 RULE_COUNT_PLACEHOLDER = "__VIBEGUARD_RULE_COUNT__"
-RULE_HEADING_RE = re.compile(r"^## [A-Z]+-[0-9]+", re.MULTILINE)
+RULE_HEADING_RE = re.compile(
+    r"^##\s+(?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+(?:\s|:|$)",
+    re.MULTILINE,
+)
 
 
 def count_rule_headings(root: Path) -> int:

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -167,7 +167,7 @@ claude_rule_id_count() {
     return 0
   fi
   while IFS= read -r rule_file; do
-    file_count=$(grep -cE '^## [A-Z]+-[0-9]+' "${rule_file}" 2>/dev/null || true)
+    file_count=$(grep -cE '^##[[:space:]]+(RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+([[:space:]:]|$)' "${rule_file}" 2>/dev/null || true)
     total=$((total + file_count))
   done < <(find "${root}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
   printf '%s\n' "${total}"

--- a/tests/test_hook_health.sh
+++ b/tests/test_hook_health.sh
@@ -19,7 +19,7 @@ header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
 assert_contains() {
   local output="$1" expected="$2" desc="$3"
   TOTAL=$((TOTAL + 1))
-  if echo "$output" | grep -qF "$expected"; then
+  if grep -qF -- "$expected" <<< "$output"; then
     green "$desc"
     PASS=$((PASS + 1))
   else

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -112,7 +112,7 @@ assert_claude_rule_banner_matches_installed_rules() {
   local rules_dest="${HOME}/.claude/rules/vibeguard"
   local actual=0 declared file_count rule_file
   while IFS= read -r rule_file; do
-    file_count=$(grep -cE '^## [A-Z]+-[0-9]+' "${rule_file}" 2>/dev/null || true)
+    file_count=$(grep -cE '^##[[:space:]]+(RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+([[:space:]:]|$)' "${rule_file}" 2>/dev/null || true)
     actual=$((actual + file_count))
   done < <(find "${rules_dest}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
   declared=$(grep -o '[0-9]* rules' "${HOME}/.claude/CLAUDE.md" 2>/dev/null | grep -o '[0-9]*' | head -1 || true)
@@ -221,6 +221,36 @@ assert_cmd "scripts/lib/settings_json.py syntax is correct" python3 -m py_compil
 assert_cmd "scripts/lib/hooks_manifest.py syntax is correct" python3 -m py_compile "${HOOKS_MANIFEST_HELPER}"
 assert_cmd "scripts/lib/project_config_validate.py syntax is correct" python3 -m py_compile "${PROJECT_CONFIG_HELPER}"
 assert_cmd "scripts/lib/claude_md.py syntax is correct" python3 -m py_compile "${REPO_DIR}/scripts/lib/claude_md.py"
+assert_cmd "CLAUDE.md helper counts canonical non-numeric rule ids" python3 - "${REPO_DIR}" <<'PY'
+import subprocess
+import sys
+from pathlib import Path
+
+repo_dir = Path(sys.argv[1])
+sys.path.insert(0, str(repo_dir / "scripts/lib"))
+import claude_md
+
+canonical = subprocess.check_output(
+    [
+        sys.executable,
+        str(repo_dir / "scripts/lib/vibeguard_manifest.py"),
+        "rule-ids",
+        "--source",
+        "canonical",
+    ],
+    text=True,
+).splitlines()
+assert "TASTE-ANSI" in canonical
+assert claude_md.count_rule_headings(repo_dir / "rules/claude-rules") == len(canonical)
+PY
+assert_cmd "setup shell rule counter counts canonical non-numeric rule ids" bash -c "
+  set -euo pipefail
+  source '${REPO_DIR}/scripts/setup/lib.sh'
+  source '${REPO_DIR}/scripts/setup/targets/claude-home.sh'
+  actual=\"\$(claude_rule_id_count '${REPO_DIR}/rules/claude-rules')\"
+  expected=\"\$(python3 '${REPO_DIR}/scripts/lib/vibeguard_manifest.py' rule-ids --source canonical | wc -l | tr -d ' ')\"
+  test \"\${actual}\" = \"\${expected}\"
+"
 assert_cmd "scripts/lib/codex_hooks_json.py syntax is correct" python3 -m py_compile "${CODEX_HOOKS_HELPER}"
 assert_cmd "scripts/lib/codex_config_toml.py syntax is correct" python3 -m py_compile "${CODEX_CONFIG_HELPER}"
 assert_cmd "hooks/_lib/codex_apply_patch_adapter.py syntax is correct" python3 -m py_compile "${REPO_DIR}/hooks/_lib/codex_apply_patch_adapter.py"


### PR DESCRIPTION
## Summary

- Count VibeGuard rule headings with the canonical rule-ID grammar instead of numeric-only IDs.
- Align the shell setup/check rule counter with the Python CLAUDE.md injector.
- Add setup regression coverage for `TASTE-*` rule IDs so injected banners stay aligned with canonical rule inventory.
- Stabilize the hook-health test helper on macOS/bash+pipefail by avoiding `echo | grep -q` broken-pipe false failures.

Closes #296.
Updates #266.

## Verification

- `python3 -m py_compile scripts/lib/claude_md.py`
- `python3 scripts/lib/claude_md.py diff-inject /tmp/nonexistent-vg-claude.md claude-md/vibeguard-rules.md /Users/lifcc/Desktop/code/AI/tools/vibeguard` renders `126 rules total`
- `bash -n scripts/setup/targets/claude-home.sh`
- `bash tests/test_setup.sh`
- `bash tests/test_hook_health.sh`
