### PR TITLE
Unify skill format validation rules

### DIFF
--- a/scripts/ci/validate-skill-format.py
+++ b/scripts/ci/validate-skill-format.py
@@ -4,108 +4,13 @@
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
 
 
-REQUIRED_SECTIONS = ("When to Activate", "Red Flags", "Checklist")
-MIN_RED_FLAGS = 3
-MIN_CHECKLIST_ITEMS = 3
-FRONTMATTER_FIELD_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*:\s*.*$")
-FRONTMATTER_BLOCK_SCALAR_PATTERN = re.compile(
-    r"^[A-Za-z][A-Za-z0-9_-]*:\s*[|>](?:(?:[1-9][+-]?)|(?:[+-][1-9]?))?\s*(?:#.*)?$",
-)
-
-
-class SkillFormatError(Exception):
-    """Raised for a single SKILL.md format problem."""
-
-
-def default_skill_paths(repo_dir: Path) -> list[Path]:
-    paths: list[Path] = []
-    for root in (repo_dir / "skills", repo_dir / "workflows"):
-        if root.is_dir():
-            paths.extend(sorted(root.glob("*/SKILL.md")))
-    template = repo_dir / "templates" / "skill-template.md"
-    if template.is_file():
-        paths.append(template)
-    return paths
-
-
-def section_body(text: str, heading: str) -> str | None:
-    pattern = re.compile(
-        rf"(?ms)^##\s+{re.escape(heading)}\s*$\n(?P<body>.*?)(?=^##\s+|\Z)",
-    )
-    match = pattern.search(text)
-    if not match:
-        return None
-    return match.group("body")
-
-
-def count_plain_bullets(body: str) -> int:
-    return sum(1 for line in body.splitlines() if re.match(r"^\s*-\s+\S", line))
-
-
-def count_checklist_items(body: str) -> int:
-    return sum(1 for line in body.splitlines() if re.match(r"^\s*-\s+\[[ xX]\]\s+\S", line))
-
-
-def validate_frontmatter(path: Path, text: str) -> list[str]:
-    errors: list[str] = []
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        errors.append("missing YAML frontmatter opening")
-        return errors
-
-    closing_index = next((index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"), None)
-    if closing_index is None:
-        errors.append("missing YAML frontmatter closing")
-        return errors
-
-    frontmatter_lines = lines[1:closing_index]
-    in_block_scalar = False
-    for line_number, line in enumerate(frontmatter_lines, start=2):
-        if not line.strip():
-            continue
-        if line.startswith((" ", "\t")):
-            if in_block_scalar:
-                continue
-            errors.append(f"invalid indented frontmatter line before closing delimiter: line {line_number}")
-            return errors
-        in_block_scalar = False
-        if not FRONTMATTER_FIELD_PATTERN.match(line):
-            errors.append(f"invalid frontmatter line before closing delimiter: line {line_number}")
-            return errors
-        if FRONTMATTER_BLOCK_SCALAR_PATTERN.match(line):
-            in_block_scalar = True
-
-    frontmatter = "\n".join(frontmatter_lines)
-    for field in ("name", "description"):
-        if not re.search(rf"(?m)^{field}:\s*\S", frontmatter):
-            errors.append(f"missing frontmatter field: {field}")
-    return errors
-
-
-def validate_skill(path: Path) -> list[str]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise SkillFormatError(f"{path}: cannot read file: {exc}") from exc
-
-    errors = validate_frontmatter(path, text)
-    for heading in REQUIRED_SECTIONS:
-        body = section_body(text, heading)
-        if body is None:
-            errors.append(f"missing ## {heading} section")
-            continue
-        if heading == "When to Activate" and count_plain_bullets(body) < 1:
-            errors.append("## When to Activate must contain at least one bullet")
-        elif heading == "Red Flags" and count_plain_bullets(body) < MIN_RED_FLAGS:
-            errors.append(f"## Red Flags must contain at least {MIN_RED_FLAGS} bullets")
-        elif heading == "Checklist" and count_checklist_items(body) < MIN_CHECKLIST_ITEMS:
-            errors.append(f"## Checklist must contain at least {MIN_CHECKLIST_ITEMS} checkbox items")
-    return errors
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+from skill_format import default_skill_paths, skill_format_errors  # noqa: E402
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -136,7 +41,7 @@ def main(argv: list[str]) -> int:
 
     failure_count = 0
     for path in paths:
-        errors = validate_skill(path)
+        errors = skill_format_errors(path)
         if errors:
             failure_count += len(errors)
             for error in errors:

--- a/scripts/lib/skill_format.py
+++ b/scripts/lib/skill_format.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Shared SKILL.md format validation rules."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+FORMAT_PATH_PATTERNS = ("skills/*/SKILL.md", "workflows/*/SKILL.md", "templates/skill-template.md")
+FORMAT_REQUIRED_SECTIONS = ("## When to Activate", "## Red Flags", "## Checklist")
+FORMAT_LIST_SECTIONS = ("## Red Flags", "## Checklist")
+MIN_RED_FLAGS = 3
+MIN_CHECKLIST_ITEMS = 3
+FRONTMATTER_FIELD_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*:\s*.*$")
+FRONTMATTER_BLOCK_SCALAR_PATTERN = re.compile(
+    r"^[A-Za-z][A-Za-z0-9_-]*:\s*[|>](?:(?:[1-9][+-]?)|(?:[+-][1-9]?))?\s*(?:#.*)?$",
+)
+
+
+def default_skill_paths(repo_dir: Path) -> list[Path]:
+    paths: list[Path] = []
+    for pattern in FORMAT_PATH_PATTERNS:
+        paths.extend(repo_dir.glob(pattern))
+    return sorted(path for path in paths if path.is_file())
+
+
+def section_body(text: str, heading: str) -> str | None:
+    label = heading.removeprefix("## ")
+    pattern = re.compile(
+        rf"(?ms)^##\s+{re.escape(label)}\s*$\n(?P<body>.*?)(?=^##\s+|\Z)",
+    )
+    match = pattern.search(text)
+    if not match:
+        return None
+    return match.group("body")
+
+
+def _list_item_text(line: str) -> str | None:
+    match = re.match(r"^\s*(?:[-*+]|\d+[.)])\s+(?P<item>\S.*)$", line)
+    if not match:
+        return None
+    return re.sub(r"^\[[ xX]\]\s+", "", match.group("item").strip())
+
+
+def _useful_item_text(item: str) -> bool:
+    lower = item.strip(" .").lower()
+    if not lower or lower in {"...", "todo", "tbd", "n/a", "none", "placeholder"}:
+        return False
+    starts_with_markdown_link = re.match(
+        r"^\[[^\]\n]+\](?:\([^)]+\)|\[[^\]\n]*\])",
+        item,
+    ) is not None
+    if lower.startswith(("todo:", "tbd:", "<")):
+        return False
+    if lower.startswith("[") and not starts_with_markdown_link:
+        return False
+    return True
+
+
+def useful_list_item(line: str) -> bool:
+    item = _list_item_text(line)
+    return item is not None and _useful_item_text(item)
+
+
+def useful_checklist_item(line: str) -> bool:
+    match = re.match(r"^\s*-\s+\[[ xX]\]\s+(?P<item>\S.*)$", line)
+    return match is not None and _useful_item_text(match.group("item").strip())
+
+
+def count_useful_bullets(body: str) -> int:
+    return sum(1 for line in body.splitlines() if useful_list_item(line))
+
+
+def count_plain_bullets(body: str) -> int:
+    return sum(1 for line in body.splitlines() if re.match(r"^\s*-\s+\S", line))
+
+
+def count_useful_checklist_items(body: str) -> int:
+    return sum(1 for line in body.splitlines() if useful_checklist_item(line))
+
+
+def validate_frontmatter(text: str) -> list[str]:
+    errors: list[str] = []
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        errors.append("missing YAML frontmatter opening")
+        return errors
+
+    closing_index = next((index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"), None)
+    if closing_index is None:
+        errors.append("missing YAML frontmatter closing")
+        return errors
+
+    frontmatter_lines = lines[1:closing_index]
+    in_block_scalar = False
+    for line_number, line in enumerate(frontmatter_lines, start=2):
+        if not line.strip():
+            continue
+        if line.startswith((" ", "\t")):
+            if in_block_scalar:
+                continue
+            errors.append(f"invalid indented frontmatter line before closing delimiter: line {line_number}")
+            return errors
+        in_block_scalar = False
+        if not FRONTMATTER_FIELD_PATTERN.match(line):
+            errors.append(f"invalid frontmatter line before closing delimiter: line {line_number}")
+            return errors
+        if FRONTMATTER_BLOCK_SCALAR_PATTERN.match(line):
+            in_block_scalar = True
+
+    frontmatter = "\n".join(frontmatter_lines)
+    for field in ("name", "description"):
+        if not re.search(rf"(?m)^{field}:\s*\S", frontmatter):
+            errors.append(f"missing frontmatter field: {field}")
+    return errors
+
+
+def skill_format_errors(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"cannot read skill file: {exc}"]
+
+    errors = validate_frontmatter(text)
+    for heading in FORMAT_REQUIRED_SECTIONS:
+        body = section_body(text, heading)
+        if body is None:
+            errors.append(f"missing required section: {heading}")
+            continue
+        if heading == "## When to Activate":
+            activation_count = count_plain_bullets(body)
+            if activation_count == 0:
+                errors.append("## When to Activate must contain at least one bullet")
+        elif heading == "## Red Flags":
+            red_flag_count = count_useful_bullets(body)
+            if red_flag_count == 0:
+                errors.append("## Red Flags has no useful list items")
+            elif red_flag_count < MIN_RED_FLAGS:
+                errors.append(f"## Red Flags must contain at least {MIN_RED_FLAGS} bullets")
+        elif heading == "## Checklist":
+            checklist_count = count_useful_checklist_items(body)
+            if checklist_count == 0:
+                errors.append("## Checklist has no useful list items")
+            elif checklist_count < MIN_CHECKLIST_ITEMS:
+                errors.append(f"## Checklist must contain at least {MIN_CHECKLIST_ITEMS} checkbox items")
+    return errors

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -10,12 +10,16 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from skill_format import (  # noqa: E402
+    FORMAT_LIST_SECTIONS,
+    FORMAT_REQUIRED_SECTIONS,
+    default_skill_paths,
+    skill_format_errors,
+)
 
 OUTCOMES = {"success", "failure"}
 DEFAULT_OUTPUT_DIR = ".vibeguard/skill-validate"
-FORMAT_PATH_PATTERNS = ("skills/*/SKILL.md", "workflows/*/SKILL.md", "templates/skill-template.md")
-FORMAT_REQUIRED_SECTIONS = ("## When to Activate", "## Red Flags", "## Checklist")
-FORMAT_LIST_SECTIONS = ("## Red Flags", "## Checklist")
 
 
 class SkillValidateError(Exception):
@@ -166,64 +170,8 @@ def extract_skill_name(path: Path) -> str:
     raise SkillValidateError("cannot infer skill name")
 
 
-def markdown_sections(text: str) -> dict[str, list[str]]:
-    sections: dict[str, list[str]] = {}
-    current: str | None = None
-    for line in text.splitlines():
-        if line.startswith("## "):
-            current = line.strip()
-            sections[current] = []
-            continue
-        if current is not None:
-            sections[current].append(line)
-    return sections
-
-
-def useful_list_item(line: str) -> bool:
-    match = re.match(r"^\s*(?:[-*+]|\d+[.)])\s+(?P<item>\S.*)$", line)
-    if not match:
-        return False
-    item = re.sub(r"^\[[ xX]\]\s+", "", match.group("item").strip())
-    lower = item.strip(" .").lower()
-    if not lower or lower in {"...", "todo", "tbd", "n/a", "none", "placeholder"}:
-        return False
-    starts_with_markdown_link = re.match(
-        r"^\[[^\]\n]+\](?:\([^)]+\)|\[[^\]\n]*\])",
-        item,
-    ) is not None
-    if lower.startswith(("todo:", "tbd:", "<")):
-        return False
-    if lower.startswith("[") and not starts_with_markdown_link:
-        return False
-    return True
-
-
-def skill_format_errors(path: Path) -> list[str]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return [f"cannot read skill file: {exc}"]
-    sections = markdown_sections(text)
-    errors: list[str] = []
-    for heading in FORMAT_REQUIRED_SECTIONS:
-        body = sections.get(heading)
-        if body is None:
-            errors.append(f"missing required section: {heading}")
-            continue
-        if not any(line.strip() for line in body):
-            errors.append(f"{heading} is empty")
-    for heading in FORMAT_LIST_SECTIONS:
-        body = sections.get(heading)
-        if body is not None and not any(useful_list_item(line) for line in body):
-            errors.append(f"{heading} has no useful list items")
-    return errors
-
-
 def repo_skill_paths(repo_root: Path) -> list[Path]:
-    paths: list[Path] = []
-    for pattern in FORMAT_PATH_PATTERNS:
-        paths.extend(repo_root.glob(pattern))
-    return sorted(path for path in paths if path.is_file())
+    return default_skill_paths(repo_root)
 
 
 def build_format_artifact(paths: list[Path], repo_root: Path | None) -> dict[str, object]:

--- a/tests/test_skill_format.sh
+++ b/tests/test_skill_format.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 VALIDATOR="${REPO_DIR}/scripts/ci/validate-skill-format.py"
+SKILL_VALIDATE="${REPO_DIR}/scripts/skill_validate.py"
+SHARED_VALIDATOR="${REPO_DIR}/scripts/lib/skill_format.py"
 
 PASS=0
 FAIL=0
@@ -76,6 +78,7 @@ MD
 
 header "syntax"
 assert_cmd "validate-skill-format.py syntax is valid" python3 -m py_compile "${VALIDATOR}"
+assert_cmd "skill_format.py syntax is valid" python3 -m py_compile "${SHARED_VALIDATOR}"
 
 header "repository coverage"
 assert_cmd "repository skills, workflows, and template pass format validation" \
@@ -89,26 +92,52 @@ header "single-file validation"
 VALID_SKILL="${TMP_DIR}/skills/demo/SKILL.md"
 write_valid_skill "${VALID_SKILL}"
 assert_cmd "valid skill passes" python3 "${VALIDATOR}" "${VALID_SKILL}"
+assert_cmd "valid skill passes skill_validate format gate" \
+  python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${VALID_SKILL}"
 
 header "missing required section"
 MISSING_RED_FLAGS="${TMP_DIR}/missing-red-flags/SKILL.md"
 write_valid_skill "${MISSING_RED_FLAGS}"
 perl -0pi -e 's/\n## Red Flags\n.*?\n## Checklist/\n## Checklist/s' "${MISSING_RED_FLAGS}"
 missing_out="$(python3 "${VALIDATOR}" "${MISSING_RED_FLAGS}" 2>&1 || true)"
-assert_contains "${missing_out}" "missing ## Red Flags section" "missing red flags section fails"
+assert_contains "${missing_out}" "missing required section: ## Red Flags" "missing red flags section fails"
 
 header "empty required lists"
 EMPTY_RED_FLAGS="${TMP_DIR}/empty-red-flags/SKILL.md"
 write_valid_skill "${EMPTY_RED_FLAGS}"
 perl -0pi -e 's/## Red Flags\n\n.*?\n## Checklist/## Red Flags\n\nNo bullets here.\n\n## Checklist/s' "${EMPTY_RED_FLAGS}"
 empty_red_out="$(python3 "${VALIDATOR}" "${EMPTY_RED_FLAGS}" 2>&1 || true)"
-assert_contains "${empty_red_out}" "## Red Flags must contain at least 3 bullets" "empty red flags list fails"
+assert_contains "${empty_red_out}" "## Red Flags has no useful list items" "empty red flags list fails"
 
 EMPTY_CHECKLIST="${TMP_DIR}/empty-checklist/SKILL.md"
 write_valid_skill "${EMPTY_CHECKLIST}"
 perl -0pi -e 's/## Checklist\n\n.*\z/## Checklist\n\nNo checkbox items here.\n/s' "${EMPTY_CHECKLIST}"
 empty_checklist_out="$(python3 "${VALIDATOR}" "${EMPTY_CHECKLIST}" 2>&1 || true)"
-assert_contains "${empty_checklist_out}" "## Checklist must contain at least 3 checkbox items" "empty checklist fails"
+assert_contains "${empty_checklist_out}" "## Checklist has no useful list items" "empty checklist fails"
+
+header "shared rule source"
+DRIFT_SKILL="${TMP_DIR}/drift/SKILL.md"
+write_valid_skill "${DRIFT_SKILL}"
+perl -0pi -e 's/## Red Flags\n\n.*?\n## Checklist/## Red Flags\n\n- Only one red flag.\n\n## Checklist/s' "${DRIFT_SKILL}"
+perl -0pi -e 's/## Checklist\n\n.*\z/## Checklist\n\n- [ ] Only one checklist item.\n/s' "${DRIFT_SKILL}"
+drift_ci_out="$(python3 "${VALIDATOR}" "${DRIFT_SKILL}" 2>&1 || true)"
+drift_skill_validate_out="$(
+  python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${DRIFT_SKILL}" 2>&1 || true
+)"
+assert_contains "${drift_ci_out}" "## Red Flags must contain at least 3 bullets" "CI validator rejects underfilled red flags"
+assert_contains "${drift_ci_out}" "## Checklist must contain at least 3 checkbox items" "CI validator rejects underfilled checklist"
+assert_contains "${drift_skill_validate_out}" "## Red Flags must contain at least 3 bullets" "skill_validate rejects underfilled red flags"
+assert_contains "${drift_skill_validate_out}" "## Checklist must contain at least 3 checkbox items" "skill_validate rejects underfilled checklist"
+
+NO_FRONTMATTER_SKILL="${TMP_DIR}/no-frontmatter/SKILL.md"
+write_valid_skill "${NO_FRONTMATTER_SKILL}"
+perl -0pi -e 's/^---\nname: demo-skill\ndescription: Use when validating VibeGuard skill format structure\.\n---\n//' "${NO_FRONTMATTER_SKILL}"
+frontmatter_ci_out="$(python3 "${VALIDATOR}" "${NO_FRONTMATTER_SKILL}" 2>&1 || true)"
+frontmatter_skill_validate_out="$(
+  python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${NO_FRONTMATTER_SKILL}" 2>&1 || true
+)"
+assert_contains "${frontmatter_ci_out}" "missing YAML frontmatter opening" "CI validator rejects missing frontmatter"
+assert_contains "${frontmatter_skill_validate_out}" "missing YAML frontmatter opening" "skill_validate rejects missing frontmatter"
 
 header "frontmatter delimiter"
 BLOCK_SCALAR_SKILL="${TMP_DIR}/block-scalar/SKILL.md"

--- a/tests/test_skill_validate.sh
+++ b/tests/test_skill_validate.sh
@@ -62,10 +62,14 @@ description: Use when validating a proposed skill change.
 ## Red Flags
 
 - The proposed skill has no repeatable trigger condition.
+- The proposed skill does not define observable failure modes.
+- The proposed skill cannot be verified with focused evidence.
 
 ## Checklist
 
-- Confirm the skill has repair evidence and no unrelated regressions.
+- [ ] Confirm the skill has repair evidence and no unrelated regressions.
+- [ ] Confirm the activation cue matches the task.
+- [ ] Run focused verification before handoff.
 MD
 
 header "syntax"
@@ -125,10 +129,14 @@ description: Use when testing Markdown link list items.
 ## Red Flags
 
 - [Routing Contract](../references/routing-contract.md) is not reflected in the skill handoff.
+- [Delivery Contract](../references/delivery-contract.md) is missing from the review.
+- [Verification Contract](../references/verification-contract.md) is absent from the checklist.
 
 ## Checklist
 
-- [Delivery Base](../references/delivery-base.md) was reviewed before final verification.
+- [ ] [Delivery Base](../references/delivery-base.md) was reviewed before final verification.
+- [ ] [Routing Contract](../references/routing-contract.md) was reflected in the handoff.
+- [ ] [Verification Contract](../references/verification-contract.md) was checked before completion.
 MD
 assert_cmd "format-only accepts Markdown-link list items" \
   python3 "${SKILL_VALIDATE}" --format-only --proposed-skill "${MARKDOWN_LINK_DIR}/SKILL.md"
@@ -149,7 +157,9 @@ description: Use when testing missing sections.
 
 ## Checklist
 
-- Detect the missing heading.
+- [ ] Detect the missing heading.
+- [ ] Report the missing heading.
+- [ ] Keep the failure message specific.
 MD
 missing_section_out="$(
   python3 "${SKILL_VALIDATE}" \
@@ -206,6 +216,8 @@ description: Use when testing workflow coverage.
 ## Red Flags
 
 - The repository check ignores workflow skills.
+- The repository check ignores required workflow sections.
+- The repository check accepts incomplete workflow checklists.
 MD
 coverage_out="$(
   python3 "${SKILL_VALIDATE}" \


### PR DESCRIPTION
## Summary

Fixes #324.

- Moves SKILL.md format rules into `scripts/lib/skill_format.py`.
- Makes both `scripts/skill_validate.py` format modes and `scripts/ci/validate-skill-format.py` consume that shared validator.
- Adds regression coverage for the previous drift: underfilled Red Flags/Checklist and missing frontmatter now fail through both entry points.

## Validation

- `python3 -m py_compile scripts/lib/skill_format.py scripts/skill_validate.py scripts/ci/validate-skill-format.py`
- `bash tests/test_skill_format.sh` (23/23)
- `bash tests/test_skill_validate.sh` (23/23)
- `bash scripts/ci/validate-skill-format.sh`
- `python3 scripts/skill_validate.py --check-repo-format --repo-root . --json >/tmp/vg_skill_format_shared.json && python3 -m json.tool /tmp/vg_skill_format_shared.json >/dev/null`
- `bash tests/test_workflow_contracts.sh` (15/15)
- `bash scripts/local-contract-check.sh --quick`
- `bash scripts/verify/doc-freshness-check.sh --strict` (document-consistent, known uncovered rule WARN only)
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml && cargo test --manifest-path vibeguard-runtime/Cargo.toml` (121 tests)
- `git diff --check`
- `bash setup.sh --yes`
- `bash setup.sh --check --strict` (HEALTHY)
