### PR TITLE
test: avoid stats assertion pipefail false negative

### DIFF
--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -19,7 +19,7 @@ header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
 assert_contains() {
   local output="$1" expected="$2" desc="$3"
   TOTAL=$((TOTAL + 1))
-  if echo "$output" | grep -qF "$expected"; then
+  if grep -qF "$expected" <<< "$output"; then
     green "$desc"
     PASS=$((PASS + 1))
   else


### PR DESCRIPTION
Fixes a macOS CI false negative in `tests/test_stats.sh`.

Root cause: the assertion helper used `echo "$output" | grep -qF ...` under `set -euo pipefail`. On macOS CI, `grep -q` can exit as soon as it finds a match, causing `echo` to see a broken pipe and the pipeline to fail even though the expected text exists.

Change: use a here-string (`grep -qF ... <<< "$output"`) so the assertion has no producer pipe.

Verification:
- `bash -n tests/test_stats.sh`: OK
- `bash tests/test_stats.sh`: OK, 6/6 passed
- `git diff --check`: OK