### PR TITLE
Track git pre-push hook in manifest

### DIFF
--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -22,6 +22,7 @@ AI coded agent hooks script, automatically triggered before and after the operat
 | `stop-guard.sh` | Stop | Record uncommitted source code changes as a non-blocking Stop signal. | native |
 | `learn-evaluator.sh` | Stop | Collect metrics at the end of session, detect corrective signals, and suggest /learn when signals exist. | native |
 | `pre-commit-guard.sh` | git pre-commit | Automatic guard before submission: quality check plus build check, timeout hard limit. | - |
+| `git/pre-push` | git pre-push | Block non-fast-forward pushes, remote branch deletion, and force-like push options by default. | - |
 <!-- hooks-manifest-table:end -->
 
 **Codex column description**: `native` = deployed to `~/.codex/hooks.json`, `unsupported` = Codex does not expose the required native event/tool surface, `-` = not applicable.

--- a/hooks/manifest.json
+++ b/hooks/manifest.json
@@ -286,6 +286,18 @@
       "decision_types": ["pass", "warn", "block"],
       "claude": {"enabled": false, "support": "not-applicable", "reason": "git hook"},
       "codex": {"enabled": false, "support": "not-applicable", "reason": "git hook"}
+    },
+    {
+      "name": "git-pre-push",
+      "script": "git/pre-push",
+      "kind": "git-hook",
+      "install_targets": [],
+      "config_exposure": {"disabled_hook": false},
+      "trigger": "git pre-push",
+      "responsibilities": "Block non-fast-forward pushes, remote branch deletion, and force-like push options by default.",
+      "decision_types": ["pass", "block"],
+      "claude": {"enabled": false, "support": "not-applicable", "reason": "git hook"},
+      "codex": {"enabled": false, "support": "not-applicable", "reason": "git hook"}
     }
   ]
 }

