### PR TITLE
fix: move post-write scan to runtime

### DIFF
--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/log.sh"
 vg_start_timer
+export VIBEGUARD_HOOK_START_MS="${_VG_START_MS:-}"
 
 INPUT=$(cat)
 

--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -1,386 +1,55 @@
 #!/usr/bin/env bash
 # VibeGuard PostToolUse(Write) Hook
 #
-# After the new source code file is created, detect whether there are duplicate implementations in the project:
-# 1. Files with the same name (source code files with the same name appear in different directories)
-# 2. Duplication of key definitions (struct/class/interface/func already exists in other files)
-#
-# After-the-fact review, the operation will not be blocked and only a warning will be output.
-# Cooperate with pre-write-guard (warn mode): pre-reminder + post-review.
+# Review-only duplicate/stub/U-16 scan after Write. The parser, project scan,
+# warning construction, and log append are owned by vibeguard-runtime.
 
 set -euo pipefail
 
 source "$(dirname "$0")/log.sh"
+vg_start_timer
 
 INPUT=$(cat)
 
-if [[ -n "${_VIBEGUARD_RUNTIME:-}" ]]; then
-  _VG_U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
-  _VG_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_VG_U16_BASE_LIMIT")
-  _VG_SCAN_MAX_FILES="${VG_SCAN_MAX_FILES:-5000}"
-  _VG_FAST_RESULT=$(printf '%s' "$INPUT" \
-    | "$_VIBEGUARD_RUNTIME" post-write-fast-check "$_VG_U16_WARN_LIMIT" "$_VG_SCAN_MAX_FILES" "$VIBEGUARD_LOG_FILE" \
-    2>/dev/null || true)
-  _VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
-  case "$_VG_FAST_STATUS" in
-    SKIP)
-      exit 0
-      ;;
-    FAST_LOGGED)
-      exit 0
-      ;;
-    FAST_PASS)
-      FILE_PATH="${_VG_FAST_RESULT#*$'\n'}"
-      [[ "$FILE_PATH" == "$_VG_FAST_RESULT" ]] && FILE_PATH=""
-      vg_log "post-write-guard" "Write" "pass" "" "$FILE_PATH"
-      exit 0
-      ;;
-  esac
-fi
+_VG_U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
+_VG_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_VG_U16_BASE_LIMIT")
+_VG_SCAN_MAX_FILES="${VG_SCAN_MAX_FILES:-5000}"
+_VG_SCAN_MAX_DEFS="${VG_SCAN_MAX_DEFS:-20}"
+_VG_SCAN_MATCH_LIMIT="${VG_SCAN_MATCH_LIMIT:-5}"
 
