### PR TITLE
fix: route log appends through runtime lock

### DIFF
--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -4,12 +4,38 @@
 vg_append_log_line() {
   local file="$1"
   local line="$2"
+  local status=0
+  local runtime_stderr=""
+
+  if [[ -n "${_VIBEGUARD_RUNTIME:-}" && -x "$_VIBEGUARD_RUNTIME" ]]; then
+    if runtime_stderr=$("$_VIBEGUARD_RUNTIME" append-jsonl "$file" <<<"$line" 2>&1); then
+      return 0
+    else
+      status=$?
+    fi
+
+    if [[ "$runtime_stderr" == *"Unknown command: append-jsonl"* ]]; then
+      _vg_append_log_line_shell "$file" "$line"
+      return $?
+    fi
+
+    [[ -z "$runtime_stderr" ]] || printf '%s\n' "$runtime_stderr" >&2
+    printf 'VIBEGUARD ERROR: runtime JSONL append failed for %s\n' "$file" >&2
+    return "$status"
+  fi
+
+  _vg_append_log_line_shell "$file" "$line"
+}
+
+_vg_append_log_line_shell() {
+  local file="$1"
+  local line="$2"
+  local status=0
   local lock_dir="${file}.lock.d"
   local acquired="false"
   local attempts=0
   local max_attempts="${VIBEGUARD_LOG_LOCK_ATTEMPTS:-100}"
   local sleep_seconds="${VIBEGUARD_LOG_LOCK_SLEEP_SECONDS:-0.01}"
-  local status=0
 
   [[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=100
   [[ "$max_attempts" -gt 0 ]] || max_attempts=1

--- a/tests/hooks/test_log_injection.sh
+++ b/tests/hooks/test_log_injection.sh
@@ -163,6 +163,83 @@ assert_contains "$(cat "$lock_test_stderr")" "failed to acquire log lock" "Log a
 assert_not_contains "$(cat "$lock_test_file")" '{"locked":true}' "Log append lock contention does not write unlocked"
 rm -rf "$lock_test_dir"
 
+header "log.sh — runtime append lock contention"
+
+runtime_lock_test_dir="$(mktemp -d)"
+runtime_lock_test_file="${runtime_lock_test_dir}/events.jsonl"
+runtime_lock_test_stderr="${runtime_lock_test_dir}/stderr"
+: > "$runtime_lock_test_file"
+mkdir "${runtime_lock_test_file}.lock.d"
+
+set +e
+runtime_lock_result=$(
+  export VIBEGUARD_LOG_LOCK_ATTEMPTS=1
+  export VIBEGUARD_LOG_LOCK_SLEEP_SECONDS=0
+  export HOME="${runtime_lock_test_dir}/home"
+  export VIBEGUARD_LOG_DIR="${runtime_lock_test_dir}/logs"
+  export VIBEGUARD_SESSION_ID="runtime-lock-test"
+  source hooks/log.sh
+  vg_append_log_line "$runtime_lock_test_file" '{"runtime_locked":true}' 2>"$runtime_lock_test_stderr"
+  printf 'rc=%s' "$?"
+)
+set -e
+
+assert_contains "$runtime_lock_result" "rc=1" "Runtime log append lock contention returns nonzero"
+assert_contains "$(cat "$runtime_lock_test_stderr")" "timed out waiting for JSONL append lock" "Runtime log append lock contention reports runtime diagnostic"
+assert_contains "$(cat "$runtime_lock_test_stderr")" "runtime JSONL append failed" "Runtime log append lock contention reports hook diagnostic"
+assert_not_contains "$(cat "$runtime_lock_test_file")" '{"runtime_locked":true}' "Runtime log append lock contention does not write unlocked"
+
+runtime_errexit_stderr="${runtime_lock_test_dir}/errexit-stderr"
+set +e
+runtime_errexit_stdout=$(
+  VIBEGUARD_LOG_LOCK_ATTEMPTS=1 \
+  VIBEGUARD_LOG_LOCK_SLEEP_SECONDS=0 \
+  HOME="${runtime_lock_test_dir}/home-errexit" \
+  VIBEGUARD_LOG_DIR="${runtime_lock_test_dir}/logs-errexit" \
+  VIBEGUARD_SESSION_ID="runtime-lock-errexit-test" \
+  bash -c '
+    set -e
+    source hooks/log.sh
+    vg_append_log_line "$1" "$2"
+    printf "after-runtime-append"
+  ' bash "$runtime_lock_test_file" '{"errexit_locked":true}' 2>"$runtime_errexit_stderr"
+)
+runtime_errexit_rc=$?
+set -e
+
+assert_contains "rc=$runtime_errexit_rc" "rc=1" "Runtime append lock failure exits direct set -e caller"
+assert_not_contains "$runtime_errexit_stdout" "after-runtime-append" "Runtime append lock failure stops direct set -e caller"
+assert_contains "$(cat "$runtime_errexit_stderr")" "runtime JSONL append failed" "Runtime append lock failure reports hook diagnostic before set -e exit"
+assert_not_contains "$(cat "$runtime_lock_test_file")" '{"errexit_locked":true}' "Runtime append set -e failure does not write unlocked"
+rm -rf "$runtime_lock_test_dir"
+
+header "log.sh — stale runtime fallback"
+
+stale_runtime_test_dir="$(mktemp -d)"
+stale_runtime_file="${stale_runtime_test_dir}/events.jsonl"
+stale_runtime_stderr="${stale_runtime_test_dir}/stderr"
+stale_runtime_bin="${stale_runtime_test_dir}/vibeguard-runtime"
+cat > "$stale_runtime_bin" <<'SH'
+#!/usr/bin/env bash
+printf 'Unknown command: %s\n' "$1" >&2
+exit 2
+SH
+chmod +x "$stale_runtime_bin"
+
+set +e
+stale_runtime_result=$(
+  _VIBEGUARD_RUNTIME="$stale_runtime_bin"
+  source hooks/_lib/log_write.sh
+  vg_append_log_line "$stale_runtime_file" '{"stale_runtime":true}' 2>"$stale_runtime_stderr"
+  printf 'rc=%s' "$?"
+)
+set -e
+
+assert_contains "$stale_runtime_result" "rc=0" "Stale runtime without append-jsonl falls back to shell append"
+assert_contains "$(cat "$stale_runtime_file")" '{"stale_runtime":true}' "Stale runtime fallback still writes the log line"
+assert_not_contains "$(cat "$stale_runtime_stderr")" "runtime JSONL append failed" "Stale runtime fallback does not report runtime append failure"
+rm -rf "$stale_runtime_test_dir"
+
 # =========================================================
 
 hook_test_finish

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -3,8 +3,9 @@ use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
 
@@ -343,14 +344,19 @@ pub(crate) fn append_jsonl(path: &Path, line: &str) -> io::Result<()> {
     }
     let existed = path.exists();
     let _lock = JsonlAppendLock::acquire(path)?;
-    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    if existed {
+        set_owner_only(path);
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options.open(path)?;
     let mut entry = String::with_capacity(line.len() + 1);
     entry.push_str(line);
     entry.push('\n');
     file.write_all(entry.as_bytes())?;
-    if !existed {
-        set_owner_only(path);
-    }
+    set_owner_only(path);
     Ok(())
 }
 
@@ -363,14 +369,18 @@ impl JsonlAppendLock {
         let mut lock_dir = path.as_os_str().to_os_string();
         lock_dir.push(".lock.d");
         let lock_dir = PathBuf::from(lock_dir);
+        let max_attempts = jsonl_lock_attempts();
+        let sleep_duration = jsonl_lock_sleep_duration();
 
-        for _ in 0..100 {
+        for attempt in 0..max_attempts {
             match fs::create_dir(&lock_dir) {
                 Ok(()) => {
                     return Ok(Self { lock_dir });
                 }
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    if attempt + 1 < max_attempts && !sleep_duration.is_zero() {
+                        std::thread::sleep(sleep_duration);
+                    }
                 }
                 Err(err) => return Err(err),
             }
@@ -379,11 +389,28 @@ impl JsonlAppendLock {
         Err(io::Error::new(
             io::ErrorKind::TimedOut,
             format!(
-                "timed out waiting for JSONL append lock: {}",
+                "timed out waiting for JSONL append lock after {max_attempts} attempts: {}",
                 lock_dir.display()
             ),
         ))
     }
+}
+
+fn jsonl_lock_attempts() -> usize {
+    env::var("VIBEGUARD_LOG_LOCK_ATTEMPTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|value| value.max(1))
+        .unwrap_or(100)
+}
+
+fn jsonl_lock_sleep_duration() -> Duration {
+    env::var("VIBEGUARD_LOG_LOCK_SLEEP_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .map(Duration::from_secs_f64)
+        .unwrap_or_else(|| Duration::from_millis(10))
 }
 
 impl Drop for JsonlAppendLock {

--- a/vibeguard-runtime/src/log_append.rs
+++ b/vibeguard-runtime/src/log_append.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+
+use crate::hook_checks_common::{append_jsonl, read_stdin};
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+pub fn run(args: &[String]) -> Result {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime append-jsonl <log-file>".into());
+    }
+
+    let mut line = read_stdin()?;
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+
+    if line.is_empty() {
+        return Err("append-jsonl input must not be empty".into());
+    }
+    if line.contains('\n') || line.contains('\r') {
+        return Err("append-jsonl input must be exactly one JSONL line".into());
+    }
+
+    let value = serde_json::from_str::<serde_json::Value>(&line)?;
+    if !value.is_object() {
+        return Err("append-jsonl input must be a JSON object".into());
+    }
+    append_jsonl(Path::new(&args[0]), &line)?;
+    Ok(())
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -9,6 +9,7 @@ mod hook_checks_history;
 mod hook_checks_scan;
 mod hook_status;
 mod json_field;
+mod log_append;
 mod log_query;
 mod pkg_rewrite;
 mod session_metrics;
@@ -60,6 +61,11 @@ static COMMANDS: &[Command] = &[
         name: "paralysis-count",
         usage: "<session>  — count consecutive read-only tool calls",
         handler: log_query::paralysis_count,
+    },
+    Command {
+        name: "append-jsonl",
+        usage: "<log-file>  — append one stdin JSONL line with runtime locking",
+        handler: log_append::run,
     },
     Command {
         name: "pkg-rewrite",

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -1,8 +1,28 @@
+use std::fs;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 fn bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "vibeguard-runtime-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+#[cfg(unix)]
+fn file_mode(path: &std::path::Path) -> u32 {
+    fs::metadata(path).unwrap().permissions().mode() & 0o777
 }
 
 #[test]
@@ -39,6 +59,7 @@ fn help_lists_all_commands() {
         "post-edit-history",
         "build-fails",
         "paralysis-count",
+        "append-jsonl",
         "pkg-rewrite",
         "session-metrics",
         "pre-write-check",
@@ -52,6 +73,215 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+#[test]
+fn append_jsonl_command_appends_one_line() {
+    let dir = unique_temp_dir("append-jsonl-one-line");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"ok\":true}\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "");
+    let content = fs::read_to_string(&log_file).unwrap();
+    assert_eq!(content, "{\"ok\":true}\n");
+    serde_json::from_str::<serde_json::Value>(content.trim_end()).unwrap();
+    #[cfg(unix)]
+    assert_eq!(file_mode(&log_file), 0o600);
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn append_jsonl_command_rejects_multiline_input() {
+    let dir = unique_temp_dir("append-jsonl-multiline");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"first\":true}\n{\"second\":true}")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("exactly one JSONL line"),
+        "expected single-line error in stderr: {stderr}"
+    );
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn append_jsonl_command_rejects_invalid_json() {
+    let dir = unique_temp_dir("append-jsonl-invalid-json");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"not-json").unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("vibeguard-runtime error:"),
+        "expected runtime error in stderr: {stderr}"
+    );
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn append_jsonl_command_rejects_non_object_json() {
+    let dir = unique_temp_dir("append-jsonl-non-object-json");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"null").unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("JSON object"),
+        "expected object-shape error in stderr: {stderr}"
+    );
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn append_jsonl_command_lock_timeout_does_not_write_unlocked() {
+    let dir = unique_temp_dir("append-jsonl-lock-timeout");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    fs::create_dir(format!("{}.lock.d", log_file.display())).unwrap();
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .env("VIBEGUARD_LOG_LOCK_ATTEMPTS", "1")
+        .env("VIBEGUARD_LOG_LOCK_SLEEP_SECONDS", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"locked\":true}")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("timed out waiting for JSONL append lock"),
+        "expected lock timeout in stderr: {stderr}"
+    );
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn append_jsonl_command_zero_lock_attempts_acts_as_one_attempt() {
+    let dir = unique_temp_dir("append-jsonl-zero-lock-attempts");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    fs::create_dir(format!("{}.lock.d", log_file.display())).unwrap();
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .env("VIBEGUARD_LOG_LOCK_ATTEMPTS", "0")
+        .env("VIBEGUARD_LOG_LOCK_SLEEP_SECONDS", "0.05")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"locked\":true}")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("after 1 attempts"),
+        "zero lock attempts should coerce to one attempt: {stderr}"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn append_jsonl_command_tightens_existing_file_permissions() {
+    let dir = unique_temp_dir("append-jsonl-permissions");
+    fs::create_dir_all(&dir).unwrap();
+    let log_file = dir.join("events.jsonl");
+    fs::write(&log_file, "{\"old\":true}\n").unwrap();
+    fs::set_permissions(&log_file, fs::Permissions::from_mode(0o644)).unwrap();
+
+    let mut child = bin()
+        .args(["append-jsonl", log_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"new\":true}")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(file_mode(&log_file), 0o600);
+    let content = fs::read_to_string(&log_file).unwrap();
+    assert!(content.contains("{\"old\":true}\n{\"new\":true}\n"));
+    let _ = fs::remove_dir_all(dir);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Partially addresses #354.

- add a Rust `append-jsonl` runtime command backed by the existing locked JSONL writer
- route `vg_append_log_line` through the runtime when supported, with a stale-runtime fallback only for unsupported `append-jsonl`
- harden runtime JSONL append semantics: single object line, explicit lock timeout, `0` attempts coerced to one attempt, and log file mode `0600`
- add regression coverage for runtime lock contention, set -e failure visibility, stale runtime fallback, JSON shape validation, and file permissions

## Verification

- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo build --release --manifest-path vibeguard-runtime/Cargo.toml --quiet && bash tests/hooks/test_log_injection.sh`
- `bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash tests/test_gc_logs_concurrent.sh`
- `bash scripts/ci/self-application/check-u29-no-silent-degrade.sh && bash scripts/ci/validate-hook-perf.sh`
- `bash tests/bench_hook_latency.sh`
- independent threads review: initial findings fixed; re-review found no blocking findings
