### PR TITLE
Move Codex apply_patch normalizer into runtime

### DIFF
--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -1,6 +1,90 @@
 #!/usr/bin/env bash
 # Codex wrapper execution loop. Keep run-hook-codex.sh as a thin dispatcher.
 
+_codex_normalize_apply_patch_runtime() {
+  local hook_name="$1" input="$2" runtime_path
+  if ! declare -F codex_runtime_path >/dev/null 2>&1; then
+    return 127
+  fi
+  if ! runtime_path="$(codex_runtime_path)"; then
+    return 127
+  fi
+  printf '%s' "${input}" | "${runtime_path}" codex-normalize-apply-patch "${hook_name}"
+}
+
+_codex_input_looks_apply_patch() {
+  local input="$1"
+  [[ "${input}" == *'"tool_name":"apply_patch"'* \
+    || "${input}" == *'"tool_name": "apply_patch"'* \
+    || "${input}" == *"*** Begin Patch"* ]]
+}
+
+_codex_normalize_apply_patch_python() {
+  local hook_name="$1" normalizer_path="$2" input="$3" normalized_file="$4"
+  [[ -f "${normalizer_path}" ]] || return 127
+  printf '%s' "${input}" | python3 "${normalizer_path}" "${hook_name}" >"${normalized_file}"
+}
+
+_codex_normalizer_fail_closed() {
+  local event_name="$1"
+  local reason="VIBEGUARD hook failed: Codex apply_patch normalizer failed."
+  case "${event_name}" in
+    PreToolUse)
+      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "${reason}"
+      ;;
+    PermissionRequest)
+      printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"%s"}}}\n' "${reason}"
+      ;;
+    PostToolUse)
+      printf '{"decision":"block","reason":"%s","hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "${reason}" "${reason}"
+      ;;
+    Stop)
+      printf '{"stopReason":"%s"}\n' "${reason}"
+      ;;
+    *)
+      printf '{"systemMessage":"%s"}\n' "${reason}"
+      ;;
+  esac
+}
+
+_codex_write_normalized_inputs() {
+  local hook_name="$1" normalizer_path="$2" input="$3" normalized_file="$4"
+  local status=0 stderr_file stderr_text
+
+  if stderr_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-normalizer.XXXXXX")"; then
+    if _codex_normalize_apply_patch_runtime "${hook_name}" "${input}" >"${normalized_file}" 2>"${stderr_file}"; then
+      rm -f "${stderr_file}" 2>/dev/null || true
+      return 0
+    else
+      status=$?
+    fi
+    stderr_text="$(cat "${stderr_file}" 2>/dev/null || true)"
+    rm -f "${stderr_file}" 2>/dev/null || true
+
+    if [[ "${status}" -ne 127 && "${stderr_text}" != *"Unknown command: codex-normalize-apply-patch"* ]]; then
+      if _codex_normalize_apply_patch_python "${hook_name}" "${normalizer_path}" "${input}" "${normalized_file}"; then
+        return 0
+      fi
+      codex_diag "${hook_name}" "${EVENT_NAME}" "normalizer-failed" "${stderr_text:-runtime exit ${status}}"
+      if _codex_input_looks_apply_patch "${input}"; then
+        return 1
+      fi
+      printf '%s\n' "${input}" >"${normalized_file}"
+      return 0
+    fi
+  fi
+
+  if _codex_normalize_apply_patch_python "${hook_name}" "${normalizer_path}" "${input}" "${normalized_file}"; then
+    return 0
+  fi
+
+  codex_diag "${hook_name}" "${EVENT_NAME}" "normalizer-failed" "${normalizer_path}"
+  if _codex_input_looks_apply_patch "${input}"; then
+    return 1
+  fi
+  printf '%s\n' "${input}" >"${normalized_file}"
+}
+
 codex_run_hook() {
   local hook_name="$1" hook_path="$2" normalizer_path="$3" input="$4"
   shift 4
@@ -9,13 +93,10 @@ codex_run_hook() {
 
   local normalized_file
   normalized_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-inputs.XXXXXX")"
-  if [[ -f "${normalizer_path}" ]]; then
-    if ! printf '%s' "${input}" | python3 "${normalizer_path}" "${hook_name}" >"${normalized_file}"; then
-      codex_diag "${hook_name}" "${EVENT_NAME}" "normalizer-failed" "${normalizer_path}"
-      printf '%s\n' "${input}" >"${normalized_file}"
-    fi
-  else
-    printf '%s\n' "${input}" >"${normalized_file}"
+  if ! _codex_write_normalized_inputs "${hook_name}" "${normalizer_path}" "${input}" "${normalized_file}"; then
+    rm -f "${normalized_file}" 2>/dev/null || true
+    _codex_normalizer_fail_closed "${EVENT_NAME}"
+    return 0
   fi
 
   local first_adapted_output=""

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -299,6 +299,92 @@ broken_runtime_wrapper_out="$(
 assert_contains "${broken_runtime_wrapper_out}" '"permissionDecision": "deny"' "run-hook-codex still denies when adapter runtime exits nonzero"
 assert_contains "${broken_runtime_wrapper_out}" 'wrapped hook output could not be adapted' "run-hook-codex explains broken adapter runtime fallback"
 
+TMP_HOME_NO_PYTHON_PATCH="${TMP_DIR}/home-no-python-patch"
+TMP_FAKE_REPO_NO_PYTHON_PATCH="${TMP_DIR}/fake-repo-no-python-patch"
+mkdir -p "${TMP_HOME_NO_PYTHON_PATCH}/.vibeguard" "${TMP_FAKE_REPO_NO_PYTHON_PATCH}/hooks"
+printf '%s' "${TMP_FAKE_REPO_NO_PYTHON_PATCH}" > "${TMP_HOME_NO_PYTHON_PATCH}/.vibeguard/repo-path"
+cat > "${TMP_FAKE_REPO_NO_PYTHON_PATCH}/hooks/vibeguard-pre-write-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+input="$(cat)"
+if [[ "${input}" == *'"tool_name":"Write"'* && "${input}" == *'src/no_python.rs'* ]]; then
+  printf '{"decision":"block","reason":"apply_patch normalized without python"}\n'
+else
+  printf '{"decision":"pass"}\n'
+fi
+HOOK
+chmod +x "${TMP_FAKE_REPO_NO_PYTHON_PATCH}/hooks/vibeguard-pre-write-guard.sh"
+no_python_patch_payload='{"hook_event_name":"PreToolUse","tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** Add File: src/no_python.rs\n+fn main() {}\n*** End Patch"}}'
+no_python_patch_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" PATH="${NO_PYTHON_BIN}:${PATH}" VIBEGUARD_RUNTIME="${VIBEGUARD_RUNTIME}" bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    source "$3"
+    EVENT_NAME=PreToolUse
+    codex_diag() { return 0; }
+    codex_hook_status() { return 0; }
+    codex_run_hook "vibeguard-pre-write-guard.sh" "$4" "$5" "$6"
+  ' -- \
+    "${REPO_DIR}/hooks/_lib/codex_diag.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_adapter.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_runner.sh" \
+    "${TMP_FAKE_REPO_NO_PYTHON_PATCH}/hooks/vibeguard-pre-write-guard.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_apply_patch_adapter.py" \
+    "${no_python_patch_payload}"
+)"
+assert_contains "${no_python_patch_out}" '"permissionDecision": "deny"' "codex_run_hook apply_patch normalizer works without python3"
+assert_contains "${no_python_patch_out}" 'apply_patch normalized without python' "codex_run_hook apply_patch path reaches normalized Write hook without python3"
+
+old_normalizer_runtime="${TMP_DIR}/old-normalizer-runtime"
+cat > "${old_normalizer_runtime}" <<'SH'
+#!/usr/bin/env bash
+printf 'Unknown command: %s\n' "$1" >&2
+exit 2
+SH
+chmod +x "${old_normalizer_runtime}"
+old_runtime_patch_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_RUNTIME="${old_normalizer_runtime}" bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    source "$3"
+    EVENT_NAME=PreToolUse
+    codex_diag() { return 0; }
+    codex_hook_status() { return 0; }
+    codex_run_hook "vibeguard-pre-write-guard.sh" "$4" "$5" "$6"
+  ' -- \
+    "${REPO_DIR}/hooks/_lib/codex_diag.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_adapter.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_runner.sh" \
+    "${TMP_FAKE_REPO_NO_PYTHON_PATCH}/hooks/vibeguard-pre-write-guard.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_apply_patch_adapter.py" \
+    "${no_python_patch_payload}"
+)"
+assert_contains "${old_runtime_patch_out}" '"permissionDecision": "deny"' "codex_run_hook falls back when old runtime lacks apply_patch normalizer"
+assert_contains "${old_runtime_patch_out}" 'apply_patch normalized without python' "old runtime fallback still normalizes apply_patch payloads"
+
+broken_no_python_patch_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" PATH="${NO_PYTHON_BIN}:${PATH}" VIBEGUARD_RUNTIME="${BROKEN_RUNTIME}" bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    source "$3"
+    EVENT_NAME=PreToolUse
+    codex_diag() { return 0; }
+    codex_hook_status() { return 0; }
+    codex_run_hook "vibeguard-pre-write-guard.sh" "$4" "$5" "$6"
+  ' -- \
+    "${REPO_DIR}/hooks/_lib/codex_diag.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_adapter.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_runner.sh" \
+    "${TMP_FAKE_REPO_NO_PYTHON_PATCH}/hooks/vibeguard-pre-write-guard.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_apply_patch_adapter.py" \
+    "${no_python_patch_payload}"
+)"
+assert_contains "${broken_no_python_patch_out}" '"permissionDecision":"deny"' "codex_run_hook fails closed when runtime normalizer and python fallback both fail"
+assert_contains "${broken_no_python_patch_out}" 'Codex apply_patch normalizer failed' "broken apply_patch normalizer failure is visible"
+assert_not_contains "${broken_no_python_patch_out}" 'apply_patch normalized without python' "broken apply_patch normalizer does not raw-pass to file hook"
+
 status_parse_out="$(
   printf '{"hookSpecificOutput":{"decision":{"behavior":"deny","message":"stop"}}}' \
     | "${VIBEGUARD_RUNTIME}" codex-status-from-output

