### PR TITLE
setup: install prebuilt runtime with checksum fallback

### DIFF
--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -42,7 +42,12 @@ VIBEGUARD_SETUP_AUTO="${VIBEGUARD_SETUP_AUTO:-0}"
 VIBEGUARD_SETUP_FORCE_OVERWRITE="${VIBEGUARD_SETUP_FORCE_OVERWRITE:-0}"
 WITH_SCHEDULER="${VIBEGUARD_SETUP_WITH_SCHEDULER:-0}"
 BUILD_FROM_SOURCE="${VIBEGUARD_SETUP_BUILD_FROM_SOURCE:-0}"
-RUNTIME_VERSION_OVERRIDE="${VIBEGUARD_SETUP_RUNTIME_VERSION:-}"
+RUNTIME_VERSION_OVERRIDE=""
+RUNTIME_VERSION_OVERRIDE_SET=0
+if [[ -n "${VIBEGUARD_SETUP_RUNTIME_VERSION+x}" ]]; then
+  RUNTIME_VERSION_OVERRIDE="${VIBEGUARD_SETUP_RUNTIME_VERSION}"
+  RUNTIME_VERSION_OVERRIDE_SET=1
+fi
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)
@@ -53,9 +58,9 @@ while [[ $# -gt 0 ]]; do
       BUILD_FROM_SOURCE=1; shift ;;
     --runtime-version)
       [[ $# -lt 2 ]] && { red "ERROR: --runtime-version requires a value (e.g. v1.2.3)"; exit 1; }
-      RUNTIME_VERSION_OVERRIDE="$2"; shift 2 ;;
+      RUNTIME_VERSION_OVERRIDE="$2"; RUNTIME_VERSION_OVERRIDE_SET=1; shift 2 ;;
     --runtime-version=*)
-      RUNTIME_VERSION_OVERRIDE="${1#*=}"; shift ;;
+      RUNTIME_VERSION_OVERRIDE="${1#*=}"; RUNTIME_VERSION_OVERRIDE_SET=1; shift ;;
     --with-scheduler)
       WITH_SCHEDULER=1; shift ;;
     --force-overwrite)
@@ -77,6 +82,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 export VIBEGUARD_SETUP_DRY_RUN VIBEGUARD_SETUP_AUTO VIBEGUARD_SETUP_FORCE_OVERWRITE
+
+if [[ "${RUNTIME_VERSION_OVERRIDE_SET}" == "1" && -z "${RUNTIME_VERSION_OVERRIDE}" ]]; then
+  red "ERROR: --runtime-version requires a non-empty value (e.g. v1.2.3)"
+  exit 1
+fi
 
 case "${PROFILE}" in
   minimal|core|full|strict) ;;
