### PR TITLE
Run prompt contract checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,10 @@ jobs:
         shell: bash
         run: bash scripts/ci/validate-workflow-contracts.sh
 
+      - name: Validate prompt contract
+        shell: bash
+        run: bash scripts/ci/validate-prompt-contract.sh --strict
+
       - name: Validate skill format
         shell: bash
         run: bash scripts/ci/validate-skill-format.sh
@@ -185,6 +189,10 @@ jobs:
       - name: Eval contract regression tests
         shell: bash
         run: bash tests/test_eval_contract.sh
+
+      - name: Prompt contract regression tests
+        shell: bash
+        run: bash tests/test_prompt_contract.sh
 
       - name: Behavior eval regression gate
         if: runner.os != 'Windows'
@@ -324,6 +332,9 @@ jobs:
 
       - name: Validate workflow contracts
         run: bash scripts/ci/validate-workflow-contracts.sh
+
+      - name: Validate prompt contract
+        run: bash scripts/ci/validate-prompt-contract.sh --strict
 
       - name: Validate hooks manifest
         run: bash scripts/ci/validate-hooks-manifest.sh

--- a/scripts/ci/validate-prompt-contract.sh
+++ b/scripts/ci/validate-prompt-contract.sh
@@ -35,9 +35,10 @@ run_one() {
 run_one "${REPO_DIR}/templates/AGENTS.md"
 
 if [[ -d "${REPO_DIR}/agents" ]]; then
-  while IFS= read -r -d '' role; do
+  for role in "${REPO_DIR}/agents"/*.md; do
+    [[ -f "${role}" ]] || continue
     run_one "$role"
-  done < <(find "${REPO_DIR}/agents" -maxdepth 1 -type f -name '*.md' -print0)
+  done
 fi
 
 exit $((FAIL > 0 ? 1 : 0))

--- a/scripts/local-contract-check.sh
+++ b/scripts/local-contract-check.sh
@@ -80,6 +80,10 @@ if [[ -f "$REPO_DIR/tests/test_manifest_contract.sh" ]]; then
   run_check "test_manifest_contract" "$REPO_DIR/tests/test_manifest_contract.sh" "true"
 fi
 
+if [[ -f "$REPO_DIR/tests/test_prompt_contract.sh" ]]; then
+  run_check "test_prompt_contract" "$REPO_DIR/tests/test_prompt_contract.sh" "true"
+fi
+
 if [[ -f "$REPO_DIR/tests/test_eval_contract.sh" ]]; then
   run_check "test_eval_contract"     "$REPO_DIR/tests/test_eval_contract.sh"     "true"
 fi

--- a/tests/test_prompt_contract.sh
+++ b/tests/test_prompt_contract.sh
@@ -9,6 +9,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
 SCHEMA="${REPO_DIR}/schemas/prompt-contract.schema.json"
 REAL_AGENTS="${REPO_DIR}/templates/AGENTS.md"
+CI_WORKFLOW="${REPO_DIR}/.github/workflows/ci.yml"
 
 PASS=0
 FAIL=0
@@ -185,6 +186,12 @@ assert_cmd "exceeds max budget without --strict -> warning only" \
   run_validator --target "$LARGE_TARGET"
 assert_cmd_fail "exceeds max budget under --strict -> error" \
   run_validator --target "$LARGE_TARGET" --strict
+
+header "CI wiring"
+assert_cmd "GitHub CI runs prompt contract validator" \
+  grep -qF "bash scripts/ci/validate-prompt-contract.sh --strict" "$CI_WORKFLOW"
+assert_cmd "GitHub CI runs prompt contract regression tests" \
+  grep -qF "bash tests/test_prompt_contract.sh" "$CI_WORKFLOW"
 
 header "summary"
 echo


### PR DESCRIPTION
## Summary
- run the prompt contract validator in GitHub CI with `--strict`
- run the prompt contract regression test in CI and local contract checks
- make the prompt contract validator avoid GNU-only `find -maxdepth` usage

## Validation
- `bash -n scripts/ci/validate-prompt-contract.sh`
- `bash -n tests/test_prompt_contract.sh`
- `bash scripts/ci/validate-prompt-contract.sh --strict`
- `bash tests/test_prompt_contract.sh`
- `bash tests/test_local_contract_gate.sh`
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`
- `bash setup.sh --yes`
- `bash setup.sh --check --strict`

Fixes #314
