### PR TITLE
Align skill_validate format output with schema

### DIFF
--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -208,6 +208,7 @@ The text artifact emitted by `scripts/live_truth.py` uses these same sections so
 ```json
 {
   "command": "skill_validate",
+  "mode": "evidence",
   "skill_name": "demo-skill",
   "proposed_skill": "path/to/SKILL.md",
   "decision_set": "baseline",
@@ -245,11 +246,32 @@ The text artifact emitted by `scripts/live_truth.py` uses these same sections so
 `scripts/skill_validate.py` appends this artifact as JSONL under `.vibeguard/skill-validate/` unless `--no-persist` is used.
 Evidence validation also fails when the proposed `SKILL.md` is missing the required reusable-skill sections: `## When to Activate`, `## Red Flags`, and `## Checklist`.
 
-Format-only checks use the same command surface:
+## skill_validate format output Schema
+
+```json
+{
+  "command": "skill_validate",
+  "mode": "format",
+  "verdict": "pass",
+  "paths_checked": 1,
+  "required_sections": [
+    "## When to Activate",
+    "## Red Flags",
+    "## Checklist"
+  ],
+  "list_required_sections": [
+    "## Red Flags",
+    "## Checklist"
+  ],
+  "errors": []
+}
+```
+
+Format-only checks use the same command surface. Add `--json` when another tool needs the schema-compatible artifact:
 
 ```bash
-python3 scripts/skill_validate.py --format-only --proposed-skill path/to/SKILL.md
-python3 scripts/skill_validate.py --check-repo-format --repo-root .
+python3 scripts/skill_validate.py --format-only --proposed-skill path/to/SKILL.md --json
+python3 scripts/skill_validate.py --check-repo-format --repo-root . --json
 ```
 
 `--check-repo-format` scans `skills/*/SKILL.md`, `workflows/*/SKILL.md`, and `templates/skill-template.md`.

--- a/schemas/command-skill-validate-output.schema.json
+++ b/schemas/command-skill-validate-output.schema.json
@@ -5,7 +5,6 @@
   "description": "Structured output contract for scripts/skill_validate.py evidence and format artifacts.",
   "type": "object",
   "required": ["command", "mode", "verdict"],
-  "additionalProperties": false,
   "oneOf": [
     {
       "required": [
@@ -19,12 +18,121 @@
         "freshness_gaps",
         "scenarios"
       ],
+      "additionalProperties": false,
       "properties": {
+        "command": {
+          "const": "skill_validate"
+        },
         "mode": {
           "const": "evidence"
         },
+        "skill_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "proposed_skill": {
+          "type": "string",
+          "minLength": 1
+        },
         "decision_set": {
           "enum": ["baseline", "held_out"]
+        },
+        "verdict": {
+          "enum": ["pass", "fail", "stale", "needs_justification", "advisory"]
+        },
+        "counts": {
+          "type": "object",
+          "required": ["repair", "regression", "no_change", "unrelated_regression", "unrelated_no_change"],
+          "additionalProperties": false,
+          "properties": {
+            "repair": {
+              "type": "integer"
+            },
+            "regression": {
+              "type": "integer"
+            },
+            "no_change": {
+              "type": "integer"
+            },
+            "unrelated_regression": {
+              "type": "integer"
+            },
+            "unrelated_no_change": {
+              "type": "integer"
+            }
+          }
+        },
+        "freshness_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "regression_justification": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "scored_against_agent": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "scored_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+        },
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scenarios": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["scenario_id", "scenario_type", "without_skill", "with_skill", "classification"],
+            "additionalProperties": false,
+            "properties": {
+              "scenario_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "scenario_type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "without_skill": {
+                "enum": ["success", "failure"]
+              },
+              "with_skill": {
+                "enum": ["success", "failure"]
+              },
+              "classification": {
+                "enum": ["repair", "regression", "no_change"]
+              },
+              "source": {
+                "type": "string",
+                "minLength": 1
+              },
+              "scored_against_agent": {
+                "type": ["string", "null"],
+                "minLength": 1
+              },
+              "scored_at": {
+                "type": ["string", "null"],
+                "minLength": 1
+              },
+              "notes": {
+                "type": ["string", "object", "null"]
+              }
+            }
+          }
         }
       }
     },
