### PR TITLE
fix: fail visibly on hook lock state errors

### DIFF
--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -7,26 +7,35 @@ vg_append_log_line() {
   local lock_dir="${file}.lock.d"
   local acquired="false"
   local attempts=0
+  local max_attempts="${VIBEGUARD_LOG_LOCK_ATTEMPTS:-100}"
+  local sleep_seconds="${VIBEGUARD_LOG_LOCK_SLEEP_SECONDS:-0.01}"
   local status=0
 
-  while [[ "$attempts" -lt 100 ]]; do
+  [[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=100
+  [[ "$max_attempts" -gt 0 ]] || max_attempts=1
+
+  while [[ "$attempts" -lt "$max_attempts" ]]; do
     if mkdir "$lock_dir" 2>/dev/null; then
       acquired="true"
       break
     fi
     attempts=$((attempts + 1))
-    sleep 0.01 2>/dev/null || true
+    sleep "$sleep_seconds" 2>/dev/null || true
   done
+
+  if [[ "$acquired" != "true" ]]; then
+    printf 'VIBEGUARD ERROR: failed to acquire log lock for %s after %s attempts\n' "$file" "$max_attempts" >&2
+    return 1
+  fi
 
   if printf '%s\n' "$line" >> "$file"; then
     status=0
   else
     status=$?
+    printf 'VIBEGUARD ERROR: failed to append log line to %s\n' "$file" >&2
   fi
 
-  if [[ "$acquired" == "true" ]]; then
-    rmdir "$lock_dir" 2>/dev/null || true
-  fi
+  rmdir "$lock_dir" 2>/dev/null || true
 
   return "$status"
 }
@@ -135,14 +144,18 @@ vg_log() {
   json="${json}}"
 
   vg_private_log_file "$VIBEGUARD_LOG_FILE"
-  vg_append_log_line "$VIBEGUARD_LOG_FILE" "$json"
+  if ! vg_append_log_line "$VIBEGUARD_LOG_FILE" "$json"; then
+    printf 'VIBEGUARD ERROR: primary event log write failed: %s\n' "$VIBEGUARD_LOG_FILE" >&2
+  fi
   vg_private_log_file "$VIBEGUARD_LOG_FILE"
 
   # Synchronously write to the global log (for stats.sh aggregation analysis)
   local global_log="${VIBEGUARD_LOG_DIR}/events.jsonl"
   if [[ "$VIBEGUARD_LOG_FILE" != "$global_log" ]]; then
     vg_private_log_file "$global_log"
-    vg_append_log_line "$global_log" "$json"
+    if ! vg_append_log_line "$global_log" "$json"; then
+      printf 'VIBEGUARD ERROR: global event log write failed: %s\n' "$global_log" >&2
+    fi
     vg_private_log_file "$global_log"
   fi
 }

--- a/hooks/analysis-paralysis-guard.sh
+++ b/hooks/analysis-paralysis-guard.sh
@@ -25,6 +25,17 @@ source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer
 VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "$0")/_lib" && pwd)}"
 
+_emit_cb_state_error() {
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "VIBEGUARD circuit breaker state error: analysis-paralysis-guard could not update its circuit breaker state; reporting visibly instead of silently auto-passing."
+  }
+}
+EOF
+}
+
 # CI guard: analysis-paralysis warnings are not actionable in CI
 vg_is_ci && exit 0
 
@@ -46,11 +57,22 @@ vg_log "analysis-paralysis-guard" "Read" "pass" "consecutive_reads=${CONSECUTIVE
 if [[ "$CONSECUTIVE" -ge "$THRESHOLD" ]]; then
   # Circuit breaker check: if this hook has been firing repeatedly without
   # resolution, open the circuit and auto-pass to prevent 716x warn loops.
+  CB_STATUS=0
   if vg_cb_check "analysis-paralysis-guard"; then
+    CB_STATUS=0
+  else
+    CB_STATUS=$?
+  fi
+
+  if [[ "$CB_STATUS" -eq 0 ]]; then
     WARNING="[ANALYSIS PARALYSIS] There have been ${CONSECUTIVE} consecutive read-only operations (Read/Glob/Grep) without any writes. You may be stuck in a \"read-read\" loop. You must choose: (1) Start writing code/editing files (2) Report the blocker to the user and explain where it is stuck."
 
     vg_log "analysis-paralysis-guard" "Read" "warn" "paralysis ${CONSECUTIVE}x" ""