@@ -127,8 +137,9 @@ runtime_release_target() {
 
 runtime_release_tag() {
   local version version_file
-  version="${RUNTIME_VERSION_OVERRIDE}"
-  if [[ -z "${version}" ]]; then
+  if [[ "${RUNTIME_VERSION_OVERRIDE_SET}" == "1" ]]; then
+    version="${RUNTIME_VERSION_OVERRIDE}"
+  else
     version_file="${REPO_DIR}/vibeguard-runtime/VERSION"
     [[ -f "${version_file}" ]] || return 1
     version="$(tr -d '[:space:]' < "${version_file}")"

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 # bash install.sh --profile full --languages rust # Use in combination
 # bash install.sh --dry-run # Show high-context diffs without writing
 # bash install.sh --yes # Apply high-context diffs non-interactively
+# bash install.sh --build-from-source # Build vibeguard-runtime with cargo instead of downloading a release binary
+# bash install.sh --runtime-version v1.2.3 # Download a specific vibeguard-runtime release tag
 # bash install.sh --with-scheduler # Opt in to launchd/systemd scheduled GC
 # bash install.sh --force-overwrite # Replace user-customized managed files/commands
 # bash install.sh --check # Check status only
@@ -39,12 +41,21 @@ VIBEGUARD_SETUP_DRY_RUN="${VIBEGUARD_SETUP_DRY_RUN:-0}"
 VIBEGUARD_SETUP_AUTO="${VIBEGUARD_SETUP_AUTO:-0}"
 VIBEGUARD_SETUP_FORCE_OVERWRITE="${VIBEGUARD_SETUP_FORCE_OVERWRITE:-0}"
 WITH_SCHEDULER="${VIBEGUARD_SETUP_WITH_SCHEDULER:-0}"
+BUILD_FROM_SOURCE="${VIBEGUARD_SETUP_BUILD_FROM_SOURCE:-0}"
+RUNTIME_VERSION_OVERRIDE="${VIBEGUARD_SETUP_RUNTIME_VERSION:-}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)
       VIBEGUARD_SETUP_DRY_RUN=1; shift ;;
     --yes|-y)
       VIBEGUARD_SETUP_AUTO=1; shift ;;
+    --build-from-source)
+      BUILD_FROM_SOURCE=1; shift ;;
+    --runtime-version)
+      [[ $# -lt 2 ]] && { red "ERROR: --runtime-version requires a value (e.g. v1.2.3)"; exit 1; }
+      RUNTIME_VERSION_OVERRIDE="$2"; shift 2 ;;
+    --runtime-version=*)
+      RUNTIME_VERSION_OVERRIDE="${1#*=}"; shift ;;
     --with-scheduler)
       WITH_SCHEDULER=1; shift ;;
     --force-overwrite)
