### PR TITLE
Align L1-L7 enforcement wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Add your own rules to `~/.vibeguard/user-rules/`. Any `.md` files placed there a
 
 | Principle | From | Implementation |
 |-----------|------|----------------|
-| Automation over documentation | Harness #3 | Hooks + guard scripts enforce mechanically |
+| Automation over documentation | Harness #3 | Mechanized checks complement rules, workflows, and review |
 | Error messages = fix instructions | Harness #3 | Every interception tells AI how to fix, not just what's wrong |
 | Maps not manuals | Harness #5 | 7-layer index + negative constraints + lazy loading |
 | Failure → capability | Harness #2 | Mistake → learn → new guard → never again |

--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -3,7 +3,7 @@
 
 > __VIBEGUARD_RULE_COUNT__ rules total. Claude loads the full set from `~/.claude/rules/vibeguard/`; Codex sees the L1-L7 layers + Key Detailed Rules table below. Repo-specific facts belong in the repo-level `AGENTS.md`.
 
-## Constraints (L1-L7 are enforced by Hooks)
+## Constraints (L1-L7 use rules, hooks, guards, and workflows)
 
 | Layers | Rules |
 |----|------|

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -77,9 +77,9 @@ Make a mistake → /vibeguard:learn → Analyze the root cause → Generate new 
 
 ---
 
-## Seven-Layer Defense (Seven-Layer Defense - Enforced)
+## Seven-Layer Defense (Mixed Coverage)
 
-Hooks + guard script **mechanized execution** without relying on AI consciousness:
+Rules, guard scripts, hooks, and workflow commands provide the coverage. Not every layer is hook-blocked:
 
 | Layers | Constraints | Execution Mode |
 |----|------|----------|
@@ -89,7 +89,7 @@ Hooks + guard script **mechanized execution** without relying on AI consciousnes
 | **L4** | Blank display with no data; API not invented | **Hook Warning** |
 | **L5** | Only do what is asked | Review constraints |
 | **L6** | Follow the canonical routing contract in `workflows/references/routing-contract.md` | Process constraints |
-| **L7** | Disable AI tag / force push / key | **Hook + git hook interception** |
+| **L7** | Disable AI tag / force push / key | Agent/review contract + pre-commit quality/build checks + git pre-push remote-history block |
 
 ---
 

--- a/docs/CLAUDE.md.example
+++ b/docs/CLAUDE.md.example
@@ -1,7 +1,7 @@
 # CLAUDE.md — 10x Engineer Configuration
 
 > Integrated Anthropic official best practices + VibeGuard seven-layer defense.
-> Different from "recommended compliance" configuration - rules are automatically intercepted by Hooks + enforced by guard scripts.
+> Different from "recommended compliance" configuration - rules, guard scripts, hooks, and workflow commands provide layered coverage; not every rule is mechanically blocked.
 
 ---
 

--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -16,7 +16,7 @@ Canonical source of truth: `rules/claude-rules/`
 | L4 | Data integrity | Rules injection + guards |
 | L5 | Minimal changes | Rules injection |
 | L6 | Process gates | `/vibeguard:preflight` + `/vibeguard:interview` + `/vibeguard:exec-plan` |
-| L7 | Commit discipline | `pre-commit-guard.sh` hook (block) |
+| L7 | Commit discipline | Agent/review contract + `pre-commit-guard.sh` quality/build gate + git `pre-push` remote-history gate |
 
 ---
 

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -14,6 +14,12 @@ if ! grep -Fq "${expected_l1}" docs/rule-reference.md; then
   exit 1
 fi
 
+expected_l7='| L7 | Commit discipline | Agent/review contract + `pre-commit-guard.sh` quality/build gate + git `pre-push` remote-history gate |'
+if ! grep -Fq "${expected_l7}" docs/rule-reference.md; then
+  echo "docs/rule-reference.md must describe L7 as mixed agent/review, pre-commit, and pre-push coverage" >&2
+  exit 1
+fi
+
 expected_strict='| Strict | Non-negotiable agent/reviewer rule. If enforcement is not mechanical, violations still need a fix, explicit DEFER, or documented downgrade path. |'
 if ! grep -Fq "${expected_strict}" docs/rule-reference.md; then
   echo "docs/rule-reference.md must define Strict as an agent/reviewer contract, not automatic hook blocking" >&2

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -37,6 +37,10 @@ require_absent "README.md" '| AI tries to finish with unverified changes | `stop
   "README.md must not describe stop-guard as a blocking Gate"
 require_present "README.md" '| AI tries to finish with unverified changes | `stop-guard` | **Signal**' \
   "README.md must describe stop-guard as a non-blocking Signal"
+require_absent "README.md" 'Hooks + guard scripts enforce mechanically' \
+  "README.md must not imply all rule coverage is mechanically enforced"
+require_present "README.md" 'Mechanized checks complement rules, workflows, and review' \
+  "README.md design principles must describe mixed coverage"
 require_present "README.md" '| `Stop` | `stop-guard.sh` | Uncommitted changes signal (logs a `gate` event, non-blocking Stop) |' \
   "README.md Codex hook table must explain stop-guard logs gate events without blocking Stop"
 require_absent "README.md" 'Stop Gate' \
@@ -97,6 +101,10 @@ require_absent "docs/CLAUDE.md.example" '| `Stop` has unverified source code cha
   "docs/CLAUDE.md.example must not describe stop-guard as a blocking Gate"
 require_absent "docs/CLAUDE.md.example" 'Stop Gate' \
   "docs/CLAUDE.md.example must not use the old Stop Gate wording"
