### PR TITLE
docs: add codebase audit remediation specs

### DIFF
--- a/plan/spec-app-server-runtime-policy-gate.md
+++ b/plan/spec-app-server-runtime-policy-gate.md
@@ -1,0 +1,179 @@
+# Spec: App-server runtime policy gate and required-hook fail closed
+
+- Status: Draft
+- Date: 2026-06-04
+- Owner: @majiayu000
+- Issue: https://github.com/majiayu000/vibeguard/issues/372
+- Readiness: plan_first
+- Severity: P1
+- Suggested labels: `bug`, `P1`, `guard`, `review`
+- Related: `vibeguard-runtime/src/codex_app_server_core.rs`, `vibeguard-runtime/src/codex_app_server_strategies.rs`, `vibeguard-runtime/src/codex_app_server_file_changes.rs`, `hooks/run-hook.sh`, `hooks/run-hook-codex.sh`, `hooks/_lib/policy.py`
+
+## Problem
+
+The Codex app-server wrapper invokes hook scripts directly through `HookRunner`.
+That path bypasses the runtime policy gate normally enforced by
+`hooks/run-hook.sh` and `hooks/run-hook-codex.sh`. A project can declare
+`disabled_hooks` in `.vibeguard.json`, but the app-server wrapper still executes
+the disabled hook and may block the user.
+
+The same path also fails open when a hook script is missing. `HookRunner::run`
+returns `HookResult::pass()` if the hook file does not exist, so a missing
+required pre-hook can make a dangerous request invisible instead of producing a
+hook error.
+
+## Verified facts
+
+- `vibeguard-runtime/src/codex_app_server_core.rs` returns pass when
+  `hook_path.exists()` is false.
+- `vibeguard-runtime/src/codex_app_server_strategies.rs` calls
+  `pre-bash-guard.sh` through `HookRunner`, not through the policy wrapper.
+- `vibeguard-runtime/src/codex_app_server_file_changes.rs` does the same for
+  pre-edit, pre-write, post-edit, and post-write hooks.
+- `hooks/run-hook.sh` and `hooks/run-hook-codex.sh` apply policy before
+  dispatching hooks; the app-server Rust path does not.
+
+Reproduction from the audit:
+
+```bash
+tmp_repo=$(mktemp -d)
+mkdir -p "$tmp_repo/hooks"
+printf '{"disabled_hooks":["pre-bash-guard"]}\n' > "$tmp_repo/.vibeguard.json"
+cat > "$tmp_repo/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 2
+EOF
+chmod +x "$tmp_repo/hooks/pre-bash-guard.sh"
+
+# Run an app-server command-approval request in tmp_repo.
+# Expected: disabled hook is skipped.
+# Actual: app-server wrapper still runs the hook and declines the request.
+```
+
+Missing-hook reproduction from the audit:
+
+```bash
+tmp_repo=$(mktemp -d)
+# Do not create hooks/pre-bash-guard.sh.
+
+# Run an app-server command-approval request for `rm -rf /`.
+# Expected: visible hook_error or decline because required pre-hook is missing.
+# Actual: HookRunner returns pass and the request is forwarded with no response.
+```
+
+## Goals
+
+- G1: App-server hook dispatch honors project policy from `.vibeguard.json` for
+  `disabled_hooks`, `disabled_rules`, profile, and enforcement mode.
+- G2: Missing required pre-hooks fail visibly instead of passing silently.
+- G3: Behavior stays consistent with the existing shell wrappers.
+- G4: The Rust app-server path remains usable without introducing a new runtime
+  dependency on Python for every request.
+
+## Non-goals
+
+- Do not redesign the full policy schema.
+- Do not change the public Codex app-server protocol.
+- Do not weaken existing shell-wrapper policy tests.
+- Do not add opportunistic hook refactors outside the app-server dispatch path.
+
+## Design
+
+### 1. Add a Rust-side app-server policy gate
+
+Introduce a small Rust policy evaluator used by `HookRunner` before it executes a
+hook. It should load `.vibeguard.json` from the active project directory and mirror
+the existing wrapper-level decisions for the fields the app-server path needs:
+
+- `disabled_hooks`
+- `disabled_rules`
+- profile / enforcement mode
+- invalid project policy handling
+
+The preferred shape is a `runtime_policy` module that returns a structured
+decision:
+
+```text
+run
+skip(reason)
+warn(reason)
+hook_error(reason)
+```
+
+This keeps app-server dispatch Rust-native while preventing policy drift from
+being hidden in individual strategy modules.
+
+### 2. Classify required versus optional hooks
+
+`HookRunner` needs to know whether the target hook is required for the current
+request:
+
+- Required pre-hooks: `pre-bash-guard.sh`, `pre-write-guard.sh`,
+  `pre-edit-guard.sh`.
+- Optional/post-observation hooks: `post-edit-guard.sh`,
+  `post-write-guard.sh`, and other future post hooks.
+
+If policy says a required hook is disabled, skip it intentionally and emit an
+audit-visible skip reason. If policy allows a required hook but the file is
+missing, return `hook_error` or a decline response instead of `pass`.
+
+### 3. Preserve wrapper semantics for warn mode
+
+When project policy resolves to warn mode, app-server should not hard decline
+solely because a guard reported a warning-class finding. It should attach visible
+context to the app-server response in the same spirit as the shell wrappers.
+
+### 4. Add regression coverage
+
+Add focused tests for:
+
+- disabled `pre-bash-guard` skips in app-server command approval.
+- missing `pre-bash-guard` fails visibly in app-server command approval.
+- disabled file hook skips in app-server file-change flows.
+- invalid `.vibeguard.json` produces a visible policy error instead of silent
+  pass.
+- shell wrapper behavior remains unchanged.
+
+## Acceptance criteria
+
+- AC1: With `.vibeguard.json` containing
+  `{"disabled_hooks":["pre-bash-guard"]}`, an app-server command approval request
+  for a command normally blocked by `pre-bash-guard.sh` is not declined by that
+  hook.
+- AC2: With no `hooks/pre-bash-guard.sh` present, the same request returns a
+  visible hook failure rather than silently forwarding the request.
+- AC3: With a valid blocking hook and no disabling policy, app-server still
+  blocks the dangerous command.
+- AC4: App-server file-change requests honor disabled pre/post file hooks.
+- AC5: Invalid `.vibeguard.json` is visible in the response or hook log; it does
+  not degrade to an unlogged pass.
+- AC6: Existing shell-wrapper runtime policy tests still pass.
+
+## Verification
+
+Run these commands before closing the issue:
+
+```bash
+cargo test --manifest-path vibeguard-runtime/Cargo.toml
+bash tests/hooks/test_runtime_policy.sh
+bash tests/test_codex_runtime.sh
+bash scripts/ci/validate-manifest-contract.sh
+```
+
+## Routing handoff
+
+```yaml
+handoff:
+  mode: fixflow
+  artifacts:
+    - plan/spec-app-server-runtime-policy-gate.md
+  runtime_pinning_snapshot: None for short direct implementation; capture W-20 if this expands into delegated or multi-session work.
+  verification_owner: implementation owner
+  stop_conditions:
+    - Missing-hook behavior cannot be made visible without changing the public Codex app-server protocol.
+    - Rust policy behavior would intentionally diverge from hooks/_lib/policy.py.
+  lane_map:
+    runtime_policy: implementation owner
+    app_server_tests: implementation owner
+    shell_wrapper_regression: implementation owner
+```