-source "$(dirname "$0")/_lib/stub_detect.sh"
-vg_start_timer
-
-RESULT=$(printf '%s' "$INPUT" | vg_json_two_fields "tool_input.file_path" "tool_input.content")
-
-FILE_PATH=$(echo "$RESULT" | head -1)
-CONTENT=$(echo "$RESULT" | tail -n +2)
-
-if [[ -z "$FILE_PATH" ]] || [[ -z "$CONTENT" ]]; then
-  exit 0
-fi
-
-#Extract file name and extension
-BASENAME=$(basename "$FILE_PATH")
-EXT="${BASENAME##*.}"
-
-# Only check source files
-if ! vg_is_source_file "$FILE_PATH"; then
-  vg_log "post-write-guard" "Write" "pass" "Non-source file" "$FILE_PATH"
-  exit 0
-fi
-
-# Find the project root directory (look up for .git).
-# Git worktrees store .git as a file, and hook inputs may use relative paths.
-case "$FILE_PATH" in
-  /*) FILE_PATH_ABS="$FILE_PATH" ;;
-  *) FILE_PATH_ABS="${PWD}/${FILE_PATH#./}" ;;
-esac
-
-SEARCH_DIR=$(dirname "$FILE_PATH_ABS")
-PROJECT_DIR=""
-while [[ "$SEARCH_DIR" != "/" ]]; do
-  if [[ -e "$SEARCH_DIR/.git" ]]; then
-    PROJECT_DIR="$SEARCH_DIR"
-    break
+_VG_RUNTIME_ERR="$(mktemp)"
+_vg_cleanup_runtime_err() {
+  local status=$?
+  if ! rm -f "$_VG_RUNTIME_ERR" 2>/dev/null; then
+    printf 'VIBEGUARD ERROR: failed to remove post-write runtime stderr temp file\n' >&2
   fi
-
-  NEXT_DIR=$(dirname "$SEARCH_DIR")
-  if [[ "$NEXT_DIR" == "$SEARCH_DIR" ]]; then
-    break
-  fi
-  SEARCH_DIR="$NEXT_DIR"
-done
-
-if [[ -z "$PROJECT_DIR" ]]; then
-  vg_log "post-write-guard" "Write" "pass" "No git project" "$FILE_PATH"
-  exit 0
-fi
-
-WARNINGS=""
-
-#Scan budget: avoid triggering a high-cost full scan for every write in a large warehouse
-MAX_SCAN_FILES="${VG_SCAN_MAX_FILES:-5000}"
-MAX_SCAN_DEFS="${VG_SCAN_MAX_DEFS:-20}"
-MAX_MATCHES="${VG_SCAN_MATCH_LIMIT:-5}"
-HAS_RG=0
-if command -v rg >/dev/null 2>&1; then
-  HAS_RG=1
-fi
-
-RG_EXCLUDES=(
-  --glob '!**/node_modules/**'
-  --glob '!**/.git/**'
-  --glob '!**/target/**'
-  --glob '!**/vendor/**'
-  --glob '!**/dist/**'
-  --glob '!**/build/**'
-  --glob '!**/__pycache__/**'
-  --glob '!**/.venv/**'
-  # Fix post-write: exclude tests directories from same-name search
-  --glob '!**/tests/**'
-  --glob '!**/__tests__/**'
-  --glob '!**/test/**'
-  --glob '!**/spec/**'
-)
-
-SCAN_DEGRADED=0
-FILE_COUNT=0
-if [[ "${HAS_RG}" -eq 1 ]]; then
-  FILE_COUNT=$({ rg --files "${RG_EXCLUDES[@]}" "$PROJECT_DIR" 2>/dev/null || true; } | wc -l | tr -d ' ')
-else
-  # PERF-OK: rg is preferred; fallback scan only decides whether to skip deeper checks.
-  FILE_COUNT=$(find "$PROJECT_DIR" \
-    -type f \
-    -not -path "*/node_modules/*" \
-    -not -path "*/.git/*" \
-    -not -path "*/target/*" \
-    -not -path "*/vendor/*" \
-    -not -path "*/dist/*" \
-    -not -path "*/build/*" \
-    -not -path "*/__pycache__/*" \
-    -not -path "*/.venv/*" \
-    2>/dev/null | wc -l | tr -d ' ')
-fi
-
-if [[ "${FILE_COUNT}" -gt "${MAX_SCAN_FILES}" ]]; then
-  SCAN_DEGRADED=1
-fi
-
-# --- Check 1: File with the same name ---
-# Search for files with the same name in the project (exclude node_modules, .git, target, vendor, etc.)
-if [[ "${HAS_RG}" -eq 1 ]]; then
-  SAME_NAME_FILES=$(rg --files "${RG_EXCLUDES[@]}" -g "**/${BASENAME}" "$PROJECT_DIR" 2>/dev/null \
-    | grep -Fvx -- "$FILE_PATH" \
-    | grep -Fvx -- "$FILE_PATH_ABS" \
-    | head -"${MAX_MATCHES}" || true)
-else
-  # PERF-OK: rg is preferred; fallback output is capped by VG_SCAN_MATCH_LIMIT.
-  SAME_NAME_FILES=$(find "$PROJECT_DIR" \
-    -name "$BASENAME" \
-    -not -path "$FILE_PATH" \
-    -not -path "$FILE_PATH_ABS" \
-    -not -path "*/node_modules/*" \
-    -not -path "*/.git/*" \
-    -not -path "*/target/*" \
-    -not -path "*/vendor/*" \
-    -not -path "*/dist/*" \
-    -not -path "*/build/*" \
-    -not -path "*/__pycache__/*" \
-    -not -path "*/.venv/*" \
-    -not -path "*/tests/*" \
-    -not -path "*/__tests__/*" \
-    -not -path "*/test/*" \
-    -not -path "*/spec/*" \
-    2>/dev/null | head -"${MAX_MATCHES}" || true)
-fi
-
-# Skip same-name detection for Go: each package is a directory, so two files
-# with the same basename are necessarily in different packages
-# (e.g. internal/foo/config.go vs internal/cli/config.go) and that is the
-# standard convention, not a duplicate. Multi-binary repos likewise have
-# many cmd/*/main.go files. Real cross-package duplicates of struct/func
-# definitions are still caught by Check 2 below.
-if [[ "$EXT" == "go" ]]; then
-  SAME_NAME_FILES=""
-fi
-
-if [[ -n "$SAME_NAME_FILES" ]]; then
-  FILE_LIST=$(echo "$SAME_NAME_FILES" | tr '\n' ', ' | sed 's/,$//')
-  WARNINGS="[L1] [review] [this-edit] OBSERVATION: duplicate filename found in project: ${FILE_LIST}
-SCOPE: REVIEW-ONLY — do not delete existing files or auto-merge; confirm intent before acting
-ACTION: REVIEW"
-fi
-
-if [[ "${SCAN_DEGRADED}" -eq 1 ]]; then
-  WARNINGS="${WARNINGS:+${WARNINGS}
----
-}[L1] [info] [this-edit] OBSERVATION: project has ${FILE_COUNT} files, exceeding ${MAX_SCAN_FILES} threshold — deep duplicate scan skipped
-SCOPE: informational only — no action required
-ACTION: SKIP"
-fi
-
-# --- Check 2: Duplicate key definition ---
-#Extract key definition names from the new file contents
-# PERF-OK: one Python parser over this write payload avoids per-definition forks.
-DEFINITIONS=$(echo "$CONTENT" | EXT="$EXT" python3 -c "
-import sys, re, os
-
-content = sys.stdin.read()
-ext = os.environ.get('EXT', '')
-names = set()
-
-# Fix post-write: use language-specific patterns to avoid cross-language pollution.
-# Each language only extracts definitions that are syntactically meaningful for it.
-if ext == 'rs':
-    patterns = [
-        r'(?:pub\s+(?:\w+\s+)?)?(?:struct|enum|trait|union)\s+(\w+)',
-        r'(?:pub\s+(?:\w+\s+)?)?fn\s+(\w+)',
-    ]
-elif ext in ('ts', 'tsx', 'js', 'jsx'):
-    patterns = [
-        r'(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(\w+)',
-        r'(?:export\s+)?interface\s+(\w+)',
-        r'(?:export\s+)?(?:async\s+)?function\s+(\w+)',
-        r'(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?\(',
-    ]
-elif ext == 'py':
-    patterns = [
-        r'class\s+(\w+)',
-        r'def\s+(\w+)\s*\(',
-    ]
-elif ext == 'go':
-    patterns = [
-        r'type\s+(\w+)\s+(?:struct|interface)',
-        r'func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(',
-    ]
-else:
-    # Minimal fallback for other languages
-    patterns = [
-        r'(?:class|interface)\s+(\w+)',
-        r'(?:function|func|def)\s+(\w+)',
-    ]
-
-for p in patterns:
-    for m in re.finditer(p, content):
-        name = m.group(1)
-        if name.startswith('_'):
-            continue
-        if len(name) > 3 and name not in ('self', 'init', 'main', 'test', 'None', 'True', 'False', 'this', 'super', 'impl', 'type', 'move', 'async'):
-            names.add(name)
-
-for name in sorted(names):
-    print(name)
-" 2>/dev/null || true)
-
-if [[ -n "$DEFINITIONS" ]] && [[ "${SCAN_DEGRADED}" -eq 0 ]]; then
-  DEFINITIONS=$(echo "$DEFINITIONS" | head -n "${MAX_SCAN_DEFS}")
-  DUPLICATE_DEFS=""
-  while IFS= read -r defname; do
-    # Search for this definition name in the project (excluding the new file itself)
-    if [[ "${HAS_RG}" -eq 1 ]]; then
-      # PERF-OK: definitions are capped by VG_SCAN_MAX_DEFS before this loop.
-      FOUND=$(rg -l "${RG_EXCLUDES[@]}" -g "**/*.${EXT}" \
-        -e "struct[[:space:]]+${defname}\\b" \
-        -e "class[[:space:]]+${defname}\\b" \
-        -e "interface[[:space:]]+${defname}\\b" \
-        -e "type[[:space:]]+${defname}\\b" \
-        -e "fn[[:space:]]+${defname}\\b" \
-        -e "func[[:space:]]+${defname}\\b" \
-        -e "def[[:space:]]+${defname}\\b" \
-        -e "function[[:space:]]+${defname}\\b" \
-        "$PROJECT_DIR" 2>/dev/null \
-        | grep -Fvx -- "$FILE_PATH" \
-        | grep -Fvx -- "$FILE_PATH_ABS" \
-        | head -3 || true)
-    else
-      # PERF-OK: definitions are capped by VG_SCAN_MAX_DEFS before this loop.
-      FOUND=$(grep -rl --include="*.${EXT}" \
-        -e "struct ${defname}" \
-        -e "class ${defname}" \
-        -e "interface ${defname}" \
-        -e "type ${defname}" \
-        -e "fn ${defname}" \
-        -e "func ${defname}" \
-        -e "def ${defname}" \
-        -e "function ${defname}" \
-        "$PROJECT_DIR" 2>/dev/null \
-        | grep -Fv -- "$FILE_PATH" \
-        | grep -v node_modules \
-        | grep -v ".git/" \
-        | grep -v "/target/" \
-        | grep -v "/vendor/" \
-        | grep -v "/dist/" \
-        | head -3 || true)
-    fi
-
-    if [[ -n "$FOUND" ]]; then
-      FOUND_LIST=$(echo "$FOUND" | tr '\n' ', ' | sed 's/,$//')
-      DUPLICATE_DEFS="${DUPLICATE_DEFS:+${DUPLICATE_DEFS} }${defname}(in ${FOUND_LIST})"
-    fi
-  done <<< "$DEFINITIONS"
-
-  if [[ -n "$DUPLICATE_DEFS" ]]; then
-    WARNINGS="${WARNINGS:+${WARNINGS}
----
-}[L1] [review] [this-edit] OBSERVATION: duplicate definition(s) found in project: ${DUPLICATE_DEFS}
-FIX: Reuse the existing definition instead of creating a new one
-DO NOT: Delete existing definitions or merge code without confirming intent"
-  fi
-fi
-
-# --- Anti-Stub detection (GSD reference: Level 2 product verification Level 2 — Substantiveness) ---
-STUB_WARNINGS=$(vg_detect_stubs "$FILE_PATH" "$CONTENT")
-if [[ -n "$STUB_WARNINGS" ]]; then
-  WARNINGS="${WARNINGS:+${WARNINGS}
----
-}${STUB_WARNINGS}"
-fi
-
-# --- [U-16] File size guard: configurable limit with project exemptions ---
-# Base limit resolved from env var > ~/.vibeguard/config.json > built-in 800.
-_U16_BASE_LIMIT=$(vg_config_get_int VG_U16_LIMIT u16.limit 800)
-_U16_WARN_LIMIT=$(vg_u16_warn_limit "$_U16_BASE_LIMIT")
-case "$FILE_PATH" in
-  *.rs|*.ts|*.tsx|*.js|*.jsx|*.py|*.go)
-    case "$FILE_PATH" in
-      */tests/*|*_test.*|*.test.*|*.spec.*|*_test.rs|*/test_*) ;;
-      *)
-        _U16_TOTAL=$(echo "$CONTENT" | wc -l | tr -d ' ')
-        if [[ "$_U16_TOTAL" -gt "$_U16_WARN_LIMIT" ]]; then
-          _U16_LIMIT="$_U16_BASE_LIMIT"
-          if [[ "$PROJECT_DIR" != "/" && -f "$PROJECT_DIR/CLAUDE.md" ]]; then
-            _U16_EXEMPT=$(VG_CLAUDE_MD="$PROJECT_DIR/CLAUDE.md" VG_FILE_PATH="$FILE_PATH" python3 -c '
-import os, re
-from pathlib import PurePath
-claude_md = os.environ["VG_CLAUDE_MD"]
-file_path = os.environ["VG_FILE_PATH"]
-limit = 0
-try:
-    with open(claude_md) as f:
-        for line in f:
-            if "U-16 exempt" not in line:
-                continue
-            for pair in re.finditer(r"`([^`]+)`\s*→\s*(\d+)", line):
-                pattern, lim = pair.group(1), int(pair.group(2))
-                try:
-                    if PurePath(file_path).match(pattern):
-                        limit = max(limit, lim)
-                except (ValueError, TypeError):
-                    continue
-except FileNotFoundError:
-    pass
-print(limit)
-' 2>/dev/null | tr -d '[:space:]' || echo "0")
-            _U16_EXEMPT="${_U16_EXEMPT:-0}"
-            if [[ "$_U16_EXEMPT" -gt 0 ]]; then
-              _U16_LIMIT="$_U16_EXEMPT"
-            fi
-          fi
-          if [[ "$_U16_TOTAL" -gt "$_U16_LIMIT" ]]; then
-            WARNINGS="${WARNINGS:+${WARNINGS}
----
-}[U-16] [review] [this-file] OBSERVATION: file has ${_U16_TOTAL} lines, exceeding ${_U16_LIMIT}-line limit
-FIX: Split into focused submodules by responsibility; plan as a separate task
-DO NOT: Start splitting now — finish the current task first, then refactor"
-          elif [[ "$_U16_LIMIT" -le "$_U16_BASE_LIMIT" && "$_U16_TOTAL" -gt "$_U16_WARN_LIMIT" ]]; then
-            WARNINGS="${WARNINGS:+${WARNINGS}
----
-}[U-16] [advisory] [this-file] OBSERVATION: file has ${_U16_TOTAL} lines, exceeding the ${_U16_WARN_LIMIT}-line typical range while staying under the ${_U16_LIMIT}-line hard limit
-FIX: Keep the current change localized; plan a split if this file keeps growing
-DO NOT: Start splitting now — finish the current task first, then refactor"
-          fi
-        fi
-        ;;
-    esac
-    ;;
-esac
-
-if [[ -z "$WARNINGS" ]]; then
-  vg_log "post-write-guard" "Write" "pass" "" "$FILE_PATH"
-  exit 0
-fi
-
-vg_log "post-write-guard" "Write" "warn" "$WARNINGS" "$FILE_PATH"
-
-VG_WARNINGS="$WARNINGS" python3 -c '
-import json, os
-warnings = os.environ.get("VG_WARNINGS", "")
-result = {
-    "hookSpecificOutput": {
-        "hookEventName": "PostToolUse",
-        "additionalContext": "VIBEGUARD duplicate detection:" + warnings
-    }
+  trap - EXIT
+  return "$status"
 }
