### PR TITLE
fix: move circuit breaker transitions to runtime

### DIFF
--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -134,6 +134,77 @@ _vg_cb_release_flock() {
   fi
 }
 
+_vg_cb_runtime_available() {
+  [[ -n "${_VIBEGUARD_RUNTIME:-}" && -x "$_VIBEGUARD_RUNTIME" ]]
+}
+
+_vg_cb_runtime_call() {
+  local action="$1"
+  local hook="$2"
+  local state_file lock_file output err_file err_output status token reason
+  state_file=$(_vg_cb_state_file "$hook")
+  lock_file=$(_vg_cb_lock_file "$hook")
+
+  if ! err_file=$(mktemp "${TMPDIR:-/tmp}/vibeguard-cb-runtime.XXXXXX"); then
+    printf 'VIBEGUARD ERROR: failed to create circuit breaker runtime stderr capture\n' >&2
+    return 2
+  fi
+
+  if output=$("$_VIBEGUARD_RUNTIME" circuit-breaker "$action" "$hook" "$state_file" "$lock_file" "$CB_THRESHOLD" "$CB_COOLDOWN" "$CB_LOCK_TIMEOUT_SECONDS" 2>"$err_file"); then
+    status=0
+  else
+    status=$?
+  fi
+  if ! err_output=$(cat "$err_file"); then
+    printf 'VIBEGUARD ERROR: failed to read circuit breaker runtime stderr: %s\n' "$err_file" >&2
+    rm -f "$err_file" || printf 'VIBEGUARD ERROR: failed to remove circuit breaker runtime stderr capture: %s\n' "$err_file" >&2
+    return 2
+  fi
+  if ! rm -f "$err_file"; then
+    printf 'VIBEGUARD ERROR: failed to remove circuit breaker runtime stderr capture: %s\n' "$err_file" >&2
+    return 2
+  fi
+
+  if [[ "$status" -ne 0 ]]; then
+    if [[ "$err_output" == *"Unknown command: circuit-breaker"* || "$output" == *"Unknown command: circuit-breaker"* ]]; then
+      return 127
+    fi
+    [[ -z "$err_output" ]] || printf '%s\n' "$err_output" >&2
+    [[ -z "$output" ]] || printf '%s\n' "$output" >&2
+    return 2
+  fi
+
+  if [[ -n "$err_output" ]]; then
+    printf '%s\n' "$err_output" >&2
+    return 2
+  fi
+
+  token="${output%%$'\n'*}"
+  reason="${output#*$'\n'}"
+  [[ "$reason" == "$output" ]] && reason=""
+
+  case "$action:$token" in
+    check:RUN)
+      return 0
+      ;;
+    check:AUTO_PASS)
+      [[ -z "$reason" ]] || _vg_cb_log "$hook" "circuit-breaker" "pass" "$reason" ""
+      return 1
+      ;;
+    record-block:RECORDED|record-pass:RECORDED)
+      return 0
+      ;;
+    record-block:OPENED)
+      [[ -z "$reason" ]] || _vg_cb_log "$hook" "circuit-breaker" "warn" "$reason" ""
+      return 0
+      ;;
+    *)
+      printf 'VIBEGUARD ERROR: unexpected circuit breaker runtime output for %s/%s: %s\n' "$action" "$hook" "$output" >&2
+      return 2
+      ;;
+  esac
+}
+
 # Load state for <hook> into CB_STATE / CB_BLOCKS / CB_LAST_BLOCK / CB_SESSION
 _vg_cb_load() {
   local hook="$1"
@@ -230,6 +301,22 @@ _vg_cb_save() {
 # concurrent hook invocations from racing on the state file.
 vg_cb_check() {
   local hook="$1"
+  local status
+  if _vg_cb_runtime_available; then
+    if _vg_cb_runtime_call "check" "$hook"; then
+      return 0
+    else
+      status=$?
+      if [[ "$status" -ne 127 ]]; then
+        return "$status"
+      fi
+    fi
+  fi
+  _vg_cb_check_shell "$hook"
+}
+
+_vg_cb_check_shell() {
+  local hook="$1"
   local lock_file lock_fd status
   lock_file=$(_vg_cb_lock_file "$hook")
   if ! mkdir -p "$(dirname "$lock_file")" 2>/dev/null; then
@@ -292,6 +379,22 @@ vg_cb_check() {
 # Protected by an exclusive flock to prevent lost-update races under concurrent access.
 vg_cb_record_block() {
   local hook="$1"
+  local status
+  if _vg_cb_runtime_available; then
+    if _vg_cb_runtime_call "record-block" "$hook"; then
+      return 0
+    else
+      status=$?
+      if [[ "$status" -ne 127 ]]; then
+        return "$status"
+      fi
+    fi
+  fi
+  _vg_cb_record_block_shell "$hook"
+}
+
+_vg_cb_record_block_shell() {
+  local hook="$1"
   local lock_file lock_fd status
   lock_file=$(_vg_cb_lock_file "$hook")
   if ! mkdir -p "$(dirname "$lock_file")" 2>/dev/null; then
@@ -328,6 +431,22 @@ vg_cb_record_block() {
 # Records a successful (non-blocking) result. Resets circuit to CLOSED.
 # Protected by an exclusive flock to prevent lost-update races under concurrent access.
 vg_cb_record_pass() {
+  local hook="$1"
+  local status
+  if _vg_cb_runtime_available; then
+    if _vg_cb_runtime_call "record-pass" "$hook"; then
+      return 0
+    else
+      status=$?
+      if [[ "$status" -ne 127 ]]; then
+        return "$status"
+      fi
+    fi
+  fi
+  _vg_cb_record_pass_shell "$hook"
+}
+
+_vg_cb_record_pass_shell() {
   local hook="$1"
   local lock_file lock_fd status
   lock_file=$(_vg_cb_lock_file "$hook")

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -511,6 +511,69 @@ else
 fi
 teardown
 
+setup
+STALE_RUNTIME_FALLBACK_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  fake_runtime='${CB_TMPDIR}/stale-runtime'
+  printf '#!/usr/bin/env bash\nprintf \"Unknown command: %%s\\\\n\" \"\$1\" >&2\nexit 2\n' > \"\$fake_runtime\"
+  chmod +x \"\$fake_runtime\"
+  source '${CB_SCRIPT}'
+  _VIBEGUARD_RUNTIME=\"\$fake_runtime\"
+  vg_cb_record_block 'stale-runtime-hook'
+  vg_cb_check 'stale-runtime-hook'
+  printf 'rc=%s\n' \"\$?\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$STALE_RUNTIME_FALLBACK_TEST" | grep -q "rc=0"; then
+  green "Stale runtime without circuit-breaker command falls back to shell state machine"; PASS=$((PASS+1))
+else
+  red "Stale runtime fallback: expected rc=0, got: $STALE_RUNTIME_FALLBACK_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+setup
+RUNTIME_ERROR_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  fake_runtime='${CB_TMPDIR}/broken-runtime'
+  printf '#!/usr/bin/env bash\nprintf \"runtime exploded\\\\n\" >&2\nexit 1\n' > \"\$fake_runtime\"
+  chmod +x \"\$fake_runtime\"
+  source '${CB_SCRIPT}'
+  _VIBEGUARD_RUNTIME=\"\$fake_runtime\"
+  vg_cb_check 'broken-runtime-hook'
+  printf 'rc=%s\n' \"\$?\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$RUNTIME_ERROR_TEST" | grep -q "rc=2" \
+    && echo "$RUNTIME_ERROR_TEST" | grep -q "runtime exploded"; then
+  green "Runtime circuit-breaker errors return status 2 with diagnostic"; PASS=$((PASS+1))
+else
+  red "Runtime circuit-breaker error: expected rc=2 with diagnostic, got: $RUNTIME_ERROR_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
+setup
+RUNTIME_SUCCESS_STDERR_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  fake_runtime='${CB_TMPDIR}/noisy-runtime'
+  printf '#!/usr/bin/env bash\nprintf \"RUN\\\\n\"\nprintf \"cleanup failed\\\\n\" >&2\nexit 0\n' > \"\$fake_runtime\"
+  chmod +x \"\$fake_runtime\"
+  source '${CB_SCRIPT}'
+  _VIBEGUARD_RUNTIME=\"\$fake_runtime\"
+  vg_cb_check 'noisy-runtime-hook'
+  printf 'rc=%s\n' \"\$?\"
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$RUNTIME_SUCCESS_STDERR_TEST" | grep -q "rc=2" \
+    && echo "$RUNTIME_SUCCESS_STDERR_TEST" | grep -q "cleanup failed"; then
+  green "Runtime circuit-breaker success stderr returns status 2 with diagnostic"; PASS=$((PASS+1))
+else
+  red "Runtime circuit-breaker success stderr: expected rc=2 with diagnostic, got: $RUNTIME_SUCCESS_STDERR_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"

--- a/vibeguard-runtime/Cargo.lock
+++ b/vibeguard-runtime/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +139,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 name = "vibeguard-runtime"
 version = "1.1.2"
 dependencies = [
+ "libc",
  "regex",
  "serde_json",
 ]

--- a/vibeguard-runtime/Cargo.toml
+++ b/vibeguard-runtime/Cargo.toml
@@ -7,6 +7,7 @@ description = "VibeGuard runtime — fast JSON/JSONL ops, hook metrics, and Code
 [dependencies]
 serde_json = "1"
 regex = "1"
+libc = "0.2"
 
 [profile.release]
 opt-level = "z"

--- a/vibeguard-runtime/src/circuit_breaker.rs
+++ b/vibeguard-runtime/src/circuit_breaker.rs
@@ -1,0 +1,475 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::time_utils::now_unix_secs;
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CircuitStateName {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+impl CircuitStateName {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Closed => "CLOSED",
+            Self::Open => "OPEN",
+            Self::HalfOpen => "HALF-OPEN",
+        }
+    }
+
+    fn parse(value: &str) -> Self {
+        match value {
+            "OPEN" => Self::Open,
+            "HALF-OPEN" => Self::HalfOpen,
+            _ => Self::Closed,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CircuitState {
+    state: CircuitStateName,
+    blocks: u64,
+    last_block: u64,
+    session: String,
+}
+
+impl Default for CircuitState {
+    fn default() -> Self {
+        Self {
+            state: CircuitStateName::Closed,
+            blocks: 0,
+            last_block: 0,
+            session: String::new(),
+        }
+    }
+}
+
+pub fn run(args: &[String]) -> Result {
+    if args.len() != 7 {
+        return Err("Usage: vibeguard-runtime circuit-breaker <check|record-block|record-pass> <hook> <state-file> <lock-file> <threshold> <cooldown-seconds> <lock-timeout-seconds>".into());
+    }
+
+    let action = args[0].as_str();
+    let hook = args[1].as_str();
+    let state_file = Path::new(&args[2]);
+    let lock_file = Path::new(&args[3]);
+    let threshold = parse_u64(&args[4], "threshold")?;
+    let cooldown = parse_u64(&args[5], "cooldown-seconds")?;
+    let lock_timeout = parse_u64(&args[6], "lock-timeout-seconds")?;
+    let session = std::env::var("VIBEGUARD_SESSION_ID").unwrap_or_default();
+
+    let _lock = CircuitLock::acquire(lock_file, lock_timeout)?;
+    let mut state = load_state(state_file)?;
+    let dirty = apply_session_reset(&mut state, &session);
+
+    match action {
+        "check" => run_check(hook, state_file, &mut state, &session, cooldown, dirty),
+        "record-block" => {
+            run_record_block(hook, state_file, &mut state, &session, threshold, cooldown)
+        }
+        "record-pass" => run_record_pass(state_file, &mut state, &session, dirty),
+        _ => Err(format!("unknown circuit-breaker action: {action}").into()),
+    }
+}
+
+fn parse_u64(value: &str, name: &str) -> Result<u64> {
+    value
+        .parse::<u64>()
+        .map_err(|_| format!("invalid circuit breaker {name}: {value}").into())
+}
+
+fn run_check(
+    _hook: &str,
+    state_file: &Path,
+    state: &mut CircuitState,
+    session: &str,
+    cooldown: u64,
+    dirty: bool,
+) -> Result {
+    let now = now_unix_secs();
+
+    match state.state {
+        CircuitStateName::Closed => {
+            if dirty {
+                save_state(state_file, state, session)?;
+            }
+            println!("RUN");
+        }
+        CircuitStateName::Open => {
+            let elapsed = now.saturating_sub(state.last_block);
+            if elapsed >= cooldown {
+                state.state = CircuitStateName::HalfOpen;
+                state.last_block = now;
+                save_state(state_file, state, session)?;
+                println!("RUN");
+            } else {
+                let remaining = cooldown - elapsed;
+                println!("AUTO_PASS");
+                println!(
+                    "CB OPEN: auto-pass ({remaining}s remaining, {} consecutive blocks)",
+                    state.blocks
+                );
+            }
+        }
+        CircuitStateName::HalfOpen => {
+            println!("AUTO_PASS");
+            println!(
+                "CB HALF-OPEN: probe in-flight, auto-passing ({} prior blocks)",
+                state.blocks
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn run_record_block(
+    _hook: &str,
+    state_file: &Path,
+    state: &mut CircuitState,
+    session: &str,
+    threshold: u64,
+    cooldown: u64,
+) -> Result {
+    state.blocks = state.blocks.saturating_add(1);
+    state.last_block = now_unix_secs();
+
+    if state.state == CircuitStateName::HalfOpen || state.blocks >= threshold {
+        state.state = CircuitStateName::Open;
+        save_state(state_file, state, session)?;
+        println!("OPENED");
+        println!(
+            "CB tripped OPEN: {} consecutive blocks, cooldown {cooldown}s",
+            state.blocks
+        );
+    } else {
+        save_state(state_file, state, session)?;
+        println!("RECORDED");
+    }
+
+    Ok(())
+}
+
+fn run_record_pass(
+    state_file: &Path,
+    state: &mut CircuitState,
+    session: &str,
+    dirty: bool,
+) -> Result {
+    if state.state != CircuitStateName::Closed || state.blocks > 0 || dirty {
+        state.state = CircuitStateName::Closed;
+        state.blocks = 0;
+        state.last_block = 0;
+        save_state(state_file, state, session)?;
+    }
+    println!("RECORDED");
+    Ok(())
+}
+
+fn apply_session_reset(state: &mut CircuitState, session: &str) -> bool {
+    if !session.is_empty() && !state.session.is_empty() && state.session != session {
+        *state = CircuitState::default();
+        true
+    } else {
+        false
+    }
+}
+
+fn load_state(path: &Path) -> Result<CircuitState> {
+    if !path.exists() {
+        return Ok(CircuitState::default());
+    }
+
+    let content = fs::read_to_string(path)
+        .map_err(|_| format!("failed to read circuit breaker state: {}", path.display()))?;
+    let mut state = CircuitState::default();
+
+    for line in content.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key {
+            "CB_STATE" => state.state = CircuitStateName::parse(value),
+            "CB_BLOCKS" => {
+                if let Ok(blocks) = value.parse::<u64>() {
+                    state.blocks = blocks;
+                }
+            }
+            "CB_LAST_BLOCK" => {
+                if let Ok(last_block) = value.parse::<u64>() {
+                    state.last_block = last_block;
+                }
+            }
+            "CB_SESSION" => {
+                if value
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'=' | b'-'))
+                {
+                    state.session = value.to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(state)
+}
+
+fn save_state(path: &Path, state: &CircuitState, session: &str) -> Result {
+    let Some(parent) = path.parent() else {
+        return Err(format!(
+            "failed to create circuit breaker state directory: {}",
+            path.display()
+        )
+        .into());
+    };
+    fs::create_dir_all(parent).map_err(|_| {
+        format!(
+            "failed to create circuit breaker state directory: {}",
+            parent.display()
+        )
+    })?;
+
+    let tmp_file = path.with_extension(format!(
+        "{}.tmp.{}",
+        path.extension().and_then(|s| s.to_str()).unwrap_or("cb"),
+        std::process::id()
+    ));
+    write_state_file(&tmp_file, state, session)?;
+    fs::rename(&tmp_file, path).map_err(|_| {
+        if let Err(remove_err) = fs::remove_file(&tmp_file) {
+            if remove_err.kind() != io::ErrorKind::NotFound {
+                eprintln!(
+                    "VIBEGUARD ERROR: failed to remove circuit breaker temp file: {}",
+                    tmp_file.display()
+                );
+            }
+        }
+        format!(
+            "failed to persist circuit breaker state: {}",
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn write_state_file(path: &Path, state: &CircuitState, session: &str) -> Result {
+    let mut file = File::create(path).map_err(|_| {
+        format!(
+            "failed to write circuit breaker state temp file: {}",
+            path.display()
+        )
+    })?;
+    write!(
+        file,
+        "CB_STATE={}\nCB_BLOCKS={}\nCB_LAST_BLOCK={}\nCB_SESSION={}\n",
+        state.state.as_str(),
+        state.blocks,
+        state.last_block,
+        session
+    )
+    .map_err(|_| {
+        format!(
+            "failed to write circuit breaker state temp file: {}",
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+struct CircuitLock {
+    #[cfg(unix)]
+    file: File,
+    lock_dir: Option<PathBuf>,
+}
+
+impl CircuitLock {
+    fn acquire(lock_file: &Path, timeout_seconds: u64) -> Result<Self> {
+        if let Some(parent) = lock_file.parent() {
+            fs::create_dir_all(parent).map_err(|_| {
+                format!(
+                    "failed to create circuit breaker lock directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        #[cfg(unix)]
+        {
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(lock_file)
+                .map_err(|_| {
+                    format!(
+                        "failed to open circuit breaker lock file: {}",
+                        lock_file.display()
+                    )
+                })?;
+            acquire_unix_flock(&file, lock_file, timeout_seconds)?;
+            let lock_dir = mkdir_lock_dir(lock_file);
+            acquire_mkdir_lock(&lock_dir, lock_file, timeout_seconds)?;
+            Ok(Self {
+                file,
+                lock_dir: Some(lock_dir),
+            })
+        }
+
+        #[cfg(not(unix))]
+        {
+            let lock_dir = mkdir_lock_dir(lock_file);
+            acquire_mkdir_lock(&lock_dir, lock_file, timeout_seconds)?;
+            Ok(Self {
+                lock_dir: Some(lock_dir),
+            })
+        }
+    }
+}
+
+fn mkdir_lock_dir(lock_file: &Path) -> PathBuf {
+    let mut lock_dir = lock_file.as_os_str().to_os_string();
+    lock_dir.push(".d");
+    PathBuf::from(lock_dir)
+}
+
+#[cfg(unix)]
+fn acquire_unix_flock(file: &File, lock_file: &Path, timeout_seconds: u64) -> Result {
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    loop {
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc == 0 {
+            return Ok(());
+        }
+
+        let err = io::Error::last_os_error();
+        let would_block = matches!(err.raw_os_error(), Some(libc::EWOULDBLOCK));
+        if !would_block {
+            return Err(format!(
+                "failed to lock circuit breaker file: {}",
+                lock_file.display()
+            )
+            .into());
+        }
+        if timeout_seconds == 0 || Instant::now() >= deadline {
+            return Err(format!(
+                "circuit breaker lock timeout for {} after {}s",
+                lock_file.display(),
+                timeout_seconds
+            )
+            .into());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn acquire_mkdir_lock(lock_dir: &Path, lock_file: &Path, timeout_seconds: u64) -> Result {
+    let max_attempts = (timeout_seconds * 10).max(1);
+    for attempt in 0..max_attempts {
+        match fs::create_dir(lock_dir) {
+            Ok(()) => return Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                if attempt + 1 < max_attempts {
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+            Err(_) => {
+                return Err(format!(
+                    "failed to lock circuit breaker file: {}",
+                    lock_file.display()
+                )
+                .into());
+            }
+        }
+    }
+    Err(format!(
+        "circuit breaker lock timeout for {} after {}s",
+        lock_file.display(),
+        timeout_seconds
+    )
+    .into())
+}
+
+impl Drop for CircuitLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            let unlock_rc = libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+            if unlock_rc != 0 {
+                eprintln!("VIBEGUARD ERROR: failed to unlock circuit breaker lock");
+            }
+        }
+
+        #[cfg(not(unix))]
+        {}
+
+        if let Some(lock_dir) = &self.lock_dir {
+            if let Err(err) = fs::remove_dir(lock_dir) {
+                if err.kind() != io::ErrorKind::NotFound {
+                    eprintln!(
+                        "VIBEGUARD ERROR: failed to remove circuit breaker mkdir lock: {}",
+                        lock_dir.display()
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_state(label: &str) -> (PathBuf, PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "vibeguard-cb-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        (dir.join("hook.cb"), dir.join("hook.cb.lock"))
+    }
+
+    #[test]
+    fn mkdir_lock_dir_matches_shell_fallback_path() {
+        assert_eq!(
+            mkdir_lock_dir(Path::new("/tmp/example.cb.lock")),
+            PathBuf::from("/tmp/example.cb.lock.d")
+        );
+    }
+
+    #[test]
+    fn load_state_ignores_unsafe_values() -> Result {
+        let (state_file, _) = temp_state("unsafe-values");
+        let Some(parent) = state_file.parent() else {
+            return Err("test state file has no parent directory".into());
+        };
+        fs::create_dir_all(parent)?;
+        fs::write(
+            &state_file,
+            "CB_STATE=BOGUS\nCB_BLOCKS=abc\nCB_LAST_BLOCK=7\nCB_SESSION=bad session!\n",
+        )?;
+
+        let state = load_state(&state_file)?;
+        assert_eq!(state.state, CircuitStateName::Closed);
+        assert_eq!(state.blocks, 0);
+        assert_eq!(state.last_block, 7);
+        assert_eq!(state.session, "");
+
+        if let Err(err) = fs::remove_dir_all(parent) {
+            eprintln!("test cleanup failed: {err}");
+        }
+        Ok(())
+    }
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -1,3 +1,4 @@
+mod circuit_breaker;
 mod codex_app_server;
 mod codex_app_server_core;
 mod codex_app_server_file_changes;
@@ -66,6 +67,11 @@ static COMMANDS: &[Command] = &[
         name: "append-jsonl",
         usage: "<log-file>  — append one stdin JSONL line with runtime locking",
         handler: log_append::run,
+    },
+    Command {
+        name: "circuit-breaker",
+        usage: "<check|record-block|record-pass> <hook> <state-file> <lock-file> <threshold> <cooldown> <lock-timeout>  — update hook circuit breaker state with runtime locking",
+        handler: circuit_breaker::run,
     },
     Command {
         name: "pkg-rewrite",

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -60,6 +60,7 @@ fn help_lists_all_commands() {
         "build-fails",
         "paralysis-count",
         "append-jsonl",
+        "circuit-breaker",
         "pkg-rewrite",
         "session-metrics",
         "pre-write-check",
@@ -73,6 +74,139 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+fn run_circuit_breaker(
+    action: &str,
+    hook: &str,
+    state_file: &std::path::Path,
+    lock_file: &std::path::Path,
+    session: &str,
+) -> std::process::Output {
+    bin()
+        .args([
+            "circuit-breaker",
+            action,
+            hook,
+            state_file.to_str().unwrap(),
+            lock_file.to_str().unwrap(),
+            "2",
+            "9999",
+            "0",
+        ])
+        .env("VIBEGUARD_SESSION_ID", session)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn circuit_breaker_command_opens_and_resets_state() {
+    let dir = unique_temp_dir("circuit-breaker-state");
+    let state_file = dir.join("hook.cb");
+    let lock_file = dir.join("hook.cb.lock");
+
+    let out = run_circuit_breaker("check", "cb-hook", &state_file, &lock_file, "session-a");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "RUN\n");
+
+    let out = run_circuit_breaker(
+        "record-block",
+        "cb-hook",
+        &state_file,
+        &lock_file,
+        "session-a",
+    );
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "RECORDED\n");
+
+    let out = run_circuit_breaker(
+        "record-block",
+        "cb-hook",
+        &state_file,
+        &lock_file,
+        "session-a",
+    );
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("OPENED"));
+    assert!(stdout.contains("CB tripped OPEN"));
+
+    let out = run_circuit_breaker("check", "cb-hook", &state_file, &lock_file, "session-a");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("AUTO_PASS"));
+    assert!(stdout.contains("CB OPEN: auto-pass"));
+
+    let out = run_circuit_breaker(
+        "record-pass",
+        "cb-hook",
+        &state_file,
+        &lock_file,
+        "session-a",
+    );
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "RECORDED\n");
+
+    let out = run_circuit_breaker("check", "cb-hook", &state_file, &lock_file, "session-a");
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "RUN\n");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn circuit_breaker_command_lock_timeout_is_error() {
+    use std::os::fd::AsRawFd;
+
+    let dir = unique_temp_dir("circuit-breaker-lock-timeout");
+    fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("hook.cb");
+    let lock_file = dir.join("hook.cb.lock");
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(&lock_file)
+        .unwrap();
+    let lock_rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    assert_eq!(lock_rc, 0);
+
+    let out = run_circuit_breaker("check", "cb-hook", &state_file, &lock_file, "session-a");
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("circuit breaker lock timeout"),
+        "expected lock timeout in stderr: {stderr}"
+    );
+
+    unsafe {
+        let _ = libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+    }
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn circuit_breaker_command_mkdir_lock_timeout_is_error() {
+    let dir = unique_temp_dir("circuit-breaker-mkdir-lock-timeout");
+    fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("hook.cb");
+    let lock_file = dir.join("hook.cb.lock");
+    fs::create_dir(&dir.join("hook.cb.lock.d")).unwrap();
+
+    let out = run_circuit_breaker("check", "cb-hook", &state_file, &lock_file, "session-a");
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("circuit breaker lock timeout"),
+        "expected mkdir lock timeout in stderr: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `vibeguard-runtime circuit-breaker` for check / record-block / record-pass state transitions
- keep shell `vg_cb_*` public API, with stale-runtime fallback only for missing `circuit-breaker` support
- acquire both Unix flock and `.lock.d` mkdir locks so runtime state updates serialize with Linux and macOS shell paths
- fail visibly on runtime stderr, lock timeout, state IO, and unexpected runtime output

Partially addresses #354.

## Verification
- `bash -n hooks/circuit-breaker.sh tests/unit/test_circuit_breaker.sh && bash tests/unit/test_circuit_breaker.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/unit/run_all.sh`
- `cargo build --release --manifest-path vibeguard-runtime/Cargo.toml --quiet && bash tests/hooks/test_pre_write_guard.sh && bash tests/hooks/test_runtime_config.sh`
- `bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/self-application/check-u29-no-silent-degrade.sh && bash scripts/ci/validate-hook-perf.sh`
- `bash tests/bench_hook_latency.sh`

## Review
- Independent read-only review thread reported no blocking findings after the stderr visibility fix.