### PR TITLE
Move Codex adapter conversions into runtime

### DIFF
--- a/hooks/_lib/codex_adapter.sh
+++ b/hooks/_lib/codex_adapter.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 # Shared Codex hook output adapter.
 
+_codex_runtime_adapter() {
+  local command_name="$1" input="$2" status
+  if ! declare -F codex_runtime_stdin >/dev/null 2>&1; then
+    return 127
+  fi
+  codex_runtime_stdin "${command_name}" "${input}" 2>/dev/null
+  status=$?
+  case "${status}" in
+    0|3) return "${status}" ;;
+    2|127) return 127 ;;
+    *) return "${status}" ;;
+  esac
+}
+
 codex_event_name() {
   local input="$1"
   if declare -F codex_runtime_stdin >/dev/null 2>&1 && codex_runtime_stdin "codex-event-name" "${input}" 2>/dev/null; then
@@ -19,6 +33,18 @@ except Exception:
 
 codex_pretool_deny() {
   local reason="$1"
+  local runtime_status=0
+  _codex_runtime_adapter "codex-pretool-deny" "${reason}" || runtime_status=$?
+  if [[ "${runtime_status}" -eq 0 ]]; then
+    return "${runtime_status}"
+  fi
+  if [[ "${runtime_status}" -eq 3 ]]; then
+    return "${runtime_status}"
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"VIBEGUARD hook failed: Codex deny adapter unavailable."}}\n'
+    return 0
+  fi
   CODEX_REASON="${reason}" python3 - <<'PY'
 import json
 import os
@@ -35,6 +61,18 @@ PY
 
 codex_permission_deny() {
   local reason="$1"
+  local runtime_status=0
+  _codex_runtime_adapter "codex-permission-deny" "${reason}" || runtime_status=$?
+  if [[ "${runtime_status}" -eq 0 ]]; then
+    return "${runtime_status}"
+  fi
+  if [[ "${runtime_status}" -eq 3 ]]; then
+    return "${runtime_status}"
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"VIBEGUARD hook failed: Codex deny adapter unavailable."}}}\n'
+    return 0
+  fi
   CODEX_REASON="${reason}" python3 - <<'PY'
 import json
 import os