-print(json.dumps(result, ensure_ascii=False))
-'
+trap _vg_cleanup_runtime_err EXIT
+
+if printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" post-write-check \
+  "$_VG_U16_BASE_LIMIT" \
+  "$_VG_U16_WARN_LIMIT" \
+  "$_VG_SCAN_MAX_FILES" \
+  "$_VG_SCAN_MAX_DEFS" \
+  "$_VG_SCAN_MATCH_LIMIT" \
+  "$VIBEGUARD_LOG_FILE" \
+  2>"$_VG_RUNTIME_ERR"; then
+  exit 0
+fi
+
+_VG_RUNTIME_MSG="$(head -c 300 "$_VG_RUNTIME_ERR" 2>/dev/null || true)"
+[[ -n "$_VG_RUNTIME_MSG" ]] || _VG_RUNTIME_MSG="unknown runtime error"
+if ! vg_log "post-write-guard" "Write" "warn" "runtime post-write-check failed; fail-closed: $_VG_RUNTIME_MSG" ""; then
+  printf 'VIBEGUARD ERROR: failed to log post-write runtime failure\n' >&2
+fi
+
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "VIBEGUARD ERROR: post-write runtime check failed; reporting visibly instead of silently passing."
+  }
+}
+EOF

--- a/tests/hooks/test_post_write_guard.sh
+++ b/tests/hooks/test_post_write_guard.sh
@@ -12,6 +12,20 @@ header "post-write-guard.sh — duplicate detection"
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_test_readme.md","content":"# test"}}' | bash hooks/post-write-guard.sh)
 assert_not_contains "$result" "VIBEGUARD" "Non-source files (.md) are allowed"
 
