### PR TITLE
Move Codex status helpers into runtime

### DIFF
--- a/hooks/_lib/codex_adapter.sh
+++ b/hooks/_lib/codex_adapter.sh
@@ -3,6 +3,9 @@
 
 codex_event_name() {
   local input="$1"
+  if declare -F codex_runtime_stdin >/dev/null 2>&1 && codex_runtime_stdin "codex-event-name" "${input}" 2>/dev/null; then
+    return 0
+  fi
   printf '%s' "${input}" | python3 -c '
 import json
 import sys

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -1,8 +1,37 @@
 #!/usr/bin/env bash
 # Codex wrapper diagnostics and tiny JSON helpers.
 
+codex_runtime_path() {
+  local helper_dir wrapper_dir candidate
+  helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
+  for candidate in \
+    "${VIBEGUARD_RUNTIME:-}" \
+    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${wrapper_dir}/vibeguard-runtime"; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+codex_runtime_stdin() {
+  local command_name="$1" input="$2" runtime_path
+  if ! runtime_path="$(codex_runtime_path)"; then
+    return 127
+  fi
+  printf '%s' "${input}" | "${runtime_path}" "${command_name}"
+}
+
 codex_raw_event_name() {
   local input="$1"
+  if codex_runtime_stdin "codex-event-name" "${input}" 2>/dev/null; then
+    return 0
+  fi
   printf '%s' "${input}" | python3 -c '
 import json
 import sys
@@ -154,6 +183,9 @@ codex_hook_timeout_ms() {
 
 codex_hook_status_detail() {
   local input="$1"
+  if codex_runtime_stdin "codex-status-detail" "${input}" 2>/dev/null; then
+    return 0
+  fi
   printf '%s' "${input}" | python3 -c '
 import json
 import sys
@@ -180,6 +212,9 @@ print("")
 
 codex_hook_status_matcher() {
   local input="$1"
+  if codex_runtime_stdin "codex-status-matcher" "${input}" 2>/dev/null; then
+    return 0
+  fi
   printf '%s' "${input}" | python3 -c '
 import json
 import sys
@@ -248,7 +283,8 @@ PY
 codex_hook_status_from_output() {
   local hook_name="$1" event_name="$2" matcher="$3" hook_output="$4" detail="${5:-}" timeout_ms="${6:-}"
   local parsed hook_status hook_reason
-  parsed=$(printf '%s' "${hook_output}" | python3 -c '
+  if ! parsed=$(codex_runtime_stdin "codex-status-from-output" "${hook_output}" 2>/dev/null); then
+    parsed=$(printf '%s' "${hook_output}" | python3 -c '
 import json
 import sys
 
@@ -281,7 +317,8 @@ elif isinstance(hook_specific, dict):
 reason = reason.replace("\t", " ").replace("\n", " ")[:300]
 print(f"{status}\t{reason}")
 ' 2>/dev/null || true
-)
+    )
+  fi
   hook_status="${parsed%%$'\t'*}"
   hook_reason="${parsed#*$'\t'}"
   if [[ "${hook_status}" == "${parsed}" ]]; then

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -225,6 +225,40 @@ else
   exit 1
 fi
 
+header "Codex protocol helpers use runtime without python3"
+NO_PYTHON_BIN="${TMP_DIR}/no-python-bin"
+mkdir -p "${NO_PYTHON_BIN}"
+cat > "${NO_PYTHON_BIN}/python3" <<'SH'
+#!/usr/bin/env bash
+exit 99
+SH
+chmod +x "${NO_PYTHON_BIN}/python3"
+
+protocol_helper_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" PATH="${NO_PYTHON_BIN}:${PATH}" bash -c '
+    source "$1"
+    source "$2"
+    payload="{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cargo test\"}}"
+    printf "raw_event=%s\n" "$(codex_raw_event_name "${payload}")"
+    printf "adapter_event=%s\n" "$(codex_event_name "${payload}")"
+    printf "matcher=%s\n" "$(codex_hook_status_matcher "${payload}")"
+    printf "detail=%s\n" "$(codex_hook_status_detail "${payload}")"
+    codex_hook_status() { printf "status=%s reason=%s\n" "$4" "$5"; }
+    codex_hook_status_from_output "vibeguard-pre-bash-guard.sh" "PreToolUse" "Bash" "{\"hookSpecificOutput\":{\"decision\":{\"behavior\":\"deny\",\"message\":\"stop\"}}}"
+  ' -- "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${REPO_DIR}/hooks/_lib/codex_adapter.sh"
+)"
+assert_contains "${protocol_helper_out}" "raw_event=PreToolUse" "codex_raw_event_name works without python3"
+assert_contains "${protocol_helper_out}" "adapter_event=PreToolUse" "codex_event_name works without python3"
+assert_contains "${protocol_helper_out}" "matcher=Bash" "codex_hook_status_matcher works without python3"
+assert_contains "${protocol_helper_out}" "detail=cargo test" "codex_hook_status_detail works without python3"
+assert_contains "${protocol_helper_out}" "status=block reason=" "codex_hook_status_from_output works without python3"
+
+status_parse_out="$(
+  printf '{"hookSpecificOutput":{"decision":{"behavior":"deny","message":"stop"}}}' \
+    | "${VIBEGUARD_RUNTIME}" codex-status-from-output
+)"
+assert_contains "${status_parse_out}" $'block\t' "runtime maps nested Codex deny status"
+
 header "run-hook-codex surfaces unsupported command rewrite"
 TMP_HOME="${TMP_DIR}/home"
 TMP_FAKE_REPO="${TMP_DIR}/fake-repo"

--- a/vibeguard-runtime/src/codex_hooks.rs
+++ b/vibeguard-runtime/src/codex_hooks.rs
@@ -1,0 +1,194 @@
+//! Codex hook protocol helpers used by run-hook-codex.sh.
+
+use crate::hook_checks_common::{read_stdin, truncate_chars};
+use serde_json::Value;
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+fn ensure_no_args(args: &[String], usage: &str) -> Result {
+    if args.is_empty() {
+        Ok(())
+    } else {
+        Err(usage.into())
+    }
+}
+
+fn read_json_tolerant() -> std::io::Result<Option<Value>> {
+    let input = read_stdin()?;
+    Ok(serde_json::from_str(&input).ok())
+}
+
+fn codex_event_name(data: &Value) -> &str {
+    data.get("hook_event_name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+}
+
+fn codex_status_matcher(data: &Value) -> &str {
+    data.get("tool_name").and_then(Value::as_str).unwrap_or("")
+}
+
+fn codex_status_detail(data: &Value) -> String {
+    let Some(tool_input) = data.get("tool_input").and_then(Value::as_object) else {
+        return String::new();
+    };
+    for key in ["file_path", "command"] {
+        if let Some(value) = tool_input.get(key).and_then(Value::as_str)
+            && !value.is_empty()
+        {
+            return truncate_chars(value, 300);
+        }
+    }
+    String::new()
+}
+
+fn codex_status_from_output(data: &Value) -> (String, String) {
+    let Some(object) = data.as_object() else {
+        return ("hook_error".to_string(), "invalid-json".to_string());
+    };
+
+    let decision = object
+        .get("decision")
+        .and_then(Value::as_str)
+        .unwrap_or("pass");
+    let reason = object
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .replace('\t', " ")
+        .replace('\n', " ");
+
+    let mut status = "pass";
+    if matches!(
+        decision,
+        "warn" | "block" | "gate" | "escalate" | "correction"
+    ) {
+        status = decision;
+    } else if decision == "skip" {
+        status = "skipped";
+    } else if let Some(hook_specific) = object.get("hookSpecificOutput").and_then(Value::as_object)
+    {
+        if hook_specific
+            .get("permissionDecision")
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            status = "block";
+        }
+        if hook_specific
+            .get("decision")
+            .and_then(Value::as_object)
+            .and_then(|decision| decision.get("behavior"))
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            status = "block";
+        }
+    }
+
+    (status.to_string(), truncate_chars(&reason, 300))
+}
+
+pub fn event_name(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-event-name")?;
+    let data = read_json_tolerant()?;
+    println!("{}", data.as_ref().map(codex_event_name).unwrap_or(""));
+    Ok(())
+}
+
+pub fn status_detail(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-status-detail")?;
+    let data = read_json_tolerant()?;
+    println!(
+        "{}",
+        data.as_ref()
+            .map(codex_status_detail)
+            .unwrap_or_else(String::new)
+    );
+    Ok(())
+}
+
+pub fn status_matcher(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-status-matcher")?;
+    let data = read_json_tolerant()?;
+    println!("{}", data.as_ref().map(codex_status_matcher).unwrap_or(""));
+    Ok(())
+}
+
+pub fn status_from_output(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-status-from-output")?;
+    let input = read_stdin()?;
+    let Some(data) = serde_json::from_str::<Value>(&input).ok() else {
+        println!("hook_error\tinvalid-json");
+        return Ok(());
+    };
+    let (status, reason) = codex_status_from_output(&data);
+    println!("{status}\t{reason}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn event_name_reads_codex_hook_event() {
+        assert_eq!(
+            codex_event_name(&json!({"hook_event_name": "PreToolUse"})),
+            "PreToolUse"
+        );
+        assert_eq!(codex_event_name(&json!({"hook_event_name": 7})), "");
+    }
+
+    #[test]
+    fn status_detail_prefers_file_path_then_command_and_truncates() {
+        assert_eq!(
+            codex_status_detail(&json!({
+                "tool_input": {"file_path": "src/main.rs", "command": "cargo test"}
+            })),
+            "src/main.rs"
+        );
+        assert_eq!(
+            codex_status_detail(&json!({"tool_input": {"command": "cargo test"}})),
+            "cargo test"
+        );
+        let long = "x".repeat(350);
+        assert_eq!(
+            codex_status_detail(&json!({"tool_input": {"command": long}}))
+                .chars()
+                .count(),
+            300
+        );
+    }
+
+    #[test]
+    fn status_matcher_reads_tool_name() {
+        assert_eq!(codex_status_matcher(&json!({"tool_name": "Bash"})), "Bash");
+        assert_eq!(codex_status_matcher(&json!({"tool_name": null})), "");
+    }
+
+    #[test]
+    fn status_from_output_maps_decisions_and_nested_denies() {
+        assert_eq!(
+            codex_status_from_output(&json!({"decision": "block", "reason": "no\tway\nnow"})),
+            ("block".to_string(), "no way now".to_string())
+        );
+        assert_eq!(
+            codex_status_from_output(&json!({"decision": "skip"})),
+            ("skipped".to_string(), String::new())
+        );
+        assert_eq!(
+            codex_status_from_output(&json!({
+                "hookSpecificOutput": {"permissionDecision": "deny"}
+            })),
+            ("block".to_string(), String::new())
+        );
+        assert_eq!(
+            codex_status_from_output(&json!({
+                "hookSpecificOutput": {"decision": {"behavior": "deny"}}
+            })),
+            ("block".to_string(), String::new())
+        );
+    }
+}

--- a/vibeguard-runtime/src/hook_checks_bash.rs
+++ b/vibeguard-runtime/src/hook_checks_bash.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use serde_json::{Value, json};
 use std::io::{self, Read};
 
-use crate::hook_checks_common::nested_str;
+use crate::hook_checks_common::{nested_str, truncate_chars};
 use crate::pkg_rewrite::rewrite_command;
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
@@ -324,10 +324,6 @@ fn should_run_precommit(command_stripped: &str, command: &str) -> bool {
 
 fn regex_is_match(pattern: &str, text: &str) -> bool {
     Regex::new(pattern).is_ok_and(|regex| regex.is_match(text))
-}
-
-fn truncate_chars(value: &str, max_chars: usize) -> String {
-    value.chars().take(max_chars).collect()
 }
 
 #[cfg(test)]

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -23,6 +23,10 @@ pub(crate) fn nested_str(data: &Value, path: &str) -> Option<String> {
     node.as_str().map(str::to_string)
 }
 
+pub(crate) fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
 fn basename_lower(path: &str) -> String {
     let real = fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
     real.file_name()

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -3,6 +3,7 @@ mod codex_app_server;
 mod codex_app_server_core;
 mod codex_app_server_file_changes;
 mod codex_app_server_strategies;
+mod codex_hooks;
 mod event_schema;
 mod hook_checks;
 mod hook_checks_bash;
@@ -95,6 +96,26 @@ static COMMANDS: &[Command] = &[
         name: "hook-status",
         usage: "[--mode minimal|focused|full] [--json] [--log-file PATH] [--diag-file PATH]  — summarize hook pass/skip/warn/timeout status without adding model context",
         handler: hook_status::run,
+    },
+    Command {
+        name: "codex-event-name",
+        usage: "  — extract hook_event_name from Codex hook stdin",
+        handler: codex_hooks::event_name,
+    },
+    Command {
+        name: "codex-status-detail",
+        usage: "  — extract Codex hook status detail from stdin",
+        handler: codex_hooks::status_detail,
+    },
+    Command {
+        name: "codex-status-matcher",
+        usage: "  — extract Codex hook status matcher from stdin",
+        handler: codex_hooks::status_matcher,
+    },
+    Command {
+        name: "codex-status-from-output",
+        usage: "  — classify wrapped hook output status from stdin",
+        handler: codex_hooks::status_from_output,
     },
     Command {
         name: "pre-write-check",

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -64,6 +64,10 @@ fn help_lists_all_commands() {
         "pkg-rewrite",
         "pre-bash-check",
         "session-metrics",
+        "codex-event-name",
+        "codex-status-detail",
+        "codex-status-matcher",
+        "codex-status-from-output",
         "pre-write-check",
         "pre-edit-check",
         "post-edit-fast-check",
@@ -76,6 +80,81 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+fn run_runtime_with_stdin(args: &[&str], input: &str) -> std::process::Output {
+    let mut child = bin()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn codex_event_name_extracts_event_and_tolerates_invalid_json() {
+    let out = run_runtime_with_stdin(
+        &["codex-event-name"],
+        r#"{"hook_event_name":"PermissionRequest"}"#,
+    );
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "PermissionRequest\n");
+
+    let invalid = run_runtime_with_stdin(&["codex-event-name"], "{not-json");
+    assert_eq!(invalid.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&invalid.stdout), "\n");
+}
+
+#[test]
+fn codex_status_helpers_extract_matcher_and_detail() {
+    let payload =
+        r#"{"tool_name":"Bash","tool_input":{"file_path":"src/lib.rs","command":"cargo test"}}"#;
+    let matcher = run_runtime_with_stdin(&["codex-status-matcher"], payload);
+    assert_eq!(matcher.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&matcher.stdout), "Bash\n");
+
+    let detail = run_runtime_with_stdin(&["codex-status-detail"], payload);
+    assert_eq!(detail.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&detail.stdout), "src/lib.rs\n");
+
+    let command_detail = run_runtime_with_stdin(
+        &["codex-status-detail"],
+        r#"{"tool_input":{"command":"rg TODO"}}"#,
+    );
+    assert_eq!(command_detail.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&command_detail.stdout), "rg TODO\n");
+}
+
+#[test]
+fn codex_status_from_output_maps_decisions_and_invalid_json() {
+    let block = run_runtime_with_stdin(
+        &["codex-status-from-output"],
+        r#"{"decision":"block","reason":"no"}"#,
+    );
+    assert_eq!(block.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&block.stdout), "block\tno\n");
+
+    let nested = run_runtime_with_stdin(
+        &["codex-status-from-output"],
+        r#"{"hookSpecificOutput":{"decision":{"behavior":"deny","message":"stop"}}}"#,
+    );
+    assert_eq!(nested.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&nested.stdout), "block\t\n");
+
+    let invalid = run_runtime_with_stdin(&["codex-status-from-output"], "{not-json");
+    assert_eq!(invalid.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&invalid.stdout),
+        "hook_error\tinvalid-json\n"
+    );
 }
 
 fn run_post_write_check(input: &str, log_file: &std::path::Path) -> std::process::Output {


### PR DESCRIPTION
Partially addresses #354.

## Summary
- add vibeguard-runtime commands for Codex hook event/status extraction
- make Codex diag/adapter helpers prefer runtime parsing before Python fallback
- cover runtime CLI behavior and no-python shell helper behavior

This does not claim the entire Codex wrapper is Python-free; apply_patch normalization and full output adaptation remain separate work.

## Verification
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/test_codex_runtime.sh (92/92 passing)
- bash scripts/ci/self-application/check-codex-wrapper-thin.sh
- bash scripts/ci/self-application/check-u29-no-silent-degrade.sh
- bash scripts/ci/validate-hook-perf.sh
- independent read-only reviewer reported no blocking findings

Issue #354 remains open for the remaining adapter and setup/config helper migration work.