### PR TITLE
Validate command doc vibeguard paths

### DIFF
--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -11,6 +11,11 @@ from pathlib import Path
 
 repo_root = Path(sys.argv[1]).resolve()
 targets = [repo_root / "README.md", repo_root / "docs" / "README_CN.md", repo_root / "CONTRIBUTING.md"]
+command_doc_targets = []
+for command_dir in (repo_root / ".claude" / "commands" / "vibeguard", repo_root / ".claude" / "commands" / "vg"):
+    command_doc_targets.extend(sorted(command_dir.glob("*.md")))
+targets.extend(command_doc_targets)
+
 renamed_targets = [
     repo_root / "README.md",
     repo_root / "CONTRIBUTING.md",
@@ -18,7 +23,7 @@ renamed_targets = [
     repo_root / "scripts" / "CLAUDE.md",
 ]
 renamed_targets.extend(sorted((repo_root / "workflows").rglob("*.md")))
-renamed_targets.extend(sorted((repo_root / ".claude" / "commands" / "vibeguard").glob("*.md")))
+renamed_targets.extend(command_doc_targets)
 
 renamed_command_paths = {
     "scripts/compliance_check.sh": "scripts/verify/compliance_check.sh",

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -33,6 +33,11 @@ path_pattern = re.compile(r"~/vibeguard/([A-Za-z0-9_./-]+)")
 failures = []
 checked = 0
 
+
+def display_path(path: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
 for md_file in targets:
     if not md_file.exists():
         continue
@@ -46,7 +51,7 @@ for md_file in targets:
             target = repo_root / rel
             ok = target.is_dir() if raw.endswith("/") else target.is_file()
             if not ok:
-                failures.append(f"{md_file.relative_to(repo_root)}:{idx} ~/vibeguard/{raw} (missing)")
+                failures.append(f"{display_path(md_file)}:{idx} ~/vibeguard/{raw} (missing)")
 
 for md_file in renamed_targets:
     if not md_file.exists():
@@ -55,7 +60,7 @@ for md_file in renamed_targets:
         for old_path, new_path in renamed_command_paths.items():
             if old_path in line:
                 failures.append(
-                    f"{md_file.relative_to(repo_root)}:{idx} stale command path {old_path}; use {new_path}"
+                    f"{display_path(md_file)}:{idx} stale command path {old_path}; use {new_path}"
                 )
 
 if failures:

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -474,6 +474,26 @@ MD
 assert_fails_with "stale compliance check command path fails validation" "scripts/verify/compliance_check.sh" \
   bash "${REPO_DIR}/scripts/ci/validate-doc-command-paths.sh" "${COMMAND_PATH_FIXTURE}"
 
+COMMAND_DOC_PATH_FIXTURE="${TMP_DIR}/command-doc-path"
+mkdir -p \
+  "${COMMAND_DOC_PATH_FIXTURE}/.claude/commands/vibeguard" \
+  "${COMMAND_DOC_PATH_FIXTURE}/.claude/commands/vg"
+cat > "${COMMAND_DOC_PATH_FIXTURE}/.claude/commands/vibeguard/bad.md" <<'MD'
+```bash
+python3 ~/vibeguard/scripts/does-not-exist.py
+```
+MD
+cat > "${COMMAND_DOC_PATH_FIXTURE}/.claude/commands/vg/bad.md" <<'MD'
+```bash
+bash ~/vibeguard/scripts/missing-shortcut.sh
+```
+MD
+command_doc_path_out="$(
+  bash "${REPO_DIR}/scripts/ci/validate-doc-command-paths.sh" "${COMMAND_DOC_PATH_FIXTURE}" 2>&1 || true
+)"
+assert_contains "${command_doc_path_out}" ".claude/commands/vibeguard/bad.md" "full command doc missing path fails validation"
+assert_contains "${command_doc_path_out}" ".claude/commands/vg/bad.md" "shortcut command doc missing path fails validation"
+
 echo
 echo "=============================="
 printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -488,9 +488,20 @@ cat > "${COMMAND_DOC_PATH_FIXTURE}/.claude/commands/vg/bad.md" <<'MD'
 bash ~/vibeguard/scripts/missing-shortcut.sh
 ```
 MD
+set +e
 command_doc_path_out="$(
-  bash "${REPO_DIR}/scripts/ci/validate-doc-command-paths.sh" "${COMMAND_DOC_PATH_FIXTURE}" 2>&1 || true
+  bash "${REPO_DIR}/scripts/ci/validate-doc-command-paths.sh" "${COMMAND_DOC_PATH_FIXTURE}" 2>&1
 )"
+command_doc_path_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ ${command_doc_path_status} -ne 0 ]]; then
+  green "command doc missing paths exit nonzero"
+  PASS=$((PASS + 1))
+else
+  red "command doc missing paths exit nonzero (expected failure)"
+  FAIL=$((FAIL + 1))
+fi
 assert_contains "${command_doc_path_out}" ".claude/commands/vibeguard/bad.md" "full command doc missing path fails validation"
 assert_contains "${command_doc_path_out}" ".claude/commands/vg/bad.md" "shortcut command doc missing path fails validation"
 


### PR DESCRIPTION
## Summary

Fixes #326.

- Adds `.claude/commands/vibeguard/*.md` and `.claude/commands/vg/*.md` to the `~/vibeguard/...` command path validator target set.
- Reuses that same command-doc target list for stale renamed command path checks.
- Adds regression coverage proving missing full command and shortcut command `~/vibeguard/...` paths fail validation.

## Validation

- `bash -n scripts/ci/validate-doc-command-paths.sh && bash -n tests/test_workflow_contracts.sh`
- `bash scripts/ci/validate-doc-command-paths.sh` (100 references)
- `bash tests/test_workflow_contracts.sh` (17/17)
- `git diff --check`
- `bash scripts/local-contract-check.sh --quick`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/verify/doc-freshness-check.sh --strict` (document-consistent, known uncovered rule WARN only)
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml && cargo test --manifest-path vibeguard-runtime/Cargo.toml` (121 tests)
- `bash setup.sh --yes`
- `bash setup.sh --check --strict` (HEALTHY)
