### PR TITLE
Fail closed on malformed write payloads

### DIFF
--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -28,6 +28,22 @@ result=$(printf '%s' '{"tool_input":' | bash hooks/pre-write-guard.sh)
 assert_contains "$result" '"decision": "block"' "Malformed Write hook JSON fails closed"
 assert_contains "$result" "malformed PreToolUse(Write)" "Malformed Write hook input explains validation failure"
 
+result=$(printf '%s' '{"tool_input":{}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "Write hook payload missing file_path fails closed"
+assert_contains "$result" "malformed PreToolUse(Write)" "Missing Write file_path explains validation failure"
+
+result=$(printf '%s' '{"tool_input":{"content":"fn main() {}"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "Write hook payload with content but no file_path fails closed"
+assert_contains "$result" "malformed PreToolUse(Write)" "Missing Write file_path with content explains validation failure"
+
+result=$(printf '%s' '{"tool_input":{"file_path":123,"content":"x"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "Write hook payload with non-string file_path fails closed"
+assert_contains "$result" "malformed PreToolUse(Write)" "Non-string Write file_path explains validation failure"
+
+result=$(printf '%s' '{"tool_input":{"file_path":"","content":"x"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "Write hook payload with empty file_path fails closed"
+assert_contains "$result" "malformed PreToolUse(Write)" "Empty Write file_path explains validation failure"
+
 header "pre-write-guard.sh — search first and then write"
 # =========================================================
 

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -36,9 +36,12 @@ pub fn pre_write_check(args: &[String]) -> Result {
         return Ok(());
     };
 
-    let file_path = nested_str(&data, "tool_input.file_path").unwrap_or_default();
+    let Some(file_path) = nested_str(&data, "tool_input.file_path") else {
+        println!("MALFORMED");
+        return Ok(());
+    };
     if file_path.is_empty() {
-        println!("PASS");
+        println!("MALFORMED");
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Treat missing, non-string, or empty `tool_input.file_path` in `PreToolUse(Write)` as malformed input.
- Reuse the existing `MALFORMED` path so `pre-write-guard.sh` blocks instead of silently passing.
- Add regression coverage for valid JSON Write payloads that cannot be validated.

Fixes #332.

## Validation

- `bash tests/hooks/test_pre_write_guard.sh` -> 43/43
- `printf '{"tool_input":{}}' | bash hooks/pre-write-guard.sh` -> block
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml` -> 121 tests
- `bash tests/test_codex_runtime.sh` -> 77/77
- `bash scripts/local-contract-check.sh --quick`
- `bash tests/test_setup.sh` -> 238/238
- `bash setup.sh --yes` -> HEALTHY
- `bash setup.sh --check --strict` -> HEALTHY
- `git diff --check`