@@ -38,165 +146,53 @@
         "list_required_sections",
         "errors"
       ],
+      "additionalProperties": false,
       "properties": {
+        "command": {
+          "const": "skill_validate"
+        },
         "mode": {
           "const": "format"
         },
         "verdict": {
           "enum": ["pass", "fail"]
-        }
-      }
-    }
-  ],
-  "properties": {
-    "command": {
-      "const": "skill_validate"
-    },
-    "mode": {
-      "enum": ["evidence", "format"]
-    },
-    "skill_name": {
-      "type": "string",
-      "minLength": 1
-    },
-    "proposed_skill": {
-      "type": "string",
-      "minLength": 1
-    },
-    "decision_set": {
-      "enum": ["baseline", "held_out"]
-    },
-    "verdict": {
-      "enum": ["pass", "fail", "stale", "needs_justification", "advisory"]
-    },
-    "counts": {
-      "type": "object",
-      "required": ["repair", "regression", "no_change", "unrelated_regression", "unrelated_no_change"],
-      "additionalProperties": false,
-      "properties": {
-        "repair": {
+        },
+        "paths_checked": {
           "type": "integer"
         },
-        "regression": {
-          "type": "integer"
-        },
-        "no_change": {
-          "type": "integer"
-        },
-        "unrelated_regression": {
-          "type": "integer"
-        },
-        "unrelated_no_change": {
-          "type": "integer"
-        }
-      }
-    },
-    "freshness_gaps": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
-    },
-    "reasons": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
-    },
-    "regression_justification": {
-      "type": ["string", "null"],
-      "minLength": 1
-    },
-    "scored_against_agent": {
-      "type": ["string", "null"],
-      "minLength": 1
-    },
-    "scored_at": {
-      "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}"
-    },
-    "artifact_path": {
-      "type": "string",
-      "minLength": 1
-    },
-    "scenarios": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["scenario_id", "scenario_type", "without_skill", "with_skill", "classification"],
-        "additionalProperties": false,
-        "properties": {
-          "scenario_id": {
+        "required_sections": {
+          "type": "array",
+          "items": {
             "type": "string",
             "minLength": 1
-          },
-          "scenario_type": {
-            "type": "string",
-            "minLength": 1
-          },
-          "without_skill": {
-            "enum": ["success", "failure"]
-          },
-          "with_skill": {
-            "enum": ["success", "failure"]
-          },
-          "classification": {
-            "enum": ["repair", "regression", "no_change"]
-          },
-          "source": {
-            "type": "string",
-            "minLength": 1
-          },
-          "scored_against_agent": {
-            "type": ["string", "null"],
-            "minLength": 1
-          },
-          "scored_at": {
-            "type": ["string", "null"],
-            "minLength": 1
-          },
-          "notes": {
-            "type": ["string", "object", "null"]
           }
-        }
-      }
-    },
-    "paths_checked": {
-      "type": "integer"
-    },
-    "required_sections": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
-    },
-    "list_required_sections": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
-    },
-    "errors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["path", "message"],
-        "additionalProperties": false,
-        "properties": {
-          "path": {
+        },
+        "list_required_sections": {
+          "type": "array",
+          "items": {
             "type": "string",
             "minLength": 1
-          },
-          "message": {
-            "type": "string",
-            "minLength": 1
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         }
       }
     }
-  }
+  ]
 }

--- a/schemas/command-skill-validate-output.schema.json
+++ b/schemas/command-skill-validate-output.schema.json
@@ -2,22 +2,58 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://vibeguard.local/schemas/command-skill-validate-output.schema.json",
   "title": "VibeGuard Skill Validate Command Output",
-  "description": "Structured output contract for scripts/skill_validate.py evidence artifacts.",
+  "description": "Structured output contract for scripts/skill_validate.py evidence and format artifacts.",
   "type": "object",
-  "required": [
-    "command",
-    "skill_name",
-    "proposed_skill",
-    "decision_set",
-    "verdict",
-    "counts",
-    "freshness_gaps",
-    "scenarios"
-  ],
+  "required": ["command", "mode", "verdict"],
   "additionalProperties": false,