@@ -61,7 +72,7 @@ while [[ $# -gt 0 ]]; do
       LANGUAGES="${1#*=}"; shift ;;
     *)
       red "ERROR: unknown argument: $1"
-      red "Usage: bash install.sh [--yes] [--dry-run] [--with-scheduler] [--force-overwrite] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean"
+      red "Usage: bash install.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--with-scheduler] [--force-overwrite] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean"
       exit 1 ;;
   esac
 done
@@ -96,6 +107,204 @@ lang_selected() {
   return 1
 }
 
+runtime_release_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}:${arch}" in
+    Darwin:arm64|Darwin:aarch64)
+      printf 'aarch64-apple-darwin' ;;
+    Darwin:x86_64|Darwin:amd64)
+      printf 'x86_64-apple-darwin' ;;
+    Linux:x86_64|Linux:amd64)
+      printf 'x86_64-unknown-linux-musl' ;;
+    Linux:aarch64|Linux:arm64)
+      printf 'aarch64-unknown-linux-musl' ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+runtime_release_tag() {
+  local version version_file
+  version="${RUNTIME_VERSION_OVERRIDE}"
+  if [[ -z "${version}" ]]; then
+    version_file="${REPO_DIR}/vibeguard-runtime/VERSION"
+    [[ -f "${version_file}" ]] || return 1
+    version="$(tr -d '[:space:]' < "${version_file}")"
+  fi
+  [[ -n "${version}" ]] || return 1
+  case "${version}" in
+    v*) printf '%s' "${version}" ;;
+    *) printf 'v%s' "${version}" ;;
+  esac
+}
+
+runtime_sha256_file() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+download_prebuilt_runtime() {
+  local target="$1" tag="$2" dest="$3"
+  local asset="vibeguard-runtime-${target}"
+  local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
+  local download_dir downloaded reason expected actual
+  local -a errors=()
+
+  download_dir="$(mktemp -d "${VIBEGUARD_HOME}/runtime_download_XXXXXX")"
+  downloaded=0
+  echo "  Downloading ${asset} from ${release_repo}@${tag}..."
+
+  if command -v gh >/dev/null 2>&1; then
+    if gh release download "${tag}" \
+      --repo "${release_repo}" \
+      --pattern "${asset}" \
+      --pattern "SHA256SUMS" \
+      --dir "${download_dir}" >/dev/null 2>&1; then
+      downloaded=1
+    else
+      errors+=("gh release download failed")
+    fi
+  else
+    errors+=("gh not found")
+  fi
+
+  if [[ "${downloaded}" != "1" ]]; then
+    if command -v curl >/dev/null 2>&1; then
+      local base_url="https://github.com/${release_repo}/releases/download/${tag}"
+      if curl -fsSL -o "${download_dir}/${asset}" "${base_url}/${asset}" >/dev/null 2>&1 \
+        && curl -fsSL -o "${download_dir}/SHA256SUMS" "${base_url}/SHA256SUMS" >/dev/null 2>&1; then
+        downloaded=1
+      else
+        errors+=("curl release download failed")
+      fi
+    else
+      errors+=("curl not found")
+    fi
+  fi
+
+  if [[ "${downloaded}" != "1" ]]; then
+    reason="download failed"
+    if [[ ${#errors[@]} -gt 0 ]]; then
+      reason="${errors[*]}"
+    fi
+    RUNTIME_PREBUILT_REASON="${reason}"
+    rm -rf "${download_dir}"
+    return 1
+  fi
+
+  if [[ ! -f "${download_dir}/${asset}" || ! -f "${download_dir}/SHA256SUMS" ]]; then
+    red "  ERROR: release download did not include ${asset} and SHA256SUMS."
+    rm -rf "${download_dir}"
+    return 10
+  fi
+
+  expected="$(awk -v file="${asset}" '($2 == file || $2 == "*" file) { print $1; exit }' "${download_dir}/SHA256SUMS")"
+  if [[ -z "${expected}" ]]; then
+    red "  ERROR: SHA256SUMS missing entry for ${asset}."
+    rm -rf "${download_dir}"
+    return 10
+  fi
+  if ! actual="$(runtime_sha256_file "${download_dir}/${asset}")"; then
+    red "  ERROR: sha256sum or shasum not found; cannot verify vibeguard-runtime release binary."
+    rm -rf "${download_dir}"
+    return 10
+  fi
+  if [[ "${actual}" != "${expected}" ]]; then
+    red "  ERROR: vibeguard-runtime checksum verification failed for ${asset}."
+    red "  Expected ${expected}, got ${actual}."
+    rm -rf "${download_dir}"
+    return 10
+  fi
+
+  mkdir -p "$(dirname "${dest}")"
+  cp "${download_dir}/${asset}" "${dest}"
+  chmod +x "${dest}"
+  rm -rf "${download_dir}"
+  green "  vibeguard-runtime downloaded and verified (${tag}, ${target})"
+}
+
+prepare_runtime_from_source() {
+  local fallback_reason="${1:-}"
+  if [[ -n "${fallback_reason}" ]]; then
+    yellow "  Falling back to source build (${fallback_reason})."
+  fi
+  if [[ ! -f "${REPO_DIR}/vibeguard-runtime/Cargo.toml" ]]; then
+    red "  ERROR: vibeguard-runtime/Cargo.toml not found; cannot install hooks without the Rust runtime."
+    exit 2
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    if [[ -n "${fallback_reason}" ]]; then
+      red "  ERROR: prebuilt vibeguard-runtime unavailable (${fallback_reason}) and cargo not found for source fallback."
+      red "  Install Rust/Cargo or use a platform with a published release binary."
+    else
+      red "  ERROR: --build-from-source requested but cargo not found. Install Rust/Cargo before installing VibeGuard."
+    fi
+    exit 2
+  fi
+  echo "  Building vibeguard-runtime from source (Rust)..."
+  if cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet 2>/dev/null; then
+    local runtime_target_dir runtime_binary
+    if ! runtime_target_dir="$(
+      cargo metadata --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --no-deps --format-version=1 2>/dev/null \
+        | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+    )" || [[ -z "${runtime_target_dir}" ]]; then
+      red "  ERROR: unable to resolve vibeguard-runtime Cargo target directory."
+      exit 2
+    fi
+    runtime_binary="${runtime_target_dir}/release/vibeguard-runtime"
+    if [[ ! -x "${runtime_binary}" ]]; then
+      red "  ERROR: vibeguard-runtime build output not found at ${runtime_binary}"
+      exit 2
+    fi
+    mkdir -p "${_INSTALL_TMP}/bin"
+    cp "${runtime_binary}" "${_INSTALL_TMP}/bin/vibeguard-runtime"
+    chmod +x "${_INSTALL_TMP}/bin/vibeguard-runtime"
+    green "  vibeguard-runtime binary prepared from source"
+  else
+    red "  ERROR: vibeguard-runtime build failed. Fix the Rust build before installing VibeGuard."
+    exit 2
+  fi
+}
+
+prepare_runtime_binary() {
+  local target tag download_rc fallback_reason
+  mkdir -p "${_INSTALL_TMP}/bin"
+
+  if [[ "${BUILD_FROM_SOURCE}" == "1" ]]; then
+    prepare_runtime_from_source ""
+    return
+  fi
+
+  if ! target="$(runtime_release_target)"; then
+    prepare_runtime_from_source "unsupported platform $(uname -s)/$(uname -m)"
+    return
+  fi
+  if ! tag="$(runtime_release_tag)"; then
+    prepare_runtime_from_source "runtime VERSION could not be resolved"
+    return
+  fi
+
+  RUNTIME_PREBUILT_REASON=""
+  download_rc=0
+  download_prebuilt_runtime "${target}" "${tag}" "${_INSTALL_TMP}/bin/vibeguard-runtime" || download_rc=$?
+  if [[ "${download_rc}" -eq 0 ]]; then
+    return
+  fi
+  if [[ "${download_rc}" -eq 10 ]]; then
+    exit 2
+  fi
+  fallback_reason="${RUNTIME_PREBUILT_REASON:-download failed}"
+  prepare_runtime_from_source "${fallback_reason}"
+}
+
 echo "=============================="
 echo "VibeGuard Setup"
 echo "Repository: ${REPO_DIR}"
@@ -108,6 +317,12 @@ if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
 fi
 if [[ "${VIBEGUARD_SETUP_FORCE_OVERWRITE}" == "1" ]]; then
   echo "Mode: force-overwrite (user-customized managed files may be replaced)"
+fi
+if [[ "${BUILD_FROM_SOURCE}" == "1" ]]; then
+  echo "Mode: build-from-source (vibeguard-runtime will be built with cargo)"
+fi
+if [[ -n "${RUNTIME_VERSION_OVERRIDE}" ]]; then
+  echo "Runtime version override: ${RUNTIME_VERSION_OVERRIDE}"
 fi
 if [[ "${WITH_SCHEDULER}" == "1" ]]; then
   echo "Mode: with-scheduler (install launchd/systemd scheduled GC)"
@@ -184,39 +399,10 @@ cp "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${_INSTALL_TMP}/schemas/
 cp "${REPO_DIR}/scripts/lib/project_config_validate.py" "${_INSTALL_TMP}/scripts/lib/"
 printf '%s' "$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')" > "${_INSTALL_TMP}/version"
 
-# Build vibeguard-runtime Rust binary before swapping the installed snapshot.
-# Runtime installation is fail-closed: there is no Python or no-runtime
-# compatibility path for hook JSON parsing, package rewrite, or metrics.
-if [[ ! -f "${REPO_DIR}/vibeguard-runtime/Cargo.toml" ]]; then
-  red "  ERROR: vibeguard-runtime/Cargo.toml not found; cannot install hooks without the Rust runtime."
-  exit 2
-fi
-if ! command -v cargo &>/dev/null; then
-  red "  ERROR: cargo not found. Install Rust/Cargo before installing VibeGuard."
-  exit 2
-fi
-echo "  Building vibeguard-runtime (Rust)..."
-if cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet 2>/dev/null; then
-  if ! _runtime_target_dir="$(
-    cargo metadata --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --no-deps --format-version=1 2>/dev/null \
-      | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
-  )" || [[ -z "${_runtime_target_dir}" ]]; then
-    red "  ERROR: unable to resolve vibeguard-runtime Cargo target directory."
-    exit 2
-  fi
-  _runtime_binary="${_runtime_target_dir}/release/vibeguard-runtime"
-  if [[ ! -x "${_runtime_binary}" ]]; then
-    red "  ERROR: vibeguard-runtime build output not found at ${_runtime_binary}"
-    exit 2
-  fi
-  mkdir -p "${_INSTALL_TMP}/bin"
-  cp "${_runtime_binary}" "${_INSTALL_TMP}/bin/vibeguard-runtime"
-  chmod +x "${_INSTALL_TMP}/bin/vibeguard-runtime"
-  green "  vibeguard-runtime binary prepared"
-else
-  red "  ERROR: vibeguard-runtime build failed. Fix the Rust build before installing VibeGuard."
-  exit 2
-fi
+# Prepare vibeguard-runtime before swapping the installed snapshot. Runtime
+# installation is fail-closed: a downloaded binary must verify, and source
+# fallback still requires a successful Rust build.
+prepare_runtime_binary
 
 # Swap: move old installed aside, rename new into place, restore on failure
 if [[ -d "${INSTALLED_DIR}" ]]; then

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -389,6 +389,9 @@ if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
     esac
   done
   [[ -n "${tag}" && -n "${VIBEGUARD_TEST_RELEASE_DIR:-}" ]] || exit 1
+  if [[ -n "${VIBEGUARD_TEST_DOWNLOAD_LOG:-}" ]]; then
+    printf 'gh tag=%s patterns=%s\n' "${tag}" "${patterns[*]}" >> "${VIBEGUARD_TEST_DOWNLOAD_LOG}"
+  fi
   mkdir -p "${dir}"
   for pattern in "${patterns[@]}"; do
     if [[ "${pattern}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; then
@@ -421,6 +424,9 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "${out}" && -n "${url}" && -n "${VIBEGUARD_TEST_RELEASE_DIR:-}" ]] || exit 1
 asset="${url##*/}"
+if [[ -n "${VIBEGUARD_TEST_DOWNLOAD_LOG:-}" ]]; then
+  printf 'curl url=%s asset=%s\n' "${url}" "${asset}" >> "${VIBEGUARD_TEST_DOWNLOAD_LOG}"
+fi
 mkdir -p "$(dirname "${out}")"
 if [[ "${asset}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; then
   cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${out}"
@@ -916,6 +922,25 @@ assert_cmd "tampered prebuilt checksum exits nonzero" test "${checksum_fail_rc}"
 assert_contains "${checksum_fail_out}" "vibeguard-runtime checksum verification failed" "tampered prebuilt checksum reports verification failure"
 assert_not_contains "${checksum_fail_out}" "Falling back to source build" "tampered prebuilt checksum does not fall back to source"
 assert_not_contains "${checksum_fail_out}" "Setup complete! All components installed." "tampered prebuilt checksum does not report setup complete"
+
+empty_version_home="${TMP_HOME}/empty-version-home"
+mkdir -p "${empty_version_home}"
+set +e
+empty_version_out="$(HOME="${empty_version_home}" bash "${REPO_DIR}/setup.sh" --yes --runtime-version= 2>&1)"
+empty_version_rc=$?
+set -e
+assert_cmd "empty --runtime-version exits nonzero" test "${empty_version_rc}" -ne 0
+assert_contains "${empty_version_out}" "--runtime-version requires a non-empty value" "empty --runtime-version reports explicit error"
+assert_not_contains "${empty_version_out}" "Setup complete! All components installed." "empty --runtime-version does not report setup complete"
+
+version_override_home="${TMP_HOME}/version-override-home"
+version_override_log="${TMP_HOME}/version-override-download.log"
+mkdir -p "${version_override_home}"
+: > "${version_override_log}"
+version_override_out="$(HOME="${version_override_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 VIBEGUARD_TEST_DOWNLOAD_LOG="${version_override_log}" bash "${REPO_DIR}/setup.sh" --yes --runtime-version v9.9.9)"
+assert_contains "${version_override_out}" "Runtime version override: v9.9.9" "--runtime-version reports selected release tag"
+assert_contains "${version_override_out}" "vibeguard-runtime downloaded and verified (v9.9.9," "--runtime-version downloads selected release tag"
+assert_cmd "--runtime-version passes selected tag to release download" grep -qF "tag=v9.9.9" "${version_override_log}"
 
 curl_download_home="${TMP_HOME}/curl-download-home"
 mkdir -p "${curl_download_home}"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -253,15 +253,42 @@ if [[ -z "${RUSTUP_HOME:-}" && -d "${ORIG_HOME}/.rustup" ]]; then
 fi
 mkdir -p "${TMP_HOME}/bin"
 REAL_UNAME="$(command -v uname)"
+REAL_CARGO="$(command -v cargo || true)"
 cat > "${TMP_HOME}/bin/uname" <<SH
 #!/usr/bin/env bash
 if [[ "\${VIBEGUARD_TEST_UNAME:-}" == "Linux" ]]; then
-  printf 'Linux\n'
+  case "\${1:-}" in
+    -m)
+      printf '%s\n' "\${VIBEGUARD_TEST_UNAME_M:-x86_64}"
+      ;;
+    -s|"")
+      printf 'Linux\n'
+      ;;
+    *)
+      exec "${REAL_UNAME}" "\$@"
+      ;;
+  esac
 else
   exec "${REAL_UNAME}" "\$@"
 fi
 SH
 chmod +x "${TMP_HOME}/bin/uname"