--- a/vibeguard-runtime/src/codex_hooks.rs
+++ b/vibeguard-runtime/src/codex_hooks.rs
@@ -207,6 +207,179 @@ fn deny_permission_payload(reason: &str) -> Value {
     })
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PatchChange {
+    kind: String,
+    path: String,
+    new_path: Option<String>,
+    added_lines: Vec<String>,
+    removed_lines: Vec<String>,
+}
+
+impl PatchChange {
+    fn new(kind: &str, path: &str) -> Self {
+        Self {
+            kind: kind.to_string(),
+            path: path.trim().to_string(),
+            new_path: None,
+            added_lines: Vec::new(),
+            removed_lines: Vec::new(),
+        }
+    }
+}
+
+fn finish_patch_change(changes: &mut Vec<PatchChange>, current: &mut Option<PatchChange>) {
+    if let Some(change) = current.take() {
+        changes.push(change);
+    }
+}
+
+fn parse_apply_patch(command: &str) -> Vec<PatchChange> {
+    let mut changes = Vec::new();
+    let mut current: Option<PatchChange> = None;
+
+    for line in command.lines() {
+        if let Some(path) = line.strip_prefix("*** Add File: ") {
+            finish_patch_change(&mut changes, &mut current);
+            current = Some(PatchChange::new("add", path));
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("*** Update File: ") {
+            finish_patch_change(&mut changes, &mut current);
+            current = Some(PatchChange::new("update", path));
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("*** Delete File: ") {
+            finish_patch_change(&mut changes, &mut current);
+            current = Some(PatchChange::new("delete", path));
+            continue;
+        }
+
+        let Some(change) = current.as_mut() else {
+            continue;
+        };
+        if let Some(path) = line.strip_prefix("*** Move to: ") {
+            change.new_path = Some(path.trim().to_string());
+        } else if let Some(added) = line.strip_prefix('+') {
+            change.added_lines.push(added.to_string());
+        } else if let Some(removed) = line.strip_prefix('-') {
+            change.removed_lines.push(removed.to_string());
+        }
+    }
+
+    finish_patch_change(&mut changes, &mut current);
+    changes
+}
+
+fn apply_patch_command(payload: &Map<String, Value>) -> &str {
+    payload
+        .get("tool_input")
+        .and_then(Value::as_object)
+        .and_then(|tool_input| tool_input.get("command"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+}
+
+fn is_apply_patch_payload(payload: &Map<String, Value>) -> bool {
+    if payload.get("tool_name").and_then(Value::as_str) == Some("apply_patch") {
+        return true;
+    }
+    apply_patch_command(payload)
+        .trim_start()
+        .starts_with("*** Begin Patch")
+}
+
+fn normalized_tool_payload(
+    payload: &Map<String, Value>,
+    tool_name: &str,
+    tool_input: Value,
+) -> Value {
+    let mut normalized = payload.clone();
+    normalized.insert("tool_name".to_string(), json!(tool_name));
+    normalized.insert("tool_input".to_string(), tool_input);
+    Value::Object(normalized)
+}
+
+fn normalized_apply_patch_payloads(hook_name: &str, payload: &Map<String, Value>) -> Vec<Value> {
+    let event = payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if !matches!(event, "PreToolUse" | "PermissionRequest" | "PostToolUse")
+        || !is_apply_patch_payload(payload)
+    {
+        return vec![Value::Object(payload.clone())];
+    }
+
+    let changes = parse_apply_patch(apply_patch_command(payload));
+    if changes.is_empty() {
+        return vec![Value::Object(payload.clone())];
+    }
+
+    if hook_name.contains("pre-write") || hook_name.contains("post-write") {
+        return changes
+            .into_iter()
+            .filter(|change| change.kind == "add")
+            .map(|change| {
+                normalized_tool_payload(
+                    payload,
+                    "Write",
+                    json!({
+                        "file_path": change.path,
+                        "content": change.added_lines.join("\n"),
+                    }),
+                )
+            })
+            .collect();
+    }
+
+    if hook_name.contains("pre-edit") || hook_name.contains("post-edit") {
+        return changes
+            .into_iter()
+            .filter(|change| change.kind != "add")
+            .map(|change| {
+                let file_path = if change.kind == "update" {
+                    change
+                        .new_path
+                        .clone()
+                        .unwrap_or_else(|| change.path.clone())
+                } else {
+                    change.path.clone()
+                };
+                let line_delta =
+                    change.added_lines.len() as i64 - change.removed_lines.len() as i64;
+                normalized_tool_payload(
+                    payload,
+                    "Edit",
+                    json!({
+                        "file_path": file_path,
+                        "old_string": "",
+                        "new_string": change.added_lines.join("\n"),
+                        "vibeguard_line_delta": line_delta,
+                    }),
+                )
+            })
+            .collect();
+    }
+
+    if hook_name.contains("post-build-check") {
+        return changes
+            .into_iter()
+            .map(|change| {
+                let file_path = change.new_path.unwrap_or(change.path);
+                let tool_name = if change.kind == "add" {
+                    "Write"
+                } else {
+                    "Edit"
+                };
+                normalized_tool_payload(payload, tool_name, json!({ "file_path": file_path }))
+            })
+            .collect();
+    }
+
+    vec![Value::Object(payload.clone())]
+}
+
 pub fn event_name(args: &[String]) -> Result {
     ensure_no_args(args, "Usage: vibeguard-runtime codex-event-name")?;
     let data = read_json_tolerant()?;
@@ -391,6 +564,23 @@ pub fn adapt_permission_request(args: &[String]) -> Result {
     Ok(())
 }
 
+pub fn normalize_apply_patch(args: &[String]) -> Result {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime codex-normalize-apply-patch <hook-name>".into());
+    }
+
+    let input = read_stdin()?;
+    let Ok(Value::Object(payload)) = serde_json::from_str::<Value>(&input) else {
+        println!("{input}");
+        return Ok(());
+    };
+
+    for item in normalized_apply_patch_payloads(&args[0], &payload) {
+        println!("{}", serde_json::to_string(&item)?);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -496,5 +686,50 @@ mod tests {
             deny_permission_payload("blocked")["hookSpecificOutput"]["decision"]["behavior"],
             "deny"
         );
+    }
+
+    #[test]
+    fn parse_apply_patch_collects_change_shapes() {
+        let changes = parse_apply_patch(
+            "*** Begin Patch\n*** Add File: src/new.rs\n+fn main() {}\n*** Update File: src/old.rs\n*** Move to: src/current.rs\n-old\n+new\n*** Delete File: src/dead.rs\n-old\n*** End Patch",
+        );
+        assert_eq!(changes.len(), 3);
+        assert_eq!(changes[0].kind, "add");
+        assert_eq!(changes[0].added_lines, vec!["fn main() {}".to_string()]);
+        assert_eq!(changes[1].new_path.as_deref(), Some("src/current.rs"));
+        assert_eq!(changes[1].removed_lines, vec!["old".to_string()]);
+        assert_eq!(changes[2].kind, "delete");
+    }
+
+    #[test]
+    fn normalize_apply_patch_fans_out_by_hook_kind() {
+        let payload = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Add File: src/new.rs\n+one\n+two\n*** Update File: src/existing.rs\n-old\n+new\n*** End Patch"
+            },
+        })
+        .as_object()
+        .expect("payload object")
+        .clone();
+
+        let write_payloads =
+            normalized_apply_patch_payloads("vibeguard-pre-write-guard.sh", &payload);
+        assert_eq!(write_payloads.len(), 1);
+        assert_eq!(write_payloads[0]["tool_name"], "Write");
+        assert_eq!(write_payloads[0]["tool_input"]["file_path"], "src/new.rs");
+        assert_eq!(write_payloads[0]["tool_input"]["content"], "one\ntwo");
+
+        let edit_payloads =
+            normalized_apply_patch_payloads("vibeguard-pre-edit-guard.sh", &payload);
+        assert_eq!(edit_payloads.len(), 1);
+        assert_eq!(edit_payloads[0]["tool_name"], "Edit");
+        assert_eq!(
+            edit_payloads[0]["tool_input"]["file_path"],
+            "src/existing.rs"
+        );
+        assert_eq!(edit_payloads[0]["tool_input"]["new_string"], "new");
+        assert_eq!(edit_payloads[0]["tool_input"]["vibeguard_line_delta"], 0);
     }
 }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -143,6 +143,11 @@ static COMMANDS: &[Command] = &[
         handler: codex_hooks::adapt_permission_request,
     },
     Command {
+        name: "codex-normalize-apply-patch",
+        usage: "<hook-name>  — normalize Codex apply_patch payloads for file hooks",
+        handler: codex_hooks::normalize_apply_patch,
+    },
+    Command {
         name: "pre-write-check",
         usage: "<base-limit> [warn-limit]  — classify PreToolUse(Write) input for hooks",
         handler: hook_checks::pre_write_check,

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -73,6 +73,7 @@ fn help_lists_all_commands() {
         "codex-adapt-pretool",
         "codex-adapt-posttool",
         "codex-adapt-permission-request",
+        "codex-normalize-apply-patch",
         "pre-write-check",
         "pre-edit-check",
         "post-edit-fast-check",
@@ -267,6 +268,107 @@ fn codex_adapter_commands_fail_closed_on_invalid_json() {
     assert_eq!(
         permission_json["hookSpecificOutput"]["decision"]["behavior"],
         "deny"
+    );
+}
+
+#[test]
+fn codex_apply_patch_normalizer_maps_file_hook_payloads() {
+    let input = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {
+            "command": "*** Begin Patch\n*** Add File: src/new.rs\n+fn main() {}\n*** Update File: src/existing.rs\n-old\n+new\n*** End Patch"
+        }
+    })
+    .to_string();
+
+    let write = run_runtime_with_stdin(
+        &[
+            "codex-normalize-apply-patch",
+            "vibeguard-pre-write-guard.sh",
+        ],
+        &input,
+    );
+    assert_eq!(write.status.code(), Some(0));
+    let write_lines = String::from_utf8_lossy(&write.stdout);
+    let write_json: Vec<serde_json::Value> = write_lines
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(write_json.len(), 1);
+    assert_eq!(write_json[0]["tool_name"], "Write");
+    assert_eq!(write_json[0]["tool_input"]["file_path"], "src/new.rs");
+    assert_eq!(write_json[0]["tool_input"]["content"], "fn main() {}");
+
+    let edit = run_runtime_with_stdin(
+        &["codex-normalize-apply-patch", "vibeguard-pre-edit-guard.sh"],
+        &input,
+    );
+    assert_eq!(edit.status.code(), Some(0));
+    let edit_lines = String::from_utf8_lossy(&edit.stdout);
+    let edit_json: Vec<serde_json::Value> = edit_lines
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(edit_json.len(), 1);
+    assert_eq!(edit_json[0]["tool_name"], "Edit");
+    assert_eq!(edit_json[0]["tool_input"]["file_path"], "src/existing.rs");
+    assert_eq!(edit_json[0]["tool_input"]["new_string"], "new");
+    assert_eq!(edit_json[0]["tool_input"]["vibeguard_line_delta"], 0);
+
+    let post_build = run_runtime_with_stdin(
+        &[
+            "codex-normalize-apply-patch",
+            "vibeguard-post-build-check.sh",
+        ],
+        &input,
+    );
+    assert_eq!(post_build.status.code(), Some(0));
+    let post_build_lines = String::from_utf8_lossy(&post_build.stdout);
+    let post_build_json: Vec<serde_json::Value> = post_build_lines
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(post_build_json.len(), 2);
+    assert_eq!(post_build_json[0]["tool_name"], "Write");
+    assert_eq!(post_build_json[1]["tool_name"], "Edit");
+
+    let moved_delete_input = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {
+            "command": "*** Begin Patch\n*** Update File: src/old.rs\n*** Move to: src/current.rs\n-old\n+new\n*** Delete File: src/dead.rs\n-gone\n*** End Patch"
+        }
+    })
+    .to_string();
+    let moved_delete = run_runtime_with_stdin(
+        &[
+            "codex-normalize-apply-patch",
+            "vibeguard-post-edit-guard.sh",
+        ],
+        &moved_delete_input,
+    );
+    assert_eq!(moved_delete.status.code(), Some(0));
+    let moved_delete_lines = String::from_utf8_lossy(&moved_delete.stdout);
+    let moved_delete_json: Vec<serde_json::Value> = moved_delete_lines
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(moved_delete_json.len(), 2);
+    assert_eq!(moved_delete_json[0]["hook_event_name"], "PostToolUse");
+    assert_eq!(
+        moved_delete_json[0]["tool_input"]["file_path"],
+        "src/current.rs"
+    );
+    assert_eq!(moved_delete_json[0]["tool_input"]["new_string"], "new");
+    assert_eq!(
+        moved_delete_json[1]["tool_input"]["file_path"],
+        "src/dead.rs"
+    );
+    assert_eq!(moved_delete_json[1]["tool_input"]["new_string"], "");
+    assert_eq!(
+        moved_delete_json[1]["tool_input"]["vibeguard_line_delta"],
+        -1
     );
 }
 


### PR DESCRIPTION
## Summary
- add `codex-normalize-apply-patch` runtime command for Codex apply_patch payload fan-out
- make `hooks/_lib/codex_runner.sh` prefer the runtime normalizer with old-runtime Python fallback
- fail closed instead of raw-passing apply_patch when runtime and fallback normalization both fail
- add CLI and shell coverage for no-python runtime normalization, old-runtime fallback, broken-normalizer fail-closed behavior, and Move/Delete/PostToolUse parity

Refs #354

## Verification
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check
- bash -n hooks/_lib/codex_runner.sh && bash -n tests/test_codex_runtime.sh && git diff --check
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/test_codex_runtime.sh
- bash scripts/ci/self-application/check-codex-wrapper-thin.sh && bash scripts/ci/self-application/check-u29-no-silent-degrade.sh && bash scripts/ci/validate-hook-perf.sh

## Review
- independent reviewer Singer found no blocking findings after the normalizer fail-closed fix
- residual non-blocking risks: fail-closed branch direct shell coverage is PreToolUse-focused; shell apply_patch detection is heuristic for the double-failure path
