### PR TITLE
[codex] Drain Claude hook stdin before early exits

### DIFF
--- a/hooks/analysis-paralysis-guard.sh
+++ b/hooks/analysis-paralysis-guard.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+if [[ ! -t 0 ]]; then
+  if ! cat >/dev/null; then
+    echo "ERROR: failed to drain analysis-paralysis hook stdin" >&2
+    exit 1
+  fi
+fi
+
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -18,6 +18,22 @@ export VIBEGUARD_CALLER_EVIDENCE="${VIBEGUARD_CALLER_EVIDENCE:-wrapper-and-paren
 HOOK_NAME="${1:?Usage: run-hook.sh <hook-name>}"
 shift
 
+_VG_HOOK_STDIN_FILE=""
+_vg_cleanup_hook_stdin() {
+  if [[ -n "${_VG_HOOK_STDIN_FILE}" ]]; then
+    rm -f "${_VG_HOOK_STDIN_FILE}" 2>/dev/null || true
+  fi
+}
+trap _vg_cleanup_hook_stdin EXIT
+
+if [[ ! -t 0 ]]; then
+  _VG_HOOK_STDIN_FILE="$(mktemp "${TMPDIR:-/tmp}/vibeguard-hook-stdin.XXXXXX")"
+  if ! cat > "${_VG_HOOK_STDIN_FILE}"; then
+    echo "ERROR: failed to drain hook stdin for ${HOOK_NAME}" >&2
+    exit 1
+  fi
+fi
+
 INSTALLED_DIR="${HOME}/.vibeguard/installed/hooks"
 HOOK_PATH="${INSTALLED_DIR}/${HOOK_NAME}"
 
@@ -68,7 +84,11 @@ if [[ "${VIBEGUARD_POLICY_ENFORCEMENT}" == "warn" ]]; then
   # Separate stderr from stdout: only stdout feeds the JSON downgrade path.
   # Mixing stderr in (2>&1) corrupts the JSON parsed by vg_policy_downgrade_output.
   hook_err_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-warn-hook.XXXXXX")"
-  hook_output="$(bash "$HOOK_PATH" "$@" 2>"${hook_err_file}")" || hook_status=$?
+  if [[ -n "${_VG_HOOK_STDIN_FILE}" ]]; then
+    hook_output="$(bash "$HOOK_PATH" "$@" < "${_VG_HOOK_STDIN_FILE}" 2>"${hook_err_file}")" || hook_status=$?
+  else
+    hook_output="$(bash "$HOOK_PATH" "$@" 2>"${hook_err_file}")" || hook_status=$?
+  fi
   if [[ -s "${hook_err_file}" ]]; then
     cat "${hook_err_file}" >&2
   fi
@@ -79,4 +99,11 @@ if [[ "${VIBEGUARD_POLICY_ENFORCEMENT}" == "warn" ]]; then
   exit "${hook_status}"
 fi
 
-exec bash "$HOOK_PATH" "$@"
+if [[ -z "${_VG_HOOK_STDIN_FILE}" ]]; then
+  trap - EXIT
+  exec bash "$HOOK_PATH" "$@"
+fi
+
+hook_status=0
+bash "$HOOK_PATH" "$@" < "${_VG_HOOK_STDIN_FILE}" || hook_status=$?
+exit "${hook_status}"

--- a/tests/hooks/test_runtime_config.sh
+++ b/tests/hooks/test_runtime_config.sh
@@ -122,6 +122,67 @@ result=$(env CI=false GITHUB_ACTIONS=false TRAVIS=false CIRCLECI=false JENKINS_U
   VG_PARALYSIS_THRESHOLD=5 bash hooks/analysis-paralysis-guard.sh)
 assert_not_contains "$result" "ANALYSIS PARALYSIS" "VG_PARALYSIS_THRESHOLD overrides JSON"
 
