### PR TITLE
fix: move pre-bash classification to runtime

### DIFF
--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 # VibeGuard PreToolUse(Bash) Hook
 #
-# Hard interception of irreversible dangerous commands:
-# - git checkout . / git restore . (discard all changes)
-# - git clean -f (remove untracked files)
-# - rm -rf project root directory or sensitive path
-#
-# Transparently correct (updatedInput) mechanically predictable commands:
-#   - npm install / yarn install → pnpm install
-#   - npm install <pkg> / yarn add <pkg> → pnpm add <pkg>
-#   - pip install / pip3 install / python -m pip install → uv pip install
-#
-# Note: force push detection has been moved to hooks/git/pre-push (git native hook),
-# This hook is installed to each project .git/hooks/pre-push through scripts/install-hook.sh.
+# Rust classifies Bash input; this shell wrapper preserves hook logging,
+# package-tool availability checks, and the git-commit pre-commit bridge.
+# Runtime malformed input contract: invalid Bash hook input JSON; fail-closed.
 
 set -euo pipefail
 
@@ -20,229 +11,116 @@ source "$(dirname "$0")/log.sh"
 vg_start_timer
 
 INPUT=$(cat)
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+VIBEGUARD_ROOT="${VIBEGUARD_DIR:-$(cd "$HOOK_DIR/.." && pwd)}"
 