--- a/plan/spec-app-server-runtime-policy-gate.md
+++ b/plan/spec-app-server-runtime-policy-gate.md
@@ -64,7 +64,7 @@ tmp_repo=$(mktemp -d)
 ## Goals
 
 - G1: App-server hook dispatch honors project policy from `.vibeguard.json` for
-  `disabled_hooks`, `disabled_rules`, profile, and enforcement mode.
+  `disabled_hooks`, profile, and enforcement mode.
 - G2: Missing required pre-hooks fail visibly instead of passing silently.
 - G3: Behavior stays consistent with the existing shell wrappers.
 - G4: The Rust app-server path remains usable without introducing a new runtime
@@ -86,7 +86,6 @@ hook. It should load `.vibeguard.json` from the active project directory and mir
 the existing wrapper-level decisions for the fields the app-server path needs:
 
 - `disabled_hooks`
-- `disabled_rules`
 - profile / enforcement mode
 - invalid project policy handling
 

--- a/plan/spec-posttool-malformed-input-fail-visible.md
+++ b/plan/spec-posttool-malformed-input-fail-visible.md
@@ -1,0 +1,142 @@
+# Spec: PostToolUse malformed input should fail visibly
+
+- Status: Draft
+- Date: 2026-06-04
+- Owner: @majiayu000
+- Issue: https://github.com/majiayu000/vibeguard/issues/373
+- Readiness: plan_first
+- Severity: P1
+- Suggested labels: `bug`, `P1`, `guard`, `review`
+- Related: `vibeguard-runtime/src/hook_checks.rs`, `vibeguard-runtime/src/hook_checks_write.rs`, `hooks/post-edit-guard.sh`, `hooks/post-write-guard.sh`, `hooks/pre-write-guard.sh`
+
+## Problem
+
+PostToolUse guards silently pass malformed JSON input. This violates the
+repository's no-silent-degradation rule: a malformed hook payload means the guard
+cannot know which file changed, so a user-visible post-write or post-edit finding
+can be missed with no warning.
+
+The pre-write path already treats malformed JSON as visible malformed input.
+Post-edit and post-write should match that safety posture.
+
+## Verified facts
+
+- `vibeguard-runtime/src/hook_checks.rs` prints `SKIP` and returns success when
+  `post_edit_fast_check` receives malformed JSON.
+- `hooks/post-edit-guard.sh` exits 0 on `SKIP`.
+- `vibeguard-runtime/src/hook_checks_write.rs` returns success with no output when
+  `post_write_check` receives malformed JSON.
+- `hooks/post-write-guard.sh` exits 0 whenever the runtime command succeeds.
+- `vibeguard-runtime/src/hook_checks.rs` already emits `MALFORMED` for malformed
+  pre-write JSON, and `hooks/pre-write-guard.sh` turns that into visible hook
+  output.
+
+Audit reproduction:
+
+```bash
+printf 'not-json' | cargo run --quiet --manifest-path vibeguard-runtime/Cargo.toml -- \
+  post-edit-fast-check 400 audit-session codex /tmp/vibeguard-audit-post-edit.jsonl
+# Actual: SKIP, exit 0
+
+printf 'not-json' | cargo run --quiet --manifest-path vibeguard-runtime/Cargo.toml -- \
+  post-write-check 800 400 5000 20 5 /tmp/vibeguard-audit-post-write.jsonl
+# Actual: empty output, exit 0
+
+printf 'not-json' | cargo run --quiet --manifest-path vibeguard-runtime/Cargo.toml -- \
+  pre-write-check 800 400
+# Existing safer contrast: MALFORMED
+```
+
+## Goals
+
+- G1: Malformed PostToolUse JSON is visible to the user or hook log.
+- G2: Valid non-file PostToolUse events remain no-op and do not create noisy
+  false positives.
+- G3: Post-edit and post-write malformed handling is consistent with pre-write.
+- G4: Tests cover runtime subcommands and shell wrappers.
+
+## Non-goals
+
+- Do not make every post hook blocking. PostToolUse can remain advisory, but it
+  must not be silent on malformed input.
+- Do not change Claude/Codex hook payload schemas.
+- Do not broaden checks beyond malformed or structurally unusable hook input.
+
+## Design
+
+### 1. Split malformed input from irrelevant input
+
+Runtime checks should distinguish:
+
+- malformed JSON: visible error or warning.
+- valid JSON that is not a supported file event: silent no-op is allowed.
+- valid file event missing required fields: visible warning, because the guard
+  expected a file event but cannot inspect it.
+
+### 2. Emit a stable runtime token for malformed post input
+
+Use a stable token such as `MALFORMED` or `HOOK_ERROR` for
+`post-edit-fast-check` and `post-write-check`. The shell wrappers then translate
+that token into hook output.
+
+The exact token can reuse the pre-write `MALFORMED` pattern if it keeps the
+wrapper code smaller.
+
+### 3. Make shell wrappers visible but proportionate
+
+`hooks/post-edit-guard.sh` and `hooks/post-write-guard.sh` should:
+
+- exit non-zero only if that is compatible with the host's PostToolUse contract;
+  otherwise exit 0 with explicit additional context.
+- write a `warn` or `error` event when malformed input prevents inspection.
+- include the first bounded slice of parse error context, without dumping large
+  payloads.
+
+### 4. Add regression tests
+
+Tests should cover:
+
+- malformed JSON to runtime subcommands.
+- malformed JSON through shell wrappers.
+- valid non-file PostToolUse payload remains silent.
+- valid post-edit/post-write file payloads still run the existing checks.
+
+## Acceptance criteria
+
+- AC1: `post-edit-fast-check` on `not-json` no longer returns plain `SKIP` with
+  no visible warning.
+- AC2: `post-write-check` on `not-json` no longer returns success with empty
+  output.
+- AC3: `post-edit-guard.sh` and `post-write-guard.sh` produce visible hook
+  context or hook log entries for malformed payloads.
+- AC4: Valid non-file PostToolUse events still exit 0 without user noise.
+- AC5: Existing pre-write malformed behavior remains unchanged.
+
+## Verification
+
+Run these commands before closing the issue:
+
+```bash
+cargo test --manifest-path vibeguard-runtime/Cargo.toml
+bash tests/test_codex_runtime.sh
+bash scripts/ci/validate-hooks.sh
+bash scripts/ci/validate-hooks-manifest.sh
+```
+
+## Routing handoff
+
+```yaml
+handoff:
+  mode: fixflow
+  artifacts:
+    - plan/spec-posttool-malformed-input-fail-visible.md
+  runtime_pinning_snapshot: None for short direct implementation; capture W-20 if this expands into delegated or multi-session work.
+  verification_owner: implementation owner
+  stop_conditions:
+    - Host PostToolUse contract forbids any visible warning/error output.
+    - Tests show valid non-file PostToolUse events become noisy.
+  lane_map:
+    runtime_checks: implementation owner
+    shell_wrappers: implementation owner
+    regression_tests: implementation owner
+```

