### PR TITLE
Register entrypoint workflow consumers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ VibeGuard is an anti-hallucination rules, hooks, and workflow repository. There 
 - Keep names snake_case unless an external API boundary requires camelCase.
 - Do not swallow errors silently. User-visible missing data or wrong output must fail loudly.
 - Do only the requested scope; avoid opportunistic refactors.
-- Follow `workflows/references/routing-contract.md` for `execute_direct`, `plan_first`, `clarify_first`, and shared handoff fields.
+- Follow `workflows/references/routing-contract.md`: set `readiness` to `execute_direct`, `plan_first`, or `clarify_first`; handoffs carry `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map`.
 - High-context files such as `AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, setup scripts, and hooks must not be modified by generated output without explicit intent.
 
 ## Validation

--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -137,6 +137,16 @@
       "requires": []
     },
     {
+      "path": "AGENTS.md",
+      "references": ["routing-contract.md"],
+      "requires": ["routing_decision", "execution_handoff"]
+    },
+    {
+      "path": "skills/vibeguard/SKILL.md",
+      "references": ["routing-contract.md"],
+      "requires": ["routing_decision", "execution_handoff"]
+    },
+    {
       "path": "docs/CLAUDE.md.example",
       "references": ["routing-contract.md", "delegation-contract.md"],
       "requires": []

--- a/skills/vibeguard/SKILL.md
+++ b/skills/vibeguard/SKILL.md
@@ -12,6 +12,7 @@ VibeGuard is an anti-hallucination framework for AI-assisted development that sy
 Canonical contract sources for this skill:
 - `README.md` — product entry and current Core vs Workflow boundary
 - `docs/rule-reference.md` — public rule/guard summary
+- `workflows/references/routing-contract.md` — canonical `readiness` decisions and execution handoff fields
 - `schemas/install-modules.json` — install/runtime contract
 
 `docs/internal/history/spec.md` remains a historical design snapshot and should not be treated as the authoritative implementation contract.
@@ -34,7 +35,7 @@ Triggered when user mentions:
 ## Red Flags
 
 - A new guard or rule is proposed without a corresponding automated detection method.
-- A workflow skips the routing contract or omits the shared handoff fields.
+- A workflow skips the routing contract or omits `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, or `lane_map`.
 - A completion claim lacks fresh verification output from the current session.
 
 ## Checklist
@@ -114,6 +115,7 @@ Refer to references/review-template.md, record:
 
 - [ ] Confirm the task goal, context, constraints, and done-when criteria.
 - [ ] Search for existing rules, hooks, workflows, skills, and tests before adding new ones.
-- [ ] Pick the correct routing lane: `execute_direct`, `plan_first`, or `clarify_first`.
+- [ ] Pick the correct routing lane by setting `readiness`: `execute_direct`, `plan_first`, or `clarify_first`.
+- [ ] Carry `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` when planning hands off to execution.
 - [ ] Attach a focused verification command to every behavior change.
 - [ ] Preserve the L1-L7 constraint summary in handoffs and compactions.

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -212,6 +212,14 @@ expected = {
         "references": {"routing-contract.md", "delegation-contract.md"},
         "requires": {"routing_decision", "execution_handoff", "lane_map", "verification_gate"},
     },
+    "AGENTS.md": {
+        "references": {"routing-contract.md"},
+        "requires": {"routing_decision", "execution_handoff"},
+    },
+    "skills/vibeguard/SKILL.md": {
+        "references": {"routing-contract.md"},
+        "requires": {"routing_decision", "execution_handoff"},
+    },
 }
 for path, contract in expected.items():
     consumer = consumers.get(path)


### PR DESCRIPTION
## Summary
- register `AGENTS.md` and `skills/vibeguard/SKILL.md` as workflow contract consumers
- make both entrypoints carry the schema-level routing decision and execution handoff tokens
- extend workflow contract regression coverage so these entrypoints cannot drop out of the registry silently

## Validation
- `python3 scripts/lib/workflow_contracts.py validate`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-skill-format.sh`
- `bash tests/test_skill_format.sh`
- `python3 scripts/skill_validate.py --check-repo-format --repo-root .`
- `bash scripts/local-contract-check.sh --quick`
- `bash tests/test_local_contract_gate.sh`
- `bash scripts/verify/doc-freshness-check.sh`
- `git diff --check`
- `bash setup.sh --yes`
- `bash setup.sh --check --strict`

Fixes #320