-    vg_cb_record_block "analysis-paralysis-guard"
+    if ! vg_cb_record_block "analysis-paralysis-guard"; then
+      vg_log "analysis-paralysis-guard" "Read" "block" "Circuit breaker state error; fail-visible" ""
+      _emit_cb_state_error
+      exit 0
+    fi
 
     VG_WARNINGS="$WARNING" python3 -c '
 import json, os
@@ -63,9 +85,15 @@ result = {
 }
 print(json.dumps(result, ensure_ascii=False))
 '
+  elif [[ "$CB_STATUS" -eq 1 ]]; then
+    : # Circuit OPEN: vg_cb_check already logged the auto-pass.
+  else
+    vg_log "analysis-paralysis-guard" "Read" "block" "Circuit breaker state error; fail-visible" ""
+    _emit_cb_state_error
   fi
-  # If circuit is OPEN, vg_cb_check returned 1 and already logged the auto-pass.
-  # We silently skip the warn to break the loop.
 else
-  vg_cb_record_pass "analysis-paralysis-guard"
+  if ! vg_cb_record_pass "analysis-paralysis-guard"; then
+    vg_log "analysis-paralysis-guard" "Read" "block" "Circuit breaker state error; fail-visible" ""
+    _emit_cb_state_error
+  fi
 fi

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -13,7 +13,12 @@
 #   source "$(dirname "$0")/circuit-breaker.sh"
 #
 #   # In a hook that can block:
-#   vg_cb_check "my-hook" || { vg_log "my-hook" "Tool" "pass" "CB auto-pass" ""; exit 0; }
+#   if vg_cb_check "my-hook"; then
+#     cb_status=0
+#   else
+#     cb_status=$?
+#   fi
+#   # cb_status: 0 = run normally, 1 = circuit auto-pass, 2+ = lock/state error
 #   if [[ blocking_condition ]]; then
 #     vg_cb_record_block "my-hook"
 #     exit 2