--- a/schemas/hooks-manifest.schema.json
+++ b/schemas/hooks-manifest.schema.json
@@ -36,7 +36,7 @@
       "additionalProperties": false,
       "properties": {
         "name": {"type": "string", "pattern": "^[a-z0-9-]+$"},
-        "script": {"type": "string", "pattern": "^[a-z0-9_-]+\\.sh$"},
+        "script": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_/-]*(\\.sh)?$"},
         "kind": {"enum": ["hook", "library", "wrapper", "manual", "git-hook"]},
         "install_targets": {
           "type": "array",

--- a/scripts/lib/hooks_manifest.py
+++ b/scripts/lib/hooks_manifest.py
@@ -25,6 +25,42 @@ HOOK_EVENTS = {
 }
 
 
+def _script_path_is_safe(script: str) -> bool:
+    path = Path(script)
+    return not path.is_absolute() and ".." not in path.parts and all(path.parts)
+
+
+def _validate_script(
+    script: Any,
+    kind: Any,
+    prefix: str,
+    repo_root: Path,
+) -> tuple[str | None, list[str]]:
+    errors: list[str] = []
+    if not isinstance(script, str) or not script:
+        return None, [f"{prefix}.script must be a non-empty string"]
+    if not _script_path_is_safe(script):
+        return script, [f"{prefix}.script must be a safe hooks-relative path"]
+    if kind != "git-hook" and ("/" in script or not script.endswith(".sh")):
+        errors.append(f"{prefix}.script must be a shell script name")
+    if kind == "git-hook" and not (script.endswith(".sh") or "/" in script):
+        errors.append(f"{prefix}.script must be a shell script name or git hook path")
+    if not (repo_root / "hooks" / script).is_file():
+        errors.append(f"{prefix}.script missing hooks/{script}")
+    return script, errors
+
+
+def _git_hook_sources(repo_root: Path) -> set[str]:
+    git_hooks_dir = repo_root / "hooks" / "git"
+    if not git_hooks_dir.is_dir():
+        return set()
+    return {
+        f"git/{path.name}"
+        for path in git_hooks_dir.iterdir()
+        if path.is_file() and not path.name.startswith(".")
+    }
+
+
 def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
@@ -145,6 +181,7 @@ def _validate_profiles(value: Any, path: str) -> None:
 def validate_manifest(data: dict[str, Any], repo_root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     names: set[str] = set()
+    git_hook_scripts: set[str] = set()
 
     if data.get("schema_version") != 1:
         errors.append("schema_version must be 1")
@@ -166,12 +203,12 @@ def validate_manifest(data: dict[str, Any], repo_root: Path = ROOT) -> list[str]
         else:
             names.add(name)
 
-        if not isinstance(script, str) or not script.endswith(".sh"):
-            errors.append(f"{prefix}.script must be a shell script name")
-        elif not (repo_root / "hooks" / script).exists():
-            errors.append(f"{prefix}.script missing hooks/{script}")
-
         kind = item.get("kind")
+        script, script_errors = _validate_script(script, kind, prefix, repo_root)
+        errors.extend(script_errors)
+        if kind == "git-hook" and isinstance(script, str):
+            git_hook_scripts.add(script)
+
         if kind in DISABLEABLE_KINDS:
             install_targets = item.get("install_targets")
             if not isinstance(install_targets, list):
@@ -231,6 +268,10 @@ def validate_manifest(data: dict[str, Any], repo_root: Path = ROOT) -> list[str]
                             errors.append(f"{prefix}.codex.script missing hooks/{codex_script}")
             except ValueError as exc:
                 errors.append(str(exc))
+
+    missing_git_hooks = sorted(_git_hook_sources(repo_root) - git_hook_scripts)
+    for script in missing_git_hooks:
+        errors.append(f"hooks/{script} missing from hooks manifest")
 
     return errors
 

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -89,7 +89,10 @@ assert_contains "${profiles_out}" "full" "profile list contains full"
 hooks_out="$(python3 "${MANIFEST_HELPER}" hook-names)"
 assert_contains "${hooks_out}" "count-active-constraints" "hook list comes from manifest names"
 assert_not_contains "${hooks_out}" "count_active_constraints" "hook list does not use script stems"
+assert_not_contains "${hooks_out}" "git-pre-push" "git pre-push is tracked but not exposed through disabled_hooks"
 assert_not_contains "${hooks_out}" "skills-loader" "manual hooks are not exposed through disabled_hooks"
+hooks_table_out="$(python3 "${REPO_DIR}/scripts/lib/hooks_manifest.py" render-doc-table)"
+assert_contains "${hooks_table_out}" '`git/pre-push` | git pre-push' "hooks manifest renders git pre-push inventory row"
 rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source canonical --scope common)"
 assert_contains "${rules_out}" "W-17" "canonical common rule ids include W-17"
 assert_contains "${rules_out}" "U-32" "canonical common rule ids include U-32"
@@ -186,6 +189,22 @@ PY
 bad_hooks_manifest_out="$(python3 "${MANIFEST_HELPER}" validate --hooks-manifest "${BAD_HOOKS_MANIFEST}" 2>&1 || true)"
 assert_contains "${bad_hooks_manifest_out}" "hook install target drift for hooks-pre" "manifest validation detects hook install target drift"
 assert_not_contains "${bad_hooks_manifest_out}" "Traceback" "hook install target drift reports without traceback"
+
+BAD_GIT_HOOKS_MANIFEST="${TMP_DIR}/bad-git-hooks-manifest.json"
+python3 - "${REPO_DIR}/hooks/manifest.json" "${BAD_GIT_HOOKS_MANIFEST}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+data["hooks"] = [hook for hook in data["hooks"] if hook["name"] != "git-pre-push"]
+target.write_text(json.dumps(data), encoding="utf-8")
+PY
+bad_git_hooks_manifest_out="$(python3 "${REPO_DIR}/scripts/lib/hooks_manifest.py" --manifest "${BAD_GIT_HOOKS_MANIFEST}" validate 2>&1 || true)"
+assert_contains "${bad_git_hooks_manifest_out}" "hooks/git/pre-push missing from hooks manifest" "hooks manifest validation detects missing git pre-push source"
+assert_not_contains "${bad_git_hooks_manifest_out}" "Traceback" "git pre-push manifest drift reports without traceback"
 
 BAD_RULE_PATHS_MANIFEST="${TMP_DIR}/bad-rule-paths-install-modules.json"
 python3 - "${REPO_DIR}/schemas/install-modules.json" "${BAD_RULE_PATHS_MANIFEST}" <<'PY'


### PR DESCRIPTION
## Summary
- add `hooks/git/pre-push` to the hook manifest and generated hook table
- allow safe hooks-relative git hook paths in manifest validation/schema
- fail validation when executable sources under `hooks/git/` are missing from the manifest

## Validation
- `python3 -m py_compile scripts/lib/hooks_manifest.py`
- `python3 scripts/lib/hooks_manifest.py validate`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-hook-behavior-docs.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash tests/hooks/test_pre_push_guard.sh`
- `bash tests/test_setup.sh`
- `git diff --check`
- `bash setup.sh --yes`
- `bash setup.sh --check --strict`

Fixes #316
