### PR TITLE
Align post hook decision types

### DIFF
--- a/hooks/manifest.json
+++ b/hooks/manifest.json
@@ -119,7 +119,7 @@
       "config_exposure": {"disabled_hook": true},
       "trigger": "PostToolUse(Edit)",
       "responsibilities": "Detect quality problems after editing: unwrap, console.log, hard-coded path, Go error discard, oversized diff, repeated editing of the same file (churn), W-15 consecutive same-file edit loop.",
-      "decision_types": ["pass", "warn", "block"],
+      "decision_types": ["pass", "warn", "escalate", "correction"],
       "claude": {
         "enabled": true,
         "event": "PostToolUse",
@@ -143,7 +143,7 @@
       "config_exposure": {"disabled_hook": true},
       "trigger": "PostToolUse(Write)",
       "responsibilities": "Detect duplicate definitions and files with the same name after creating a new file.",
-      "decision_types": ["pass", "warn", "block"],
+      "decision_types": ["pass", "warn"],
       "claude": {
         "enabled": true,
         "event": "PostToolUse",
@@ -201,7 +201,7 @@
       "config_exposure": {"disabled_hook": true},
       "trigger": "PostToolUse(Edit/Write)",
       "responsibilities": "Automatically run the build check corresponding to the language after editing.",
-      "decision_types": ["pass", "warn", "block"],
+      "decision_types": ["pass", "warn", "escalate"],
       "claude": {
         "enabled": true,
         "event": "PostToolUse",

--- a/scripts/ci/validate-hooks-manifest.sh
+++ b/scripts/ci/validate-hooks-manifest.sh
@@ -36,5 +36,22 @@ if errors:
         print(f"FAIL: {error}")
     raise SystemExit(1)
 print("OK: install hook modules are covered by hooks manifest")
+
+expected_decisions = {
+    "post-edit-guard": ["pass", "warn", "escalate", "correction"],
+    "post-write-guard": ["pass", "warn"],
+    "post-build-check": ["pass", "warn", "escalate"],
+}
+hooks_by_name = {item.get("name"): item for item in manifest.get("hooks", [])}
+decision_errors = []
+for hook_name, expected in expected_decisions.items():
+    actual = hooks_by_name.get(hook_name, {}).get("decision_types")
+    if actual != expected:
+        decision_errors.append(f"{hook_name}: decision_types={actual!r}, expected={expected!r}")
+if decision_errors:
+    for error in decision_errors:
+        print(f"FAIL: {error}")
+    raise SystemExit(1)
+print("OK: post hook decision_types match actual logging contract")
 PY
 bash "${REPO_DIR}/scripts/setup/regenerate-hooks-from-manifest.sh" --check

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -93,6 +93,28 @@ assert_not_contains "${hooks_out}" "git-pre-push" "git pre-push is tracked but n
 assert_not_contains "${hooks_out}" "skills-loader" "manual hooks are not exposed through disabled_hooks"
 hooks_table_out="$(python3 "${REPO_DIR}/scripts/lib/hooks_manifest.py" render-doc-table)"
 assert_contains "${hooks_table_out}" '`git/pre-push` | git pre-push' "hooks manifest renders git pre-push inventory row"
+post_decision_contract_out="$(python3 - "${REPO_DIR}/hooks/manifest.json" <<'PY' 2>&1 || true
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+hooks = {hook["name"]: hook for hook in manifest["hooks"]}
+expected = {
+    "post-edit-guard": ["pass", "warn", "escalate", "correction"],
+    "post-write-guard": ["pass", "warn"],
+    "post-build-check": ["pass", "warn", "escalate"],
+}
+for name, decision_types in expected.items():
+    actual = hooks[name]["decision_types"]
+    if actual != decision_types:
+        print(f"FAIL: {name} decision_types={actual!r}, expected={decision_types!r}")
+        raise SystemExit(1)
+print("OK: post hook decision_types match actual logging contract")
+PY
+)"
+assert_contains "${post_decision_contract_out}" "OK: post hook decision_types match actual logging contract" "post hook decision_types match actual logging contract"
+assert_not_contains "${post_decision_contract_out}" "FAIL:" "post hook decision_types contract reports without failure"
 rules_out="$(python3 "${MANIFEST_HELPER}" rule-ids --source canonical --scope common)"
 assert_contains "${rules_out}" "W-17" "canonical common rule ids include W-17"
 assert_contains "${rules_out}" "U-32" "canonical common rule ids include U-32"


### PR DESCRIPTION
## Summary
- align post-edit, post-write, and post-build manifest decision_types with actual vg_log decisions
- add CI validation for the post hook decision type contract
- add manifest contract regression coverage for the same decision type contract

## Validation
- `bash -n scripts/ci/validate-hooks-manifest.sh`
- `bash -n tests/test_manifest_contract.sh`
- `python3 scripts/lib/hooks_manifest.py validate`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash tests/test_manifest_contract.sh`
- `bash tests/hooks/test_post_edit_churn.sh`
- `bash tests/hooks/test_post_write_guard.sh`
- `bash tests/hooks/test_post_build_check.sh`
- `bash scripts/ci/validate-hook-behavior-docs.sh`
- `bash tests/test_setup.sh`
- `git diff --check`
- `bash setup.sh --yes`
- `bash setup.sh --check --strict`

Fixes #318
