### PR TITLE
Avoid cargo metadata in source runtime install

### DIFF
--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -261,15 +261,9 @@ prepare_runtime_from_source() {
     exit 2
   fi
   echo "  Building vibeguard-runtime from source (Rust)..."
-  if cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet 2>/dev/null; then
-    local runtime_target_dir runtime_binary
-    if ! runtime_target_dir="$(
-      cargo metadata --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --no-deps --format-version=1 2>/dev/null \
-        | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
-    )" || [[ -z "${runtime_target_dir}" ]]; then
-      red "  ERROR: unable to resolve vibeguard-runtime Cargo target directory."
-      exit 2
-    fi
+  local runtime_target_dir="${_INSTALL_TMP}/cargo-target"
+  if cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --target-dir "${runtime_target_dir}" --quiet 2>/dev/null; then
+    local runtime_binary
     runtime_binary="${runtime_target_dir}/release/vibeguard-runtime"
     if [[ ! -x "${runtime_binary}" ]]; then
       red "  ERROR: vibeguard-runtime build output not found at ${runtime_binary}"
@@ -278,6 +272,7 @@ prepare_runtime_from_source() {
     mkdir -p "${_INSTALL_TMP}/bin"
     cp "${runtime_binary}" "${_INSTALL_TMP}/bin/vibeguard-runtime"
     chmod +x "${_INSTALL_TMP}/bin/vibeguard-runtime"
+    rm -rf "${runtime_target_dir}"
     green "  vibeguard-runtime binary prepared from source"
   else
     red "  ERROR: vibeguard-runtime build failed. Fix the Rust build before installing VibeGuard."

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -196,6 +196,24 @@ assert_scheduled_gc_present() {
   fi
 }
 
+assert_prepare_runtime_from_source_no_cargo_metadata() {
+  python3 - <<'PY' "${REPO_DIR}/scripts/setup/install.sh"
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+match = re.search(
+    r"^prepare_runtime_from_source\(\) \{\n(?P<body>.*?)(?=^}\n\nprepare_runtime_binary\(\) \{)",
+    text,
+    re.MULTILINE | re.DOTALL,
+)
+if not match:
+    raise SystemExit(1)
+raise SystemExit(1 if "cargo metadata" in match.group("body") else 0)
+PY
+}
+
 ORIG_HOME="${HOME}"
 TMP_HOME="$(mktemp -d)"
 ORIG_PATH="${PATH}"
@@ -473,6 +491,7 @@ export VIBEGUARD_TEST_RELEASE_DIR="${TEST_RELEASE_DIR}"
 header "setup scripts syntax"
 assert_cmd "setup.sh syntax is correct" bash -n "${REPO_DIR}/setup.sh"
 assert_cmd "scripts/setup/install.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/install.sh"
+assert_cmd "source runtime build does not call cargo metadata" assert_prepare_runtime_from_source_no_cargo_metadata
 assert_cmd "scripts/setup/check.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/check.sh"
 assert_cmd "scripts/setup/clean.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/clean.sh"
 assert_cmd "scripts/setup/codex-status.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/codex-status.sh"
@@ -965,6 +984,8 @@ source_build_out="$(HOME="${source_build_home}" CARGO_TARGET_DIR="${CUSTOM_CARGO
 assert_contains "${source_build_out}" "Mode: build-from-source" "--build-from-source reports source mode"
 assert_contains "${source_build_out}" "Building vibeguard-runtime from source (Rust)..." "--build-from-source builds runtime from source"
 assert_cmd "--build-from-source invokes cargo build" grep -qF "build --release" "${source_cargo_log}"
+assert_cmd "--build-from-source uses setup-owned target dir" grep -qF -- "--target-dir" "${source_cargo_log}"
+assert_cmd "--build-from-source does not install cargo target tree" test ! -d "${source_build_home}/.vibeguard/installed/cargo-target"
 
 offline_build_home="${TMP_HOME}/offline-build-home"
 offline_cargo_log="${TMP_HOME}/offline-cargo.log"
@@ -973,6 +994,8 @@ mkdir -p "${offline_build_home}"
 offline_build_out="$(HOME="${offline_build_home}" CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" VIBEGUARD_TEST_DOWNLOAD_FAIL=1 VIBEGUARD_TEST_CARGO_LOG="${offline_cargo_log}" bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${offline_build_out}" "Falling back to source build" "offline prebuilt download falls back to source build"
 assert_cmd "offline fallback invokes cargo build" grep -qF "build --release" "${offline_cargo_log}"
+assert_cmd "offline fallback uses setup-owned target dir" grep -qF -- "--target-dir" "${offline_cargo_log}"
+assert_cmd "offline fallback does not install cargo target tree" test ! -d "${offline_build_home}/.vibeguard/installed/cargo-target"
 
 switch_runtime_home="${TMP_HOME}/switch-runtime-home"
 mkdir -p "${switch_runtime_home}"


### PR DESCRIPTION
Partially addresses #354.

## Summary
- build vibeguard-runtime source installs with a setup-owned Cargo target directory via --target-dir
- remove the setup-owned Cargo target tree before moving the install snapshot into place
- add setup regressions that forbid cargo metadata in prepare_runtime_from_source and ensure source/fallback installs do not persist cargo-target

## Verification
- bash -n scripts/setup/install.sh && bash -n tests/test_setup.sh && git diff --check
- bash tests/test_setup.sh (284/284 passing)
- independent read-only reviewer reported no blocking findings after fixes

Issue #354 remains open for the remaining setup/config helper migration work.