+cat > "${TMP_HOME}/bin/cargo" <<SH
+#!/usr/bin/env bash
+if [[ "\${VIBEGUARD_TEST_CARGO_UNAVAILABLE:-0}" == "1" ]]; then
+  printf 'cargo unavailable for test\n' >&2
+  exit 127
+fi
+if [[ -n "\${VIBEGUARD_TEST_CARGO_LOG:-}" ]]; then
+  printf '%s\n' "\$*" >> "\${VIBEGUARD_TEST_CARGO_LOG}"
+fi
+if [[ -z "${REAL_CARGO}" ]]; then
+  printf 'real cargo not found\n' >&2
+  exit 127
+fi
+exec "${REAL_CARGO}" "\$@"
+SH
+chmod +x "${TMP_HOME}/bin/cargo"
 cat > "${TMP_HOME}/bin/launchctl" <<'SH'
 #!/usr/bin/env bash
 state="${HOME}/.launchctl-vibeguard-loaded"
@@ -338,7 +365,104 @@ case "${1:-}" in
 esac
 SH
 chmod +x "${TMP_HOME}/bin/systemctl"
+cat > "${TMP_HOME}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "${VIBEGUARD_TEST_DOWNLOAD_FAIL:-0}" == "1" || "${VIBEGUARD_TEST_GH_FAIL:-0}" == "1" ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
+  shift 2
+  tag="${1:-}"
+  shift || true
+  dir="."
+  patterns=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dir)
+        dir="$2"; shift 2 ;;
+      --pattern)
+        patterns+=("$2"); shift 2 ;;
+      --repo)
+        shift 2 ;;
+      *)
+        shift ;;
+    esac
+  done
+  [[ -n "${tag}" && -n "${VIBEGUARD_TEST_RELEASE_DIR:-}" ]] || exit 1
+  mkdir -p "${dir}"
+  for pattern in "${patterns[@]}"; do
+    if [[ "${pattern}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; then
+      cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${dir}/SHA256SUMS"
+    else
+      cp "${VIBEGUARD_TEST_RELEASE_DIR}/${pattern}" "${dir}/${pattern}"
+    fi
+  done
+  exit 0
+fi
+exit 1
+SH
+chmod +x "${TMP_HOME}/bin/gh"
+cat > "${TMP_HOME}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+if [[ "${VIBEGUARD_TEST_DOWNLOAD_FAIL:-0}" == "1" ]]; then
+  exit 22
+fi
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      out="$2"; shift 2 ;;
+    -*)
+      shift ;;
+    *)
+      url="$1"; shift ;;
+  esac
+done
+[[ -n "${out}" && -n "${url}" && -n "${VIBEGUARD_TEST_RELEASE_DIR:-}" ]] || exit 1
+asset="${url##*/}"
+mkdir -p "$(dirname "${out}")"
+if [[ "${asset}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; then
+  cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${out}"
+else
+  cp "${VIBEGUARD_TEST_RELEASE_DIR}/${asset}" "${out}"
+fi
+SH
+chmod +x "${TMP_HOME}/bin/curl"
 export PATH="${TMP_HOME}/bin:${PATH}"
+
+TEST_RELEASE_DIR="${TMP_HOME}/release-assets"
+mkdir -p "${TEST_RELEASE_DIR}"
+: > "${TEST_RELEASE_DIR}/SHA256SUMS"
+for target in \
+  aarch64-apple-darwin \
+  x86_64-apple-darwin \
+  x86_64-unknown-linux-musl \
+  aarch64-unknown-linux-musl; do
+  asset="${TEST_RELEASE_DIR}/vibeguard-runtime-${target}"
+  cat > "${asset}" <<SH
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "${asset}"
+  asset_hash="$(shasum -a 256 "${asset}" | cut -d' ' -f1)"
+  printf '%s  %s\n' "${asset_hash}" "vibeguard-runtime-${target}" >> "${TEST_RELEASE_DIR}/SHA256SUMS"
+done
+python3 - <<'PY' "${TEST_RELEASE_DIR}/SHA256SUMS" "${TEST_RELEASE_DIR}/SHA256SUMS.bad"
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+dest = Path(sys.argv[2])
+lines = src.read_text(encoding="utf-8").splitlines()
+bad_lines = []
+for line in lines:
+    digest, asset = line.split(None, 1)
+    bad_lines.append("0" * len(digest) + "  " + asset)
+lines = bad_lines
+dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+export VIBEGUARD_TEST_RELEASE_DIR="${TEST_RELEASE_DIR}"
 
 header "setup scripts syntax"
 assert_cmd "setup.sh syntax is correct" bash -n "${REPO_DIR}/setup.sh"
@@ -781,8 +905,65 @@ state = {
 (home / ".vibeguard/install-state.json").write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 PY
 CUSTOM_CARGO_TARGET_DIR="${TMP_HOME}/custom cargo target"
-install_out="$(CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes)"
+
+checksum_fail_home="${TMP_HOME}/checksum-fail-home"
+mkdir -p "${checksum_fail_home}"
+set +e
+checksum_fail_out="$(HOME="${checksum_fail_home}" VIBEGUARD_TEST_BAD_SHA=1 VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes 2>&1)"
+checksum_fail_rc=$?
+set -e
+assert_cmd "tampered prebuilt checksum exits nonzero" test "${checksum_fail_rc}" -ne 0
+assert_contains "${checksum_fail_out}" "vibeguard-runtime checksum verification failed" "tampered prebuilt checksum reports verification failure"
+assert_not_contains "${checksum_fail_out}" "Falling back to source build" "tampered prebuilt checksum does not fall back to source"
+assert_not_contains "${checksum_fail_out}" "Setup complete! All components installed." "tampered prebuilt checksum does not report setup complete"
+
+curl_download_home="${TMP_HOME}/curl-download-home"
+mkdir -p "${curl_download_home}"
+curl_download_out="$(
+  command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "gh" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  export -f command
+  HOME="${curl_download_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes
+)"
+assert_contains "${curl_download_out}" "vibeguard-runtime downloaded and verified" "prebuilt runtime downloads when gh is absent and curl is available"
+assert_not_contains "${curl_download_out}" "Falling back to source build" "curl download path does not use source fallback"
+
+source_build_home="${TMP_HOME}/source-build-home"
+source_cargo_log="${TMP_HOME}/source-cargo.log"
+mkdir -p "${source_build_home}"
+: > "${source_cargo_log}"
+source_build_out="$(HOME="${source_build_home}" CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" VIBEGUARD_TEST_CARGO_LOG="${source_cargo_log}" bash "${REPO_DIR}/setup.sh" --yes --build-from-source)"
+assert_contains "${source_build_out}" "Mode: build-from-source" "--build-from-source reports source mode"
+assert_contains "${source_build_out}" "Building vibeguard-runtime from source (Rust)..." "--build-from-source builds runtime from source"
+assert_cmd "--build-from-source invokes cargo build" grep -qF "build --release" "${source_cargo_log}"
+
+offline_build_home="${TMP_HOME}/offline-build-home"
+offline_cargo_log="${TMP_HOME}/offline-cargo.log"
+mkdir -p "${offline_build_home}"
+: > "${offline_cargo_log}"
+offline_build_out="$(HOME="${offline_build_home}" CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" VIBEGUARD_TEST_DOWNLOAD_FAIL=1 VIBEGUARD_TEST_CARGO_LOG="${offline_cargo_log}" bash "${REPO_DIR}/setup.sh" --yes)"
+assert_contains "${offline_build_out}" "Falling back to source build" "offline prebuilt download falls back to source build"
+assert_cmd "offline fallback invokes cargo build" grep -qF "build --release" "${offline_cargo_log}"
+
+switch_runtime_home="${TMP_HOME}/switch-runtime-home"
+mkdir -p "${switch_runtime_home}"
+HOME="${switch_runtime_home}" CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes --build-from-source >/dev/null
+switch_download_out="$(HOME="${switch_runtime_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes)"
+assert_contains "${switch_download_out}" "vibeguard-runtime downloaded and verified" "source-built install can switch to downloaded runtime"
+set +e
+switch_check_out="$(HOME="${switch_runtime_home}" bash "${REPO_DIR}/setup.sh" --check --strict 2>&1)"
+switch_check_rc=$?
+set -e
+assert_cmd "source-to-download switch remains healthy under --check --strict" test "${switch_check_rc}" -eq 0
+assert_not_contains "${switch_check_out}" "[BROKEN]" "source-to-download switch does not report BROKEN"
+
+install_out="$(VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
+assert_contains "${install_out}" "vibeguard-runtime downloaded and verified" "default setup uses verified prebuilt runtime without cargo"
 assert_contains "${install_out}" "Scheduled GC not installed by default" "default setup reports scheduled GC opt-in"
 assert_cmd "default setup does not install scheduled GC" assert_scheduled_gc_absent
 assert_contains "${install_out}" "Removed retired VibeGuard skill link" "setup install removes tracked retired skill links"


### PR DESCRIPTION
## Summary
- Download `vibeguard-runtime-<target>` from GitHub Releases by default, pinned to `vibeguard-runtime/VERSION` or `--runtime-version`.
- Verify downloaded binaries against `SHA256SUMS`; checksum or manifest mismatch aborts without source fallback.
- Keep `--build-from-source` and automatic source fallback for offline/unsupported/download-unavailable cases.
- Extend setup regression tests for default prebuilt install without cargo, tampered checksums, curl when `gh` is absent, explicit source builds, offline source fallback, and source-built to downloaded runtime switching.

Closes #340.
Spec: `docs/specs/install-friction-reduction.md` (#338).
Depends on #345, now merged.

## Validation
- `bash tests/test_setup.sh` (273/273)
- `bash tests/test_setup_check.sh` (98/98)
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash tests/test_setup_hardening.sh` (8/8)
- `bash scripts/ci/validate-no-personal-paths.sh`
- `bash tests/test_release_workflow.sh` (16/16)
- `cargo check --locked --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --locked --manifest-path vibeguard-runtime/Cargo.toml`
- `git diff --check`