+  "oneOf": [
+    {
+      "required": [
+        "command",
+        "mode",
+        "skill_name",
+        "proposed_skill",
+        "decision_set",
+        "verdict",
+        "counts",
+        "freshness_gaps",
+        "scenarios"
+      ],
+      "properties": {
+        "mode": {
+          "const": "evidence"
+        },
+        "decision_set": {
+          "enum": ["baseline", "held_out"]
+        }
+      }
+    },
+    {
+      "required": [
+        "command",
+        "mode",
+        "verdict",
+        "paths_checked",
+        "required_sections",
+        "list_required_sections",
+        "errors"
+      ],
+      "properties": {
+        "mode": {
+          "const": "format"
+        },
+        "verdict": {
+          "enum": ["pass", "fail"]
+        }
+      }
+    }
+  ],
   "properties": {
     "command": {
       "const": "skill_validate"
+    },
+    "mode": {
+      "enum": ["evidence", "format"]
     },
     "skill_name": {
       "type": "string",
@@ -123,6 +159,41 @@
           },
           "notes": {
             "type": ["string", "object", "null"]
+          }
+        }
+      }
+    },
+    "paths_checked": {
+      "type": "integer"
+    },
+    "required_sections": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "list_required_sections": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "message"],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -61,6 +61,11 @@
     },
     {
       "path": "docs/command-schemas.md",
+      "heading": "skill_validate format output Schema",
+      "schema": "skill_validate_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
       "heading": "review output Schema",
       "schema": "review_output"
     },

--- a/scripts/lib/workflow_contracts.py
+++ b/scripts/lib/workflow_contracts.py
@@ -86,6 +86,26 @@ def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") ->
     if "enum" in schema and instance not in schema["enum"]:
         errors.append(f"{path}: expected one of {schema['enum']}, got {instance!r}")
 