-if ! COMMAND=$(printf '%s' "$INPUT" | vg_json_field_strict "tool_input.command"); then
-  vg_log "pre-bash-guard" "Bash" "block" "invalid Bash hook input JSON; fail-closed" ""
-  vg_json_output_kv decision block reason "VIBEGUARD interception: invalid Bash hook input JSON; fail-closed because tool_input.command could not be parsed."
-  exit 0
-fi
-
-if [[ -z "$COMMAND" ]]; then
-  exit 0
-fi
-
-# Remove heredoc bodies to avoid false positives caused by multi-line text.
-# Cover variants: <<EOF, <<'EOF', <<"EOF", <<-EOF, <<-'EOF', << 'EOF' etc.
-# This is intentionally line-oriented rather than a DOTALL regex so adversarial
-# unterminated heredocs cannot force broad backtracking across the full command.
-if [[ "$COMMAND" == *"<<"* ]]; then
-  COMMAND_NO_HEREDOC=$(printf '%s' "$COMMAND" | python3 -c '
-import re, sys
-
-terminator = None
-strip_tabs = False
-out = []
-
-for line in sys.stdin.read().splitlines(keepends=True):
-    if terminator is not None:
-        candidate = line.rstrip("\r\n")
-        if strip_tabs:
-            candidate = candidate.lstrip("\t")
-        if candidate == terminator:
-            terminator = None
-            strip_tabs = False
-        continue
-
-    out.append(line)
-    match = re.search(r"<<(?P<dash>-?)\s*([\"'"'"']?)(?P<tag>[A-Za-z0-9_]+)\2", line)
-    if match:
-        terminator = match.group("tag")
-        strip_tabs = bool(match.group("dash"))
-
-sys.stdout.write("".join(out))
-' 2>/dev/null || printf '%s' "$COMMAND")
-else
-  COMMAND_NO_HEREDOC="$COMMAND"
-fi
-
-# Strip quotation marks (commit message, echo string, etc.) to avoid text content triggering false alarms
-# Keep the command structure and replace the quoted content with an empty string
-if [[ "$COMMAND_NO_HEREDOC" == *\"* || "$COMMAND_NO_HEREDOC" == *"'"* ]]; then
-  COMMAND_STRIPPED=$(echo "$COMMAND_NO_HEREDOC" | python3 -c "
-import re, sys
-cmd = sys.stdin.read()
-# Remove double quotes and single quotes
-cmd = re.sub(r'\"[^\"]*\"', '\"\"', cmd)
-cmd = re.sub(r\"'[^']*'\", \"''\", cmd)
-print(cmd)
-" 2>/dev/null || echo "$COMMAND_NO_HEREDOC")
-else
-  COMMAND_STRIPPED="$COMMAND_NO_HEREDOC"
-fi
-
-# Use path scanning: remove quotation marks but retain the content to prevent rm -rf \"/Users/...\" from being bypassed
-if [[ "$COMMAND_NO_HEREDOC" == *\"* || "$COMMAND_NO_HEREDOC" == *"'"* ]]; then
-  COMMAND_PATH_SCAN=$(printf '%s' "$COMMAND_NO_HEREDOC" | tr -d "\"'")
-else
-  COMMAND_PATH_SCAN="$COMMAND_NO_HEREDOC"
-fi
-
-# Variant of COMMAND_STRIPPED that converts "." / '.' (standalone quoted dot) into a bare dot
-# before stripping other quoted content. This lets the same no-anchor regex detect both
-# `git checkout .` and `git checkout "."` (including wrappers like `GIT_TRACE=1 git checkout "."`
-# or `echo y | git checkout "."`) without exposing separators that were inside larger quoted
-# strings (which would cause false positives when stripping all quotes via COMMAND_PATH_SCAN).
-if [[ "$COMMAND_NO_HEREDOC" == *\"* || "$COMMAND_NO_HEREDOC" == *"'"* ]]; then
-  COMMAND_STRIPPED_WITH_DOT=$(printf '%s' "$COMMAND_NO_HEREDOC" | python3 -c "
-import re, sys
-cmd = sys.stdin.read()
-# Replace standalone quoted dot (\".\"/'.') with bare dot before stripping other quoted content
-cmd = re.sub(r'\"\.\"', '.', cmd)
-cmd = re.sub(r\"'\\.'\", '.', cmd)
-# Strip remaining quoted content so separators inside strings stay invisible
-cmd = re.sub(r'\"[^\"]*\"', '\"\"', cmd)
-cmd = re.sub(r\"'[^']*'\", \"''\", cmd)
-print(cmd)
-" 2>/dev/null || echo "$COMMAND_NO_HEREDOC")
-else
-  COMMAND_STRIPPED_WITH_DOT="$COMMAND_NO_HEREDOC"
-fi
-
-block() {
+fail_closed_runtime() {
   local reason="$1"
-  vg_log "pre-bash-guard" "Bash" "block" "$reason" "$COMMAND"
+  local detail="${2:-}"
+  vg_log "pre-bash-guard" "Bash" "block" "$reason" "$detail"
   vg_json_output_kv decision block reason "VIBEGUARD interception: ${reason}"
   exit 0
 }
 
-authorized_discard_hint() {
-  local root="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
-  printf ' To perform an audited cleanup, run: python3 "%s/scripts/authorized-discard.py" --plan, then rerun with --confirm "discard listed changes" after reviewing the enumerated paths.' "$root"
+pre_bash_required_field() {
+  local field="$1"
+  printf '%s' "$PRE_BASH_BODY" | vg_json_field_strict "$field"
 }
 
-# git reset --hard — Allow execution (users need to use it in scenarios such as rebase conflicts)
-
-# git checkout . / git restore . (discard all changes)
-# Only matches pure "." endings, excluding legal path operations such as git checkout ./src/file
-# COMMAND_STRIPPED_WITH_DOT converts "." / '.' to a bare dot then strips other quoted content,
-# so a no-anchor regex safely detects all wrapper forms (env vars, pipes, `command`, `env`,
-# and shell redirections such as heredoc openers) without false-positives from separators
-# inside commit messages or string arguments.
-if echo "$COMMAND_STRIPPED_WITH_DOT" | grep -qE 'git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||[<>]|$)'; then
-  block "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding.$(authorized_discard_hint)"
+runtime_err=$(mktemp "${TMPDIR:-/tmp}/vibeguard-pre-bash.XXXXXX") || \
+  fail_closed_runtime "pre-bash-check stderr capture could not be created" ""
+if PRE_BASH_RESULT=$(printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" pre-bash-check "$VIBEGUARD_ROOT" 2>"$runtime_err"); then
+  runtime_status=0
+else
+  runtime_status=$?
 fi
-
-# git clean -f (delete untracked files)
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+clean\s+.*-f'; then
-  block "Disable git clean -f (untracked files are permanently deleted and cannot be recovered). Alternatives: git clean -n (dry run preview) to see what will be deleted first; git stash --include-untracked to temporarily store untracked files; manually rm to specify files.$(authorized_discard_hint)"
-fi
-
-# rm -rf dangerous path detection (covers rm -rf, rm -fr, rm -Rf, rm --recursive --force and other variants)
-# First identify the rm -rf command in the command structure of "remove quotation marks", and then perform dangerous path matching in the text that retains the path content.
-if echo "$COMMAND_STRIPPED" | grep -qE '(^|[;&|][[:space:]]*)(sudo[[:space:]]+)?(\\?rm)[[:space:]]+((-[a-zA-Z]*([rR][a-zA-Z]*f|f[a-zA-Z]*[rR]))|(--(recursive|force)[[:space:]]+--(recursive|force)))([[:space:]]|$)'; then
-  DANGEROUS=false
-  # Dangerous paths: root directory, home directory (including /Users/xxx, /home/xxx), system directory
-  for pattern in \
-    '[[:space:]]/([[:space:];|&]|$)' \
-    '[[:space:]]~([[:space:];|&/]|$)' \
-    '\$HOME' \
-    '[[:space:]]/Users(/[^/[:space:];|&]*)?([[:space:];|&]|$)' \
-    '[[:space:]]/home(/[^/[:space:];|&]*)?([[:space:];|&]|$)' \
-    '[[:space:]]/(etc|var|usr|bin|sbin|opt|System|Library)([[:space:];|&/]|$)'; do
-    if echo "$COMMAND_PATH_SCAN" | grep -qE "$pattern"; then
-      DANGEROUS=true
-      break
-    fi
-  done
-  if [[ "$DANGEROUS" == true ]]; then
-    block "Prohibit rm -rf dangerous paths (the root directory, home directory, and system directory are not recoverable). Alternatives: rm -rf <specific deep subdirectory> specifies the exact path; rm -ri interactively confirms; first confirm the target with ls and then delete it."
+if ! runtime_stderr=$(cat "$runtime_err"); then
+  if ! rm -f "$runtime_err"; then
+    printf 'VIBEGUARD ERROR: failed to remove pre-bash stderr capture: %s\n' "$runtime_err" >&2
   fi
+  fail_closed_runtime "pre-bash-check stderr capture could not be read" ""
+fi
+if ! rm -f "$runtime_err"; then
+  fail_closed_runtime "pre-bash-check stderr capture could not be removed" ""
+fi
+if [[ "$runtime_status" -ne 0 ]]; then
+  fail_closed_runtime "pre-bash-check runtime failed: ${runtime_stderr:-exit $runtime_status}" ""
+fi
+if [[ -n "$runtime_stderr" ]]; then
+  fail_closed_runtime "pre-bash-check runtime wrote stderr: $runtime_stderr" ""
 fi
 
+PRE_BASH_TOKEN="${PRE_BASH_RESULT%%$'\n'*}"
+PRE_BASH_BODY="${PRE_BASH_RESULT#*$'\n'}"
+[[ "$PRE_BASH_BODY" == "$PRE_BASH_RESULT" ]] && PRE_BASH_BODY="{}"
 
-# --- git commit interception: Claude Code has no PreCommit event, and is filled in through Bash hook ---
-if echo "$COMMAND_STRIPPED" | grep -qE 'git\s+commit\b'; then
-  # Explicit skip
-  if ! echo "$COMMAND" | grep -qE 'VIBEGUARD_SKIP_PRECOMMIT=1'; then
-    HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-    PRECOMMIT_SCRIPT="${HOOK_DIR}/pre-commit-guard.sh"
-    if [[ -f "$PRECOMMIT_SCRIPT" ]]; then
-      PRECOMMIT_EXIT=0
-      PRECOMMIT_OUTPUT=$(VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$HOOK_DIR/.." && pwd)}" bash "$PRECOMMIT_SCRIPT" 2>&1) || PRECOMMIT_EXIT=$?
-      if [[ $PRECOMMIT_EXIT -ne 0 ]]; then
-        vg_log "pre-bash-guard" "Bash" "block" "pre-commit check failed" "$COMMAND"
-        # Embed detailed output into reason so Claude Code can see it
-        # (stderr is not visible to the agent, only the JSON reason field is)
-        # Pass via stdin to avoid execve argv+env size limit on large output.
-        printf '%s' "$PRECOMMIT_OUTPUT" | python3 -c '
-import json, sys
-output = sys.stdin.read()
-reason = "VIBEGUARD Pre-Commit 检查失败。请根据上方错误信息修复问题后重新提交。禁止使用环境变量绕过。\n\n" + output
-print(json.dumps({"decision": "block", "reason": reason}))
-'
-        exit 0
+case "$PRE_BASH_TOKEN" in
+  EMPTY)
+    exit 0
+    ;;
+  BLOCK)
+    if ! LOG_REASON=$(pre_bash_required_field log_reason) \
+        || ! DETAIL=$(pre_bash_required_field detail) \
+        || ! HOOK_OUTPUT=$(pre_bash_required_field output); then
+      fail_closed_runtime "pre-bash-check emitted invalid BLOCK payload" ""
+    fi
+    vg_log "pre-bash-guard" "Bash" "block" "$LOG_REASON" "$DETAIL"
+    printf '%s\n' "$HOOK_OUTPUT"
+    exit 0
+    ;;
+  WARN)
+    if ! LOG_REASON=$(pre_bash_required_field log_reason) \
+        || ! DETAIL=$(pre_bash_required_field detail) \
+        || ! HOOK_OUTPUT=$(pre_bash_required_field output); then
+      fail_closed_runtime "pre-bash-check emitted invalid WARN payload" ""
+    fi
+    vg_log "pre-bash-guard" "Bash" "warn" "$LOG_REASON" "$DETAIL"
+    printf '%s\n' "$HOOK_OUTPUT"
+    exit 0
+    ;;
+  CORRECTION)
+    if ! COMMAND=$(pre_bash_required_field command) \
+        || ! CORRECTED=$(pre_bash_required_field corrected) \
+        || ! HOOK_OUTPUT=$(pre_bash_required_field output); then
+      fail_closed_runtime "pre-bash-check emitted invalid CORRECTION payload" ""
+    fi
+    target_tool="${CORRECTED%% *}"
+    if ! command -v "$target_tool" &>/dev/null; then
+      vg_log "pre-bash-guard" "Bash" "pass" "pkg-rewrite skipped (${target_tool} not found)" "${COMMAND:0:120}"
+      exit 0
+    fi
+    if [[ "$CORRECTED" == uv\ pip\ install* ]] \
+        && [[ -z "${VIRTUAL_ENV:-}" ]] && [[ ! -d ".venv" ]]; then
+      vg_log "pre-bash-guard" "Bash" "pass" "pkg-rewrite skipped (no active venv for uv pip)" "${COMMAND:0:120}"
+      exit 0
+    fi
+    vg_log "pre-bash-guard" "Bash" "correction" "package manager auto-rewrite" "${COMMAND:0:120} → $CORRECTED"
+    printf '%s\n' "$HOOK_OUTPUT"
+    exit 0
+    ;;
+  PASS)
+    if ! COMMAND=$(pre_bash_required_field command) \
+        || ! PRECOMMIT=$(pre_bash_required_field precommit); then
+      fail_closed_runtime "pre-bash-check emitted invalid PASS payload" ""
+    fi
+    if [[ "$PRECOMMIT" == "true" ]]; then
+      PRECOMMIT_SCRIPT="${HOOK_DIR}/pre-commit-guard.sh"
+      if [[ -f "$PRECOMMIT_SCRIPT" ]]; then
+        PRECOMMIT_EXIT=0
+        PRECOMMIT_OUTPUT=$(VIBEGUARD_DIR="$VIBEGUARD_ROOT" bash "$PRECOMMIT_SCRIPT" 2>&1) || PRECOMMIT_EXIT=$?
+        if [[ $PRECOMMIT_EXIT -ne 0 ]]; then
+          vg_log "pre-bash-guard" "Bash" "block" "pre-commit check failed" "$COMMAND"
+          vg_json_output_kv decision block reason "VIBEGUARD Pre-Commit 检查失败。请根据上方错误信息修复问题后重新提交。禁止使用环境变量绕过。
+
+$PRECOMMIT_OUTPUT"
+          exit 0
+        fi
       fi
     fi
-  fi
-fi
-
-# --- doc-file-blocker: Detect creation of non-standard .md files ---
-# Allowed .md files: README, CLAUDE, CONTRIBUTING, CHANGELOG, LICENSE, SKILL
-# Fix doc-file-blocker: exclude temp file paths and paths containing numbers
-# (e.g. /tmp/doc123.md, mktemp output) which are not persistent documentation.
-if echo "$COMMAND_STRIPPED" | grep -qE "(cat|echo|printf|tee)\s.*>.*\.md\b" 2>/dev/null; then
-  # Skip if writing to a temp/system directory (not a project doc)
-  if echo "$COMMAND_STRIPPED" | grep -qE ">.*(/tmp/|/var/|/proc/|\$TMPDIR|\$TEMP|mktemp)" 2>/dev/null; then
-    true  # temp path — pass through
-  elif ! echo "$COMMAND_STRIPPED" | grep -qiE "(README|CLAUDE|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\.md" 2>/dev/null; then
-    # Output a warning instead of blocking (probably reasonable document creation)
-    vg_log "pre-bash-guard" "Bash" "warn" "Non-standard .md file" "$COMMAND"
-    VG_CONTEXT="VIBEGUARD Warning: Creation of non-standard .md file detected. Only README/CLAUDE/CONTRIBUTING/CHANGELOG/LICENSE/SKILL.md is allowed to be created. Please confirm the file purpose if necessary." python3 - <<'PY'
-import json
-import os
-
-print(json.dumps({
-    "hookSpecificOutput": {
-        "hookEventName": "PreToolUse",
-        "additionalContext": os.environ["VG_CONTEXT"],
-    }
-}, ensure_ascii=False))
-PY
+    vg_log "pre-bash-guard" "Bash" "pass" "" "$COMMAND"
     exit 0
-  fi
-fi
-
-# --- Package manager transparent correction (updatedInput) ---
-# Mechanically predictable commands can be rewritten directly without block+retry.
-# Only for simple single commands (chain commands including && and other chain commands are not corrected to avoid mistakenly modifying complex pipelines).
-_PKG_CORRECTION=$(printf '%s' "$COMMAND" | "$_VIBEGUARD_RUNTIME" pkg-rewrite 2>/dev/null || echo "")
-
-if [[ -n "$_PKG_CORRECTION" ]]; then
-  # Verify target tool is actually installed before rewriting — avoids turning
-  # a working command into one that will always fail (e.g. no pnpm/uv on PATH).
-  _target_tool="${_PKG_CORRECTION%% *}"
-  if ! command -v "$_target_tool" &>/dev/null; then
-    vg_log "pre-bash-guard" "Bash" "pass" "pkg-rewrite skipped (${_target_tool} not found)" "${COMMAND:0:120}"
-    exit 0
-  fi
-  # For uv pip install, also require an active or local virtual environment;
-  # without one uv pip fails immediately, making the rewrite harmful.
-  if [[ "$_PKG_CORRECTION" == uv\ pip\ install* ]] \
-      && [[ -z "${VIRTUAL_ENV:-}" ]] && [[ ! -d ".venv" ]]; then
-    vg_log "pre-bash-guard" "Bash" "pass" "pkg-rewrite skipped (no active venv for uv pip)" "${COMMAND:0:120}"
-    exit 0
-  fi
-  vg_log "pre-bash-guard" "Bash" "correction" "package manager auto-rewrite" "${COMMAND:0:120} → $_PKG_CORRECTION"
-  # PKG-CORRECTION-ARGV-CONTRACT: pass the generated command as sys.argv[1].
-  # Never interpolate _PKG_CORRECTION into inline Python source or shell eval.
-  python3 -c "
-import json, sys
-corrected = sys.argv[1]
-print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
-" "$_PKG_CORRECTION"
-  exit 0
-fi
-
-# Pass all checks → Release
-vg_log "pre-bash-guard" "Bash" "pass" "" "$COMMAND"
-exit 0
+    ;;
+  *)
+    fail_closed_runtime "pre-bash-check emitted unexpected token: $PRE_BASH_TOKEN" ""
+    ;;
+esac

--- a/scripts/ci/self-application/check-pkg-correction-argv-only.sh
+++ b/scripts/ci/self-application/check-pkg-correction-argv-only.sh
@@ -20,9 +20,6 @@ def shell_var_ref(name: str) -> re.Pattern[str]:
     return re.compile(rf"\${escaped}(?![A-Za-z0-9_])|\$\{{{escaped}[^}}]*\}}")
 
 
-pkg_correction_ref = shell_var_ref("_PKG_CORRECTION")
-
-
 def shell_word_plain(raw: str) -> str:
     try:
         parts = shlex.split(raw, posix=True)
@@ -134,34 +131,43 @@ if not path.exists():
 else:
     text = path.read_text(encoding="utf-8")
 
-    if "PKG-CORRECTION-ARGV-CONTRACT" not in text:
-        errors.append("missing PKG-CORRECTION-ARGV-CONTRACT comment")
+    runtime_owned = "pre-bash-check" in text and "_PKG_CORRECTION" not in text
+    taint_source_vars = {"_PKG_CORRECTION"}
+    if runtime_owned:
+        taint_source_vars.add("CORRECTED")
 
-    if "corrected = sys.argv[1]" not in text:
-        errors.append("package correction JSON emitter must read sys.argv[1]")
+    if not runtime_owned:
+        if "PKG-CORRECTION-ARGV-CONTRACT" not in text:
+            errors.append("missing PKG-CORRECTION-ARGV-CONTRACT comment")
+
+        if "corrected = sys.argv[1]" not in text:
+            errors.append("package correction JSON emitter must read sys.argv[1]")
 
     python_sources = list(iter_python_c_sources(text))
     argv_ref_pattern = re.compile(
         r'\s+"(?:\$_PKG_CORRECTION|\$\{_PKG_CORRECTION\})"'
     )
-    if not any(
-        "sys.argv[1]" in src and argv_ref_pattern.match(text[quote_end:])
-        for src, _start, quote_end in python_sources
-    ):
-        errors.append("_PKG_CORRECTION is not passed as a python3 argv argument")
+    if not runtime_owned:
+        if not any(
+            "sys.argv[1]" in src and argv_ref_pattern.match(text[quote_end:])
+            for src, _start, quote_end in python_sources
+        ):
+            errors.append("_PKG_CORRECTION is not passed as a python3 argv argument")
 
     for src, start, _quote_end in python_sources:
-        if pkg_correction_ref.search(src):
-            line = text[:start].count("\n") + 1
-            errors.append(
-                f"line {line}: _PKG_CORRECTION is interpolated into inline Python source"
-            )
+        for tainted in sorted(taint_source_vars):
+            if shell_var_ref(tainted).search(src):
+                line = text[:start].count("\n") + 1
+                errors.append(
+                    f"line {line}: {tainted} is interpolated into inline Python source"
+                )
 
     for src, line in iter_python_stdin_sources(text):
-        if pkg_correction_ref.search(src):
-            errors.append(
-                f"line {line}: _PKG_CORRECTION is interpolated into stdin Python source"
-            )
+        for tainted in sorted(taint_source_vars):
+            if shell_var_ref(tainted).search(src):
+                errors.append(
+                    f"line {line}: {tainted} is interpolated into stdin Python source"
+                )
 
     shell_eval_pattern = re.compile(r"\b(?:eval|bash\s+-c|sh\s+-c)\b")
     assignment_pattern = re.compile(
@@ -170,7 +176,7 @@ else:
         r"([A-Za-z_][A-Za-z0-9_]*)=([^;#]*)"
     )
     set_positional_pattern = re.compile(r"(?:^|[;&|])\s*set\s+--\s+([^;#]*)")
-    tainted_vars = {"_PKG_CORRECTION"}
+    tainted_vars = set(taint_source_vars)
     for line_no, line in iter_shell_logical_lines(text):
         if line.lstrip().startswith("#"):
             continue
@@ -185,7 +191,7 @@ else:
         if shell_eval_pattern.search(line) and any(
             shell_var_ref(tainted).search(line) for tainted in tainted_vars
         ):
-            errors.append(f"line {line_no}: _PKG_CORRECTION flows through shell evaluation")
+            errors.append(f"line {line_no}: package correction value flows through shell evaluation")
 
 if errors:
     print("FAIL: package correction argv-only contract failed")

--- a/scripts/ci/self-application/check-u29-no-silent-degrade.sh
+++ b/scripts/ci/self-application/check-u29-no-silent-degrade.sh
@@ -72,8 +72,8 @@ if precommit.exists():
 prebash = repo / "hooks/pre-bash-guard.sh"
 if prebash.exists():
     text = prebash.read_text(encoding="utf-8")
-    if 'vg_json_field_strict "tool_input.command"' not in text:
-        errors.append("hooks/pre-bash-guard.sh: Bash command extraction is not strict")
+    if "pre-bash-check" not in text:
+        errors.append("hooks/pre-bash-guard.sh: Bash command extraction is not runtime fail-closed")
     if "invalid Bash hook input JSON; fail-closed" not in text:
         errors.append("hooks/pre-bash-guard.sh: missing fail-closed parse warning")
 

--- a/tests/hooks/test_pre_bash_guard.sh
+++ b/tests/hooks/test_pre_bash_guard.sh
@@ -5,6 +5,58 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
 hook_test_init
 
+run_pre_bash_with_fake_runtime() {
+  local fake_case="$1"
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  mkdir -p "${tmp_dir}/hooks/_lib" "${tmp_dir}/home" "${tmp_dir}/log"
+  cp hooks/pre-bash-guard.sh hooks/log.sh "${tmp_dir}/hooks/"
+  cp hooks/_lib/*.sh "${tmp_dir}/hooks/_lib/"
+  cat > "${tmp_dir}/hooks/vibeguard-runtime" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  pre-bash-check)
+    case "${VIBEGUARD_FAKE_PRE_BASH:-}" in
+      stderr)
+        printf 'runtime noise\n' >&2
+        printf 'PASS\n{"command":"npm run build","precommit":false}\n'
+        exit 0
+        ;;
+      nonzero)
+        printf 'runtime exploded\n' >&2
+        exit 1
+        ;;
+      token)
+        printf 'SURPRISE\n{}\n'
+        exit 0
+        ;;
+      bad_payload)
+        printf 'BLOCK\n{}\n'
+        exit 0
+        ;;
+    esac
+    ;;
+  append-jsonl)
+    printf 'Unknown command: append-jsonl\n' >&2
+    exit 2
+    ;;
+  json-field)
+    printf 'Unknown command: json-field\n' >&2
+    exit 2
+    ;;
+esac
+printf 'Unknown command: %s\n' "$1" >&2
+exit 2
+EOF
+  chmod +x "${tmp_dir}/hooks/vibeguard-runtime"
+  HOME="${tmp_dir}/home" \
+    VIBEGUARD_FAKE_PRE_BASH="$fake_case" \
+    VIBEGUARD_LOG_DIR="${tmp_dir}/log" \
+    bash "${tmp_dir}/hooks/pre-bash-guard.sh" \
+    <<< '{"tool_input":{"command":"npm run build"}}' 2>&1
+  rm -rf "$tmp_dir"
+}
+
 header "pre-bash-guard.sh — Dangerous command interception"
 # =========================================================
 
@@ -114,13 +166,29 @@ assert_not_contains "$result" '"decision": "block"' "release vitest --run"
 > "$VIBEGUARD_LOG_DIR/events.jsonl"
 result=$(printf '{"tool_input":' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Malformed Bash hook JSON fails closed"
-assert_contains "$(cat "$VIBEGUARD_LOG_DIR/events.jsonl")" "json-field strict failed" "Malformed Bash hook JSON writes parse warning"
+assert_contains "$(cat "$VIBEGUARD_LOG_DIR/events.jsonl")" "invalid Bash hook input JSON; fail-closed" "Malformed Bash hook JSON writes parse warning"
 
 result=$(echo '{"tool_input":{}}' | bash hooks/pre-bash-guard.sh)
 assert_contains "$result" '"decision": "block"' "Missing Bash command field fails closed"
 
 result=$(echo '{"tool_input":{"command":""}}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "Empty Bash command string remains a no-op"
+
+runtime_stderr_result=$(run_pre_bash_with_fake_runtime stderr)
+assert_contains "$runtime_stderr_result" '"decision": "block"' "Runtime stderr fails closed"
+assert_contains "$runtime_stderr_result" "runtime wrote stderr" "Runtime stderr diagnostic is visible"
+
+runtime_nonzero_result=$(run_pre_bash_with_fake_runtime nonzero)
+assert_contains "$runtime_nonzero_result" '"decision": "block"' "Runtime nonzero exit fails closed"
+assert_contains "$runtime_nonzero_result" "runtime failed" "Runtime nonzero diagnostic is visible"
+
+runtime_token_result=$(run_pre_bash_with_fake_runtime token)
+assert_contains "$runtime_token_result" '"decision": "block"' "Runtime unexpected token fails closed"
+assert_contains "$runtime_token_result" "unexpected token" "Runtime unexpected token diagnostic is visible"
+
+runtime_payload_result=$(run_pre_bash_with_fake_runtime bad_payload)
+assert_contains "$runtime_payload_result" '"decision": "block"' "Runtime malformed payload fails closed"
+assert_contains "$runtime_payload_result" "invalid BLOCK payload" "Runtime malformed payload diagnostic is visible"
 
 # =========================================================
 header "pre-bash-guard.sh — Package manager transparent correction (updatedInput)"

--- a/tests/test_self_application_ci.sh
+++ b/tests/test_self_application_ci.sh
@@ -109,6 +109,26 @@ print(json.dumps({'decision': 'allow', 'updatedInput': {'command': corrected}}))
 EOF
 assert_cmd "argv-only package correction passes" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${good_pkg_correction}"
 
+good_runtime_pkg_correction="${TMP_DIR}/good-runtime-pkg-correction"
+mkdir -p "${good_runtime_pkg_correction}/hooks"
+cat > "${good_runtime_pkg_correction}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+PRE_BASH_RESULT=$("$_VIBEGUARD_RUNTIME" pre-bash-check "$VIBEGUARD_ROOT")
+CORRECTED=$(pre_bash_required_field corrected)
+printf '%s\n' "$CORRECTED"
+EOF
+assert_cmd "runtime-owned package correction passes taint check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${good_runtime_pkg_correction}"
+
+bad_runtime_pkg_eval="${TMP_DIR}/bad-runtime-pkg-eval"
+mkdir -p "${bad_runtime_pkg_eval}/hooks"
+cat > "${bad_runtime_pkg_eval}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+PRE_BASH_RESULT=$("$_VIBEGUARD_RUNTIME" pre-bash-check "$VIBEGUARD_ROOT")
+CORRECTED=$(pre_bash_required_field corrected)
+eval "$CORRECTED"
+EOF
+assert_fails "runtime-owned package correction eval fails taint check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${bad_runtime_pkg_eval}"
+
 bad_pkg_correction="${TMP_DIR}/bad-pkg-correction"
 mkdir -p "${bad_pkg_correction}/hooks"
 cat > "${bad_pkg_correction}/hooks/pre-bash-guard.sh" <<'EOF'

--- a/vibeguard-runtime/src/hook_checks_bash.rs
+++ b/vibeguard-runtime/src/hook_checks_bash.rs
@@ -1,0 +1,450 @@
+use regex::Regex;
+use serde_json::{Value, json};
+use std::io::{self, Read};
+
+use crate::hook_checks_common::nested_str;
+use crate::pkg_rewrite::rewrite_command;
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+const INVALID_INPUT_LOG_REASON: &str = "invalid Bash hook input JSON; fail-closed";
+const INVALID_INPUT_REASON: &str = "VIBEGUARD interception: invalid Bash hook input JSON; fail-closed because tool_input.command could not be parsed.";
+const DOC_WARNING_CONTEXT: &str = "VIBEGUARD Warning: Creation of non-standard .md file detected. Only README/CLAUDE/CONTRIBUTING/CHANGELOG/LICENSE/SKILL.md is allowed to be created. Please confirm the file purpose if necessary.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BashDecision {
+    Empty,
+    Pass {
+        command: String,
+        precommit: bool,
+    },
+    Block {
+        log_reason: String,
+        detail: String,
+        output: String,
+    },
+    Warn {
+        log_reason: String,
+        detail: String,
+        output: String,
+    },
+    Correction {
+        log_reason: String,
+        detail: String,
+        command: String,
+        corrected: String,
+        output: String,
+    },
+}
+
+pub fn pre_bash_check(args: &[String]) -> Result {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime pre-bash-check <vibeguard-root>".into());
+    }
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let decision = classify_input(&input, &args[0]);
+    emit_decision(&decision)?;
+    Ok(())
+}
+
+fn emit_decision(decision: &BashDecision) -> Result {
+    match decision {
+        BashDecision::Empty => {
+            println!("EMPTY");
+            println!("{{}}");
+        }
+        BashDecision::Pass { command, precommit } => {
+            println!("PASS");
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "command": command,
+                    "precommit": precommit,
+                }))?
+            );
+        }
+        BashDecision::Block {
+            log_reason,
+            detail,
+            output,
+        } => {
+            println!("BLOCK");
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "log_reason": log_reason,
+                    "detail": detail,
+                    "output": output,
+                }))?
+            );
+        }
+        BashDecision::Warn {
+            log_reason,
+            detail,
+            output,
+        } => {
+            println!("WARN");
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "log_reason": log_reason,
+                    "detail": detail,
+                    "output": output,
+                }))?
+            );
+        }
+        BashDecision::Correction {
+            log_reason,
+            detail,
+            command,
+            corrected,
+            output,
+        } => {
+            println!("CORRECTION");
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "log_reason": log_reason,
+                    "detail": detail,
+                    "command": command,
+                    "corrected": corrected,
+                    "output": output,
+                }))?
+            );
+        }
+    }
+    Ok(())
+}
+
+fn classify_input(input: &str, vibeguard_root: &str) -> BashDecision {
+    let Ok(data) = serde_json::from_str::<Value>(input) else {
+        return invalid_input_block();
+    };
+    let Some(command) = nested_str(&data, "tool_input.command") else {
+        return invalid_input_block();
+    };
+    if command.is_empty() {
+        return BashDecision::Empty;
+    }
+
+    classify_command(&command, vibeguard_root)
+}
+
+fn invalid_input_block() -> BashDecision {
+    BashDecision::Block {
+        log_reason: INVALID_INPUT_LOG_REASON.to_string(),
+        detail: String::new(),
+        output: native_output(json!({
+            "decision": "block",
+            "reason": INVALID_INPUT_REASON,
+        })),
+    }
+}
+
+fn classify_command(command: &str, vibeguard_root: &str) -> BashDecision {
+    let command_no_heredoc = strip_heredoc_bodies(command);
+    let command_stripped = strip_quoted_content(&command_no_heredoc);
+    let command_path_scan = command_no_heredoc.replace(['"', '\''], "");
+    let command_stripped_with_dot =
+        strip_quoted_content(&normalize_quoted_dot(&command_no_heredoc));
+
+    if regex_is_match(
+        r"git\s+(checkout|restore)\s+\.\s*(;|&&|\|\||[<>]|$)",
+        &command_stripped_with_dot,
+    ) {
+        return block_decision(
+            &format!(
+                "Disable git checkout/restore. (discard all changes in batches). Alternatives: git checkout -- <specific file> specifies the files to be discarded; git stash temporarily stores all changes (recoverable); git diff first checks the changes before deciding.{}",
+                authorized_discard_hint(vibeguard_root)
+            ),
+            command,
+        );
+    }
+
+    if regex_is_match(r"git\s+clean\s+.*-f", &command_stripped) {
+        return block_decision(
+            &format!(
+                "Disable git clean -f (untracked files are permanently deleted and cannot be recovered). Alternatives: git clean -n (dry run preview) to see what will be deleted first; git stash --include-untracked to temporarily store untracked files; manually rm to specify files.{}",
+                authorized_discard_hint(vibeguard_root)
+            ),
+            command,
+        );
+    }
+
+    if has_rm_recursive_force(&command_stripped) && has_dangerous_rm_path(&command_path_scan) {
+        return block_decision(
+            "Prohibit rm -rf dangerous paths (the root directory, home directory, and system directory are not recoverable). Alternatives: rm -rf <specific deep subdirectory> specifies the exact path; rm -ri interactively confirms; first confirm the target with ls and then delete it.",
+            command,
+        );
+    }
+
+    if is_nonstandard_markdown_write(&command_stripped) {
+        return BashDecision::Warn {
+            log_reason: "Non-standard .md file".to_string(),
+            detail: command.to_string(),
+            output: native_output(json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": DOC_WARNING_CONTEXT,
+                }
+            })),
+        };
+    }
+
+    if let Some(corrected) = rewrite_command(command.trim()) {
+        return BashDecision::Correction {
+            log_reason: "package manager auto-rewrite".to_string(),
+            detail: format!("{} → {}", truncate_chars(command, 120), corrected),
+            command: command.to_string(),
+            corrected: corrected.clone(),
+            output: native_output(json!({
+                "decision": "allow",
+                "updatedInput": {
+                    "command": corrected,
+                }
+            })),
+        };
+    }
+
+    BashDecision::Pass {
+        precommit: should_run_precommit(&command_stripped, command),
+        command: command.to_string(),
+    }
+}
+
+fn block_decision(reason: &str, command: &str) -> BashDecision {
+    BashDecision::Block {
+        log_reason: reason.to_string(),
+        detail: command.to_string(),
+        output: native_output(json!({
+            "decision": "block",
+            "reason": format!("VIBEGUARD interception: {reason}"),
+        })),
+    }
+}
+
+fn native_output(value: Value) -> String {
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn authorized_discard_hint(vibeguard_root: &str) -> String {
+    format!(
+        " To perform an audited cleanup, run: python3 \"{}/scripts/authorized-discard.py\" --plan, then rerun with --confirm \"discard listed changes\" after reviewing the enumerated paths.",
+        vibeguard_root
+    )
+}
+
+fn strip_heredoc_bodies(command: &str) -> String {
+    let Ok(heredoc) = Regex::new(r#"<<(?P<dash>-?)\s*(['"]?)(?P<tag>[A-Za-z0-9_]+)['"]?"#) else {
+        return command.to_string();
+    };
+    let mut terminator: Option<String> = None;
+    let mut strip_tabs = false;
+    let mut out = String::new();
+
+    for line in command.split_inclusive('\n') {
+        if let Some(expected) = &terminator {
+            let mut candidate = line.trim_end_matches(['\r', '\n']).to_string();
+            if strip_tabs {
+                candidate = candidate.trim_start_matches('\t').to_string();
+            }
+            if candidate == *expected {
+                terminator = None;
+                strip_tabs = false;
+            }
+            continue;
+        }
+
+        out.push_str(line);
+        if let Some(captures) = heredoc.captures(line) {
+            terminator = captures.name("tag").map(|m| m.as_str().to_string());
+            strip_tabs = captures.name("dash").is_some_and(|m| m.as_str() == "-");
+        }
+    }
+
+    out
+}
+
+fn strip_quoted_content(command: &str) -> String {
+    let Ok(double_quoted) = Regex::new(r#""[^"]*""#) else {
+        return command.to_string();
+    };
+    let Ok(single_quoted) = Regex::new(r#"'[^']*'"#) else {
+        return command.to_string();
+    };
+    let stripped = double_quoted.replace_all(command, r#""""#);
+    single_quoted.replace_all(&stripped, "''").to_string()
+}
+
+fn normalize_quoted_dot(command: &str) -> String {
+    command.replace("\".\"", ".").replace("'.'", ".")
+}
+
+fn has_rm_recursive_force(command_stripped: &str) -> bool {
+    regex_is_match(
+        r"(?m)(^|[;&|]\s*)(sudo\s+)?(\\?rm)\s+((-[A-Za-z]*([rR][A-Za-z]*f|f[A-Za-z]*[rR]))|(--(recursive|force)\s+--(recursive|force)))(\s|$)",
+        command_stripped,
+    )
+}
+
+fn has_dangerous_rm_path(command_path_scan: &str) -> bool {
+    [
+        r"\s/(\s|[;|&]|$)",
+        r"\s~(\s|[;|&/]|$)",
+        r"\$HOME",
+        r"\s/Users(/[^/\s;|&]*)?(\s|[;|&]|$)",
+        r"\s/home(/[^/\s;|&]*)?(\s|[;|&]|$)",
+        r"\s/(etc|var|usr|bin|sbin|opt|System|Library)(\s|[;|&/]|$)",
+    ]
+    .iter()
+    .any(|pattern| regex_is_match(pattern, command_path_scan))
+}
+
+fn is_nonstandard_markdown_write(command_stripped: &str) -> bool {
+    if !regex_is_match(r"(cat|echo|printf|tee)\s.*>.*\.md\b", command_stripped) {
+        return false;
+    }
+    if regex_is_match(
+        r">.*(/tmp/|/var/|/proc/|\$TMPDIR|\$TEMP|mktemp)",
+        command_stripped,
+    ) {
+        return false;
+    }
+    !regex_is_match(
+        r"(?i)(README|CLAUDE|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\.md",
+        command_stripped,
+    )
+}
+
+fn should_run_precommit(command_stripped: &str, command: &str) -> bool {
+    regex_is_match(r"git\s+commit\b", command_stripped)
+        && !regex_is_match(r"VIBEGUARD_SKIP_PRECOMMIT=1", command)
+}
+
+fn regex_is_match(pattern: &str, text: &str) -> bool {
+    Regex::new(pattern).is_ok_and(|regex| regex.is_match(text))
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(command: &str) -> BashDecision {
+        classify_command(command, "/repo")
+    }
+
+    fn is_block(command: &str) -> bool {
+        matches!(classify(command), BashDecision::Block { .. })
+    }
+
+    #[test]
+    fn invalid_and_empty_inputs_have_explicit_decisions() {
+        assert!(matches!(
+            classify_input("{", "/repo"),
+            BashDecision::Block { .. }
+        ));
+        assert!(matches!(
+            classify_input(r#"{"tool_input":{}}"#, "/repo"),
+            BashDecision::Block { .. }
+        ));
+        assert_eq!(
+            classify_input(r#"{"tool_input":{"command":""}}"#, "/repo"),
+            BashDecision::Empty
+        );
+    }
+
+    #[test]
+    fn checkout_restore_dot_variants_block() {
+        for command in [
+            "git checkout .",
+            "git checkout \".\"",
+            "git checkout '.'",
+            "git restore \".\"",
+            "GIT_TRACE=1 git checkout \".\"",
+            "env GIT_TRACE=1 git restore \".\"",
+            "command git checkout \".\"",
+            "echo y | git checkout \".\"",
+        ] {
+            assert!(is_block(command), "{command}");
+        }
+    }
+
+    #[test]
+    fn quoted_text_and_heredoc_bodies_do_not_false_positive() {
+        for command in [
+            "echo \"git checkout .\"",
+            "printf \"%s\\n\" \"git restore .\"",
+            "git commit -m \"repro: git checkout .\"",
+            "git commit -m \"docs; git checkout .\"",
+            "echo \"note && git restore .\"",
+            "cat <<'EOF'\ngit checkout .\nrm -rf /\nEOF",
+            "cat <<-EOF\n\tgit checkout .\n\tEOF",
+            "cat <<123\ngit checkout .\nrm -rf /\n123",
+        ] {
+            assert!(!is_block(command), "{command}");
+        }
+    }
+
+    #[test]
+    fn real_command_before_heredoc_still_blocks() {
+        assert!(is_block("git checkout . <<'EOF'\nnot command text\nEOF"));
+    }
+
+    #[test]
+    fn git_clean_and_dangerous_rm_block() {
+        for command in [
+            "git clean -fd",
+            "rm -rf /",
+            "rm -rf ~/",
+            "rm -rf /Users/foo",
+            "rm --recursive --force /home/me",
+            "sudo rm -Rf /etc",
+        ] {
+            assert!(is_block(command), "{command}");
+        }
+        assert!(!is_block("rm -rf ./node_modules"));
+    }
+
+    #[test]
+    fn markdown_write_warns_without_blocking() {
+        assert!(matches!(
+            classify("printf x > notes.md"),
+            BashDecision::Warn { .. }
+        ));
+        assert!(matches!(
+            classify("printf x > README.md"),
+            BashDecision::Pass { .. }
+        ));
+    }
+
+    #[test]
+    fn package_rewrite_and_precommit_signals_are_reported() {
+        assert!(matches!(
+            classify("npm install"),
+            BashDecision::Correction { .. }
+        ));
+        assert!(matches!(
+            classify("  npm install  "),
+            BashDecision::Correction { .. }
+        ));
+        assert!(matches!(
+            classify("git commit -m \"ok\""),
+            BashDecision::Pass {
+                precommit: true,
+                ..
+            }
+        ));
+        assert!(matches!(
+            classify("VIBEGUARD_SKIP_PRECOMMIT=1 git commit -m ok"),
+            BashDecision::Pass {
+                precommit: false,
+                ..
+            }
+        ));
+    }
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -5,6 +5,7 @@ mod codex_app_server_file_changes;
 mod codex_app_server_strategies;
 mod event_schema;
 mod hook_checks;
+mod hook_checks_bash;
 mod hook_checks_common;
 mod hook_checks_history;
 mod hook_checks_scan;
@@ -77,6 +78,11 @@ static COMMANDS: &[Command] = &[
         name: "pkg-rewrite",
         usage: "  — rewrite package manager command from stdin",
         handler: pkg_rewrite::run,
+    },
+    Command {
+        name: "pre-bash-check",
+        usage: "<vibeguard-root>  — classify PreToolUse(Bash) input for hooks",
+        handler: hook_checks_bash::pre_bash_check,
     },
     Command {
         name: "session-metrics",

--- a/vibeguard-runtime/src/pkg_rewrite.rs
+++ b/vibeguard-runtime/src/pkg_rewrite.rs
@@ -16,7 +16,7 @@ pub fn run(_args: &[String]) -> Result {
     Ok(())
 }
 
-fn rewrite_command(cmd: &str) -> Option<String> {
+pub(crate) fn rewrite_command(cmd: &str) -> Option<String> {
     // Skip complex commands (&&, ||, ;, pipe, redirection, $(), backtick)
     let complex = Regex::new(r"&&|&|\|\||;|[|<>\n\r]|\$\(|`").ok()?;
     if complex.is_match(cmd) {

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -62,6 +62,7 @@ fn help_lists_all_commands() {
         "append-jsonl",
         "circuit-breaker",
         "pkg-rewrite",
+        "pre-bash-check",
         "session-metrics",
         "pre-write-check",
         "pre-edit-check",
@@ -74,6 +75,85 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+fn run_pre_bash_check(input: &str) -> std::process::Output {
+    let mut child = bin()
+        .args(["pre-bash-check", "/repo"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn pre_bash_check_blocks_dangerous_command() {
+    let out = run_pre_bash_check(r#"{"tool_input":{"command":"git checkout ."}}"#);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("BLOCK\n"), "{stdout}");
+    assert!(stdout.contains("Disable git checkout/restore"), "{stdout}");
+    assert!(
+        stdout.contains("\\\"decision\\\": \\\"block\\\""),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn pre_bash_check_warns_for_nonstandard_markdown() {
+    let out = run_pre_bash_check(r#"{"tool_input":{"command":"printf x > notes.md"}}"#);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("WARN\n"), "{stdout}");
+    assert!(
+        stdout.contains("\\\"hookEventName\\\": \\\"PreToolUse\\\""),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn pre_bash_check_reports_correction_payload() {
+    let out = run_pre_bash_check(r#"{"tool_input":{"command":"npm install lodash"}}"#);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("CORRECTION\n"), "{stdout}");
+    assert!(
+        stdout.contains("\"corrected\":\"pnpm add lodash\""),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("\\\"command\\\": \\\"pnpm add lodash\\\""),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn pre_bash_check_pass_marks_precommit_bridge() {
+    let out = run_pre_bash_check(r#"{"tool_input":{"command":"git commit -m ok"}}"#);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("PASS\n"), "{stdout}");
+    assert!(stdout.contains("\"precommit\":true"), "{stdout}");
+}
+
+#[test]
+fn pre_bash_check_malformed_input_fails_closed() {
+    let out = run_pre_bash_check(r#"{"tool_input":"#);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("BLOCK\n"), "{stdout}");
+    assert!(
+        stdout.contains("invalid Bash hook input JSON; fail-closed"),
+        "{stdout}"
+    );
 }
 
 fn run_circuit_breaker(


### PR DESCRIPTION
Partially addresses #354.

## Summary
- add `vibeguard-runtime pre-bash-check` for Bash hook command classification, destructive-command blocking, markdown advisory, package rewrite, and precommit signal detection
- keep shell-owned responsibilities in `pre-bash-guard.sh`: logging, target tool availability checks, and precommit bridge execution
- harden fail-closed handling for runtime stderr, nonzero exit, unexpected tokens, malformed payloads, and invalid Bash hook JSON
- update self-application sentinels for runtime-owned package correction and U-29 coverage

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `git diff --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml` (117 unit, 28 CLI)
- `cargo build --release --manifest-path vibeguard-runtime/Cargo.toml --quiet`
- `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/hooks/test_pre_bash_guard.sh` (67/67)
- `bash tests/test_hooks.sh` (all shards passed)
- `bash tests/test_codex_runtime.sh` (86/86)
- `bash tests/unit/run_all.sh` (22/22)
- `bash tests/test_self_application_ci.sh` (63/63)
- `bash tests/test_behavior_eval.sh` (10/10)
- `bash scripts/ci/self-application/check-u29-no-silent-degrade.sh`
- `bash scripts/ci/self-application/check-pkg-correction-argv-only.sh`
- `bash scripts/ci/validate-hook-perf.sh`
- `bash tests/bench_hook_latency.sh` (pre-bash P95 115ms / 300ms budget)