+# Runtime-owned post-write logs should preserve the shell hook timer telemetry.
+tmp_repo_duration="$(mktemp -d)"
+git -C "$tmp_repo_duration" init -q
+tmp_duration_dir="$(mktemp -d)"
+tmp_duration_log="$tmp_duration_dir/events.jsonl"
+json_payload=$(printf '{"tool_input":{"file_path":"%s","content":"# test"}}' "$tmp_repo_duration/README.md")
+result=$(echo "$json_payload" \
+  | VIBEGUARD_PROJECT_LOG_DIR="$tmp_duration_dir" \
+    VIBEGUARD_LOG_FILE="$tmp_duration_log" \
+    bash hooks/post-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "Post-write duration fixture is silent"
+assert_contains "$(cat "$tmp_duration_log")" '"duration_ms":' "Runtime post-write log preserves duration_ms"
+rm -rf "$tmp_repo_duration" "$tmp_duration_dir"
+
 # Release when there is no git project (use a path that does not exist under /tmp)
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_no_git_project/src/main.rs","content":"fn main() {}"}}' | bash hooks/post-write-guard.sh)
 assert_not_contains "$result" "VIBEGUARD" "Release if there is no git project"

--- a/tests/hooks/test_post_write_guard.sh
+++ b/tests/hooks/test_post_write_guard.sh
@@ -114,6 +114,23 @@ result=$(echo "$json_payload" | bash hooks/post-write-guard.sh)
 assert_contains "$result" "duplicate filename" "Python: same basename across packages still warns (Go-only carve-out)"
 rm -rf "$tmp_repo_py_check"
 
+# Runtime failures must remain visible even when the fallback log write also
+# fails, because PostToolUse is review-only and should not fail silently.
+tmp_repo_runtime_fail="$(mktemp -d)"
+git -C "$tmp_repo_runtime_fail" init -q
+tmp_log_dir="$(mktemp -d)"
+locked_log="$tmp_log_dir/events.jsonl"
+mkdir "${locked_log}.lock.d"
+json_payload=$(printf '{"tool_input":{"file_path":"%s","content":"# x"}}' "$tmp_repo_runtime_fail/README.md")
+result=$(echo "$json_payload" \
+  | VIBEGUARD_PROJECT_LOG_DIR="$tmp_log_dir" \
+    VIBEGUARD_LOG_FILE="$locked_log" \
+    VIBEGUARD_LOG_LOCK_ATTEMPTS=1 \
+    VIBEGUARD_LOG_LOCK_SLEEP_SECONDS=0 \
+    bash hooks/post-write-guard.sh 2>/dev/null)
+assert_contains "$result" "post-write runtime check failed" "Runtime failure remains visible when fallback logging fails"
+rm -rf "$tmp_repo_runtime_fail" "$tmp_log_dir"
+
 # =========================================================
 
 hook_test_finish

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
+use crate::time_utils::{format_unix_secs_utc, now_unix_millis, now_unix_secs};
 
 pub(crate) fn read_stdin() -> io::Result<String> {
     let mut input = String::new();
@@ -298,6 +298,9 @@ pub(crate) fn write_log_event(
         "reason": reason,
         "detail": detail,
     });
+    if let Some(duration_ms) = runtime_hook_duration_ms() {
+        event[crate::event_schema::field::DURATION_MS] = serde_json::Value::from(duration_ms);
+    }
     for (env_name, field_name) in [
         ("VIBEGUARD_CLI", crate::event_schema::field::CLI),
         ("VIBEGUARD_AGENT_TYPE", crate::event_schema::field::AGENT),
@@ -336,6 +339,14 @@ pub(crate) fn write_log_event(
         }
     }
     Ok(())
+}
+
+fn runtime_hook_duration_ms() -> Option<u64> {
+    let start_ms = env::var("VIBEGUARD_HOOK_START_MS")
+        .ok()?
+        .parse::<u64>()
+        .ok()?;
+    Some(now_unix_millis().saturating_sub(start_ms))
 }
 
 pub(crate) fn append_jsonl(path: &Path, line: &str) -> io::Result<()> {

--- a/vibeguard-runtime/src/hook_checks_scan.rs
+++ b/vibeguard-runtime/src/hook_checks_scan.rs
@@ -102,7 +102,7 @@ fn should_skip_scan_dir(path: &Path) -> bool {
     )
 }
 