@@ -53,6 +91,14 @@ PY
 
 codex_adapt_pretool() {
   local hook_output="$1"
+  local runtime_status=0
+  _codex_runtime_adapter "codex-adapt-pretool" "${hook_output}" || runtime_status=$?
+  if [[ "${runtime_status}" -eq 0 || "${runtime_status}" -eq 3 ]]; then
+    return "${runtime_status}"
+  fi
+  if [[ "${runtime_status}" -ne 127 ]]; then
+    return "${runtime_status}"
+  fi
   printf '%s' "${hook_output}" | python3 -c '
 import json
 import sys
@@ -121,6 +167,14 @@ elif decision == "allow" and isinstance(updated, dict):
 
 codex_adapt_posttool() {
   local hook_output="$1"
+  local runtime_status=0
+  _codex_runtime_adapter "codex-adapt-posttool" "${hook_output}" || runtime_status=$?
+  if [[ "${runtime_status}" -eq 0 || "${runtime_status}" -eq 3 ]]; then
+    return "${runtime_status}"
+  fi
+  if [[ "${runtime_status}" -ne 127 ]]; then
+    return "${runtime_status}"
+  fi
   printf '%s' "${hook_output}" | python3 -c '
 import json
 import sys
@@ -173,6 +227,14 @@ elif decision == "warn":
 
 codex_adapt_permission_request() {
   local hook_output="$1"
+  local runtime_status=0
+  _codex_runtime_adapter "codex-adapt-permission-request" "${hook_output}" || runtime_status=$?
+  if [[ "${runtime_status}" -eq 0 || "${runtime_status}" -eq 3 ]]; then
+    return "${runtime_status}"
+  fi
+  if [[ "${runtime_status}" -ne 127 ]]; then
+    return "${runtime_status}"
+  fi
   printf '%s' "${hook_output}" | python3 -c '
 import json
 import sys

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -236,6 +236,7 @@ chmod +x "${NO_PYTHON_BIN}/python3"
 
 protocol_helper_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" PATH="${NO_PYTHON_BIN}:${PATH}" bash -c '
+    set -euo pipefail
     source "$1"
     source "$2"
     payload="{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cargo test\"}}"
@@ -245,6 +246,11 @@ protocol_helper_out="$(
     printf "detail=%s\n" "$(codex_hook_status_detail "${payload}")"
     codex_hook_status() { printf "status=%s reason=%s\n" "$4" "$5"; }
     codex_hook_status_from_output "vibeguard-pre-bash-guard.sh" "PreToolUse" "Bash" "{\"hookSpecificOutput\":{\"decision\":{\"behavior\":\"deny\",\"message\":\"stop\"}}}"
+    printf "pretool_deny_start\n"; codex_pretool_deny "blocked without python"; printf "pretool_deny_end\n"
+    printf "permission_deny_start\n"; codex_permission_deny "permission blocked without python"; printf "permission_deny_end\n"
+    printf "pretool_adapt_start\n"; codex_adapt_pretool "{\"decision\":\"block\",\"reason\":\"adapted without python\"}"; printf "pretool_adapt_end\n"
+    printf "posttool_adapt_start\n"; codex_adapt_posttool "{\"decision\":\"block\",\"reason\":\"posttool without python\"}"; printf "posttool_adapt_end\n"
+    printf "permission_adapt_start\n"; codex_adapt_permission_request "{\"decision\":\"block\",\"reason\":\"permission adapted without python\"}"; printf "permission_adapt_end\n"
   ' -- "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${REPO_DIR}/hooks/_lib/codex_adapter.sh"
 )"
 assert_contains "${protocol_helper_out}" "raw_event=PreToolUse" "codex_raw_event_name works without python3"
@@ -252,6 +258,46 @@ assert_contains "${protocol_helper_out}" "adapter_event=PreToolUse" "codex_event
 assert_contains "${protocol_helper_out}" "matcher=Bash" "codex_hook_status_matcher works without python3"
 assert_contains "${protocol_helper_out}" "detail=cargo test" "codex_hook_status_detail works without python3"
 assert_contains "${protocol_helper_out}" "status=block reason=" "codex_hook_status_from_output works without python3"
+assert_contains "${protocol_helper_out}" "blocked without python" "codex_pretool_deny works without python3"
+assert_contains "${protocol_helper_out}" "permission blocked without python" "codex_permission_deny works without python3"
+assert_contains "${protocol_helper_out}" "adapted without python" "codex_adapt_pretool works without python3"
+assert_contains "${protocol_helper_out}" "posttool without python" "codex_adapt_posttool works without python3"
+assert_contains "${protocol_helper_out}" "permission adapted without python" "codex_adapt_permission_request works without python3"
+
+BROKEN_RUNTIME="${TMP_DIR}/broken-vibeguard-runtime"
+cat > "${BROKEN_RUNTIME}" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "${BROKEN_RUNTIME}"
+broken_runtime_deny_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_RUNTIME="${BROKEN_RUNTIME}" bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    codex_pretool_deny "pretool fallback reason"
+    codex_permission_deny "permission fallback reason"
+  ' -- "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${REPO_DIR}/hooks/_lib/codex_adapter.sh"
+)"
+assert_contains "${broken_runtime_deny_out}" "pretool fallback reason" "codex_pretool_deny falls back when runtime exits nonzero"
+assert_contains "${broken_runtime_deny_out}" "permission fallback reason" "codex_permission_deny falls back when runtime exits nonzero"
+
+TMP_HOME_BROKEN_RUNTIME="${TMP_DIR}/home-broken-runtime"
+TMP_FAKE_REPO_BROKEN_RUNTIME="${TMP_DIR}/fake-repo-broken-runtime"
+mkdir -p "${TMP_HOME_BROKEN_RUNTIME}/.vibeguard" "${TMP_FAKE_REPO_BROKEN_RUNTIME}/hooks"
+printf '%s' "${TMP_FAKE_REPO_BROKEN_RUNTIME}" > "${TMP_HOME_BROKEN_RUNTIME}/.vibeguard/repo-path"
+cat > "${TMP_FAKE_REPO_BROKEN_RUNTIME}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{'
+HOOK
+chmod +x "${TMP_FAKE_REPO_BROKEN_RUNTIME}/hooks/vibeguard-pre-bash-guard.sh"
+broken_runtime_wrapper_out="$(
+  printf '{"hook_event_name":"PreToolUse","tool_input":{"command":"rm -rf /"}}' \
+    | HOME="${TMP_HOME_BROKEN_RUNTIME}" VIBEGUARD_RUNTIME="${BROKEN_RUNTIME}" bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${broken_runtime_wrapper_out}" '"permissionDecision": "deny"' "run-hook-codex still denies when adapter runtime exits nonzero"
+assert_contains "${broken_runtime_wrapper_out}" 'wrapped hook output could not be adapted' "run-hook-codex explains broken adapter runtime fallback"
 
 status_parse_out="$(
   printf '{"hookSpecificOutput":{"decision":{"behavior":"deny","message":"stop"}}}' \

--- a/vibeguard-runtime/src/codex_hooks.rs
+++ b/vibeguard-runtime/src/codex_hooks.rs
@@ -1,7 +1,8 @@
 //! Codex hook protocol helpers used by run-hook-codex.sh.
 
 use crate::hook_checks_common::{read_stdin, truncate_chars};
-use serde_json::Value;
+use serde_json::{Map, Value, json};
+use std::process;
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
@@ -89,6 +90,123 @@ fn codex_status_from_output(data: &Value) -> (String, String) {
     (status.to_string(), truncate_chars(&reason, 300))
 }
 
+fn print_json(value: &Value) -> Result {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn read_json_object_or_invalid_pretool() -> std::io::Result<Map<String, Value>> {
+    let input = read_stdin()?;
+    match serde_json::from_str::<Value>(&input) {
+        Ok(Value::Object(object)) => Ok(object),
+        _ => {
+            print_json(&json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": "VIBEGUARD hook failed: wrapped hook produced invalid JSON.",
+                }
+            }))
+            .ok();
+            process::exit(3);
+        }
+    }
+}
+
+fn read_json_object_or_invalid_permission() -> std::io::Result<Map<String, Value>> {
+    let input = read_stdin()?;
+    match serde_json::from_str::<Value>(&input) {
+        Ok(Value::Object(object)) => Ok(object),
+        _ => {
+            print_json(&json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {
+                        "behavior": "deny",
+                        "message": "VIBEGUARD hook failed: wrapped hook produced invalid JSON.",
+                    },
+                }
+            }))
+            .ok();
+            process::exit(3);
+        }
+    }
+}
+
+fn read_json_object_or_exit_3() -> std::io::Result<Map<String, Value>> {
+    let input = read_stdin()?;
+    match serde_json::from_str::<Value>(&input) {
+        Ok(Value::Object(object)) => Ok(object),
+        _ => process::exit(3),
+    }
+}
+
+fn decision_field(object: &Map<String, Value>) -> &str {
+    match object.get("decision") {
+        None => "pass",
+        Some(Value::String(decision)) => decision,
+        Some(_) => "",
+    }
+}
+
+fn string_field<'a>(object: &'a Map<String, Value>, key: &str) -> &'a str {
+    object.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn has_native_output(object: &Map<String, Value>) -> bool {
+    object
+        .get("hookSpecificOutput")
+        .is_some_and(Value::is_object)
+        || object.contains_key("systemMessage")
+}
+
+fn updated_input_is_absent_or_null(object: &Map<String, Value>) -> bool {
+    !object.contains_key("updatedInput") || object.get("updatedInput") == Some(&Value::Null)
+}
+
+fn native_output(object: &Map<String, Value>) -> Map<String, Value> {
+    let mut output = Map::new();
+    if let Some(system_message) = object.get("systemMessage") {
+        output.insert("systemMessage".to_string(), system_message.clone());
+    }
+    if let Some(hook_specific) = object.get("hookSpecificOutput").and_then(Value::as_object) {
+        output.insert(
+            "hookSpecificOutput".to_string(),
+            Value::Object(hook_specific.clone()),
+        );
+    }
+    output
+}
+
+fn print_object_if_not_empty(object: Map<String, Value>) -> Result {
+    if !object.is_empty() {
+        print_json(&Value::Object(object))?;
+    }
+    Ok(())
+}
+
+fn deny_pretool_payload(reason: &str) -> Value {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    })
+}
+
+fn deny_permission_payload(reason: &str) -> Value {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {
+                "behavior": "deny",
+                "message": reason,
+            },
+        }
+    })
+}
+
 pub fn event_name(args: &[String]) -> Result {
     ensure_no_args(args, "Usage: vibeguard-runtime codex-event-name")?;
     let data = read_json_tolerant()?;
@@ -124,6 +242,152 @@ pub fn status_from_output(args: &[String]) -> Result {
     };
     let (status, reason) = codex_status_from_output(&data);
     println!("{status}\t{reason}");
+    Ok(())
+}
+
+pub fn deny_pretool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-pretool-deny")?;
+    let reason = read_stdin()?;
+    print_json(&deny_pretool_payload(&reason))
+}
+
+pub fn deny_permission(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-permission-deny")?;
+    let reason = read_stdin()?;
+    print_json(&deny_permission_payload(&reason))
+}
+
+pub fn adapt_pretool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-adapt-pretool")?;
+    let object = read_json_object_or_invalid_pretool()?;
+    let decision = decision_field(&object);
+    let reason = string_field(&object, "reason");
+    let updated = object.get("updatedInput").and_then(Value::as_object);
+    let native = has_native_output(&object);
+
+    if native && decision == "pass" && updated_input_is_absent_or_null(&object) {
+        return print_object_if_not_empty(native_output(&object));
+    }
+
+    if decision == "block" {
+        let mut hook_specific = object
+            .get("hookSpecificOutput")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        hook_specific.insert("hookEventName".to_string(), json!("PreToolUse"));
+        hook_specific.insert("permissionDecision".to_string(), json!("deny"));
+        hook_specific.insert("permissionDecisionReason".to_string(), json!(reason));
+        return print_json(&json!({ "hookSpecificOutput": hook_specific }));
+    }
+
+    if decision == "warn" {
+        let mut output = if native {
+            native_output(&object)
+        } else {
+            Map::new()
+        };
+        if !reason.is_empty() {
+            output.insert("systemMessage".to_string(), json!(reason));
+        }
+        return print_object_if_not_empty(output);
+    }
+
+    if decision == "allow"
+        && let Some(command) = updated
+            .and_then(|updated| updated.get("command"))
+            .and_then(Value::as_str)
+        && !command.is_empty()
+    {
+        return print_json(&json!({
+            "systemMessage": format!(
+                "VIBEGUARD note: Codex CLI hooks cannot auto-apply command rewrites. Suggested command: {command}"
+            )
+        }));
+    }
+
+    Ok(())
+}
+
+pub fn adapt_posttool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-adapt-posttool")?;
+    let object = read_json_object_or_exit_3()?;
+    let decision = decision_field(&object);
+    let reason = string_field(&object, "reason");
+    let native = has_native_output(&object);
+
+    if native && decision == "pass" {
+        return print_object_if_not_empty(native_output(&object));
+    }
+
+    if decision == "block" || decision == "escalate" {
+        let mut hook_specific = object
+            .get("hookSpecificOutput")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        hook_specific.insert("hookEventName".to_string(), json!("PostToolUse"));
+        hook_specific
+            .entry("additionalContext".to_string())
+            .or_insert_with(|| json!(reason));
+        return print_json(&json!({
+            "decision": "block",
+            "reason": reason,
+            "hookSpecificOutput": hook_specific,
+        }));
+    }
+
+    if decision == "warn" {
+        let mut output = if native {
+            native_output(&object)
+        } else {
+            Map::new()
+        };
+        if !reason.is_empty() {
+            output.insert("systemMessage".to_string(), json!(reason));
+        }
+        return print_object_if_not_empty(output);
+    }
+
+    Ok(())
+}
+
+pub fn adapt_permission_request(args: &[String]) -> Result {
+    ensure_no_args(
+        args,
+        "Usage: vibeguard-runtime codex-adapt-permission-request",
+    )?;
+    let object = read_json_object_or_invalid_permission()?;
+    let decision = decision_field(&object);
+    let reason = string_field(&object, "reason");
+    let updated = object.get("updatedInput").and_then(Value::as_object);
+
+    if has_native_output(&object) && decision == "pass" && updated_input_is_absent_or_null(&object)
+    {
+        return print_object_if_not_empty(native_output(&object));
+    }
+
+    if decision == "block" {
+        return print_json(&deny_permission_payload(reason));
+    }
+
+    if decision == "warn" {
+        return print_json(&json!({ "systemMessage": reason }));
+    }
+
+    if decision == "allow"
+        && let Some(command) = updated
+            .and_then(|updated| updated.get("command"))
+            .and_then(Value::as_str)
+        && !command.is_empty()
+    {
+        return print_json(&json!({
+            "systemMessage": format!(
+                "VIBEGUARD note: Codex CLI PermissionRequest hooks cannot auto-apply command rewrites. Suggested command: {command}"
+            )
+        }));
+    }
+
     Ok(())
 }
 