--- a/plan/spec-runtime-config-contract-clarity.md
+++ b/plan/spec-runtime-config-contract-clarity.md
@@ -1,0 +1,144 @@
+# Spec: Clarify project policy config versus user runtime config
+
+- Status: Draft
+- Date: 2026-06-04
+- Owner: @majiayu000
+- Issue: https://github.com/majiayu000/vibeguard/issues/374
+- Readiness: plan_first
+- Severity: P2
+- Suggested labels: `documentation`, `P2`, `dx`, `review`
+- Related: `README.md`, `templates/vibeguard-config.README.md`, `schemas/vibeguard-project.schema.json`, `scripts/setup/install.sh`, `scripts/lib/project_config_validate.py`
+
+## Problem
+
+The documentation currently mixes two different configuration surfaces:
+
+- project policy config: `.vibeguard.json`
+- user runtime config: `~/.vibeguard/config.json`
+
+As a result, README guidance implies that runtime tuning keys such as
+`write_mode`, `u16.warn_limit`, and `u16.limit` can be placed in
+`.vibeguard.json`. The project schema rejects those keys because
+`.vibeguard.json` is a policy file, not the per-user runtime-threshold file.
+
+This creates a documentation/schema contract drift: a user following one doc path
+can produce a config rejected by another supported path.
+
+## Verified facts
+
+- `README.md` describes `write_mode=block` and `u16.warn_limit` /
+  `u16.limit`.
+- `templates/vibeguard-config.README.md` documents
+  `~/.vibeguard/config.json` as the runtime config file.
+- `schemas/vibeguard-project.schema.json` has `additionalProperties: false` and
+  does not include `write_mode` or `u16`.
+- `scripts/setup/install.sh` prints "Runtime configuration (env vars or
+  .vibeguard.json)", which conflates runtime tuning with project policy.
+
+Audit reproduction:
+
+```bash
+tmp_cfg=$(mktemp)
+printf '{"write_mode":"block"}\n' > "$tmp_cfg"
+python3 scripts/lib/project_config_validate.py "$tmp_cfg" schemas/vibeguard-project.schema.json
+# Actual: VibeGuard project config invalid: .write_mode: unknown property
+rm -f "$tmp_cfg"
+```
+
+## Goals
+
+- G1: Every public doc clearly states which keys belong in `.vibeguard.json`
+  versus `~/.vibeguard/config.json`.
+- G2: Setup and validation error messages point users to the right file.
+- G3: The project schema remains strict for project policy keys.
+- G4: If runtime config needs schema validation, it gets its own schema instead
+  of expanding the project schema with user-only keys.
+
+## Non-goals
+
+- Do not merge project policy and user runtime config into one file.
+- Do not relax `additionalProperties: false` on
+  `schemas/vibeguard-project.schema.json`.
+- Do not rename existing config files.
+- Do not add unrelated documentation rewrites.
+
+## Design
+
+### 1. Define the two config surfaces in docs
+
+Update README and template docs to use these terms consistently:
+
+- `.vibeguard.json`: repository/project policy.
+  Examples: profile, enforcement mode, disabled hooks, disabled rules.
+- `~/.vibeguard/config.json`: user runtime tuning.
+  Examples: write mode, U-16 thresholds, circuit breaker, paralysis guard.
+
+The README should place project policy examples near policy behavior and user
+runtime examples near local tuning behavior.
+
+### 2. Fix setup wording
+
+Change setup/check output that currently says runtime config may live in
+`.vibeguard.json`. It should point project policy checks to `.vibeguard.json` and
+runtime tuning checks to `~/.vibeguard/config.json`.
+
+### 3. Improve validation diagnostics
+
+When `project_config_validate.py` rejects user-runtime keys in
+`.vibeguard.json`, the message should include a bounded hint:
+
+```text
+write_mode belongs in ~/.vibeguard/config.json, not .vibeguard.json
+```
+
+This can be a small known-key map for common drift keys instead of a broad schema
+change.
+
+### 4. Optional runtime-config schema
+
+If the project wants machine validation for `~/.vibeguard/config.json`, add a
+separate runtime-config schema under `schemas/`. Do not reuse the project policy
+schema for that file.
+
+## Acceptance criteria
+
+- AC1: README no longer implies `write_mode` or `u16.*` belongs in
+  `.vibeguard.json`.
+- AC2: Setup/check output distinguishes project policy config from user runtime
+  config.
+- AC3: `.vibeguard.json` containing `write_mode` remains invalid, but the error
+  message points to `~/.vibeguard/config.json`.
+- AC4: The project schema still rejects unknown project-policy keys.
+- AC5: Documentation path and command validators pass.
+
+## Verification
+
+Run these commands before closing the issue:
+
+```bash
+python3 scripts/lib/project_config_validate.py /path/to/test-project-config.json schemas/vibeguard-project.schema.json
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+bash tests/test_setup.sh
+```
+
+Use a temporary config fixture for the first command in implementation; do not
+commit machine-specific paths.
+
+## Routing handoff
+
+```yaml
+handoff:
+  mode: fixflow
+  artifacts:
+    - plan/spec-runtime-config-contract-clarity.md
+  runtime_pinning_snapshot: None
+  verification_owner: implementation owner
+  stop_conditions:
+    - Fix requires changing the meaning of existing .vibeguard.json keys.
+    - Runtime config validation needs a new schema larger than this documentation fix.
+  lane_map:
+    docs: implementation owner
+    setup_messages: implementation owner
+    validation_hint: implementation owner
+```