@@ -34,9 +39,11 @@ _vg_cb_to_int() { local v="$1" d="$2"; [[ "$v" =~ ^[0-9]+$ ]] && printf '%s' "$v
 if declare -F vg_config_get_int >/dev/null 2>&1; then
   CB_COOLDOWN=$(_vg_cb_to_int "$(vg_config_get_int VG_CB_COOLDOWN circuit_breaker.cooldown_seconds 300)" 300)
   CB_THRESHOLD=$(_vg_cb_to_int "$(vg_config_get_int VG_CB_THRESHOLD circuit_breaker.threshold 3)" 3)
+  CB_LOCK_TIMEOUT_SECONDS=$(_vg_cb_to_int "$(vg_config_get_int VG_CB_LOCK_TIMEOUT_SECONDS circuit_breaker.lock_timeout_seconds 5)" 5)
 else
   CB_COOLDOWN=$(_vg_cb_to_int "${VG_CB_COOLDOWN:-300}" 300)
   CB_THRESHOLD=$(_vg_cb_to_int "${VG_CB_THRESHOLD:-3}" 3)
+  CB_LOCK_TIMEOUT_SECONDS=$(_vg_cb_to_int "${VG_CB_LOCK_TIMEOUT_SECONDS:-5}" 5)
 fi
 
 mkdir -p "$CB_DIR" 2>/dev/null || true
@@ -74,10 +81,9 @@ _vg_cb_lock_file() {
   printf '%s.lock' "$(_vg_cb_state_file "$hook")"
 }
 
-# Acquire an exclusive lock on fd $1, waiting up to 5 seconds.
+# Acquire an exclusive lock on fd $1, waiting up to CB_LOCK_TIMEOUT_SECONDS.
 # Uses flock(1) when available (Linux). On macOS (no flock), falls back to
 # a mkdir-based spinlock on the lock file path associated with fd $1.
-# Always returns 0 so callers under set -euo pipefail are not aborted.
 _VG_CB_LOCK_OWNED=false
 _VG_CB_LOCK_DIR=""
 
@@ -88,15 +94,24 @@ _vg_cb_try_flock() {
   _VG_CB_LOCK_DIR=""
 
   if command -v flock >/dev/null 2>&1; then
-    flock -x -w 5 "$lock_fd" 2>/dev/null || true
+    if flock -x -w "$CB_LOCK_TIMEOUT_SECONDS" "$lock_fd" 2>/dev/null; then
+      return 0
+    fi
+    printf 'VIBEGUARD ERROR: circuit breaker lock timeout for %s after %ss\n' "${lock_file_path:-fd:$lock_fd}" "$CB_LOCK_TIMEOUT_SECONDS" >&2
+    return 2
   else
     # macOS fallback: mkdir is atomic on all POSIX systems.
     # Store the acquired lock dir in module state so EXIT traps do not depend
     # on a caller-local lock_file variable still being in scope.
-    [[ -n "$lock_file_path" ]] || return 0
+    if [[ -z "$lock_file_path" ]]; then
+      printf 'VIBEGUARD ERROR: circuit breaker lock path missing for fd %s\n' "$lock_fd" >&2
+      return 2
+    fi
     local lockdir="${lock_file_path}.d"
+    local max_attempts=$(( CB_LOCK_TIMEOUT_SECONDS * 10 ))
+    [[ "$max_attempts" -gt 0 ]] || max_attempts=1
     local _i=0
-    while [[ $_i -lt 50 ]]; do
+    while [[ $_i -lt "$max_attempts" ]]; do
       if mkdir "$lockdir" 2>/dev/null; then
         _VG_CB_LOCK_OWNED=true
         _VG_CB_LOCK_DIR="$lockdir"
@@ -105,7 +120,8 @@ _vg_cb_try_flock() {
       sleep 0.1
       _i=$((_i + 1))
     done
-    # Timeout: proceed without lock rather than blocking the hook
+    printf 'VIBEGUARD ERROR: circuit breaker lock timeout for %s after %ss\n' "$lock_file_path" "$CB_LOCK_TIMEOUT_SECONDS" >&2
+    return 2
   fi
 }
 
@@ -152,7 +168,10 @@ _vg_cb_load() {
           [[ "$_val" =~ ^[a-zA-Z0-9_=-]*$ ]] && CB_SESSION="$_val"
           ;;
       esac
-    done < "$state_file"
+    done < "$state_file" || {
+      printf 'VIBEGUARD ERROR: failed to read circuit breaker state: %s\n' "$state_file" >&2
+      return 2
+    }
   fi
   # Reset if the state belongs to a different session
   local cur_session="${VIBEGUARD_SESSION_ID:-}"
@@ -161,8 +180,9 @@ _vg_cb_load() {
     CB_BLOCKS=0
     CB_LAST_BLOCK=0
     CB_SESSION=""
-    _vg_cb_save "$hook"
+    _vg_cb_save "$hook" || return 2
   fi
+  return 0
 }
 
 # Persist CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION for <hook>.
@@ -172,14 +192,32 @@ _vg_cb_save() {
   local hook="$1"
   local state_file tmp_file
   state_file=$(_vg_cb_state_file "$hook")
-  mkdir -p "$(dirname "$state_file")" 2>/dev/null || true
+  if ! mkdir -p "$(dirname "$state_file")" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to create circuit breaker state directory: %s\n' "$(dirname "$state_file")" >&2
+    return 2
+  fi
   tmp_file="${state_file}.tmp.$$"
-  {
+  if ! ( : > "$tmp_file" ) 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to write circuit breaker state temp file: %s\n' "$tmp_file" >&2
+    rm -f "$tmp_file" 2>/dev/null || true
+    return 2
+  fi
+  if ! {
     printf 'CB_STATE=%s\n' "$CB_STATE"
     printf 'CB_BLOCKS=%s\n' "$CB_BLOCKS"
     printf 'CB_LAST_BLOCK=%s\n' "$CB_LAST_BLOCK"
     printf 'CB_SESSION=%s\n' "${VIBEGUARD_SESSION_ID:-}"
-  } > "$tmp_file" 2>/dev/null && mv "$tmp_file" "$state_file" 2>/dev/null || true
+  } > "$tmp_file" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to write circuit breaker state temp file: %s\n' "$tmp_file" >&2
+    rm -f "$tmp_file" 2>/dev/null || true
+    return 2
+  fi
+  if ! mv "$tmp_file" "$state_file" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to persist circuit breaker state: %s\n' "$state_file" >&2
+    rm -f "$tmp_file" 2>/dev/null || true
+    return 2
+  fi
+  return 0
 }
 
 # ── Public API ───────────────────────────────────────────────────────────────
@@ -192,13 +230,20 @@ _vg_cb_save() {
 # concurrent hook invocations from racing on the state file.
 vg_cb_check() {
   local hook="$1"
-  local lock_file
+  local lock_file lock_fd status
   lock_file=$(_vg_cb_lock_file "$hook")
-  mkdir -p "$(dirname "$lock_file")" 2>/dev/null || true
-  (
-    _vg_cb_try_flock 9 "$lock_file"
+  if ! mkdir -p "$(dirname "$lock_file")" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to create circuit breaker lock directory: %s\n' "$(dirname "$lock_file")" >&2
+    return 2
+  fi
+  if ! exec {lock_fd}>"$lock_file"; then
+    printf 'VIBEGUARD ERROR: failed to open circuit breaker lock file: %s\n' "$lock_file" >&2
+    return 2
+  fi
+  if (
+    _vg_cb_try_flock "$lock_fd" "$lock_file" || exit 2
     trap '_vg_cb_release_flock' EXIT
-    _vg_cb_load "$hook"
+    _vg_cb_load "$hook" || exit 2
     now=$(_vg_cb_now)
 
     case "$CB_STATE" in
@@ -210,7 +255,7 @@ vg_cb_check() {
         if [[ "$elapsed" -ge "$CB_COOLDOWN" ]]; then
           CB_STATE="HALF-OPEN"
           CB_LAST_BLOCK=$(_vg_cb_now)
-          _vg_cb_save "$hook"
+          _vg_cb_save "$hook" || exit 2
           exit 0  # Let one probe through
         else
           remaining=$(( CB_COOLDOWN - elapsed ))
@@ -229,11 +274,17 @@ vg_cb_check() {
         ;;
       *)
         CB_STATE="CLOSED"; CB_BLOCKS=0
-        _vg_cb_save "$hook"
+        _vg_cb_save "$hook" || exit 2
         exit 0
         ;;
     esac
-  ) 9>"$lock_file"
+  ); then
+    status=0
+  else
+    status=$?
+  fi
+  exec {lock_fd}>&-
+  return "$status"
 }
 
 # vg_cb_record_block <hook>
@@ -241,13 +292,20 @@ vg_cb_check() {
 # Protected by an exclusive flock to prevent lost-update races under concurrent access.
 vg_cb_record_block() {
   local hook="$1"
-  local lock_file
+  local lock_file lock_fd status
   lock_file=$(_vg_cb_lock_file "$hook")
-  mkdir -p "$(dirname "$lock_file")" 2>/dev/null || true
-  (
-    _vg_cb_try_flock 9 "$lock_file"
+  if ! mkdir -p "$(dirname "$lock_file")" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to create circuit breaker lock directory: %s\n' "$(dirname "$lock_file")" >&2
+    return 2
+  fi
+  if ! exec {lock_fd}>"$lock_file"; then
+    printf 'VIBEGUARD ERROR: failed to open circuit breaker lock file: %s\n' "$lock_file" >&2
+    return 2
+  fi
+  if (
+    _vg_cb_try_flock "$lock_fd" "$lock_file" || exit 2
     trap '_vg_cb_release_flock' EXIT
-    _vg_cb_load "$hook"
+    _vg_cb_load "$hook" || exit 2
     CB_BLOCKS=$(( CB_BLOCKS + 1 ))
     CB_LAST_BLOCK=$(_vg_cb_now)
 
@@ -256,8 +314,14 @@ vg_cb_record_block() {
       _vg_cb_log "$hook" "circuit-breaker" "warn" \
         "CB tripped OPEN: ${CB_BLOCKS} consecutive blocks, cooldown ${CB_COOLDOWN}s" ""
     fi
-    _vg_cb_save "$hook"
-  ) 9>"$lock_file"
+    _vg_cb_save "$hook" || exit 2
+  ); then
+    status=0
+  else
+    status=$?
+  fi
+  exec {lock_fd}>&-
+  return "$status"
 }
 
 # vg_cb_record_pass <hook>
@@ -265,20 +329,33 @@ vg_cb_record_block() {
 # Protected by an exclusive flock to prevent lost-update races under concurrent access.
 vg_cb_record_pass() {
   local hook="$1"
-  local lock_file
+  local lock_file lock_fd status
   lock_file=$(_vg_cb_lock_file "$hook")
-  mkdir -p "$(dirname "$lock_file")" 2>/dev/null || true
-  (
-    _vg_cb_try_flock 9 "$lock_file"
+  if ! mkdir -p "$(dirname "$lock_file")" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to create circuit breaker lock directory: %s\n' "$(dirname "$lock_file")" >&2
+    return 2
+  fi
+  if ! exec {lock_fd}>"$lock_file"; then
+    printf 'VIBEGUARD ERROR: failed to open circuit breaker lock file: %s\n' "$lock_file" >&2
+    return 2
+  fi
+  if (
+    _vg_cb_try_flock "$lock_fd" "$lock_file" || exit 2
     trap '_vg_cb_release_flock' EXIT
-    _vg_cb_load "$hook"
+    _vg_cb_load "$hook" || exit 2
     if [[ "$CB_STATE" != "CLOSED" ]] || [[ "$CB_BLOCKS" -gt 0 ]]; then
       CB_STATE="CLOSED"
       CB_BLOCKS=0
       CB_LAST_BLOCK=0
-      _vg_cb_save "$hook"
+      _vg_cb_save "$hook" || exit 2
     fi
-  ) 9>"$lock_file"
+  ); then
+    status=0
+  else
+    status=$?
+  fi
+  exec {lock_fd}>&-
+  return "$status"
 }
 
 # ── CI guard ─────────────────────────────────────────────────────────────────

--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -16,7 +16,10 @@ source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer
 
 _pass_and_exit() {
-  vg_cb_record_pass "pre-write-guard"
+  if ! vg_cb_record_pass "pre-write-guard"; then
+    vg_log "pre-write-guard" "Write" "block" "Circuit breaker state error; fail-closed" ""
+    vg_json_output_kv decision block reason "VIBEGUARD interception: pre-write circuit breaker state could not be updated; fail-closed instead of silently continuing."
+  fi
   exit 0
 }
 
@@ -188,9 +191,20 @@ EOF
 
   vg_log "pre-write-guard" "Write" "warn" "New source file attempt" "$FILE_PATH"
 
+  CB_STATUS=0
   if vg_cb_check "pre-write-guard"; then
+    CB_STATUS=0
+  else
+    CB_STATUS=$?
+  fi
+
+  if [[ "$CB_STATUS" -eq 0 ]]; then
     vg_log "pre-write-guard" "Write" "warn" "New source file reminder" "$FILE_PATH"
-    vg_cb_record_block "pre-write-guard"
+    if ! vg_cb_record_block "pre-write-guard"; then
+      vg_log "pre-write-guard" "Write" "block" "Circuit breaker state error; fail-closed" "$FILE_PATH"
+      vg_json_output_kv decision block reason "VIBEGUARD interception: pre-write circuit breaker state could not be persisted; fail-closed instead of silently continuing."
+      exit 0
+    fi
     VG_U16_FILE="${FILE_PATH##*/}" \
     VG_U16_LINES="$_U16_SOURCE_NEW_LINES" \
     VG_U16_WARN="$_U16_SOURCE_NEW_WARN" \
@@ -224,6 +238,11 @@ print(json.dumps({
     }
 }, ensure_ascii=False))
 PY
+  elif [[ "$CB_STATUS" -eq 1 ]]; then
+    : # Circuit OPEN: silent pass (vg_cb_check already logged the auto-pass).
+  else
+    vg_log "pre-write-guard" "Write" "block" "Circuit breaker state error; fail-closed" "$FILE_PATH"
+    vg_json_output_kv decision block reason "VIBEGUARD interception: pre-write circuit breaker state could not be read; fail-closed instead of silently auto-passing."
+    exit 0
   fi
-  # Circuit OPEN: silent pass (vg_cb_check already logged the auto-pass).
 fi

--- a/tests/hooks/test_log_injection.sh
+++ b/tests/hooks/test_log_injection.sh
@@ -140,6 +140,29 @@ assert_contains "$mode_result" "dir=700" "Existing log directory permissions are
 assert_contains "$mode_result" "primary=600" "Existing primary log permissions are tightened"
 assert_contains "$mode_result" "global=600" "Existing global log permissions are tightened"
 
+header "log.sh — lock contention"
+
+lock_test_dir="$(mktemp -d)"
+lock_test_file="${lock_test_dir}/events.jsonl"
+lock_test_stderr="${lock_test_dir}/stderr"
+: > "$lock_test_file"
+mkdir "${lock_test_file}.lock.d"
+
+set +e
+lock_result=$(
+  export VIBEGUARD_LOG_LOCK_ATTEMPTS=1
+  export VIBEGUARD_LOG_LOCK_SLEEP_SECONDS=0
+  source hooks/_lib/log_write.sh
+  vg_append_log_line "$lock_test_file" '{"locked":true}' 2>"$lock_test_stderr"
+  printf 'rc=%s' "$?"
+)
+set -e
+
+assert_contains "$lock_result" "rc=1" "Log append lock contention returns nonzero"
+assert_contains "$(cat "$lock_test_stderr")" "failed to acquire log lock" "Log append lock contention reports diagnostic"
+assert_not_contains "$(cat "$lock_test_file")" '{"locked":true}' "Log append lock contention does not write unlocked"
+rm -rf "$lock_test_dir"
+
 # =========================================================
 
 hook_test_finish

--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -132,6 +132,41 @@ assert_not_contains "$result" "VIBEGUARD" "CB OPEN: write #4 also silent"
 rm -rf "$cb_state_dir"
 unset VG_CB_THRESHOLD VG_CB_COOLDOWN cb_state_dir
 
+header "pre-write-guard.sh — circuit breaker errors fail closed"
+
+cb_state_dir=$(mktemp -d)
+export VIBEGUARD_LOG_DIR="$cb_state_dir"
+export VIBEGUARD_SESSION_ID="prewrite-cb-error"
+export VG_CB_LOCK_TIMEOUT_SECONDS=0
+lock_file=$(bash -c 'source hooks/log.sh; source hooks/circuit-breaker.sh; _vg_cb_lock_file "pre-write-guard"')
+mkdir -p "$(dirname "$lock_file")"
+
+if command -v flock >/dev/null 2>&1; then
+  ready_file="${cb_state_dir}/lock-ready"
+  (
+    exec 8>"$lock_file"
+    flock -x 8
+    : > "$ready_file"
+    sleep 1
+  ) &
+  lock_holder=$!
+  while [[ ! -f "$ready_file" ]]; do sleep 0.01; done
+  result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_error.go"}}' | bash hooks/pre-write-guard.sh 2>&1)
+  wait "$lock_holder" 2>/dev/null || true
+  unset lock_holder ready_file
+else
+  mkdir "${lock_file}.d"
+  result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_error.go"}}' | bash hooks/pre-write-guard.sh 2>&1)
+  rmdir "${lock_file}.d"
+fi
+
+assert_contains "$result" '"decision": "block"' "CB lock error blocks instead of silently passing"
+assert_contains "$result" "circuit breaker state" "CB lock error explains state failure"
+
+rm -rf "$cb_state_dir"
+export VIBEGUARD_LOG_DIR="$prev_log_dir"
+unset VIBEGUARD_SESSION_ID VG_CB_LOCK_TIMEOUT_SECONDS cb_state_dir lock_file
+
 # Escalation must count source-new attempts even when the circuit breaker is
 # OPEN and individual reminder advisories are being silenced.
 header "pre-write-guard.sh — escalation counts circuit-breaker auto-pass attempts"

--- a/tests/hooks/test_runtime_config.sh
+++ b/tests/hooks/test_runtime_config.sh
@@ -183,6 +183,35 @@ assert_contains "$paralysis_drain_out" '"code":0' "analysis-paralysis warning pa
 assert_contains "$paralysis_drain_out" '"stdinError":""' "analysis-paralysis drains large stdin before warning"
 assert_contains "$paralysis_drain_out" "ANALYSIS PARALYSIS" "analysis-paralysis still emits warning after draining large stdin"
 
+paralysis_cb_error_log="$(make_log_dir)"
+seed_research_events "$paralysis_cb_error_log" "cfg-paralysis-cb-error" 2
+lock_file=$(VIBEGUARD_LOG_DIR="$paralysis_cb_error_log" VIBEGUARD_SESSION_ID="cfg-paralysis-cb-error" bash -c 'source hooks/log.sh; source hooks/circuit-breaker.sh; _vg_cb_lock_file "analysis-paralysis-guard"')
+mkdir -p "$(dirname "$lock_file")"
+if command -v flock >/dev/null 2>&1; then
+  ready_file="${paralysis_cb_error_log}/lock-ready"
+  (
+    exec 8>"$lock_file"
+    flock -x 8
+    : > "$ready_file"
+    sleep 1
+  ) &
+  lock_holder=$!
+  while [[ ! -f "$ready_file" ]]; do sleep 0.01; done
+  result=$(env CI=false GITHUB_ACTIONS=false TRAVIS=false CIRCLECI=false JENKINS_URL= GITLAB_CI=false TF_BUILD=false \
+    VIBEGUARD_LOG_DIR="$paralysis_cb_error_log" VIBEGUARD_SESSION_ID="cfg-paralysis-cb-error" VIBEGUARD_CONFIG_FILE="$cfg" \
+    VG_CB_LOCK_TIMEOUT_SECONDS=0 bash hooks/analysis-paralysis-guard.sh 2>&1)
+  wait "$lock_holder" 2>/dev/null || true
+  unset lock_holder ready_file
+else
+  mkdir "${lock_file}.d"
+  result=$(env CI=false GITHUB_ACTIONS=false TRAVIS=false CIRCLECI=false JENKINS_URL= GITLAB_CI=false TF_BUILD=false \
+    VIBEGUARD_LOG_DIR="$paralysis_cb_error_log" VIBEGUARD_SESSION_ID="cfg-paralysis-cb-error" VIBEGUARD_CONFIG_FILE="$cfg" \
+    VG_CB_LOCK_TIMEOUT_SECONDS=0 bash hooks/analysis-paralysis-guard.sh 2>&1)
+  rmdir "${lock_file}.d"
+fi
+assert_contains "$result" "VIBEGUARD circuit breaker state error" "analysis-paralysis CB lock error is visible"
+unset lock_file
+
 header "runtime config — U-16"
 big_write_input="$WORK_DIR/big-write.json"
 python3 - "$WORK_DIR/big.py" > "$big_write_input" <<'PY'

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -366,6 +366,151 @@ else
 fi
 teardown
 
+# ── 12. Failure states are distinct from circuit auto-pass ───────────────────
+printf '\n--- Lock and persistence failures ---\n'
+
+setup
+AUTO_PASS_STATUS_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VG_CB_THRESHOLD=1
+  export VG_CB_COOLDOWN=9999
+  source '${CB_SCRIPT}'
+  vg_cb_record_block 'status-hook'
+  vg_cb_check 'status-hook'
+  printf 'rc=%s\n' \"\$?\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$AUTO_PASS_STATUS_TEST" | grep -q "rc=1"; then
+  green "OPEN circuit returns exact status 1 for auto-pass"; PASS=$((PASS+1))
+else
+  red "OPEN circuit status: expected rc=1, got: $AUTO_PASS_STATUS_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+setup
+if command -v flock >/dev/null 2>&1; then
+  LOCK_FAILURE_TEST=$(bash -c "
+    export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+    export VIBEGUARD_SESSION_ID='testsession01'
+    export VG_CB_LOCK_TIMEOUT_SECONDS=0
+    source '${CB_SCRIPT}'
+    lock_file=\$(_vg_cb_lock_file 'lock-hook')
+    mkdir -p \"\$(dirname \"\$lock_file\")\"
+    ready='${CB_TMPDIR}/lock-ready'
+    (
+      exec 8>\"\$lock_file\"
+      flock -x 8
+      : > \"\$ready\"
+      sleep 1
+    ) &
+    holder=\$!
+    while [[ ! -f \"\$ready\" ]]; do sleep 0.01; done
+    vg_cb_check 'lock-hook'
+    rc=\$?
+    wait \"\$holder\" 2>/dev/null || true
+    printf 'rc=%s\n' \"\$rc\"
+  " 2>&1 || true)
+else
+  LOCK_FAILURE_TEST=$(bash -c "
+    export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+    export VIBEGUARD_SESSION_ID='testsession01'
+    export VG_CB_LOCK_TIMEOUT_SECONDS=0
+    source '${CB_SCRIPT}'
+    lock_file=\$(_vg_cb_lock_file 'lock-hook')
+    mkdir -p \"\$(dirname \"\$lock_file\")\"
+    mkdir \"\${lock_file}.d\"
+    vg_cb_check 'lock-hook'
+    rc=\$?
+    rmdir \"\${lock_file}.d\"
+    printf 'rc=%s\n' \"\$rc\"
+  " 2>&1 || true)
+fi
+TOTAL=$((TOTAL+1))
+if echo "$LOCK_FAILURE_TEST" | grep -q "rc=2" \
+    && echo "$LOCK_FAILURE_TEST" | grep -q "circuit breaker lock timeout"; then
+  green "Lock contention returns status 2 with diagnostic"; PASS=$((PASS+1))
+else
+  red "Lock contention: expected rc=2 with diagnostic, got: $LOCK_FAILURE_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+setup
+LOCK_OPEN_FAILURE_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  source '${CB_SCRIPT}'
+  lock_file=\$(_vg_cb_lock_file 'lock-open-hook')
+  mkdir -p \"\$(dirname \"\$lock_file\")\"
+  mkdir \"\$lock_file\"
+  vg_cb_check 'lock-open-hook'
+  rc=\$?
+  rmdir \"\$lock_file\"
+  printf 'rc=%s\n' \"\$rc\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$LOCK_OPEN_FAILURE_TEST" | grep -q "rc=2" \
+    && echo "$LOCK_OPEN_FAILURE_TEST" | grep -q "failed to open circuit breaker lock file"; then
+  green "Lock file open failure returns status 2 with diagnostic"; PASS=$((PASS+1))
+else
+  red "Lock file open failure: expected rc=2 with diagnostic, got: $LOCK_OPEN_FAILURE_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+setup
+STATE_READ_FAILURE_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  source '${CB_SCRIPT}'
+  state_file=\$(_vg_cb_state_file 'state-read-hook')
+  mkdir -p \"\$(dirname \"\$state_file\")\"
+  printf 'CB_STATE=OPEN\nCB_BLOCKS=3\nCB_LAST_BLOCK=%s\nCB_SESSION=testsession01\n' \"\$(date +%s)\" > \"\$state_file\"
+  chmod 000 \"\$state_file\"
+  vg_cb_check 'state-read-hook'
+  rc=\$?
+  chmod 600 \"\$state_file\"
+  printf 'rc=%s\n' \"\$rc\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$STATE_READ_FAILURE_TEST" | grep -q "rc=2" \
+    && echo "$STATE_READ_FAILURE_TEST" | grep -q "failed to read circuit breaker state"; then
+  green "State read failure returns status 2 with diagnostic"; PASS=$((PASS+1))
+else
+  red "State read failure: expected rc=2 with diagnostic, got: $STATE_READ_FAILURE_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+setup
+SAVE_FAILURE_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  fake_bin='${CB_TMPDIR}/fake-bin'
+  mkdir -p \"\$fake_bin\"
+  printf '#!/usr/bin/env bash\nexit 0\n' > \"\$fake_bin/flock\"
+  chmod +x \"\$fake_bin/flock\"
+  PATH=\"\$fake_bin:\$PATH\"
+  source '${CB_SCRIPT}'
+  state_file=\$(_vg_cb_state_file 'save-hook')
+  lock_file=\$(_vg_cb_lock_file 'save-hook')
+  state_dir=\$(dirname \"\$state_file\")
+  mkdir -p \"\$state_dir\"
+  : > \"\$lock_file\"
+  chmod 600 \"\$lock_file\"
+  chmod 500 \"\$state_dir\"
+  vg_cb_record_block 'save-hook'
+  rc=\$?
+  chmod 700 \"\$state_dir\"
+  printf 'rc=%s\n' \"\$rc\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$SAVE_FAILURE_TEST" | grep -q "rc=2" \
+    && echo "$SAVE_FAILURE_TEST" | grep -q "failed to write circuit breaker state temp file"; then
+  green "Persistence failure returns status 2 with diagnostic"; PASS=$((PASS+1))
+else
+  red "Persistence failure: expected rc=2 with diagnostic, got: $SAVE_FAILURE_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Partially addresses #354 by hardening the hook locking/state hot paths that could silently continue under contention or persistence errors.

- Make JSONL append fail with a diagnostic instead of writing without its mkdir lock.
- Make circuit breaker lock acquisition, lock file open, state read, and state persistence failures return `2` instead of being treated as normal run or OPEN auto-pass.
- Update `pre-write-guard` and `analysis-paralysis-guard` to distinguish `0=run`, `1=auto-pass`, and `2+=state error` so state failures are fail-closed or fail-visible.
- Add regression coverage for lock contention, lock file open failures, unreadable state files, persistence failures, and hook call-site behavior.

## Review

- Independent review found two blocking status-semantics gaps; both were reproduced and fixed.
- Re-review found no blocking findings.
- `shellcheck` is unavailable locally.

## Verification

- `bash -n hooks/_lib/log_write.sh && bash -n hooks/circuit-breaker.sh && bash -n hooks/pre-write-guard.sh && bash -n hooks/analysis-paralysis-guard.sh && bash -n tests/unit/test_circuit_breaker.sh && bash -n tests/hooks/test_log_injection.sh && bash -n tests/hooks/test_pre_write_guard.sh && bash -n tests/hooks/test_runtime_config.sh`
- `bash tests/unit/test_circuit_breaker.sh` -> 28/28
- `bash tests/hooks/test_log_injection.sh` -> 34/34
- `bash tests/hooks/test_pre_write_guard.sh` -> 45/45
- `bash tests/hooks/test_runtime_config.sh` -> 20/20
- `git diff --check`
- `bash tests/test_hooks.sh` -> all hook shards passed
- `bash scripts/ci/self-application/check-u29-no-silent-degrade.sh`
- `bash scripts/ci/validate-hook-perf.sh`
- `bash tests/test_codex_runtime.sh` -> 86/86
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml` -> 121 tests
- `bash tests/test_setup.sh` -> 279/279