@@ -189,6 +453,48 @@ mod tests {
                 "hookSpecificOutput": {"decision": {"behavior": "deny"}}
             })),
             ("block".to_string(), String::new())
+        );
+    }
+
+    #[test]
+    fn native_output_preserves_system_message_and_hook_specific_output() {
+        let object = json!({
+            "systemMessage": "note",
+            "hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "context"},
+            "ignored": "field",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let output = Value::Object(native_output(&object));
+        assert_eq!(output["systemMessage"], "note");
+        assert_eq!(output["hookSpecificOutput"]["additionalContext"], "context");
+        assert!(output.get("ignored").is_none());
+    }
+
+    #[test]
+    fn decision_field_defaults_only_when_missing() {
+        let missing = Map::new();
+        let mut null_decision = Map::new();
+        null_decision.insert("decision".to_string(), Value::Null);
+        let mut string_decision = Map::new();
+        string_decision.insert("decision".to_string(), json!("warn"));
+
+        assert_eq!(decision_field(&missing), "pass");
+        assert_eq!(decision_field(&null_decision), "");
+        assert_eq!(decision_field(&string_decision), "warn");
+    }
+
+    #[test]
+    fn deny_payloads_match_codex_native_shapes() {
+        assert_eq!(
+            deny_pretool_payload("blocked")["hookSpecificOutput"]["permissionDecision"],
+            "deny"
+        );
+        assert_eq!(
+            deny_permission_payload("blocked")["hookSpecificOutput"]["decision"]["behavior"],
+            "deny"
         );
     }
 }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -118,6 +118,31 @@ static COMMANDS: &[Command] = &[
         handler: codex_hooks::status_from_output,
     },
     Command {
+        name: "codex-pretool-deny",
+        usage: "  — emit a Codex PreToolUse deny payload from stdin reason",
+        handler: codex_hooks::deny_pretool,
+    },
+    Command {
+        name: "codex-permission-deny",
+        usage: "  — emit a Codex PermissionRequest deny payload from stdin reason",
+        handler: codex_hooks::deny_permission,
+    },
+    Command {
+        name: "codex-adapt-pretool",
+        usage: "  — adapt wrapped hook output to Codex PreToolUse JSON",
+        handler: codex_hooks::adapt_pretool,
+    },
+    Command {
+        name: "codex-adapt-posttool",
+        usage: "  — adapt wrapped hook output to Codex PostToolUse JSON",
+        handler: codex_hooks::adapt_posttool,
+    },
+    Command {
+        name: "codex-adapt-permission-request",
+        usage: "  — adapt wrapped hook output to Codex PermissionRequest JSON",
+        handler: codex_hooks::adapt_permission_request,
+    },
+    Command {
         name: "pre-write-check",
         usage: "<base-limit> [warn-limit]  — classify PreToolUse(Write) input for hooks",
         handler: hook_checks::pre_write_check,

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -68,6 +68,11 @@ fn help_lists_all_commands() {
         "codex-status-detail",
         "codex-status-matcher",
         "codex-status-from-output",
+        "codex-pretool-deny",
+        "codex-permission-deny",
+        "codex-adapt-pretool",
+        "codex-adapt-posttool",
+        "codex-adapt-permission-request",
         "pre-write-check",
         "pre-edit-check",
         "post-edit-fast-check",
@@ -154,6 +159,114 @@ fn codex_status_from_output_maps_decisions_and_invalid_json() {
     assert_eq!(
         String::from_utf8_lossy(&invalid.stdout),
         "hook_error\tinvalid-json\n"
+    );
+}
+
+#[test]
+fn codex_deny_helpers_emit_native_deny_payloads() {
+    let pretool = run_runtime_with_stdin(&["codex-pretool-deny"], "blocked");
+    assert_eq!(pretool.status.code(), Some(0));
+    let pretool_json: serde_json::Value = serde_json::from_slice(&pretool.stdout).unwrap();
+    assert_eq!(
+        pretool_json["hookSpecificOutput"]["permissionDecision"],
+        "deny"
+    );
+    assert_eq!(
+        pretool_json["hookSpecificOutput"]["permissionDecisionReason"],
+        "blocked"
+    );
+
+    let permission = run_runtime_with_stdin(&["codex-permission-deny"], "blocked");
+    assert_eq!(permission.status.code(), Some(0));
+    let permission_json: serde_json::Value = serde_json::from_slice(&permission.stdout).unwrap();
+    assert_eq!(
+        permission_json["hookSpecificOutput"]["decision"]["behavior"],
+        "deny"
+    );
+    assert_eq!(
+        permission_json["hookSpecificOutput"]["decision"]["message"],
+        "blocked"
+    );
+}
+
+#[test]
+fn codex_adapter_commands_map_wrapped_outputs() {
+    let pretool = run_runtime_with_stdin(
+        &["codex-adapt-pretool"],
+        r#"{"decision":"block","reason":"force push denied"}"#,
+    );
+    assert_eq!(pretool.status.code(), Some(0));
+    let pretool_json: serde_json::Value = serde_json::from_slice(&pretool.stdout).unwrap();
+    assert_eq!(
+        pretool_json["hookSpecificOutput"]["permissionDecision"],
+        "deny"
+    );
+    assert_eq!(
+        pretool_json["hookSpecificOutput"]["permissionDecisionReason"],
+        "force push denied"
+    );
+
+    let rewrite = run_runtime_with_stdin(
+        &["codex-adapt-pretool"],
+        r#"{"decision":"allow","updatedInput":{"command":"pnpm install"}}"#,
+    );
+    assert_eq!(rewrite.status.code(), Some(0));
+    let rewrite_json: serde_json::Value = serde_json::from_slice(&rewrite.stdout).unwrap();
+    assert!(
+        rewrite_json["systemMessage"]
+            .as_str()
+            .unwrap()
+            .contains("pnpm install")
+    );
+
+    let posttool = run_runtime_with_stdin(
+        &["codex-adapt-posttool"],
+        r#"{"decision":"escalate","reason":"build failed"}"#,
+    );
+    assert_eq!(posttool.status.code(), Some(0));
+    let posttool_json: serde_json::Value = serde_json::from_slice(&posttool.stdout).unwrap();
+    assert_eq!(posttool_json["decision"], "block");
+    assert_eq!(
+        posttool_json["hookSpecificOutput"]["additionalContext"],
+        "build failed"
+    );
+
+    let permission = run_runtime_with_stdin(
+        &["codex-adapt-permission-request"],
+        r#"{"decision":"block","reason":"permission denied"}"#,
+    );
+    assert_eq!(permission.status.code(), Some(0));
+    let permission_json: serde_json::Value = serde_json::from_slice(&permission.stdout).unwrap();
+    assert_eq!(
+        permission_json["hookSpecificOutput"]["decision"]["behavior"],
+        "deny"
+    );
+    assert_eq!(
+        permission_json["hookSpecificOutput"]["decision"]["message"],
+        "permission denied"
+    );
+}
+
+#[test]
+fn codex_adapter_commands_fail_closed_on_invalid_json() {
+    let pretool = run_runtime_with_stdin(&["codex-adapt-pretool"], "{not-json");
+    assert_eq!(pretool.status.code(), Some(3));
+    let pretool_json: serde_json::Value = serde_json::from_slice(&pretool.stdout).unwrap();
+    assert_eq!(
+        pretool_json["hookSpecificOutput"]["permissionDecision"],
+        "deny"
+    );
+
+    let posttool = run_runtime_with_stdin(&["codex-adapt-posttool"], "{not-json");
+    assert_eq!(posttool.status.code(), Some(3));
+    assert!(posttool.stdout.is_empty());
+
+    let permission = run_runtime_with_stdin(&["codex-adapt-permission-request"], "{not-json");
+    assert_eq!(permission.status.code(), Some(3));
+    let permission_json: serde_json::Value = serde_json::from_slice(&permission.stdout).unwrap();
+    assert_eq!(
+        permission_json["hookSpecificOutput"]["decision"]["behavior"],
+        "deny"
     );
 }
 


### PR DESCRIPTION
## Summary
- add runtime commands for Codex deny payloads and adapter conversions
- make hooks/_lib/codex_adapter.sh prefer vibeguard-runtime with Python fallback only for old/missing runtime
- add no-python, broken-runtime, invalid JSON, and CLI coverage for adapter paths

Refs #354

## Verification
- bash -n hooks/_lib/codex_adapter.sh
- bash -n tests/test_codex_runtime.sh
- git diff --check
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/test_codex_runtime.sh
- bash scripts/ci/self-application/check-codex-wrapper-thin.sh
- bash scripts/ci/self-application/check-u29-no-silent-degrade.sh
- bash scripts/ci/validate-hook-perf.sh

## Review
- independent reviewer Carson found no merge-blocking findings after the set -e fallback fix
- residual non-blocking risk: if runtime is unavailable and a present python3 binary itself fails, the static no-python fallback does not cover that stacked failure