--- a/plan/spec-test-file-size-decomposition.md
+++ b/plan/spec-test-file-size-decomposition.md
@@ -1,0 +1,147 @@
+# Spec: Decompose oversized test and runtime support files
+
+- Status: Draft
+- Date: 2026-06-04
+- Owner: @majiayu000
+- Issue: https://github.com/majiayu000/vibeguard/issues/375
+- Readiness: plan_first
+- Severity: P3
+- Suggested labels: `enhancement`, `P3`, `dx`, `review`
+- Related: `tests/test_setup.sh`, `tests/test_codex_runtime.sh`, `vibeguard-runtime/tests/cli.rs`, `scripts/lib/guard_packs.py`, `vibeguard-runtime/src/codex_hooks.rs`, `vibeguard-runtime/src/hook_checks_common.rs`
+
+## Problem
+
+Several test and support files exceed or approach the repository's U-16 file-size
+limit. The current monoliths make focused changes hard to review, hide unrelated
+test failures in large scripts, and increase the chance that future fixes become
+opportunistic rewrites.
+
+This is not an immediate correctness bug, but it is a maintainability issue that
+will make future guard/runtime work riskier.
+
+## Verified facts
+
+Line counts from the audit:
+
+| File | Lines |
+| --- | ---: |
+| `tests/test_setup.sh` | 1504 |
+| `tests/test_codex_runtime.sh` | 1187 |
+| `vibeguard-runtime/tests/cli.rs` | 1090 |
+| `scripts/lib/guard_packs.py` | 793 |
+| `vibeguard-runtime/src/codex_hooks.rs` | 735 |
+| `vibeguard-runtime/src/hook_checks_common.rs` | 709 |
+
+U-16 guidance says 200-400 lines is typical and 800 lines is the hard ceiling.
+
+## Goals
+
+- G1: Split files above 800 lines into domain-focused files.
+- G2: Preserve existing aggregate commands so CI and users do not need to learn a
+  new test entry point.
+- G3: Keep behavior unchanged; this is a structural refactor.
+- G4: Make future app-server, setup, and CLI changes easier to test in isolation.
+
+## Non-goals
+
+- Do not rewrite tests to a new framework.
+- Do not change hook/runtime behavior as part of the split.
+- Do not remove existing aggregate commands.
+- Do not chase files below the ceiling unless the split is directly adjacent and
+  low-risk.
+
+## Design
+
+### 1. Split `tests/test_codex_runtime.sh`
+
+Keep `tests/test_codex_runtime.sh` as the aggregate runner. Move domain tests into
+smaller files, for example:
+
+- protocol helper tests.
+- native wrapper tests.
+- app-server tests.
+- file-change tests.
+
+Shared helpers should live in one helper file, not be duplicated.
+
+### 2. Split `tests/test_setup.sh`
+
+Keep `tests/test_setup.sh` as the aggregate runner. Move setup tests into domain
+files, for example:
+
+- install-state tests.
+- config-validation tests.
+- settings-write tests.
+- health-check tests.
+
+Preserve current setup test isolation behavior and cleanup traps.
+
+### 3. Split Rust CLI integration tests
+
+Split `vibeguard-runtime/tests/cli.rs` into multiple integration test files under
+`vibeguard-runtime/tests/`, for example:
+
+- `cli_json.rs`
+- `cli_hook_checks.rs`
+- `cli_policy.rs`
+- `cli_session_metrics.rs`
+- `cli_codex.rs`
+
+Move shared Rust test helpers into a small module if needed.
+
+### 4. Defer near-ceiling runtime support files unless needed
+
+`scripts/lib/guard_packs.py`, `vibeguard-runtime/src/codex_hooks.rs`, and
+`vibeguard-runtime/src/hook_checks_common.rs` are near the hard ceiling. Split
+them only when the work can be done with mechanical, behavior-preserving module
+extraction and full tests.
+
+## Acceptance criteria
+
+- AC1: No tracked source or test file remains above 800 lines, excluding generated
+  or vendored files.
+- AC2: `bash tests/test_setup.sh` still runs the full setup suite.
+- AC3: `bash tests/test_codex_runtime.sh` still runs the full Codex runtime suite.
+- AC4: `cargo test --manifest-path vibeguard-runtime/Cargo.toml` still runs the
+  full Rust runtime suite.
+- AC5: CI references do not break after the split.
+- AC6: File movement is behavior-preserving; no assertions are weakened to make
+  the split pass.
+
+## Verification
+
+Run these commands before closing the issue:
+
+```bash
+bash tests/test_setup.sh
+bash tests/test_codex_runtime.sh
+cargo test --manifest-path vibeguard-runtime/Cargo.toml
+find . -path './.git' -prune -o -type f -print | xargs wc -l | sort -nr | head -20
+```
+
+If the implementation touches documentation paths or CI command references, also
+run:
+
+```bash
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+```
+
+## Routing handoff
+
+```yaml
+handoff:
+  mode: plan_first
+  artifacts:
+    - plan/spec-test-file-size-decomposition.md
+  runtime_pinning_snapshot: capture W-20 if this is implemented across more than one session.
+  verification_owner: implementation owner
+  stop_conditions:
+    - Any split requires weakening or deleting existing assertions.
+    - Aggregate test runners cannot be preserved.
+  lane_map:
+    shell_setup_tests: implementation owner
+    shell_codex_tests: implementation owner
+    rust_cli_tests: implementation owner
+    optional_runtime_support_split: implementation owner
+```

--- a/plan/spec-test-file-size-decomposition.md
+++ b/plan/spec-test-file-size-decomposition.md
@@ -116,7 +116,7 @@ Run these commands before closing the issue:
 bash tests/test_setup.sh
 bash tests/test_codex_runtime.sh
 cargo test --manifest-path vibeguard-runtime/Cargo.toml
-find . -path './.git' -prune -o -type f -print | xargs wc -l | sort -nr | head -20
+git ls-files -z | xargs -0 wc -l | sort -nr | head -20
 ```
 
 If the implementation touches documentation paths or CI command references, also


### PR DESCRIPTION
## Summary

Adds four planning specs for the codebase-audit findings and links them to the GitHub issues created for implementation tracking.

## Specs / issues

- App-server runtime policy gate and required-hook fail-closed behavior: #372
- PostToolUse malformed JSON should fail visibly: #373
- Clarify project policy config versus user runtime config: #374
- Decompose oversized test and runtime support files: #375

## Notes

This PR intentionally does not use issue-closing keywords. The linked issues track the future implementation work; this PR only adds the durable specs.

## Verification

- `git diff --cached --check`
- `git diff --check`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