+require_absent "docs/CLAUDE.md.example" 'rules are automatically intercepted by Hooks + enforced by guard scripts' \
+  "docs/CLAUDE.md.example intro must not imply all rule coverage is mechanically enforced"
+require_present "docs/CLAUDE.md.example" 'rules, guard scripts, hooks, and workflow commands provide layered coverage; not every rule is mechanically blocked' \
+  "docs/CLAUDE.md.example intro must describe mixed coverage"
 require_absent "docs/CLAUDE.md.example" 'Seven-Layer Defense (Seven-Layer Defense - Enforced)' \
   "docs/CLAUDE.md.example must not claim the seven-layer block is fully enforced"
 require_present "docs/CLAUDE.md.example" '## Seven-Layer Defense (Mixed Coverage)' \

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -28,6 +28,11 @@ require_present() {
   fi
 }
 
+require_absent "claude-md/vibeguard-rules.md" 'L1-L7 are enforced by Hooks' \
+  "managed VibeGuard rule block must not claim all L1-L7 layers are hook-enforced"
+require_present "claude-md/vibeguard-rules.md" '## Constraints (L1-L7 use rules, hooks, guards, and workflows)' \
+  "managed VibeGuard rule block must describe mixed layer coverage"
+
 require_absent "README.md" '| AI tries to finish with unverified changes | `stop-guard` | **Gate**' \
   "README.md must not describe stop-guard as a blocking Gate"
 require_present "README.md" '| AI tries to finish with unverified changes | `stop-guard` | **Signal**' \
@@ -92,6 +97,12 @@ require_absent "docs/CLAUDE.md.example" '| `Stop` has unverified source code cha
   "docs/CLAUDE.md.example must not describe stop-guard as a blocking Gate"
 require_absent "docs/CLAUDE.md.example" 'Stop Gate' \
   "docs/CLAUDE.md.example must not use the old Stop Gate wording"
+require_absent "docs/CLAUDE.md.example" 'Seven-Layer Defense (Seven-Layer Defense - Enforced)' \
+  "docs/CLAUDE.md.example must not claim the seven-layer block is fully enforced"
+require_present "docs/CLAUDE.md.example" '## Seven-Layer Defense (Mixed Coverage)' \
+  "docs/CLAUDE.md.example must name the seven-layer block as mixed coverage"
+require_present "docs/CLAUDE.md.example" 'Rules, guard scripts, hooks, and workflow commands provide the coverage. Not every layer is hook-blocked:' \
+  "docs/CLAUDE.md.example must explain mixed enforcement coverage"
 require_present "docs/CLAUDE.md.example" '| `Stop` has unverified source code changes | **Signal**' \
   "docs/CLAUDE.md.example must describe stop-guard as a signal"
 require_present "docs/CLAUDE.md.example" 'additionally enable Stop signal / Learn evaluator' \
@@ -110,6 +121,10 @@ require_absent "docs/CLAUDE.md.example" '| git `pre-push` detects non-fast-forwa
   "docs/CLAUDE.md.example must not suggest force-with-lease, which pre-push still blocks"
 require_absent "docs/CLAUDE.md.example" '- **Disable** force push — use `--force-with-lease`' \
   "docs/CLAUDE.md.example L7 guidance must not suggest force-with-lease, which pre-push still blocks"
+require_absent "docs/CLAUDE.md.example" '| **L7** | Disable AI tag / force push / key | **Hook + git hook interception** |' \
+  "docs/CLAUDE.md.example must not overstate L7 as only hook interception"
+require_present "docs/CLAUDE.md.example" '| **L7** | Disable AI tag / force push / key | Agent/review contract + pre-commit quality/build checks + git pre-push remote-history block |' \
+  "docs/CLAUDE.md.example must describe L7 mixed coverage"
 require_present "docs/CLAUDE.md.example" '| git `pre-push` detects non-fast-forward push / branch deletion | **Block** — protects remote history; rewrites and deletions require explicit human approval plus the repository bypass policy |' \
   "docs/CLAUDE.md.example must assign force-push protection to git pre-push"
 

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -391,7 +391,7 @@ Canonical source of truth: `rules/claude-rules/`
 | L4 | Data integrity | Rules injection + guards |
 | L5 | Minimal changes | Rules injection |
 | L6 | Process gates | `/vibeguard:preflight` + `/vibeguard:interview` + `/vibeguard:exec-plan` |
-| L7 | Commit discipline | `pre-commit-guard.sh` hook (block) |
+| L7 | Commit discipline | Agent/review contract + `pre-commit-guard.sh` quality/build gate + git `pre-push` remote-history gate |
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the managed rule-block claim that all L1-L7 layers are hook-enforced with mixed coverage wording
- align docs/CLAUDE and generated rule-reference L7 coverage with the actual agent/review + pre-commit + pre-push mechanisms
- add CI checks so the overclaim does not regress

## Verification
- python3 scripts/generate_rule_docs.py
- bash scripts/ci/validate-generated-rule-docs.sh
- bash scripts/ci/validate-hook-behavior-docs.sh
- bash scripts/ci/validate-rules.sh
- bash tests/test_manifest_contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash tests/test_setup.sh
- bash setup.sh --yes
- bash setup.sh --check --strict
- git diff --check

Fixes #308