+    one_of = schema.get("oneOf")
+    if isinstance(one_of, list):
+        matches: list[int] = []
+        branch_errors: list[str] = []
+        for index, branch in enumerate(one_of):
+            if not isinstance(branch, dict):
+                branch_errors.append(f"schema {index}: branch must be an object")
+                continue
+            current_errors = validate_instance(instance, branch, path)
+            if current_errors:
+                branch_errors.append(f"schema {index}: {'; '.join(current_errors)}")
+            else:
+                matches.append(index)
+        if len(matches) != 1:
+            if matches:
+                errors.append(f"{path}: matched multiple oneOf schemas: {matches}")
+            else:
+                detail = "; ".join(branch_errors[:3])
+                errors.append(f"{path}: must match exactly one oneOf schema; {detail}")
+
     if isinstance(instance, str):
         min_length = schema.get("minLength")
         if isinstance(min_length, int) and len(instance) < min_length:

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -366,6 +366,7 @@ def build_artifact(args: argparse.Namespace) -> tuple[dict[str, object], Path | 
     )
     artifact: dict[str, object] = {
         "command": "skill_validate",
+        "mode": "evidence",
         "skill_name": skill_name,
         "proposed_skill": str(proposed_skill),
         "decision_set": decision_set,
@@ -399,6 +400,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--as-of", help="Evaluation date, YYYY-MM-DD; defaults to today")
     parser.add_argument("--allow-stale", action="store_true", help="Report stale gaps without failing the verdict")
     parser.add_argument("--regression-justification", help="Required when regression count is nonzero")
+    parser.add_argument("--json", action="store_true", help="Emit the structured artifact as JSON")
     format_group = parser.add_mutually_exclusive_group()
     format_group.add_argument(
         "--format-only",
@@ -420,13 +422,19 @@ def main(argv: list[str]) -> int:
     if args.check_repo_format:
         repo_root = Path(args.repo_root).resolve()
         artifact = build_format_artifact(repo_skill_paths(repo_root), repo_root)
-        print_format_report(artifact)
+        if args.json:
+            print(json.dumps(artifact, sort_keys=True))
+        else:
+            print_format_report(artifact)
         return 0 if artifact["verdict"] == "pass" else 1
     if args.format_only:
         if not args.proposed_skill:
             parser.error("--format-only requires --proposed-skill")
         artifact = build_format_artifact([Path(args.proposed_skill).resolve()], None)
-        print_format_report(artifact)
+        if args.json:
+            print(json.dumps(artifact, sort_keys=True))
+        else:
+            print_format_report(artifact)
         return 0 if artifact["verdict"] == "pass" else 1
     if not args.proposed_skill:
         parser.error("--proposed-skill is required unless --check-repo-format is used")
@@ -437,7 +445,10 @@ def main(argv: list[str]) -> int:
     except SkillValidateError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
-    print_report(artifact, artifact_path)
+    if args.json:
+        print(json.dumps(artifact, sort_keys=True))
+    else:
+        print_report(artifact, artifact_path)
     return 0 if artifact["verdict"] == "pass" else 1
 
 

--- a/tests/test_skill_validate.sh
+++ b/tests/test_skill_validate.sh
@@ -76,6 +76,37 @@ assert_cmd "format-only accepts shaped skill" \
   python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${SKILL_DIR}/SKILL.md"
 assert_cmd "format-only accepts repository skill template" \
   python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${REPO_DIR}/templates/skill-template.md" --no-persist
+format_json="$(
+  python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${SKILL_DIR}/SKILL.md" --json
+)"
+TOTAL=$((TOTAL + 1))
+if FORMAT_JSON="${format_json}" python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+artifact = json.loads(os.environ["FORMAT_JSON"])
+if artifact.get("mode") != "format":
+    raise SystemExit(f"expected mode=format, got {artifact.get('mode')!r}")
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+errors = module.validate_instance(artifact, schema)
+if errors:
+    raise SystemExit("\n".join(errors))
+PY
+  green "format-only JSON output matches skill_validate schema"
+  PASS=$((PASS + 1))
+else
+  red "format-only JSON output matches skill_validate schema"
+  FAIL=$((FAIL + 1))
+fi
 
 MARKDOWN_LINK_DIR="${TMP_DIR}/markdown-link"
 mkdir -p "${MARKDOWN_LINK_DIR}"
@@ -225,6 +256,43 @@ passing_out="$(
 assert_contains "${passing_out}" "verdict: pass" "pass verdict when repair beats regression"
 assert_contains "${passing_out}" "repair: 1" "pass output records repair count"
 assert_cmd "pass verdict writes an artifact" test -f "${TMP_DIR}/artifacts/demo-skill-2026-05-18.jsonl"
+passing_json="$(
+  python3 "${SKILL_VALIDATE}" \
+    --proposed-skill "${SKILL_DIR}/SKILL.md" \
+    --baseline-trajectories "${PASSING_JSONL}" \
+    --current-agent claude-opus-4-7 \
+    --as-of 2026-05-18 \
+    --no-persist \
+    --json
+)"
+TOTAL=$((TOTAL + 1))
+if PASSING_JSON="${passing_json}" python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+artifact = json.loads(os.environ["PASSING_JSON"])
+if artifact.get("mode") != "evidence":
+    raise SystemExit(f"expected mode=evidence, got {artifact.get('mode')!r}")
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+errors = module.validate_instance(artifact, schema)
+if errors:
+    raise SystemExit("\n".join(errors))
+PY
+  green "evidence JSON output matches skill_validate schema"
+  PASS=$((PASS + 1))
+else
+  red "evidence JSON output matches skill_validate schema"
+  FAIL=$((FAIL + 1))
+fi
 
 header "unrelated evidence is required"
 NO_UNRELATED_JSONL="${TMP_DIR}/no-unrelated.jsonl"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -263,6 +263,88 @@ else
 fi
 TOTAL=$((TOTAL + 1))
 if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+payload = {
+    "command": "skill_validate",
+    "mode": "format",
+    "verdict": "pass",
+    "paths_checked": 1,
+    "required_sections": ["## When to Activate", "## Red Flags", "## Checklist"],
+    "list_required_sections": ["## Red Flags", "## Checklist"],
+    "errors": [],
+    "counts": {
+        "repair": 1,
+        "regression": 0,
+        "no_change": 2,
+        "unrelated_regression": 0,
+        "unrelated_no_change": 2,
+    },
+}
+errors = module.validate_instance(payload, schema)
+if not errors:
+    raise SystemExit("expected format artifact with evidence fields to fail")
+PY
+  green "skill_validate format-only artifact rejects evidence fields"
+  PASS=$((PASS + 1))
+else
+  red "skill_validate format-only artifact rejects evidence fields"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+payload = {
+    "command": "skill_validate",
+    "mode": "evidence",
+    "skill_name": "demo-skill",
+    "proposed_skill": "/tmp/demo/SKILL.md",
+    "decision_set": "baseline",
+    "verdict": "pass",
+    "counts": {
+        "repair": 1,
+        "regression": 0,
+        "no_change": 2,
+        "unrelated_regression": 0,
+        "unrelated_no_change": 2,
+    },
+    "freshness_gaps": [],
+    "scenarios": [],
+    "paths_checked": 1,
+}
+errors = module.validate_instance(payload, schema)
+if not errors:
+    raise SystemExit("expected evidence artifact with format fields to fail")
+PY
+  green "skill_validate evidence artifact rejects format fields"
+  PASS=$((PASS + 1))
+else
+  red "skill_validate evidence artifact rejects format fields"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
 import json
 import sys
 from pathlib import Path

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -153,6 +153,7 @@ spec.loader.exec_module(module)
 schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
 payload = {
     "command": "skill_validate",
+    "mode": "evidence",
     "skill_name": "demo-skill",
     "proposed_skill": "/tmp/demo/SKILL.md",
     "decision_set": "baseline",
@@ -192,6 +193,72 @@ PY
   PASS=$((PASS + 1))
 else
   red "skill_validate schema accepts persisted artifact fields"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+payload = {
+    "command": "skill_validate",
+    "mode": "format",
+    "verdict": "pass",
+    "paths_checked": 1,
+    "required_sections": ["## When to Activate", "## Red Flags", "## Checklist"],
+    "list_required_sections": ["## Red Flags", "## Checklist"],
+    "errors": [],
+}
+errors = module.validate_instance(payload, schema)
+if errors:
+    raise SystemExit("\n".join(errors))
+PY
+  green "skill_validate schema accepts format-only artifact fields"
+  PASS=$((PASS + 1))
+else
+  red "skill_validate schema accepts format-only artifact fields"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-skill-validate-output.schema.json").read_text(encoding="utf-8"))
+payload = {
+    "command": "skill_validate",
+    "mode": "format",
+    "verdict": "stale",
+    "paths_checked": 1,
+    "required_sections": ["## When to Activate", "## Red Flags", "## Checklist"],
+    "list_required_sections": ["## Red Flags", "## Checklist"],
+    "errors": [],
+}
+errors = module.validate_instance(payload, schema)
+if not errors:
+    raise SystemExit("expected stale verdict to fail for format mode")
+PY
+  green "skill_validate format-only artifact uses the format verdict set"
+  PASS=$((PASS + 1))
+else
+  red "skill_validate format-only artifact uses the format verdict set"
   FAIL=$((FAIL + 1))
 fi
 TOTAL=$((TOTAL + 1))
@@ -241,6 +308,7 @@ expected_examples = {
     ("check output Schema", "check_output"),
     ("live_truth output Schema", "live_truth_output"),
     ("skill_validate output Schema", "skill_validate_output"),
+    ("skill_validate format output Schema", "skill_validate_output"),
     ("review output Schema", "review_output"),
     ("learn output Schema", "learn_output"),
 }


### PR DESCRIPTION
## Summary
- add schema-compatible JSON output for `skill_validate` format and evidence modes
- extend the skill_validate command schema to distinguish `mode: evidence` and `mode: format`
- validate both evidence and format examples through the workflow contract registry
- add CLI regressions proving `--format-only --json` and evidence `--json` match the schema

## Validation
- `python3 -m py_compile scripts/lib/workflow_contracts.py scripts/skill_validate.py`
- `python3 scripts/lib/workflow_contracts.py validate`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash tests/test_skill_validate.sh`
- `bash tests/test_manifest_contract.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/local-contract-check.sh --quick`
- `bash scripts/verify/doc-freshness-check.sh`
- `bash -n tests/test_skill_validate.sh && bash -n tests/test_workflow_contracts.sh`
- `python3 scripts/skill_validate.py --check-repo-format --repo-root . --json >/tmp/vg_skill_format.json && python3 -m json.tool /tmp/vg_skill_format.json >/dev/null`
- `python3 scripts/skill_validate.py --format-only --proposed-skill /tmp/does-not-exist --json >/tmp/vg_bad_skill.json || code=$?; test "${code:-0}" = 1; python3 -m json.tool /tmp/vg_bad_skill.json >/dev/null`
- `git diff --check`
- `bash setup.sh --yes`
- `bash setup.sh --check --strict`

Fixes #322
