### PR TITLE
[codex] Make staged guards portable without mapfile

### DIFF
--- a/guards/go/check_error_handling.sh
+++ b/guards/go/check_error_handling.sh
@@ -37,7 +37,10 @@ if command -v ast-grep >/dev/null 2>&1; then
   else
     # staged mode: only scan staged Go files to avoid full warehouse scanning blocking irrelevant submissions
     if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-      mapfile -t _ASG_TARGETS < <(grep -E '\.go$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null || true)
+      _ASG_TARGETS=()
+      while IFS= read -r _VG_TARGET; do
+        [[ -n "$_VG_TARGET" ]] && _ASG_TARGETS+=("$_VG_TARGET")
+      done < <(list_go_files "${TARGET_DIR}")
     else
       _ASG_TARGETS=("${TARGET_DIR}")
     fi

--- a/guards/typescript/check_any_abuse.sh
+++ b/guards/typescript/check_any_abuse.sh
@@ -38,7 +38,10 @@ if command -v ast-grep >/dev/null 2>&1; then
   else
     # staged mode: only scan staged TS files to avoid full warehouse scanning blocking irrelevant submissions
     if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-      mapfile -t _ASG_TARGETS < <(grep -E '\.(ts|tsx|js|jsx)$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null || true)
+      _ASG_TARGETS=()
+      while IFS= read -r _VG_TARGET; do
+        [[ -n "$_VG_TARGET" ]] && _ASG_TARGETS+=("$_VG_TARGET")
+      done < <(list_ts_files "${TARGET_DIR}")
     else
       _ASG_TARGETS=("${TARGET_DIR}")
     fi

--- a/guards/typescript/check_console_residual.sh
+++ b/guards/typescript/check_console_residual.sh
@@ -49,7 +49,10 @@ if command -v ast-grep >/dev/null 2>&1; then
   else
     # staged mode: only scan staged TS files to avoid full warehouse scanning blocking irrelevant submissions
     if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]]; then