+paralysis_drain_log="$(make_log_dir)"
+seed_research_events "$paralysis_drain_log" "cfg-paralysis-drain" 2
+paralysis_drain_out=$(node - "${REPO_DIR}" "$paralysis_drain_log" "$cfg" <<'NODE'
+const { spawn } = require('node:child_process');
+
+const [repoDir, logDir, configFile] = process.argv.slice(2);
+const child = spawn('bash', ['hooks/analysis-paralysis-guard.sh'], {
+  cwd: repoDir,
+  env: {
+    ...process.env,
+    CI: 'false',
+    GITHUB_ACTIONS: 'false',
+    TRAVIS: 'false',
+    CIRCLECI: 'false',
+    JENKINS_URL: '',
+    GITLAB_CI: 'false',
+    TF_BUILD: 'false',
+    VIBEGUARD_LOG_DIR: logDir,
+    VIBEGUARD_SESSION_ID: 'cfg-paralysis-drain',
+    VIBEGUARD_CONFIG_FILE: configFile,
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let stdinError = '';
+let stdout = '';
+let stderr = '';
+
+child.stdout.on('data', (data) => { stdout += data; });
+child.stderr.on('data', (data) => { stderr += data; });
+child.stdin.on('error', (error) => { stdinError = error.code || String(error); });
+
+const payload = JSON.stringify({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Read',
+  tool_input: {
+    file_path: '/tmp/example',
+    content: 'x'.repeat(8 * 1024 * 1024),
+  },
+});
+
+child.stdin.write(payload, (error) => {
+  if (error) stdinError = error.code || String(error);
+});
+child.stdin.end();
+
+child.on('close', (code, signal) => {
+  console.log(JSON.stringify({
+    code,
+    signal,
+    stdinError,
+    stdout: stdout.slice(0, 500),
+    stderr: stderr.slice(0, 120),
+  }));
+});
+NODE
+)
+assert_contains "$paralysis_drain_out" '"code":0' "analysis-paralysis warning path exits cleanly after large stdin"
+assert_contains "$paralysis_drain_out" '"stdinError":""' "analysis-paralysis drains large stdin before warning"
+assert_contains "$paralysis_drain_out" "ANALYSIS PARALYSIS" "analysis-paralysis still emits warning after draining large stdin"
+
 header "runtime config — U-16"
 big_write_input="$WORK_DIR/big-write.json"
 python3 - "$WORK_DIR/big.py" > "$big_write_input" <<'PY'

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -50,6 +50,54 @@ run_codex_wrapper() {
       bash "${REPO_DIR}/hooks/run-hook-codex.sh" "${hook_name}"
 }
 
+probe_large_claude_stdin() {
+  local home_dir="$1" project_dir="$2" hook_name="$3"
+  node - "${home_dir}" "${project_dir}" "${hook_name}" "${REPO_DIR}" <<'NODE'
+const { spawn } = require('node:child_process');
+
+const [homeDir, projectDir, hookName, repoDir] = process.argv.slice(2);
+const child = spawn('bash', [`${repoDir}/hooks/run-hook.sh`, hookName], {
+  cwd: projectDir,
+  env: {
+    ...process.env,
+    HOME: homeDir,
+    VIBEGUARD_LOG_DIR: `${homeDir}/.vibeguard`,
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let stdinError = '';
+let stdout = '';
+let stderr = '';
+
+child.stdout.on('data', (data) => { stdout += data; });
+child.stderr.on('data', (data) => { stderr += data; });
+child.stdin.on('error', (error) => { stdinError = error.code || String(error); });
+
+const payload = JSON.stringify({
+  tool_input: {
+    command: 'git push --force',
+    content: 'x'.repeat(8 * 1024 * 1024),
+  },
+});
+
+child.stdin.write(payload, (error) => {
+  if (error) stdinError = error.code || String(error);
+});
+child.stdin.end();
+
+child.on('close', (code, signal) => {
+  console.log(JSON.stringify({
+    code,
+    signal,
+    stdinError,
+    stdout: stdout.slice(0, 120),
+    stderr: stderr.slice(0, 120),
+  }));
+});
+NODE
+}
+
 pretool_block_input='{"tool_input":{"command":"git push --force"}}'
 codex_pretool_input='{"hook_event_name":"PreToolUse","tool_input":{"command":"git push --force"}}'
 pretool_danger_input='{"tool_input":{"command":"git clean -f"}}'
@@ -72,6 +120,12 @@ disabled_codex_out="$(run_codex_wrapper "${disabled_home}" "${disabled_project}"
 disabled_codex_status=$?
 set -e
 assert_empty_success "${disabled_codex_status}" "${disabled_codex_out}" "Codex wrapper honors disabled_hooks before executing hook"
+
+disabled_large_stdin_out="$(probe_large_claude_stdin "${disabled_home}" "${disabled_project}" pre-bash-guard.sh)"
+assert_contains "${disabled_large_stdin_out}" '"code":0' "Claude wrapper disabled hook exits cleanly after large stdin"
+assert_contains "${disabled_large_stdin_out}" '"stdinError":""' "Claude wrapper drains large stdin before disabled hook skip"
+assert_contains "${disabled_large_stdin_out}" '"stdout":""' "Claude wrapper disabled hook produces no stdout after large stdin"
+assert_contains "${disabled_large_stdin_out}" '"stderr":""' "Claude wrapper disabled hook produces no stderr after large stdin"
 
 assert_contains "$(cat "${disabled_home}/.vibeguard/policy.jsonl")" "policy_skip" "runtime policy emits policy_skip telemetry"
 


### PR DESCRIPTION
## Summary

- drain Claude hook stdin into a temp file before wrapper policy/missing-hook early exits
- re-feed drained stdin to hooks in normal and warn enforcement paths while preserving TTY inheritance
- drain unused stdin in analysis-paralysis-guard.sh and add large PostToolUse regression coverage

Refs #352. This PR only covers the Claude stdin-drain side; the Codex env-var payload path remains separate.

## Verification

- bash tests/hooks/test_runtime_policy.sh
- bash tests/hooks/test_runtime_config.sh
- bash tests/test_hooks.sh
- bash tests/test_setup.sh
- git diff --check
