### PR TITLE
Parse Codex hook payloads via stdin

### DIFF
--- a/hooks/_lib/codex_adapter.sh
+++ b/hooks/_lib/codex_adapter.sh
@@ -3,15 +3,15 @@
 
 codex_event_name() {
   local input="$1"
-  CODEX_INPUT="${input}" python3 - <<'PY'
+  printf '%s' "${input}" | python3 -c '
 import json
-import os
+import sys
 
 try:
-    print(json.loads(os.environ.get("CODEX_INPUT", "")).get("hook_event_name", ""))
+    print(json.loads(sys.stdin.read()).get("hook_event_name", ""))
 except Exception:
     print("")
-PY
+'
 }
 
 codex_pretool_deny() {
@@ -50,13 +50,12 @@ PY
 
 codex_adapt_pretool() {
   local hook_output="$1"
-  CODEX_HOOK_OUTPUT="${hook_output}" python3 - <<'PY'
+  printf '%s' "${hook_output}" | python3 -c '
 import json
-import os
 import sys
 
 try:
-    data = json.loads(os.environ.get("CODEX_HOOK_OUTPUT", ""))
+    data = json.loads(sys.stdin.read())
 except Exception:
     print(json.dumps({
         "hookSpecificOutput": {
@@ -114,18 +113,17 @@ elif decision == "allow" and isinstance(updated, dict):
                 "Suggested command: " + command
             )
         }, ensure_ascii=False))
-PY
+'
 }
 
 codex_adapt_posttool() {
   local hook_output="$1"
-  CODEX_HOOK_OUTPUT="${hook_output}" python3 - <<'PY'
+  printf '%s' "${hook_output}" | python3 -c '
 import json
-import os
 import sys
 
 try:
-    data = json.loads(os.environ.get("CODEX_HOOK_OUTPUT", ""))
+    data = json.loads(sys.stdin.read())
 except Exception:
     sys.exit(3)
 
@@ -167,18 +165,17 @@ elif decision == "warn":
         output["systemMessage"] = reason
     if output:
         print(json.dumps(output, ensure_ascii=False))
-PY
+'
 }
 
 codex_adapt_permission_request() {
   local hook_output="$1"
-  CODEX_HOOK_OUTPUT="${hook_output}" python3 - <<'PY'
+  printf '%s' "${hook_output}" | python3 -c '
 import json
-import os
 import sys
 
 try:
-    data = json.loads(os.environ.get("CODEX_HOOK_OUTPUT", ""))
+    data = json.loads(sys.stdin.read())
 except Exception:
     print(json.dumps({
         "hookSpecificOutput": {
@@ -228,5 +225,5 @@ elif decision == "allow" and isinstance(updated, dict):
                 "Suggested command: " + command
             )
         }, ensure_ascii=False))
-PY
+'
 }

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -3,15 +3,15 @@
 
 codex_raw_event_name() {
   local input="$1"
-  CODEX_INPUT="${input}" python3 - <<'PY'
+  printf '%s' "${input}" | python3 -c '
 import json
-import os
+import sys
 
 try:
-    print(json.loads(os.environ.get("CODEX_INPUT", "")).get("hook_event_name", ""))
+    print(json.loads(sys.stdin.read()).get("hook_event_name", ""))
 except Exception:
     print("")
-PY
+'
 }
 
 codex_pretool_deny_raw() {
@@ -108,13 +108,14 @@ codex_set_caller_identity() {
 
 codex_diag() {
   local hook_name="$1" event_name="$2" reason="$3" detail="${4:-}"
+  local detail_excerpt="${detail:0:300}"
   local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
   mkdir -p "$(dirname "${diag_file}")" 2>/dev/null || return 0
   VIBEGUARD_DIAG_FILE="${diag_file}" \
   VIBEGUARD_DIAG_HOOK="${hook_name}" \
   VIBEGUARD_DIAG_EVENT="${event_name}" \
   VIBEGUARD_DIAG_REASON="${reason}" \
-  VIBEGUARD_DIAG_DETAIL="${detail}" \
+  VIBEGUARD_DIAG_DETAIL="${detail_excerpt}" \
   VIBEGUARD_DIAG_CWD="${PWD}" \
     python3 - <<'PY' 2>/dev/null || true
 import datetime
@@ -153,12 +154,12 @@ codex_hook_timeout_ms() {
 
 codex_hook_status_detail() {
   local input="$1"
-  CODEX_INPUT="${input}" python3 - <<'PY'
+  printf '%s' "${input}" | python3 -c '
 import json
-import os
+import sys
 
 try:
-    payload = json.loads(os.environ.get("CODEX_INPUT", ""))
+    payload = json.loads(sys.stdin.read())
 except Exception:
     print("")
     raise SystemExit
@@ -174,29 +175,30 @@ for key in ("file_path", "command"):
         print(value[:300])
         raise SystemExit
 print("")
-PY
+'
 }
 
 codex_hook_status_matcher() {
   local input="$1"
-  CODEX_INPUT="${input}" python3 - <<'PY'
+  printf '%s' "${input}" | python3 -c '
 import json
-import os
+import sys
 
 try:
-    payload = json.loads(os.environ.get("CODEX_INPUT", ""))
+    payload = json.loads(sys.stdin.read())
 except Exception:
     print("")
     raise SystemExit
 
 tool_name = payload.get("tool_name")
 print(tool_name if isinstance(tool_name, str) else "")
-PY
+'
 }
 
 codex_hook_status() {
   local hook_name="$1" event_name="$2" matcher="$3" status="$4" reason="${5:-}" detail="${6:-}"
   local timeout_ms="${7:-}"
+  local detail_excerpt="${detail:0:300}"
   local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
   mkdir -p "$(dirname "${diag_file}")" 2>/dev/null || return 0
   VIBEGUARD_DIAG_FILE="${diag_file}" \
@@ -205,7 +207,7 @@ codex_hook_status() {
   VIBEGUARD_DIAG_MATCHER="${matcher}" \
   VIBEGUARD_DIAG_STATUS="${status}" \
   VIBEGUARD_DIAG_REASON="${reason}" \
-  VIBEGUARD_DIAG_DETAIL="${detail}" \
+  VIBEGUARD_DIAG_DETAIL="${detail_excerpt}" \
   VIBEGUARD_DIAG_TIMEOUT_MS="${timeout_ms}" \
     python3 - <<'PY' 2>/dev/null || true
 import datetime
@@ -246,12 +248,12 @@ PY
 codex_hook_status_from_output() {
   local hook_name="$1" event_name="$2" matcher="$3" hook_output="$4" detail="${5:-}" timeout_ms="${6:-}"
   local parsed hook_status hook_reason
-  parsed=$(CODEX_HOOK_OUTPUT="${hook_output}" python3 - <<'PY' 2>/dev/null || true
+  parsed=$(printf '%s' "${hook_output}" | python3 -c '
 import json
-import os
+import sys
 
 try:
-    data = json.loads(os.environ.get("CODEX_HOOK_OUTPUT", ""))
+    data = json.loads(sys.stdin.read())
 except Exception:
     print("hook_error\tinvalid-json")
     raise SystemExit
@@ -278,7 +280,7 @@ elif isinstance(hook_specific, dict):
 
 reason = reason.replace("\t", " ").replace("\n", " ")[:300]
 print(f"{status}\t{reason}")
-PY
+' 2>/dev/null || true
 )
   hook_status="${parsed%%$'\t'*}"
   hook_reason="${parsed#*$'\t'}"

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -42,13 +42,12 @@ assert_not_contains() {
 assert_codex_pretool_output_contract() {
   local output="$1" desc="$2"
   TOTAL=$((TOTAL + 1))
-  if CODEX_HOOK_OUTPUT="${output}" python3 - <<'PY'
+  if printf '%s' "${output}" | python3 -c '
 import json
-import os
 import sys
 
 try:
-    data = json.loads(os.environ["CODEX_HOOK_OUTPUT"])
+    data = json.loads(sys.stdin.read())
 except Exception as exc:
     print(f"invalid JSON: {exc}", file=sys.stderr)
     raise SystemExit(1)
@@ -124,7 +123,7 @@ elif "permissionDecisionReason" in specific:
 if "updatedInput" in specific:
     print("VibeGuard Codex wrapper must not emit updatedInput on native PreToolUse", file=sys.stderr)
     raise SystemExit(1)
-PY
+'
   then
     green "$desc"
     PASS=$((PASS + 1))
@@ -137,13 +136,12 @@ PY
 assert_codex_posttool_output_contract() {
   local output="$1" desc="$2"
   TOTAL=$((TOTAL + 1))
-  if CODEX_HOOK_OUTPUT="${output}" python3 - <<'PY'
+  if printf '%s' "${output}" | python3 -c '
 import json
-import os
 import sys
 
 try:
-    data = json.loads(os.environ["CODEX_HOOK_OUTPUT"])
+    data = json.loads(sys.stdin.read())
 except Exception as exc:
     print(f"invalid JSON: {exc}", file=sys.stderr)
     raise SystemExit(1)
@@ -194,7 +192,7 @@ if specific.get("hookEventName") != "PostToolUse":
 if "updatedMCPToolOutput" in specific:
     print("VibeGuard Codex wrapper must not emit updatedMCPToolOutput", file=sys.stderr)
     raise SystemExit(1)
-PY
+'
   then
     green "$desc"
     PASS=$((PASS + 1))
@@ -469,6 +467,139 @@ missing_posttool_adapter_out="$(
 )"
 assert_contains "${missing_posttool_adapter_out}" '"decision": "block"' "missing PostToolUse adapter emits visible feedback"
 assert_codex_posttool_output_contract "${missing_posttool_adapter_out}" "missing PostToolUse adapter output matches Codex contract"
+
+header "run-hook-codex handles large payloads without env overflow"
+TMP_HOME_LARGE_PAYLOAD="${TMP_DIR}/home-large-payload"
+TMP_FAKE_REPO_LARGE_PAYLOAD="${TMP_DIR}/fake-repo-large-payload"
+LARGE_PAYLOAD_DIAG="${TMP_DIR}/large-payload-codex-wrapper.jsonl"
+mkdir -p "${TMP_HOME_LARGE_PAYLOAD}/.vibeguard" "${TMP_FAKE_REPO_LARGE_PAYLOAD}/hooks"
+printf '%s' "${TMP_FAKE_REPO_LARGE_PAYLOAD}" > "${TMP_HOME_LARGE_PAYLOAD}/.vibeguard/repo-path"
+
+cat > "${TMP_FAKE_REPO_LARGE_PAYLOAD}/hooks/vibeguard-post-build-check.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+HOOK
+chmod +x "${TMP_FAKE_REPO_LARGE_PAYLOAD}/hooks/vibeguard-post-build-check.sh"
+
+large_payload_probe="$(
+  node - "${REPO_DIR}" "${TMP_HOME_LARGE_PAYLOAD}" "${LARGE_PAYLOAD_DIAG}" <<'NODE'
+const { spawn } = require('node:child_process');
+
+const [repoDir, homeDir, diagFile] = process.argv.slice(2);
+const child = spawn('bash', [`${repoDir}/hooks/run-hook-codex.sh`, 'vibeguard-post-build-check.sh'], {
+  cwd: repoDir,
+  env: {
+    ...process.env,
+    HOME: homeDir,
+    VIBEGUARD_CODEX_DIAG_FILE: diagFile,
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let stdinError = '';
+let stdout = '';
+let stderr = '';
+
+child.stdout.on('data', (data) => { stdout += data; });
+child.stderr.on('data', (data) => { stderr += data; });
+child.stdin.on('error', (error) => { stdinError = error.code || String(error); });
+
+const payload = JSON.stringify({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Bash',
+  tool_input: {
+    command: 'x'.repeat(2 * 1024 * 1024),
+  },
+});
+
+child.stdin.write(payload, (error) => {
+  if (error) stdinError = error.code || String(error);
+});
+child.stdin.end();
+
+child.on('close', (code, signal) => {
+  console.log(JSON.stringify({
+    code,
+    signal,
+    stdinError,
+    stdout: stdout.slice(0, 120),
+    stderr: stderr.slice(0, 200),
+  }));
+});
+NODE
+)"
+assert_contains "${large_payload_probe}" '"code":0' "large Codex payload exits cleanly"
+assert_contains "${large_payload_probe}" '"stdinError":""' "large Codex payload is accepted over stdin"
+assert_not_contains "${large_payload_probe}" "Argument list too long" "large Codex payload avoids execve env overflow"
+assert_contains "$(cat "${LARGE_PAYLOAD_DIAG}")" '"status": "pass"' "large Codex payload records pass status"
+
+header "run-hook-codex handles large hook output without env overflow"
+TMP_HOME_LARGE_OUTPUT="${TMP_DIR}/home-large-output"
+TMP_FAKE_REPO_LARGE_OUTPUT="${TMP_DIR}/fake-repo-large-output"
+LARGE_OUTPUT_DIAG="${TMP_DIR}/large-output-codex-wrapper.jsonl"
+mkdir -p "${TMP_HOME_LARGE_OUTPUT}/.vibeguard" "${TMP_FAKE_REPO_LARGE_OUTPUT}/hooks"
+printf '%s' "${TMP_FAKE_REPO_LARGE_OUTPUT}" > "${TMP_HOME_LARGE_OUTPUT}/.vibeguard/repo-path"
+
+cat > "${TMP_FAKE_REPO_LARGE_OUTPUT}/hooks/vibeguard-post-build-check.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+python3 - <<'PY'
+import json
+
+print(json.dumps({
+    "decision": "block",
+    "reason": "large-hook-output-sentinel:" + ("x" * (2 * 1024 * 1024)),
+}))
+PY
+HOOK
+chmod +x "${TMP_FAKE_REPO_LARGE_OUTPUT}/hooks/vibeguard-post-build-check.sh"
+
+large_output_probe="$(
+  node - "${REPO_DIR}" "${TMP_HOME_LARGE_OUTPUT}" "${LARGE_OUTPUT_DIAG}" <<'NODE'
+const { spawn } = require('node:child_process');
+
+const [repoDir, homeDir, diagFile] = process.argv.slice(2);
+const child = spawn('bash', [`${repoDir}/hooks/run-hook-codex.sh`, 'vibeguard-post-build-check.sh'], {
+  cwd: repoDir,
+  env: {
+    ...process.env,
+    HOME: homeDir,
+    VIBEGUARD_CODEX_DIAG_FILE: diagFile,
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let stdout = '';
+let stderr = '';
+
+child.stdout.on('data', (data) => { stdout += data; });
+child.stderr.on('data', (data) => { stderr += data; });
+
+child.stdin.end(JSON.stringify({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Bash',
+  tool_input: {
+    command: 'cargo check',
+  },
+}));
+
+child.on('close', (code, signal) => {
+  console.log(JSON.stringify({
+    code,
+    signal,
+    stdoutHasBlock: stdout.includes('"decision": "block"'),
+    stdoutHasSentinel: stdout.includes('large-hook-output-sentinel'),
+    stderr: stderr.slice(0, 200),
+  }));
+});
+NODE
+)"
+assert_contains "${large_output_probe}" '"code":0' "large Codex hook output exits cleanly"
+assert_contains "${large_output_probe}" '"stdoutHasBlock":true' "large Codex hook output is adapted"
+assert_contains "${large_output_probe}" '"stdoutHasSentinel":true' "large Codex hook output preserves the reason"
+assert_not_contains "${large_output_probe}" "Argument list too long" "large Codex hook output avoids execve env overflow"
+assert_contains "$(cat "${LARGE_OUTPUT_DIAG}")" '"status": "block"' "large Codex hook output records block status"
 
 header "run-hook-codex adapts posttool block output"
 TMP_HOME_POSTTOOL="${TMP_DIR}/home-posttool"


### PR DESCRIPTION
## Summary

- pass Codex hook payload/output JSON to Python over stdin instead of CODEX_INPUT / CODEX_HOOK_OUTPUT env vars
- cap diagnostic detail before exporting it through bounded VIBEGUARD_DIAG_* env vars
- add 2 MiB regressions for incoming Codex payloads and wrapped hook output

PR #359 already handled the Claude stdin-drain half of this issue. This PR handles the remaining Codex env-var overflow half.

Fixes #352

## Verification

- bash -n hooks/_lib/codex_diag.sh && bash -n hooks/_lib/codex_adapter.sh && bash -n tests/test_codex_runtime.sh
- rg -n "CODEX_INPUT|CODEX_HOOK_OUTPUT" hooks tests (no matches)
- git diff --check
- bash tests/test_codex_runtime.sh (86/86)
- bash tests/test_hooks.sh (all hook test shards passed)
- bash tests/test_setup.sh (279/279)
- independent read-only reviewer: no blocking findings; shellcheck unavailable locally