-      mapfile -t _ASG_TARGETS < <(grep -E '\.(ts|tsx|js|jsx)$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null || true)
+      _ASG_TARGETS=()
+      while IFS= read -r _VG_TARGET; do
+        [[ -n "$_VG_TARGET" ]] && _ASG_TARGETS+=("$_VG_TARGET")
+      done < <(list_ts_files "${TARGET_DIR}")
     else
       _ASG_TARGETS=("${TARGET_DIR}")
     fi

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -303,12 +303,31 @@ fi
 # --- Build check: all detected languages run (not elif) ---
 BUILD_FAILS=""
 
+append_build_failure() {
+  local fail_msg="$1"
+  local output="${2:-}"
+  local excerpt=""
+
+  BUILD_FAILS="${BUILD_FAILS}  ${fail_msg}\n"
+
+  if [[ -n "$output" ]]; then
+    excerpt=$(printf '%s\n' "$output" | sed '/^[[:space:]]*$/d' | sed -n '1,8p')
+    if [[ -n "$excerpt" ]]; then
+      BUILD_FAILS="${BUILD_FAILS}    output excerpt:\n"
+      while IFS= read -r line; do
+        BUILD_FAILS="${BUILD_FAILS}      ${line}\n"
+      done <<< "$excerpt"
+    fi
+  fi
+}
+
 run_build_check() {
   local cmd="$1"
   local fail_msg="$2"
   local code=0
+  local output=""
 
-  run_with_timeout "$cmd" >/dev/null 2>&1 || code=$?
+  output=$(run_with_timeout "$cmd" 2>&1) || code=$?
   if [[ $code -eq 124 ]]; then
     if [[ "$TIMEOUT_BEHAVIOR" == "warn" ]]; then
       vg_log "pre-commit-guard" "git-commit" "warn" "build timeout after ${TIMEOUT}s; allowed by VIBEGUARD_PRECOMMIT_TIMEOUT_BEHAVIOR=warn" "$fail_msg"
@@ -319,7 +338,7 @@ run_build_check() {
     return 0
   fi
   if [[ $code -ne 0 ]]; then
-    BUILD_FAILS="${BUILD_FAILS}  ${fail_msg}\n"
+    append_build_failure "$fail_msg" "$output"
   fi
 }
 
@@ -341,7 +360,7 @@ for lang in $DETECTED_LANGS; do
         [[ -z "$build_root" ]] && continue
         build_root_q=$(printf '%q' "$build_root")
         repo_root_q=$(printf '%q' "$REPO_ROOT")
-        run_build_check "cd ${build_root_q} && tsc_cmd=''; search_dir=\"\$PWD\"; while true; do if [[ -x \"\$search_dir/node_modules/.bin/tsc\" ]]; then tsc_cmd=\"\$search_dir/node_modules/.bin/tsc\"; break; fi; [[ \"\$search_dir\" == ${repo_root_q} ]] && break; parent_dir=\$(dirname \"\$search_dir\"); [[ \"\$parent_dir\" == \"\$search_dir\" ]] && break; search_dir=\"\$parent_dir\"; done; [[ -z \"\$tsc_cmd\" ]] && command -v tsc >/dev/null 2>&1 && tsc_cmd=\$(command -v tsc); [[ -z \"\$tsc_cmd\" ]] && exit 0; \"\$tsc_cmd\" --noEmit" "tsc --noEmit failed (${build_root})"
+        run_build_check "cd ${build_root_q} && tsc_cmd=''; search_dir=\"\$PWD\"; while true; do if [[ -x \"\$search_dir/node_modules/.bin/tsc\" ]]; then tsc_cmd=\"\$search_dir/node_modules/.bin/tsc\"; break; fi; [[ \"\$search_dir\" == ${repo_root_q} ]] && break; parent_dir=\$(dirname \"\$search_dir\"); [[ \"\$parent_dir\" == \"\$search_dir\" ]] && break; search_dir=\"\$parent_dir\"; done; [[ -z \"\$tsc_cmd\" ]] && command -v tsc >/dev/null 2>&1 && tsc_cmd=\$(command -v tsc); [[ -z \"\$tsc_cmd\" ]] && exit 0; printf 'tsc command: %s\n' \"\$tsc_cmd\" >&2; \"\$tsc_cmd\" --noEmit" "tsc --noEmit failed (${build_root})"
       done <<< "$TYPESCRIPT_BUILD_ROOTS"
       ;;
     javascript)

--- a/tests/hooks/test_precommit_ts_quality.sh
+++ b/tests/hooks/test_precommit_ts_quality.sh
@@ -33,6 +33,7 @@ EOF
 
 cat >"$tmp_repo_precommit_ts_js/bin/tsc" <<'EOF'
 #!/usr/bin/env bash
+echo "simulated tsc stderr: cannot find name missingSymbol" >&2
 exit 1
 EOF
 
@@ -40,6 +41,10 @@ chmod +x "$tmp_repo_precommit_ts_js/bin/node" "$tmp_repo_precommit_ts_js/bin/tsc
 git -C "$tmp_repo_precommit_ts_js" add tsconfig.json src/bad.js
 _stub_guards="$(make_stub_guard_dir)"
 assert_exit_nonzero "JS-only staged changes in a TS repo still run tsc --noEmit" bash -c "cd '$tmp_repo_precommit_ts_js' && PATH='$tmp_repo_precommit_ts_js/bin:/usr/bin:/bin:$PATH' VIBEGUARD_DIR='$_stub_guards' bash '$REPO_DIR/hooks/pre-commit-guard.sh'"
+ts_build_diag_out=$(cd "$tmp_repo_precommit_ts_js" && PATH="$tmp_repo_precommit_ts_js/bin:/usr/bin:/bin:$PATH" VIBEGUARD_DIR="$_stub_guards" bash "$REPO_DIR/hooks/pre-commit-guard.sh" 2>&1 || true)
+assert_contains "$ts_build_diag_out" "Build failed:" "TypeScript build failure prints build section"
+assert_contains "$ts_build_diag_out" "tsc command:" "TypeScript build failure includes resolved tsc command"
+assert_contains "$ts_build_diag_out" "simulated tsc stderr" "TypeScript build failure includes stderr excerpt"
 rm -rf "$_stub_guards" "$tmp_repo_precommit_ts_js"
 
 # Mixed TS + JS staged changes should only run the shared TS quality guards once.

--- a/tests/unit/test_go_check_error_handling.sh
+++ b/tests/unit/test_go_check_error_handling.sh
@@ -134,6 +134,38 @@ func TestRun(t *testing.T) {
 EOF
 assert_ok "discarded error in _test.go is excluded" bash "$GUARD" --strict "$proj_test"
 
+# --- FAIL: staged mode works when bash mapfile is unavailable ---
+proj_staged_no_mapfile="${tmpdir}/fail_staged_no_mapfile"
+mkdir -p "${proj_staged_no_mapfile}"
+proj_staged_no_mapfile="$(cd "${proj_staged_no_mapfile}" && pwd -P)"
+git -C "${proj_staged_no_mapfile}" init -q
+cat > "${proj_staged_no_mapfile}/main.go" <<'EOF'
+package main
+
+import "os"
+
+func main() {
+    _ = os.Remove("/tmp/old-file.txt")
+}
+EOF
+git -C "${proj_staged_no_mapfile}" add main.go
+staged_no_mapfile_list="${tmpdir}/go_staged_files.txt"
+printf '%s\n' "${proj_staged_no_mapfile}/main.go" > "$staged_no_mapfile_list"
+disable_mapfile_env="${tmpdir}/disable_mapfile.bashenv"
+printf '%s\n' 'enable -n mapfile 2>/dev/null || true' > "$disable_mapfile_env"
+ast_grep_stub_dir="${tmpdir}/ast_grep_stub_go"
+mkdir -p "$ast_grep_stub_dir"
+cat > "$ast_grep_stub_dir/ast-grep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+target="${!#}"
+printf '[{"file":"%s","range":{"start":{"line":5}},"message":"stub discarded error"}]\n' "$target"
+EOF
+chmod +x "$ast_grep_stub_dir/ast-grep"
+assert_output_contains "staged mode without mapfile uses ast-grep target collection" "stub discarded error" \
+  env PATH="$ast_grep_stub_dir:$PATH" BASH_ENV="$disable_mapfile_env" VIBEGUARD_STAGED_FILES="$staged_no_mapfile_list" \
+  bash "$GUARD" --strict "$proj_staged_no_mapfile"
+
 # --- PASS: code with no blank identifier assignments ---
 proj_clean2="${tmpdir}/pass_clean2"
 mkdir -p "${proj_clean2}"

--- a/tests/unit/test_ts_check_any_abuse.sh
+++ b/tests/unit/test_ts_check_any_abuse.sh
@@ -125,6 +125,32 @@ const x: any = 42;
 EOF
 assert_ok "violations in .test.ts files are excluded" bash "$GUARD" --strict "$proj_test_excluded"
 
+# --- FAIL: staged mode works when bash mapfile is unavailable ---
+proj_staged_no_mapfile="${tmpdir}/fail_staged_no_mapfile"
+mkdir -p "${proj_staged_no_mapfile}/src"
+proj_staged_no_mapfile="$(cd "${proj_staged_no_mapfile}" && pwd -P)"
+git -C "${proj_staged_no_mapfile}" init -q
+cat > "${proj_staged_no_mapfile}/src/staged.ts" <<'EOF'
+export const value = input as any;
+EOF
+git -C "${proj_staged_no_mapfile}" add src/staged.ts
+staged_no_mapfile_list="${tmpdir}/ts_any_staged_files.txt"
+printf '%s\n' "${proj_staged_no_mapfile}/src/staged.ts" > "$staged_no_mapfile_list"
+disable_mapfile_env="${tmpdir}/disable_mapfile.bashenv"
+printf '%s\n' 'enable -n mapfile 2>/dev/null || true' > "$disable_mapfile_env"
+ast_grep_stub_dir="${tmpdir}/ast_grep_stub_ts_any"
+mkdir -p "$ast_grep_stub_dir"
+cat > "$ast_grep_stub_dir/ast-grep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+target="${!#}"
+printf '[{"file":"%s","range":{"start":{"line":0}},"message":"stub any usage"}]\n' "$target"
+EOF
+chmod +x "$ast_grep_stub_dir/ast-grep"
+assert_output_contains "staged mode without mapfile uses ast-grep target collection" "stub any usage" \
+  env PATH="$ast_grep_stub_dir:$PATH" BASH_ENV="$disable_mapfile_env" VIBEGUARD_STAGED_FILES="$staged_no_mapfile_list" \
+  bash "$GUARD" --strict "$proj_staged_no_mapfile"
+
 # --- PASS: empty project ---
 proj_empty="${tmpdir}/pass_empty"
 mkdir -p "${proj_empty}/src"

--- a/tests/unit/test_ts_check_console_residual.sh
+++ b/tests/unit/test_ts_check_console_residual.sh
@@ -146,6 +146,34 @@ describe("handler", () => {
 EOF
 assert_ok "console.log in .test.ts is excluded" bash "$GUARD" --strict "$proj_test"
 
+# --- FAIL: staged mode works when bash mapfile is unavailable ---
+proj_staged_no_mapfile="${tmpdir}/fail_staged_no_mapfile"
+mkdir -p "${proj_staged_no_mapfile}/src"
+proj_staged_no_mapfile="$(cd "${proj_staged_no_mapfile}" && pwd -P)"
+git -C "${proj_staged_no_mapfile}" init -q
+cat > "${proj_staged_no_mapfile}/src/staged.ts" <<'EOF'
+export function run(): void {
+  console.log("debug");
+}
+EOF
+git -C "${proj_staged_no_mapfile}" add src/staged.ts
+staged_no_mapfile_list="${tmpdir}/ts_console_staged_files.txt"
+printf '%s\n' "${proj_staged_no_mapfile}/src/staged.ts" > "$staged_no_mapfile_list"
+disable_mapfile_env="${tmpdir}/disable_mapfile.bashenv"
+printf '%s\n' 'enable -n mapfile 2>/dev/null || true' > "$disable_mapfile_env"
+ast_grep_stub_dir="${tmpdir}/ast_grep_stub_ts_console"
+mkdir -p "$ast_grep_stub_dir"
+cat > "$ast_grep_stub_dir/ast-grep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+target="${!#}"
+printf '[{"file":"%s","range":{"start":{"line":1}},"message":"stub console residual"}]\n' "$target"
+EOF
+chmod +x "$ast_grep_stub_dir/ast-grep"
+assert_output_contains "staged mode without mapfile uses ast-grep target collection" "stub console residual" \
+  env PATH="$ast_grep_stub_dir:$PATH" BASH_ENV="$disable_mapfile_env" VIBEGUARD_STAGED_FILES="$staged_no_mapfile_list" \
+  bash "$GUARD" --strict "$proj_staged_no_mapfile"
+
 # --- PASS: console in comment is not flagged ---
 proj_commented="${tmpdir}/pass_commented"
 mkdir -p "${proj_commented}/src"


### PR DESCRIPTION
## Summary

- Replace bash-only staged target collection in TypeScript and Go guards with portable read loops over existing file-list helpers.
- Add deterministic staged-mode regressions that disable mapfile and stub ast-grep so the modified branch is exercised even when local tooling differs.
- Include resolved tsc command and a short output excerpt in TypeScript pre-commit build failures.

Fixes #355.

## Validation

- bash tests/unit/test_ts_check_any_abuse.sh
- bash tests/unit/test_ts_check_console_residual.sh
- bash tests/unit/test_go_check_error_handling.sh
- bash tests/hooks/test_precommit_ts_quality.sh
- bash tests/test_hooks.sh
- bash tests/test_guard_packs.sh
- bash tests/test_setup.sh
- git diff --check