-fn absolute_path(path: &str) -> PathBuf {
+pub(crate) fn absolute_path(path: &str) -> PathBuf {
     let path = Path::new(path);
     if path.is_absolute() {
         path.to_path_buf()

--- a/vibeguard-runtime/src/hook_checks_write.rs
+++ b/vibeguard-runtime/src/hook_checks_write.rs
@@ -1,0 +1,313 @@
+use regex::Regex;
+use serde_json::json;
+use std::path::Path;
+
+use crate::hook_checks_common::{
+    count_lines, is_source_path, is_test_path, nested_str, project_u16_limit, read_stdin,
+    write_log_event,
+};
+use crate::hook_checks_scan::find_project_dir;
+use crate::hook_checks_write_scan::{
+    duplicate_definition_scan, scan_project_files, scan_same_name_matches,
+};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PostWriteConfig {
+    base_limit: usize,
+    warn_limit: usize,
+    max_scan_files: usize,
+    max_scan_defs: usize,
+    max_matches: usize,
+}
+
+pub fn post_write_check(args: &[String]) -> Result {
+    if args.len() < 6 {
+        return Err("Usage: vibeguard-runtime post-write-check <base-limit> <warn-limit> <max-scan-files> <max-scan-defs> <max-matches> <log-file>".into());
+    }
+
+    let config = PostWriteConfig {
+        base_limit: parse_usize(&args[0], 800),
+        warn_limit: parse_usize(&args[1], 400),
+        max_scan_files: parse_usize(&args[2], 5000),
+        max_scan_defs: parse_usize(&args[3], 20),
+        max_matches: parse_usize(&args[4], 5),
+    };
+    let log_file = &args[5];
+    let input = read_stdin()?;
+    let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
+        return Ok(());
+    };
+
+    let file_path = nested_str(&data, "tool_input.file_path").unwrap_or_default();
+    let content = nested_str(&data, "tool_input.content").unwrap_or_default();
+    if file_path.is_empty() || content.is_empty() {
+        return Ok(());
+    }
+
+    let outcome = evaluate_post_write(&file_path, &content, config);
+    match outcome {
+        PostWriteOutcome::Pass { reason } => {
+            write_log_event(
+                log_file,
+                "post-write-guard",
+                "Write",
+                "pass",
+                reason,
+                &file_path,
+            )?;
+        }
+        PostWriteOutcome::Warn { warnings } => {
+            write_log_event(
+                log_file,
+                "post-write-guard",
+                "Write",
+                "warn",
+                &warnings,
+                &file_path,
+            )?;
+            println!("{}", post_write_warning_output(&warnings)?);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PostWriteOutcome {
+    Pass { reason: &'static str },
+    Warn { warnings: String },
+}
+
+fn evaluate_post_write(
+    file_path: &str,
+    content: &str,
+    config: PostWriteConfig,
+) -> PostWriteOutcome {
+    if !is_source_path(file_path) {
+        return PostWriteOutcome::Pass {
+            reason: "Non-source file",
+        };
+    }
+
+    let Some(project_dir) = find_project_dir(file_path) else {
+        return PostWriteOutcome::Pass {
+            reason: "No git project",
+        };
+    };
+
+    let ext = extension(file_path);
+    let mut warnings = Vec::new();
+    let mut scan_incomplete = false;
+    let scan_files = scan_project_files(&project_dir, config.max_scan_files);
+
+    if ext != "go" {
+        let same_name = scan_same_name_matches(&project_dir, file_path, config.max_matches);
+        scan_incomplete |= same_name.incomplete;
+        if !same_name.matches.is_empty() {
+            warnings.push(format!(
+                "[L1] [review] [this-edit] OBSERVATION: duplicate filename found in project: {}\nSCOPE: REVIEW-ONLY - do not delete existing files or auto-merge; confirm intent before acting\nACTION: REVIEW",
+                same_name.matches.join(", ")
+            ));
+        }
+    }
+
+    scan_incomplete |= scan_files.incomplete;
+    if scan_files.degraded {
+        warnings.push(format!(
+            "[L1] [info] [this-edit] OBSERVATION: project has at least {} files, exceeding {} threshold - deep duplicate scan skipped\nSCOPE: informational only - no action required\nACTION: SKIP",
+            scan_files.count, config.max_scan_files
+        ));
+    }
+
+    if !scan_files.degraded {
+        let duplicate_defs = duplicate_definition_scan(
+            &scan_files.files,
+            file_path,
+            content,
+            &ext,
+            config.max_scan_defs,
+            config.max_matches,
+        );
+        scan_incomplete |= duplicate_defs.incomplete;
+        if !duplicate_defs.duplicates.is_empty() {
+            warnings.push(format!(
+                "[L1] [review] [this-edit] OBSERVATION: duplicate definition(s) found in project: {}\nFIX: Reuse the existing definition instead of creating a new one\nDO NOT: Delete existing definitions or merge code without confirming intent",
+                duplicate_defs.duplicates.join(" ")
+            ));
+        }
+    }
+
+    if scan_incomplete {
+        warnings.push(
+            "[L1] [info] [this-edit] OBSERVATION: post-write project scan was incomplete because one or more paths could not be read\nSCOPE: informational only - review manually if this result looks suspicious\nACTION: REVIEW"
+                .to_string(),
+        );
+    }
+
+    if let Some(stub_warning) = stub_warning(file_path, content) {
+        warnings.push(stub_warning);
+    }
+
+    if let Some(u16_warning) = u16_warning(file_path, content, config.base_limit, config.warn_limit)
+    {
+        warnings.push(u16_warning);
+    }
+
+    if warnings.is_empty() {
+        PostWriteOutcome::Pass { reason: "" }
+    } else {
+        PostWriteOutcome::Warn {
+            warnings: warnings.join("\n---\n"),
+        }
+    }
+}
+
+fn stub_warning(file_path: &str, content: &str) -> Option<String> {
+    let (patterns, lang_desc) = match extension(file_path).as_str() {
+        "rs" => {
+            if !(content.contains("todo!(")
+                || content.contains("unimplemented!(")
+                || content.contains("panic!(\"not implemented"))
+            {
+                return None;
+            }
+            (
+                &[
+                    r"^\s*todo!\(",
+                    r"^\s*unimplemented!\(",
+                    r#"^\s*panic!\("not implemented"#,
+                ][..],
+                "todo!/unimplemented!",
+            )
+        }
+        "ts" | "tsx" | "js" | "jsx" => {
+            if !(content.contains("not implemented")
+                || content.contains("TODO")
+                || content.contains("FIXME")
+                || content.contains("stub"))
+            {
+                return None;
+            }
+            (
+                &[
+                    r"^\s*throw new Error\(.*(not implemented|TODO|FIXME)",
+                    r"^\s*// TODO",
+                    r"^\s*// FIXME",
+                    r"^\s*return null.*// stub",
+                ][..],
+                "throw not implemented / TODO",
+            )
+        }
+        "py" => {
+            if !(content.contains("pass")
+                || content.contains("NotImplementedError")
+                || content.contains("TODO")
+                || content.contains("FIXME"))
+            {
+                return None;
+            }
+            (
+                &[
+                    r"^\s*pass\s*$",
+                    r"^\s*pass\s*#",
+                    r"^\s*raise NotImplementedError",
+                    r"^\s*# TODO",
+                    r"^\s*# FIXME",
+                ][..],
+                "pass/NotImplementedError/TODO",
+            )
+        }
+        "go" => {
+            if !(content.contains("panic(\"not implemented")
+                || content.contains("TODO")
+                || content.contains("FIXME"))
+            {
+                return None;
+            }
+            (
+                &[
+                    r#"^\s*panic\("not implemented"#,
+                    r"^\s*// TODO",
+                    r"^\s*// FIXME",
+                ][..],
+                "panic not implemented / TODO",
+            )
+        }
+        _ => return None,
+    };
+
+    let mut stub_count = 0usize;
+    for pattern in patterns {
+        let Ok(regex) = Regex::new(pattern) else {
+            continue;
+        };
+        stub_count += content.lines().filter(|line| regex.is_match(line)).count();
+    }
+
+    if stub_count == 0 {
+        return None;
+    }
+    Some(format!(
+        "[STUB] [review] [this-edit] OBSERVATION: {stub_count} stub placeholder(s) found in new file ({lang_desc})\nFIX: Replace with real implementation in this task, or add a DEFER comment explaining why\nDO NOT: Add DEFER markers to stubs in other files"
+    ))
+}
+
+fn u16_warning(
+    file_path: &str,
+    content: &str,
+    base_limit: usize,
+    warn_limit: usize,
+) -> Option<String> {
+    if !matches!(
+        extension(file_path).as_str(),
+        "rs" | "ts" | "tsx" | "js" | "jsx" | "py" | "go"
+    ) || is_test_path(file_path)
+    {
+        return None;
+    }
+
+    let total = count_lines(content);
+    if total <= warn_limit {
+        return None;
+    }
+
+    let limit = project_u16_limit(file_path, base_limit);
+    if total > limit {
+        return Some(format!(
+            "[U-16] [review] [this-file] OBSERVATION: file has {total} lines, exceeding {limit}-line limit\nFIX: Split into focused submodules by responsibility; plan as a separate task\nDO NOT: Start splitting now - finish the current task first, then refactor"
+        ));
+    }
+    if limit <= base_limit && total > warn_limit {
+        return Some(format!(
+            "[U-16] [advisory] [this-file] OBSERVATION: file has {total} lines, exceeding the {warn_limit}-line typical range while staying under the {limit}-line hard limit\nFIX: Keep the current change localized; plan a split if this file keeps growing\nDO NOT: Start splitting now - finish the current task first, then refactor"
+        ));
+    }
+    None
+}
+
+fn post_write_warning_output(warnings: &str) -> Result<String> {
+    Ok(serde_json::to_string(&json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": format!("VIBEGUARD duplicate detection:{warnings}"),
+        }
+    }))?)
+}
+
+fn parse_usize(value: &str, fallback: usize) -> usize {
+    value.parse::<usize>().unwrap_or(fallback)
+}
+
+fn extension(file_path: &str) -> String {
+    Path::new(file_path)
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+#[cfg(test)]
+#[path = "hook_checks_write_tests.rs"]
+mod tests;

--- a/vibeguard-runtime/src/hook_checks_write_scan.rs
+++ b/vibeguard-runtime/src/hook_checks_write_scan.rs
@@ -1,0 +1,334 @@
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::hook_checks_scan::absolute_path;
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    ".git",
+    "target",
+    "vendor",
+    "dist",
+    "build",
+    "__pycache__",
+    ".venv",
+    "tests",
+    "__tests__",
+    "test",
+    "spec",
+];
+const IGNORED_DEFINITION_NAMES: &[&str] = &[
+    "self", "init", "main", "test", "None", "True", "False", "this", "super", "impl", "type",
+    "move", "async",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ProjectScan {
+    pub(crate) files: Vec<PathBuf>,
+    pub(crate) count: usize,
+    pub(crate) degraded: bool,
+    pub(crate) incomplete: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SameNameScan {
+    pub(crate) matches: Vec<String>,
+    pub(crate) incomplete: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct DefinitionScan {
+    pub(crate) duplicates: Vec<String>,
+    pub(crate) incomplete: bool,
+}
+
+pub(crate) fn scan_project_files(project_dir: &Path, max_files: usize) -> ProjectScan {
+    let mut files = Vec::new();
+    let mut count = 0usize;
+    let mut incomplete = false;
+    let degraded = scan_dir(
+        project_dir,
+        max_files,
+        Some(&mut files),
+        &mut count,
+        &mut incomplete,
+    );
+    ProjectScan {
+        files,
+        count,
+        degraded,
+        incomplete,
+    }
+}
+
+pub(crate) fn scan_same_name_matches(
+    project_dir: &Path,
+    file_path: &str,
+    max_matches: usize,
+) -> SameNameScan {
+    let Some(basename) = Path::new(file_path).file_name().and_then(|s| s.to_str()) else {
+        return SameNameScan {
+            matches: Vec::new(),
+            incomplete: false,
+        };
+    };
+    let target = absolute_path(file_path);
+    let mut count = 0usize;
+    let mut incomplete = false;
+    let mut matches = Vec::new();
+    scan_same_name_dir(
+        project_dir,
+        basename,
+        &target,
+        max_matches,
+        &mut count,
+        &mut incomplete,
+        &mut matches,
+    );
+    SameNameScan {
+        matches,
+        incomplete,
+    }
+}
+
+pub(crate) fn duplicate_definition_scan(
+    files: &[PathBuf],
+    file_path: &str,
+    content: &str,
+    ext: &str,
+    max_scan_defs: usize,
+    max_matches: usize,
+) -> DefinitionScan {
+    let definitions = extract_definitions(content, ext)
+        .into_iter()
+        .take(max_scan_defs)
+        .collect::<Vec<_>>();
+    if definitions.is_empty() {
+        return DefinitionScan {
+            duplicates: Vec::new(),
+            incomplete: false,
+        };
+    }
+
+    let target = absolute_path(file_path);
+    let mut duplicates = Vec::new();
+    let mut incomplete = false;
+    for defname in definitions {
+        let found = find_definition_matches(files, &target, ext, &defname, max_matches.min(3));
+        incomplete |= found.incomplete;
+        if !found.matches.is_empty() {
+            duplicates.push(format!("{defname}(in {})", found.matches.join(", ")));
+        }
+    }
+    DefinitionScan {
+        duplicates,
+        incomplete,
+    }
+}
+
+fn scan_dir(
+    dir: &Path,
+    max_files: usize,
+    mut files: Option<&mut Vec<PathBuf>>,
+    count: &mut usize,
+    incomplete: &mut bool,
+) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        *incomplete = true;
+        return false;
+    };
+    for entry_result in entries {
+        let Ok(entry) = entry_result else {
+            *incomplete = true;
+            continue;
+        };
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            *incomplete = true;
+            continue;
+        };
+        if file_type.is_dir() {
+            if should_skip_dir(&path) {
+                continue;
+            }
+            let child_files = files.as_deref_mut();
+            if scan_dir(&path, max_files, child_files, count, incomplete) {
+                return true;
+            }
+        } else if file_type.is_file() {
+            *count += 1;
+            if *count > max_files {
+                return true;
+            }
+            if let Some(files) = files.as_deref_mut() {
+                files.push(path);
+            }
+        }
+    }
+    false
+}
+
+fn scan_same_name_dir(
+    dir: &Path,
+    basename: &str,
+    target: &Path,
+    max_matches: usize,
+    count: &mut usize,
+    incomplete: &mut bool,
+    matches: &mut Vec<String>,
+) {
+    if matches.len() >= max_matches {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        *incomplete = true;
+        return;
+    };
+    for entry_result in entries {
+        if matches.len() >= max_matches {
+            break;
+        }
+        let Ok(entry) = entry_result else {
+            *incomplete = true;
+            continue;
+        };
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            *incomplete = true;
+            continue;
+        };
+        if file_type.is_dir() {
+            if should_skip_dir(&path) {
+                continue;
+            }
+            scan_same_name_dir(
+                &path,
+                basename,
+                target,
+                max_matches,
+                count,
+                incomplete,
+                matches,
+            );
+        } else if file_type.is_file() {
+            *count += 1;
+            if path.file_name().and_then(|s| s.to_str()) == Some(basename)
+                && absolute_path(path.to_string_lossy().as_ref()) != target
+            {
+                matches.push(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+}
+
+fn extract_definitions(content: &str, ext: &str) -> Vec<String> {
+    let patterns = definition_patterns(ext);
+    let mut names = Vec::new();
+    for pattern in patterns {
+        let Ok(regex) = Regex::new(pattern) else {
+            continue;
+        };
+        for captures in regex.captures_iter(content) {
+            let Some(name) = captures.get(1).map(|m| m.as_str()) else {
+                continue;
+            };
+            if is_meaningful_definition_name(name) && !names.iter().any(|existing| existing == name)
+            {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    names
+}
+
+fn definition_patterns(ext: &str) -> &'static [&'static str] {
+    match ext {
+        "rs" => &[
+            r"(?:pub\s+(?:\w+\s+)?)?(?:struct|enum|trait|union)\s+(\w+)",
+            r"(?:pub\s+(?:\w+\s+)?)?fn\s+(\w+)",
+        ],
+        "ts" | "tsx" | "js" | "jsx" => &[
+            r"(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(\w+)",
+            r"(?:export\s+)?interface\s+(\w+)",
+            r"(?:export\s+)?(?:async\s+)?function\s+(\w+)",
+            r"(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?\(",
+        ],
+        "py" => &[r"class\s+(\w+)", r"def\s+(\w+)\s*\("],
+        "go" => &[
+            r"type\s+(\w+)\s+(?:struct|interface)",
+            r"func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(",
+        ],
+        _ => &[
+            r"(?:class|interface)\s+(\w+)",
+            r"(?:function|func|def)\s+(\w+)",
+        ],
+    }
+}
+
+struct DefinitionMatchScan {
+    matches: Vec<String>,
+    incomplete: bool,
+}
+
+fn find_definition_matches(
+    files: &[PathBuf],
+    target: &Path,
+    ext: &str,
+    defname: &str,
+    max_matches: usize,
+) -> DefinitionMatchScan {
+    let mut found = Vec::new();
+    let Ok(regex) = duplicate_definition_regex(defname) else {
+        return DefinitionMatchScan {
+            matches: found,
+            incomplete: true,
+        };
+    };
+    let mut incomplete = false;
+    for path in files {
+        if found.len() >= max_matches {
+            break;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some(ext) {
+            continue;
+        }
+        if absolute_path(path.to_string_lossy().as_ref()) == target {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(path) else {
+            incomplete = true;
+            continue;
+        };
+        if regex.is_match(&text) {
+            found.push(path.to_string_lossy().into_owned());
+        }
+    }
+    DefinitionMatchScan {
+        matches: found,
+        incomplete,
+    }
+}
+
+fn duplicate_definition_regex(defname: &str) -> std::result::Result<Regex, regex::Error> {
+    let name = regex::escape(defname);
+    Regex::new(&format!(
+        r"\b(?:struct|class|interface|type|fn|func|def|function)\s+{}\b",
+        name
+    ))
+}
+
+fn is_meaningful_definition_name(name: &str) -> bool {
+    name.len() > 3 && !name.starts_with('_') && !IGNORED_DEFINITION_NAMES.contains(&name)
+}
+
+fn should_skip_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .is_some_and(|name| SKIP_DIRS.contains(&name))
+}
+
+#[cfg(test)]
+#[path = "hook_checks_write_scan_tests.rs"]
+mod tests;

--- a/vibeguard-runtime/src/hook_checks_write_scan_tests.rs
+++ b/vibeguard-runtime/src/hook_checks_write_scan_tests.rs
@@ -1,0 +1,86 @@
+use super::*;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+fn temp_write_scan_project(name: &str) -> std::io::Result<PathBuf> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "vibeguard_write_scan_{name}_{}_{}",
+        std::process::id(),
+        unique
+    ));
+    fs::create_dir_all(root.join(".git"))?;
+    Ok(root)
+}
+
+#[test]
+fn scan_skips_test_dirs_and_respects_budget() -> TestResult {
+    let root = temp_write_scan_project("skip_tests")?;
+    fs::create_dir_all(root.join("src"))?;
+    fs::create_dir_all(root.join("tests"))?;
+    let target = root.join("src").join("lib.py");
+    fs::write(&target, "def realThing():\n    pass\n")?;
+    fs::write(
+        root.join("tests").join("lib.py"),
+        "def testThing():\n    pass\n",
+    )?;
+
+    let scan = scan_project_files(&root, 10);
+    assert_eq!(scan.count, 1);
+    assert!(!scan.degraded);
+    assert!(
+        scan_same_name_matches(&root, target.to_string_lossy().as_ref(), 5)
+            .matches
+            .is_empty()
+    );
+
+    let degraded = scan_project_files(&root, 0);
+    assert!(degraded.degraded);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn duplicate_definition_matches_same_extension_only() -> TestResult {
+    let root = temp_write_scan_project("duplicate_defs")?;
+    fs::create_dir_all(root.join("src"))?;
+    fs::write(
+        root.join("src").join("existing.py"),
+        "def sharedName():\n    pass\n",
+    )?;
+    fs::write(
+        root.join("src").join("existing.ts"),
+        "function sharedName() {}\n",
+    )?;
+    let scan = scan_project_files(&root, 10);
+
+    let found = duplicate_definition_scan(
+        &scan.files,
+        root.join("src").join("new.py").to_string_lossy().as_ref(),
+        "def sharedName():\n    return 1\n",
+        "py",
+        20,
+        5,
+    );
+    assert_eq!(found.duplicates.len(), 1);
+    assert!(found.duplicates[0].contains("existing.py"), "{found:?}");
+    assert!(!found.duplicates[0].contains("existing.ts"), "{found:?}");
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn missing_scan_root_marks_incomplete() -> TestResult {
+    let root = temp_write_scan_project("missing_root")?;
+    let missing = root.join("missing");
+
+    assert!(scan_project_files(&missing, 10).incomplete);
+    assert!(scan_same_name_matches(&missing, "new.py", 5).incomplete);
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}

--- a/vibeguard-runtime/src/hook_checks_write_tests.rs
+++ b/vibeguard-runtime/src/hook_checks_write_tests.rs
@@ -1,0 +1,180 @@
+#[cfg(test)]
+use super::*;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_post_write_project(name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "vibeguard_post_write_{name}_{}_{}",
+        std::process::id(),
+        unique
+    ));
+    fs::create_dir_all(root.join(".git")).expect("git marker should be created");
+    root
+}
+
+fn config() -> PostWriteConfig {
+    PostWriteConfig {
+        base_limit: 800,
+        warn_limit: 400,
+        max_scan_files: 5000,
+        max_scan_defs: 20,
+        max_matches: 5,
+    }
+}
+
+#[test]
+fn detects_same_name_and_definition_duplicates() {
+    let root = temp_post_write_project("duplicates");
+    let existing = root.join("src").join("existing");
+    let new_dir = root.join("src").join("new");
+    fs::create_dir_all(&existing).expect("existing dir");
+    fs::create_dir_all(&new_dir).expect("new dir");
+    fs::write(
+        existing.join("service.py"),
+        "def processOrder():\n    return 1\n",
+    )
+    .expect("existing file");
+    let file_path = new_dir.join("service.py");
+    let outcome = evaluate_post_write(
+        file_path.to_string_lossy().as_ref(),
+        "def processOrder():\n    return 2\n",
+        config(),
+    );
+    let PostWriteOutcome::Warn { warnings } = outcome else {
+        panic!("expected warning");
+    };
+    assert!(warnings.contains("duplicate filename"), "{warnings}");
+    assert!(warnings.contains("processOrder"), "{warnings}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn go_same_name_is_not_duplicate_filename() {
+    let root = temp_post_write_project("go_same_name");
+    let foo = root.join("internal").join("foo");
+    let cli = root.join("internal").join("cli");
+    fs::create_dir_all(&foo).expect("foo dir");
+    fs::create_dir_all(&cli).expect("cli dir");
+    fs::write(
+        foo.join("config.go"),
+        "package foo\n\ntype FooConfig struct{}\n",
+    )
+    .expect("foo config");
+    let file_path = cli.join("config.go");
+    let outcome = evaluate_post_write(
+        file_path.to_string_lossy().as_ref(),
+        "package cli\n\ntype CLIConfig struct{}\n",
+        config(),
+    );
+    assert_eq!(outcome, PostWriteOutcome::Pass { reason: "" });
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn scan_budget_degrades_duplicate_definitions() {
+    let root = temp_post_write_project("budget");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("src dir");
+    fs::write(
+        src.join("existing.py"),
+        "def keepExisting():\n    return 1\n",
+    )
+    .expect("existing file");
+    let file_path = src.join("new.py");
+    let mut cfg = config();
+    cfg.max_scan_files = 0;
+    let outcome = evaluate_post_write(
+        file_path.to_string_lossy().as_ref(),
+        "def keepExisting():\n    return 2\n",
+        cfg,
+    );
+    let PostWriteOutcome::Warn { warnings } = outcome else {
+        panic!("expected budget warning");
+    };
+    assert!(
+        warnings.contains("deep duplicate scan skipped"),
+        "{warnings}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn same_name_detection_survives_scan_budget() {
+    let root = temp_post_write_project("same_name_budget");
+    let old_dir = root.join("old");
+    let new_dir = root.join("new");
+    fs::create_dir_all(&old_dir).expect("old dir");
+    fs::create_dir_all(&new_dir).expect("new dir");
+    fs::write(
+        old_dir.join("service.py"),
+        "def existingThing():\n    return 1\n",
+    )
+    .expect("old file");
+    let file_path = new_dir.join("service.py");
+    let mut cfg = config();
+    cfg.max_scan_files = 0;
+
+    let outcome = evaluate_post_write(
+        file_path.to_string_lossy().as_ref(),
+        "def newThing():\n    return 2\n",
+        cfg,
+    );
+    let PostWriteOutcome::Warn { warnings } = outcome else {
+        panic!("expected warning");
+    };
+    assert!(warnings.contains("duplicate filename"), "{warnings}");
+    assert!(
+        warnings.contains("deep duplicate scan skipped"),
+        "{warnings}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn go_duplicate_definition_still_warns_without_same_name_warning() {
+    let root = temp_post_write_project("go_dup_def");
+    let old_dir = root.join("internal").join("foo");
+    let new_dir = root.join("internal").join("cli");
+    fs::create_dir_all(&old_dir).expect("old dir");
+    fs::create_dir_all(&new_dir).expect("new dir");
+    fs::write(
+        old_dir.join("config.go"),
+        "package foo\n\ntype CLIConfig struct{}\n",
+    )
+    .expect("old file");
+    let file_path = new_dir.join("config.go");
+
+    let outcome = evaluate_post_write(
+        file_path.to_string_lossy().as_ref(),
+        "package cli\n\ntype CLIConfig struct{}\n",
+        config(),
+    );
+    let PostWriteOutcome::Warn { warnings } = outcome else {
+        panic!("expected warning");
+    };
+    assert!(!warnings.contains("duplicate filename"), "{warnings}");
+    assert!(warnings.contains("CLIConfig"), "{warnings}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn stubs_and_u16_are_reported() {
+    let root = temp_post_write_project("stub_u16");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("src dir");
+    let file_path = src.join("new.py");
+    let content = ["pass"; 401].join("\n");
+    let outcome = evaluate_post_write(file_path.to_string_lossy().as_ref(), &content, config());
+    let PostWriteOutcome::Warn { warnings } = outcome else {
+        panic!("expected warnings");
+    };
+    assert!(warnings.contains("[STUB]"), "{warnings}");
+    assert!(warnings.contains("[U-16]"), "{warnings}");
+    let _ = fs::remove_dir_all(root);
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -9,6 +9,8 @@ mod hook_checks_bash;
 mod hook_checks_common;
 mod hook_checks_history;
 mod hook_checks_scan;
+mod hook_checks_write;
+mod hook_checks_write_scan;
 mod hook_status;
 mod json_field;
 mod log_append;
@@ -113,6 +115,11 @@ static COMMANDS: &[Command] = &[
         name: "post-write-fast-check",
         usage: "<base-limit> <max-scan-files> <log-file>  — fast-pass simple PostToolUse(Write) inputs",
         handler: hook_checks::post_write_fast_check,
+    },
+    Command {
+        name: "post-write-check",
+        usage: "<base-limit> <warn-limit> <max-scan-files> <max-scan-defs> <max-matches> <log-file>  — classify and handle PostToolUse(Write) input for hooks",
+        handler: hook_checks_write::post_write_check,
     },
     Command {
         name: "codex-app-server-wrapper",

--- a/vibeguard-runtime/src/time_utils.rs
+++ b/vibeguard-runtime/src/time_utils.rs
@@ -8,6 +8,16 @@ pub(crate) fn now_unix_secs() -> u64 {
         .as_secs()
 }
 
+/// Returns milliseconds since Unix epoch via SystemTime.
+pub(crate) fn now_unix_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
 /// Parse ISO 8601 UTC timestamp (YYYY-MM-DDTHH:MM:SSZ or +00:00) to Unix seconds.
 /// Returns None if the string cannot be parsed.
 pub(crate) fn parse_iso_ts(ts: &str) -> Option<u64> {

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -92,6 +92,7 @@ fn run_post_write_check(input: &str, log_file: &std::path::Path) -> std::process
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .env("VIBEGUARD_HOOK_START_MS", "1")
         .spawn()
         .unwrap();
     child
@@ -151,11 +152,9 @@ fn post_write_check_silent_pass_for_non_source() {
     let out = run_post_write_check(&input, &log_file);
     assert_eq!(out.status.code(), Some(0));
     assert!(out.stdout.is_empty());
-    assert!(
-        fs::read_to_string(&log_file)
-            .unwrap()
-            .contains("Non-source file")
-    );
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("Non-source file"));
+    assert!(log_text.contains("\"duration_ms\":"), "{log_text}");
     let _ = fs::remove_dir_all(root);
 }
 

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -68,6 +68,7 @@ fn help_lists_all_commands() {
         "pre-edit-check",
         "post-edit-fast-check",
         "post-write-fast-check",
+        "post-write-check",
         "codex-app-server-wrapper",
     ] {
         assert!(
@@ -75,6 +76,87 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+fn run_post_write_check(input: &str, log_file: &std::path::Path) -> std::process::Output {
+    let mut child = bin()
+        .args([
+            "post-write-check",
+            "800",
+            "400",
+            "5000",
+            "20",
+            "5",
+            log_file.to_string_lossy().as_ref(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn post_write_check_reports_duplicate_definition() {
+    let root = unique_temp_dir("post-write-dup");
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("existing.py"),
+        "def processOrder():\n    return 1\n",
+    )
+    .unwrap();
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": root.join("src").join("new.py"),
+            "content": "def processOrder():\n    return 2\n"
+        }
+    })
+    .to_string();
+
+    let out = run_post_write_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("PostToolUse"), "{stdout}");
+    assert!(stdout.contains("duplicate definition"), "{stdout}");
+    assert!(
+        fs::read_to_string(&log_file)
+            .unwrap()
+            .contains("processOrder")
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_write_check_silent_pass_for_non_source() {
+    let root = unique_temp_dir("post-write-pass");
+    fs::create_dir_all(root.join(".git")).unwrap();
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": root.join("README.md"),
+            "content": "# title"
+        }
+    })
+    .to_string();
+
+    let out = run_post_write_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(out.stdout.is_empty());
+    assert!(
+        fs::read_to_string(&log_file)
+            .unwrap()
+            .contains("Non-source file")
+    );
+    let _ = fs::remove_dir_all(root);
 }
 
 fn run_pre_bash_check(input: &str) -> std::process::Output {


### PR DESCRIPTION
Partially addresses #354.

## Summary
- Move PostToolUse(Write) duplicate/stub/U-16 review logic from shell/Python/rg into `vibeguard-runtime post-write-check`.
- Keep `hooks/post-write-guard.sh` as a thin runtime shim with visible JSON failure output when runtime/logging fails.
- Preserve review-only duplicate filename/definition warnings, Go same-name carve-out, scan budget downgrade, stub warnings, and U-16 post-write advisories.
- Add runtime unit/CLI coverage plus shell coverage for visible runtime failure.

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `git diff --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo build --release --manifest-path vibeguard-runtime/Cargo.toml --quiet`
- `bash tests/test_hooks.sh`
- `bash tests/test_codex_runtime.sh`
- `bash tests/test_self_application_ci.sh`
- `bash scripts/ci/validate-hook-perf.sh`
- `bash tests/bench_hook_latency.sh`
- `bash tests/test_manifest_contract.sh`
- `bash tests/unit/run_all.sh`