### PR TITLE
Validate Codex hook entries schema

### DIFF
--- a/schemas/hooks-manifest.schema.json
+++ b/schemas/hooks-manifest.schema.json
@@ -58,11 +58,11 @@
           "items": {"enum": ["pass", "warn", "block", "gate", "escalate", "correction", "complete"]},
           "uniqueItems": true
         },
-        "claude": {"$ref": "#/$defs/platform"},
-        "codex": {"$ref": "#/$defs/platform"}
+        "claude": {"$ref": "#/$defs/claude_platform"},
+        "codex": {"$ref": "#/$defs/codex_platform"}
       }
     },
-    "platform": {
+    "claude_platform": {
       "type": "object",
       "required": ["enabled"],
       "additionalProperties": false,
@@ -96,6 +96,58 @@
         "script": {"type": "string", "pattern": "^vibeguard-[a-z0-9-]+\\.sh$"},
         "timeout": {"type": "integer", "minimum": 1}
       }
+    },
+    "codex_platform": {
+      "type": "object",
+      "required": ["enabled"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "support": {"enum": ["native", "unsupported", "manual", "not-applicable"]},
+        "reason": {"type": "string"},
+        "event": {"$ref": "#/$defs/codex_event"},
+        "matcher": {
+          "anyOf": [
+            {"type": "string"},
+            {"type": "null"}
+          ]
+        },
+        "script": {"type": "string", "pattern": "^vibeguard-[a-z0-9-]+\\.sh$"},
+        "timeout": {"type": "integer", "minimum": 1},
+        "entries": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/codex_entry"},
+          "minItems": 1
+        }
+      }
+    },
+    "codex_entry": {
+      "type": "object",
+      "required": ["event"],
+      "additionalProperties": false,
+      "properties": {
+        "event": {"$ref": "#/$defs/codex_event"},
+        "matcher": {
+          "anyOf": [
+            {"type": "string"},
+            {"type": "null"}
+          ]
+        },
+        "script": {"type": "string", "pattern": "^vibeguard-[a-z0-9-]+\\.sh$"},
+        "timeout": {"type": "integer", "minimum": 1}
+      }
+    },
+    "codex_event": {
+      "enum": [
+        "PreToolUse",
+        "PermissionRequest",
+        "PostToolUse",
+        "Stop",
+        "SessionStart",
+        "PreCompact",
+        "PostCompact",
+        "UserPromptSubmit"
+      ]
     }
   }
 }

--- a/scripts/lib/hooks_manifest.py
+++ b/scripts/lib/hooks_manifest.py
@@ -8,9 +8,12 @@ import json
 from pathlib import Path
 from typing import Any, Iterable
 
