### PR TITLE
ci: pin release publish repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           if gh release view "${TAG_NAME}" >/dev/null 2>&1; then

--- a/tests/test_gc_config.sh
+++ b/tests/test_gc_config.sh
@@ -19,7 +19,7 @@ header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
 assert_contains() {
   local output="$1" expected="$2" desc="$3"
   TOTAL=$((TOTAL + 1))
-  if printf '%s' "$output" | grep -qF -- "$expected"; then
+  if grep -qF -- "$expected" <<< "$output"; then
     green "$desc"; PASS=$((PASS + 1))
   else
     red "$desc (expected to contain: $expected)"; FAIL=$((FAIL + 1))

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -80,6 +80,7 @@ assert_contains "$workflow_text" "git merge-base --is-ancestor" "tag must be rea
 assert_contains "$workflow_text" "RUNTIME_VERSION_FILE" "workflow reads runtime VERSION file"
 assert_contains "$workflow_text" "release tag \${TAG_NAME} does not match" "tag/version mismatch fails loudly"
 assert_contains "$workflow_text" "sha256sum vibeguard-runtime-* | sort -k2 > SHA256SUMS" "checksums use deterministic sorted layout"
+assert_contains "$workflow_text" 'GH_REPO: ${{ github.repository }}' "publish job pins gh target repository"
 
 for target in \
   aarch64-apple-darwin \


### PR DESCRIPTION
Follow-up to release CI validation from #339 / #348.

## Root cause
The `publish-release` job downloads artifacts without checking out the repository. In that environment, `gh release view "$TAG_NAME"` can fail with `fatal: not a git repository` unless the target repository is explicit.

## Change
- Set `GH_REPO: ${{ github.repository }}` for the release publish step.
- Add a release workflow contract assertion so the target repository remains pinned.

## Validation
- `bash tests/test_release_workflow.sh` -> Total 17 / Pass 17 / Fail 0
- `GH_REPO=majiayu000/vibeguard gh release view v1.1.2 --json tagName --jq .tagName` from a temp non-git directory -> `v1.1.2`