+from workflow_contracts import validate_instance
+
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "hooks" / "manifest.json"
+DEFAULT_SCHEMA = ROOT / "schemas" / "hooks-manifest.schema.json"
 PROFILE_ORDER = ("minimal", "core", "full", "strict")
 DISABLEABLE_KINDS = {"hook", "git-hook"}
 HOOK_EVENTS = {
@@ -66,6 +69,14 @@ def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
         data = json.load(f)
     if not isinstance(data, dict):
         raise ValueError("hooks manifest root must be an object")
+    return data
+
+
+def load_schema(path: Path = DEFAULT_SCHEMA) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("hooks manifest schema root must be an object")
     return data
 
 
@@ -309,7 +320,9 @@ def _print_json(items: Iterable[dict[str, Any]]) -> None:
 
 def cmd_validate(args: argparse.Namespace) -> int:
     manifest = load_manifest(Path(args.manifest))
-    errors = validate_manifest(manifest, ROOT)
+    schema = load_schema(Path(args.schema))
+    errors = [f"schema: {error}" for error in validate_instance(manifest, schema)]
+    errors.extend(validate_manifest(manifest, ROOT))
     if errors:
         for error in errors:
             print(f"FAIL: {error}")
@@ -343,6 +356,7 @@ def cmd_claude_specs(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="VibeGuard hooks manifest helper")
     parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("validate").set_defaults(func=cmd_validate)

--- a/scripts/lib/workflow_contracts.py
+++ b/scripts/lib/workflow_contracts.py
@@ -70,8 +70,34 @@ def _type_matches(value: Any, expected: str) -> bool:
     return False
 
 
-def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+def _resolve_schema_ref(ref: str, root_schema: dict[str, Any]) -> dict[str, Any] | None:
+    if not ref.startswith("#/"):
+        return None
+    current: Any = root_schema
+    for raw_part in ref[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current if isinstance(current, dict) else None
+
+
+def validate_instance(
+    instance: Any,
+    schema: dict[str, Any],
+    path: str = "$",
+    root_schema: dict[str, Any] | None = None,
+) -> list[str]:
     errors: list[str] = []
+    if root_schema is None:
+        root_schema = schema
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _resolve_schema_ref(ref, root_schema)
+        if resolved is None:
+            return [f"{path}: unresolved schema ref {ref!r}"]
+        return validate_instance(instance, resolved, path, root_schema)
 
     expected_type = schema.get("type")
     if expected_type is not None:
@@ -86,6 +112,21 @@ def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") ->
     if "enum" in schema and instance not in schema["enum"]:
         errors.append(f"{path}: expected one of {schema['enum']}, got {instance!r}")
 
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        branch_errors: list[str] = []
+        for index, branch in enumerate(any_of):
+            if not isinstance(branch, dict):
+                branch_errors.append(f"schema {index}: branch must be an object")
+                continue
+            current_errors = validate_instance(instance, branch, path, root_schema)
+            if not current_errors:
+                break
+            branch_errors.append(f"schema {index}: {'; '.join(current_errors)}")
+        else:
+            detail = "; ".join(branch_errors[:3])
+            errors.append(f"{path}: must match at least one anyOf schema; {detail}")
+
     one_of = schema.get("oneOf")
     if isinstance(one_of, list):
         matches: list[int] = []
@@ -94,7 +135,7 @@ def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") ->
             if not isinstance(branch, dict):
                 branch_errors.append(f"schema {index}: branch must be an object")
                 continue
-            current_errors = validate_instance(instance, branch, path)
+            current_errors = validate_instance(instance, branch, path, root_schema)
             if current_errors:
                 branch_errors.append(f"schema {index}: {'; '.join(current_errors)}")
             else:
@@ -114,6 +155,11 @@ def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") ->
         if isinstance(pattern, str) and not re.search(pattern, instance):
             errors.append(f"{path}: string does not match pattern {pattern!r}")
 
+    if isinstance(instance, (int, float)) and not isinstance(instance, bool):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, (int, float)) and instance < minimum:
+            errors.append(f"{path}: number is less than minimum {minimum}")
+
     if isinstance(instance, list):
         min_items = schema.get("minItems")
         if isinstance(min_items, int) and len(instance) < min_items:
@@ -125,7 +171,7 @@ def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") ->
         item_schema = schema.get("items")
         if isinstance(item_schema, dict):
             for index, item in enumerate(instance):
-                errors.extend(validate_instance(item, item_schema, f"{path}[{index}]"))
+                errors.extend(validate_instance(item, item_schema, f"{path}[{index}]", root_schema))
 
     if isinstance(instance, dict):
         min_properties = schema.get("minProperties")
@@ -151,11 +197,11 @@ def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") ->
             for key, value in instance.items():
                 child_path = f"{path}.{key}"
                 if key in properties and isinstance(properties[key], dict):
-                    errors.extend(validate_instance(value, properties[key], child_path))
+                    errors.extend(validate_instance(value, properties[key], child_path, root_schema))
                 elif additional is False:
                     errors.append(f"{child_path}: additional property is not allowed")
                 elif isinstance(additional, dict):
-                    errors.extend(validate_instance(value, additional, child_path))
+                    errors.extend(validate_instance(value, additional, child_path, root_schema))
 
     return errors
 

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -212,6 +212,25 @@ bad_hooks_manifest_out="$(python3 "${MANIFEST_HELPER}" validate --hooks-manifest
 assert_contains "${bad_hooks_manifest_out}" "hook install target drift for hooks-pre" "manifest validation detects hook install target drift"
 assert_not_contains "${bad_hooks_manifest_out}" "Traceback" "hook install target drift reports without traceback"
 
+BAD_CODEX_ENTRIES_HOOKS_MANIFEST="${TMP_DIR}/bad-codex-entries-hooks-manifest.json"
+python3 - "${REPO_DIR}/hooks/manifest.json" "${BAD_CODEX_ENTRIES_HOOKS_MANIFEST}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+for hook in data["hooks"]:
+    if hook["name"] == "pre-bash-guard":
+        hook["codex"]["entries"][0]["extra_field"] = True
+        break
+target.write_text(json.dumps(data), encoding="utf-8")
+PY
+bad_codex_entries_out="$(python3 "${REPO_DIR}/scripts/lib/hooks_manifest.py" --manifest "${BAD_CODEX_ENTRIES_HOOKS_MANIFEST}" validate 2>&1 || true)"
+assert_contains "${bad_codex_entries_out}" "codex.entries[0].extra_field" "hooks manifest schema rejects malformed codex entries"
+assert_not_contains "${bad_codex_entries_out}" "Traceback" "malformed codex entries report without traceback"
+
 BAD_GIT_HOOKS_MANIFEST="${TMP_DIR}/bad-git-hooks-manifest.json"
 python3 - "${REPO_DIR}/hooks/manifest.json" "${BAD_GIT_HOOKS_MANIFEST}" <<'PY'
 import json


### PR DESCRIPTION
Fixes #328

## Summary
- Model Codex-specific hook manifest entries in the published hooks manifest schema, including PermissionRequest.
- Run hooks manifest validation through the schema before semantic manifest checks.
- Add a malformed codex.entries regression so schema drift fails without a traceback.

## Validation
- bash scripts/ci/validate-hooks-manifest.sh
- bash tests/test_manifest_contract.sh
- bash scripts/ci/validate-workflow-contracts.sh
- bash tests/test_workflow_contracts.sh
- bash scripts/local-contract-check.sh --quick
- bash tests/test_setup.sh
- bash setup.sh --yes
- bash setup.sh --check --strict
