### PR TITLE
fix: enforce app-server hook policy

### DIFF
--- a/tests/hooks/test_runtime_config.sh
+++ b/tests/hooks/test_runtime_config.sh
@@ -30,7 +30,7 @@ PY
 run_pre_write() {
   local cfg="$1"
   shift
-  env VIBEGUARD_LOG_DIR="$(make_log_dir)" VIBEGUARD_CONFIG_FILE="$cfg" "$@" \
+  env -u VIBEGUARD_WRITE_MODE VIBEGUARD_LOG_DIR="$(make_log_dir)" VIBEGUARD_CONFIG_FILE="$cfg" "$@" \
     bash hooks/pre-write-guard.sh < "$prewrite_input"
 }
 

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -99,6 +99,12 @@ command="${1:-}"
 shift || true
 
 case "$command" in
+  append-jsonl)
+    file="${1:?append-jsonl requires a file path}"
+    line="$(cat)"
+    mkdir -p "$(dirname "$file")"
+    printf '%s\n' "$line" >> "$file"
+    ;;
   json-field)
     strict=0
     if [[ "${1:-}" == "--strict" ]]; then

--- a/vibeguard-runtime/src/codex_app_server_core.rs
+++ b/vibeguard-runtime/src/codex_app_server_core.rs
@@ -1,3 +1,6 @@
+use crate::codex_app_server_policy::{
+    HookPolicyDecision, evaluate_hook_policy, required_hook_missing_message,
+};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::io::Write;
@@ -77,6 +80,17 @@ impl HookResult {
             failed: true,
         }
     }
+
+    pub fn skip(reason: impl Into<String>) -> Self {
+        Self {
+            decision: "skip".into(),
+            output: String::new(),
+            payloads: Vec::new(),
+            reason: Some(reason.into()),
+            updated_command: None,
+            failed: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -99,7 +113,15 @@ impl HookRunner {
         env_overrides: &HashMap<String, String>,
     ) -> HookResult {
         let hook_path = self.hooks_dir.join(hook_name);
-        if !hook_path.exists() {
+        let warn_mode = match evaluate_hook_policy(hook_name, cwd, env_overrides) {
+            HookPolicyDecision::Run { warn_mode, .. } => warn_mode,
+            HookPolicyDecision::Skip(reason) => return HookResult::skip(reason),
+            HookPolicyDecision::Error(reason) => return HookResult::hook_error(reason),
+        };
+        if !hook_path.is_file() {
+            if let Some(reason) = required_hook_missing_message(hook_name, &hook_path) {
+                return HookResult::hook_error(reason);
+            }
             return HookResult::pass();
         }
 
@@ -176,15 +198,40 @@ impl HookRunner {
             None
         };
 
-        HookResult {
+        let mut result = HookResult {
             decision,
             output: stripped,
             payloads,
             reason,
             updated_command,
             failed: false,
+        };
+        if warn_mode {
+            downgrade_to_warn(&mut result);
         }
+        result
     }
+}
+
+fn downgrade_to_warn(result: &mut HookResult) {
+    if result.failed || result.decision == "hook_error" {
+        return;
+    }
+    if !matches!(result.decision.as_str(), "block" | "gate" | "escalate") {
+        return;
+    }
+
+    result.decision = "warn".into();
+    result.updated_command = None;
+    result.reason = Some(
+        match result.reason.as_deref().filter(|reason| !reason.is_empty()) {
+            Some(reason) => format!("VIBEGUARD warn-mode advisory: {reason}"),
+            None => {
+                "VIBEGUARD warn-mode advisory: hook result downgraded by project enforcement=warn"
+                    .into()
+            }
+        },
+    );
 }
 
 fn extract_payloads(output: &str) -> Vec<Value> {

--- a/vibeguard-runtime/src/codex_app_server_file_changes.rs
+++ b/vibeguard-runtime/src/codex_app_server_file_changes.rs
@@ -344,7 +344,7 @@ impl FileChangeApprovalStrategy {
     fn is_blocking_pre_result(&self, result: &HookResult) -> bool {
         if !matches!(
             result.decision.as_str(),
-            "pass" | "allow" | "warn" | "block" | "hook_error"
+            "pass" | "allow" | "warn" | "block" | "hook_error" | "skip"
         ) {
             return true;
         }

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -1,0 +1,387 @@
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookPolicyDecision {
+    Run {
+        warn_mode: bool,
+        reason: Option<String>,
+    },
+    Skip(String),
+    Error(String),
+}
+
+pub fn evaluate_hook_policy(
+    hook_name: &str,
+    cwd: Option<&str>,
+    env_overrides: &HashMap<String, String>,
+) -> HookPolicyDecision {
+    let Some(path) = project_config_path(cwd, env_overrides) else {
+        return HookPolicyDecision::Run {
+            warn_mode: false,
+            reason: None,
+        };
+    };
+
+    let config = match load_project_config(&path) {
+        Ok(config) => config,
+        Err(reason) => return HookPolicyDecision::Error(reason),
+    };
+
+    let canonical_hook = app_server_canonical_hook_name(hook_name);
+    match config.enforcement.as_deref().unwrap_or("block") {
+        "off" => {
+            return HookPolicyDecision::Skip("VibeGuard policy skip: enforcement=off".into());
+        }
+        "warn" => {
+            return HookPolicyDecision::Run {
+                warn_mode: true,
+                reason: Some("VibeGuard policy warn: enforcement=warn".into()),
+            };
+        }
+        _ => {}
+    }
+
+    if config
+        .disabled_hooks
+        .iter()
+        .any(|hook| hook == &canonical_hook)
+    {
+        return HookPolicyDecision::Skip(format!(
+            "VibeGuard policy skip: disabled_hooks contains {canonical_hook}"
+        ));
+    }
+
+    if let Some(profile) = config.profile.as_deref() {
+        if !profile_allows_hook(profile, &canonical_hook) {
+            return HookPolicyDecision::Skip(format!(
+                "VibeGuard policy skip: profile={profile} excludes {canonical_hook}"
+            ));
+        }
+    }
+
+    HookPolicyDecision::Run {
+        warn_mode: false,
+        reason: None,
+    }
+}
+
+pub fn required_hook_missing_message(hook_name: &str, hook_path: &Path) -> Option<String> {
+    if matches!(
+        app_server_canonical_hook_name(hook_name).as_str(),
+        "pre-bash-guard" | "pre-edit-guard" | "pre-write-guard"
+    ) {
+        return Some(format!(
+            "VIBEGUARD install incomplete: missing required hook {hook_name} at {}",
+            hook_path.display()
+        ));
+    }
+    None
+}
+
+fn project_config_path(
+    cwd: Option<&str>,
+    env_overrides: &HashMap<String, String>,
+) -> Option<PathBuf> {
+    if let Some(configured) = env_value("VIBEGUARD_PROJECT_CONFIG", env_overrides) {
+        let path = PathBuf::from(configured);
+        return path.is_file().then_some(path);
+    }
+
+    let cwd_path = cwd
+        .filter(|text| !text.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())?;
+
+    if let Some(git_root) = git_root_for(&cwd_path) {
+        let candidate = git_root.join(".vibeguard.json");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    let candidate = cwd_path.join(".vibeguard.json");
+    candidate.is_file().then_some(candidate)
+}
+
+fn env_value(name: &str, env_overrides: &HashMap<String, String>) -> Option<String> {
+    env_overrides
+        .get(name)
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .or_else(|| std::env::var(name).ok().filter(|value| !value.is_empty()))
+}
+
+fn git_root_for(cwd: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+struct ProjectConfig {
+    enforcement: Option<String>,
+    profile: Option<String>,
+    disabled_hooks: Vec<String>,
+}
+
+fn load_project_config(path: &Path) -> Result<ProjectConfig, String> {
+    let text = std::fs::read_to_string(path).map_err(|err| {
+        format!(
+            "VibeGuard project config cannot be read: {}: {err}",
+            path.display()
+        )
+    })?;
+    let value = serde_json::from_str::<Value>(&text).map_err(|err| {
+        format!(
+            "VibeGuard project config invalid JSON: {}: {err}",
+            path.display()
+        )
+    })?;
+    let object = value.as_object().ok_or_else(|| {
+        format!(
+            "VibeGuard project config invalid: {} must be a JSON object",
+            path.display()
+        )
+    })?;
+
+    validate_known_properties(path, object)?;
+    let enforcement = optional_enum(path, object, "enforcement", &["block", "warn", "off"])?;
+    let profile = optional_enum(
+        path,
+        object,
+        "profile",
+        &["minimal", "core", "full", "strict"],
+    )?;
+    let disabled_hooks = optional_string_array(path, object, "disabled_hooks")?;
+    validate_disabled_hooks(path, &disabled_hooks)?;
+
+    Ok(ProjectConfig {
+        enforcement,
+        profile,
+        disabled_hooks,
+    })
+}
+
+fn validate_known_properties(
+    path: &Path,
+    object: &serde_json::Map<String, Value>,
+) -> Result<(), String> {
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "profile"
+                | "enforcement"
+                | "languages"
+                | "disabled_hooks"
+                | "disabled_rules"
+                | "disabled_guards"
+                | "gc"
+        ) {
+            return Err(format!(
+                "VibeGuard project config invalid: {} contains unknown field {key}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn optional_enum(
+    path: &Path,
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    allowed: &[&str],
+) -> Result<Option<String>, String> {
+    let Some(value) = object.get(field) else {
+        return Ok(None);
+    };
+    let Some(text) = value.as_str() else {
+        return Err(format!(
+            "VibeGuard project config invalid: {} field {field} must be a string",
+            path.display()
+        ));
+    };
+    if allowed.iter().any(|allowed| allowed == &text) {
+        Ok(Some(text.to_string()))
+    } else {
+        Err(format!(
+            "VibeGuard project config invalid: {} field {field} has unsupported value {text}",
+            path.display()
+        ))
+    }
+}
+
+fn optional_string_array(
+    path: &Path,
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<Vec<String>, String> {
+    let Some(value) = object.get(field) else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = value.as_array() else {
+        return Err(format!(
+            "VibeGuard project config invalid: {} field {field} must be an array",
+            path.display()
+        ));
+    };
+
+    items
+        .iter()
+        .map(|item| {
+            item.as_str().map(str::to_string).ok_or_else(|| {
+                format!(
+                    "VibeGuard project config invalid: {} field {field} must contain only strings",
+                    path.display()
+                )
+            })
+        })
+        .collect()
+}
+
+fn validate_disabled_hooks(path: &Path, hooks: &[String]) -> Result<(), String> {
+    for hook in hooks {
+        if !matches!(
+            hook.as_str(),
+            "analysis-paralysis-guard"
+                | "count-active-constraints"
+                | "learn-evaluator"
+                | "post-build-check"
+                | "post-edit-guard"
+                | "post-write-guard"
+                | "pre-bash-guard"
+                | "pre-commit-guard"
+                | "pre-edit-guard"
+                | "pre-write-guard"
+                | "stop-guard"
+        ) {
+            return Err(format!(
+                "VibeGuard project config invalid: {} disabled_hooks contains unsupported hook {hook}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn app_server_canonical_hook_name(hook_name: &str) -> String {
+    let file = Path::new(hook_name)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(hook_name);
+    file.strip_suffix(".sh")
+        .unwrap_or(file)
+        .strip_prefix("vibeguard-")
+        .unwrap_or_else(|| file.strip_suffix(".sh").unwrap_or(file))
+        .replace('_', "-")
+}
+
+fn profile_allows_hook(profile: &str, hook_name: &str) -> bool {
+    match hook_name {
+        "post-build-check" | "stop-guard" | "learn-evaluator" => {
+            matches!(profile, "full" | "strict")
+        }
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_policy_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "vibeguard_policy_{name}_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(&root).expect("temp dir should be created");
+        root
+    }
+
+    #[test]
+    fn disabled_hook_policy_skips_canonical_name() {
+        let repo = temp_policy_dir("disabled");
+        fs::write(
+            repo.join(".vibeguard.json"),
+            r#"{"disabled_hooks":["pre-bash-guard"]}"#,
+        )
+        .expect("project config should be written");
+
+        let decision = evaluate_hook_policy(
+            "vibeguard-pre-bash-guard.sh",
+            repo.to_str(),
+            &HashMap::new(),
+        );
+
+        assert!(
+            matches!(decision, HookPolicyDecision::Skip(reason) if reason.contains("pre-bash-guard"))
+        );
+        let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn warn_enforcement_runs_in_warn_mode() {
+        let repo = temp_policy_dir("warn");
+        fs::write(repo.join(".vibeguard.json"), r#"{"enforcement":"warn"}"#)
+            .expect("project config should be written");
+
+        let decision = evaluate_hook_policy("pre-edit-guard.sh", repo.to_str(), &HashMap::new());
+
+        assert!(matches!(
+            decision,
+            HookPolicyDecision::Run {
+                warn_mode: true,
+                ..
+            }
+        ));
+        let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn invalid_json_returns_policy_error() {
+        let repo = temp_policy_dir("invalid");
+        fs::write(repo.join(".vibeguard.json"), "{").expect("project config should be written");
+
+        let decision = evaluate_hook_policy("pre-edit-guard.sh", repo.to_str(), &HashMap::new());
+
+        assert!(
+            matches!(decision, HookPolicyDecision::Error(reason) if reason.contains("invalid JSON"))
+        );
+        let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn unsupported_disabled_hook_returns_policy_error() {
+        let repo = temp_policy_dir("unsupported_disabled_hook");
+        fs::write(
+            repo.join(".vibeguard.json"),
+            r#"{"disabled_hooks":["missing-hook"]}"#,
+        )
+        .expect("project config should be written");
+
+        let decision = evaluate_hook_policy("pre-edit-guard.sh", repo.to_str(), &HashMap::new());
+
+        assert!(
+            matches!(decision, HookPolicyDecision::Error(reason) if reason.contains("unsupported hook missing-hook"))
+        );
+        let _ = fs::remove_dir_all(repo);
+    }
+}

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -46,12 +46,11 @@ pub fn evaluate_hook_policy(
         ));
     }
 
-    if let Some(profile) = config.profile.as_deref() {
-        if !profile_allows_hook(profile, &canonical_hook) {
-            return HookPolicyDecision::Skip(format!(
-                "VibeGuard policy skip: profile={profile} excludes {canonical_hook}"
-            ));
-        }
+    let profile = config.profile.as_deref().unwrap_or("core");
+    if !profile_allows_hook(profile, &canonical_hook) {
+        return HookPolicyDecision::Skip(format!(
+            "VibeGuard policy skip: profile={profile} excludes {canonical_hook}"
+        ));
     }
 
     if enforcement == "warn" {
@@ -396,6 +395,23 @@ mod tests {
                 ..
             }
         ));
+        if let Err(err) = fs::remove_dir_all(&repo) {
+            panic!("temp policy dir should be removed: {err}");
+        }
+    }
+
+    #[test]
+    fn omitted_profile_uses_core_default_for_full_only_hooks() {
+        let repo = temp_policy_dir("default_core_profile");
+        if let Err(err) = fs::write(repo.join(".vibeguard.json"), r#"{"enforcement":"block"}"#) {
+            panic!("project config should be written: {err}");
+        }
+
+        let decision = evaluate_hook_policy("post-build-check.sh", repo.to_str(), &HashMap::new());
+
+        assert!(
+            matches!(decision, HookPolicyDecision::Skip(reason) if reason.contains("profile=core excludes post-build-check"))
+        );
         if let Err(err) = fs::remove_dir_all(&repo) {
             panic!("temp policy dir should be removed: {err}");
         }

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -163,6 +163,43 @@ fn load_project_config(path: &Path) -> Result<ProjectConfig, String> {
     )?;
     let disabled_hooks = optional_string_array(path, object, "disabled_hooks")?;
     validate_disabled_hooks(path, &disabled_hooks)?;
+    validate_string_enum_array(
+        path,
+        object,
+        "languages",
+        &["rust", "python", "go", "typescript", "javascript"],
+    )?;
+    validate_disabled_rules(path, object)?;
+    validate_string_enum_array(
+        path,
+        object,
+        "disabled_guards",
+        &[
+            "check_any_abuse",
+            "check_circular_deps",
+            "check_code_slop",
+            "check_component_duplication",
+            "check_console_residual",
+            "check_dead_shims",
+            "check_declaration_execution_gap",
+            "check_defer_in_loop",
+            "check_dependency_layers",
+            "check_duplicate_constants",
+            "check_duplicate_types",
+            "check_duplicates",
+            "check_error_handling",
+            "check_goroutine_leak",
+            "check_naming_convention",
+            "check_nested_locks",
+            "check_semantic_effect",
+            "check_single_source_of_truth",
+            "check_taste_invariants",
+            "check_test_integrity",
+            "check_unwrap_in_prod",
+            "check_workspace_consistency",
+        ],
+    )?;
+    validate_gc_config(path, object)?;
 
     Ok(ProjectConfig {
         enforcement,
@@ -266,6 +303,97 @@ fn validate_disabled_hooks(path: &Path, hooks: &[String]) -> Result<(), String> 
         ) {
             return Err(format!(
                 "VibeGuard project config invalid: {} disabled_hooks contains unsupported hook {hook}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_string_enum_array(
+    path: &Path,
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    allowed: &[&str],
+) -> Result<(), String> {
+    let values = optional_string_array(path, object, field)?;
+    for (index, value) in values.iter().enumerate() {
+        if !allowed.iter().any(|allowed| allowed == &value.as_str()) {
+            return Err(format!(
+                "VibeGuard project config invalid: {} .{field}.{index}: unsupported value {value}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_disabled_rules(
+    path: &Path,
+    object: &serde_json::Map<String, Value>,
+) -> Result<(), String> {
+    let rules = optional_string_array(path, object, "disabled_rules")?;
+    for (index, rule) in rules.iter().enumerate() {
+        if !valid_disabled_rule_id(rule) {
+            return Err(format!(
+                "VibeGuard project config invalid: {} .disabled_rules.{index}: unsupported rule id {rule}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn valid_disabled_rule_id(rule: &str) -> bool {
+    let Some((prefix, suffix)) = rule.split_once('-') else {
+        return false;
+    };
+    if !matches!(
+        prefix,
+        "SEC" | "RS" | "GO" | "TS" | "PY" | "U" | "W" | "TASTE"
+    ) {
+        return false;
+    }
+    !suffix.is_empty()
+        && suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+}
+
+fn validate_gc_config(path: &Path, object: &serde_json::Map<String, Value>) -> Result<(), String> {
+    let Some(value) = object.get("gc") else {
+        return Ok(());
+    };
+    let Some(gc) = value.as_object() else {
+        return Err(format!(
+            "VibeGuard project config invalid: {} .gc: expected object",
+            path.display()
+        ));
+    };
+    let allowed = [
+        "log_threshold_mb",
+        "archive_retain_months",
+        "worktree_max_days",
+        "session_metrics_retain_days",
+        "learning_window_days",
+        "gc_log_max_kb",
+    ];
+    for key in gc.keys() {
+        if !allowed.iter().any(|allowed| allowed == &key.as_str()) {
+            return Err(format!(
+                "VibeGuard project config invalid: {} .gc.{key}: unknown property",
+                path.display()
+            ));
+        }
+    }
+    for (key, value) in gc {
+        let valid_positive_integer = match value.as_i64() {
+            Some(number) => number >= 1,
+            None => false,
+        };
+        if !valid_positive_integer {
+            return Err(format!(
+                "VibeGuard project config invalid: {} .gc.{key}: expected integer >= 1",
                 path.display()
             ));
         }
@@ -414,6 +542,56 @@ mod tests {
         );
         if let Err(err) = fs::remove_dir_all(&repo) {
             panic!("temp policy dir should be removed: {err}");
+        }
+    }
+
+    #[test]
+    fn malformed_allowed_project_config_fields_return_policy_error() {
+        let cases = [
+            (
+                "bad_languages_type",
+                r#"{"languages":[123]}"#,
+                "field languages must contain only strings",
+            ),
+            (
+                "bad_disabled_rule",
+                r#"{"disabled_rules":["not-a-rule"]}"#,
+                ".disabled_rules.0: unsupported rule id not-a-rule",
+            ),
+            (
+                "bad_disabled_guard",
+                r#"{"disabled_guards":["missing_guard"]}"#,
+                ".disabled_guards.0: unsupported value missing_guard",
+            ),
+            ("bad_gc_type", r#"{"gc":"bad"}"#, ".gc: expected object"),
+            (
+                "bad_gc_threshold",
+                r#"{"gc":{"log_threshold_mb":0}}"#,
+                ".gc.log_threshold_mb: expected integer >= 1",
+            ),
+            (
+                "bad_gc_key",
+                r#"{"gc":{"unexpected_gc_key":1}}"#,
+                ".gc.unexpected_gc_key: unknown property",
+            ),
+        ];
+
+        for (name, config, expected) in cases {
+            let repo = temp_policy_dir(name);
+            if let Err(err) = fs::write(repo.join(".vibeguard.json"), config) {
+                panic!("project config should be written: {err}");
+            }
+
+            let decision =
+                evaluate_hook_policy("pre-edit-guard.sh", repo.to_str(), &HashMap::new());
+
+            assert!(
+                matches!(decision, HookPolicyDecision::Error(reason) if reason.contains(expected)),
+                "expected policy error containing {expected}"
+            );
+            if let Err(err) = fs::remove_dir_all(&repo) {
+                panic!("temp policy dir should be removed: {err}");
+            }
         }
     }
 

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -288,6 +288,7 @@ fn app_server_canonical_hook_name(hook_name: &str) -> String {
 
 fn profile_allows_hook(profile: &str, hook_name: &str) -> bool {
     match hook_name {
+        "analysis-paralysis-guard" => matches!(profile, "core" | "full" | "strict"),
         "post-build-check" | "stop-guard" | "learn-evaluator" => {
             matches!(profile, "full" | "strict")
         }
@@ -352,6 +353,52 @@ mod tests {
             }
         ));
         let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn minimal_profile_excludes_analysis_paralysis_guard() {
+        let repo = temp_policy_dir("minimal_analysis");
+        if let Err(err) = fs::write(repo.join(".vibeguard.json"), r#"{"profile":"minimal"}"#) {
+            panic!("project config should be written: {err}");
+        }
+
+        let decision = evaluate_hook_policy(
+            "analysis-paralysis-guard.sh",
+            repo.to_str(),
+            &HashMap::new(),
+        );
+
+        assert!(
+            matches!(decision, HookPolicyDecision::Skip(reason) if reason.contains("profile=minimal excludes analysis-paralysis-guard"))
+        );
+        if let Err(err) = fs::remove_dir_all(&repo) {
+            panic!("temp policy dir should be removed: {err}");
+        }
+    }
+
+    #[test]
+    fn core_profile_allows_analysis_paralysis_guard() {
+        let repo = temp_policy_dir("core_analysis");
+        if let Err(err) = fs::write(repo.join(".vibeguard.json"), r#"{"profile":"core"}"#) {
+            panic!("project config should be written: {err}");
+        }
+
+        let decision = evaluate_hook_policy(
+            "analysis-paralysis-guard.sh",
+            repo.to_str(),
+            &HashMap::new(),
+        );
+
+        assert!(matches!(
+            decision,
+            HookPolicyDecision::Run {
+                warn_mode: false,
+                ..
+            }
+        ));
+        if let Err(err) = fs::remove_dir_all(&repo) {
+            panic!("temp policy dir should be removed: {err}");
+        }
     }
 
     #[test]

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -31,17 +31,9 @@ pub fn evaluate_hook_policy(
     };
 
     let canonical_hook = app_server_canonical_hook_name(hook_name);
-    match config.enforcement.as_deref().unwrap_or("block") {
-        "off" => {
-            return HookPolicyDecision::Skip("VibeGuard policy skip: enforcement=off".into());
-        }
-        "warn" => {
-            return HookPolicyDecision::Run {
-                warn_mode: true,
-                reason: Some("VibeGuard policy warn: enforcement=warn".into()),
-            };
-        }
-        _ => {}
+    let enforcement = config.enforcement.as_deref().unwrap_or("block");
+    if enforcement == "off" {
+        return HookPolicyDecision::Skip("VibeGuard policy skip: enforcement=off".into());
     }
 
     if config
@@ -60,6 +52,13 @@ pub fn evaluate_hook_policy(
                 "VibeGuard policy skip: profile={profile} excludes {canonical_hook}"
             ));
         }
+    }
+
+    if enforcement == "warn" {
+        return HookPolicyDecision::Run {
+            warn_mode: true,
+            reason: Some("VibeGuard policy warn: enforcement=warn".into()),
+        };
     }
 
     HookPolicyDecision::Run {
@@ -317,11 +316,11 @@ mod tests {
     }
 
     #[test]
-    fn disabled_hook_policy_skips_canonical_name() {
+    fn warn_mode_disabled_hook_policy_skips_canonical_name() {
         let repo = temp_policy_dir("disabled");
         fs::write(
             repo.join(".vibeguard.json"),
-            r#"{"disabled_hooks":["pre-bash-guard"]}"#,
+            r#"{"enforcement":"warn","disabled_hooks":["pre-bash-guard"]}"#,
         )
         .expect("project config should be written");
 

--- a/vibeguard-runtime/src/codex_app_server_profile_tests.rs
+++ b/vibeguard-runtime/src/codex_app_server_profile_tests.rs
@@ -73,3 +73,61 @@ printf '{"decision":"pass"}\n'
         panic!("temp strategy dir should be removed: {err}");
     }
 }
+
+#[test]
+fn command_approval_disabled_pre_bash_keeps_analysis_observation() {
+    let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(err) => panic!("system time should be after unix epoch: {err}"),
+    };
+    let root = std::env::temp_dir().join(format!(
+        "vibeguard_runtime_profile_disabled_pre_bash_analysis_{}_{}",
+        std::process::id(),
+        unique
+    ));
+    if let Err(err) = fs::create_dir_all(&root) {
+        panic!("temp dir should be created: {err}");
+    }
+    let repo_dir = root.to_string_lossy().to_string();
+    if let Err(err) = fs::write(
+        Path::new(&repo_dir).join(".vibeguard.json"),
+        r#"{"disabled_hooks":["pre-bash-guard"]}"#,
+    ) {
+        panic!("project policy should be written: {err}");
+    }
+    let mut strategy = match VibeGuardGateStrategy::new(&repo_dir, Some("guarded")) {
+        Ok(strategy) => strategy,
+        Err(err) => panic!("strategy should init: {err}"),
+    };
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-disabled-pre-bash", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    for i in 0..3 {
+        let handled = strategy.handle_server_request(
+            &json!({
+                "id": format!("req-disabled-pre-bash-{i}"),
+                "method": "item/commandExecution/requestApproval",
+                "params": {"threadId": "thread-disabled-pre-bash", "command": "rg TODO src"}
+            }),
+            &mut state,
+            &mut |value| outputs.push(value),
+        );
+        assert!(!handled);
+    }
+
+    let rendered = outputs.iter().map(Value::to_string).collect::<String>();
+    let thread = match state.threads.get("thread-disabled-pre-bash") {
+        Some(thread) => thread,
+        None => panic!("thread should exist"),
+    };
+    assert_eq!(thread.research_streak, 3);
+    assert!(rendered.contains("disabled_hooks contains pre-bash-guard"));
+
+    if let Err(err) = fs::remove_dir_all(&repo_dir) {
+        panic!("temp strategy dir should be removed: {err}");
+    }
+}

--- a/vibeguard-runtime/src/codex_app_server_profile_tests.rs
+++ b/vibeguard-runtime/src/codex_app_server_profile_tests.rs
@@ -1,16 +1,14 @@
 use super::*;
 use std::fs;
-use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[test]
-fn command_approval_minimal_profile_skips_analysis_observation() {
+fn temp_profile_repo(name: &str, policy: &str, pre_bash_hook: bool) -> String {
     let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(duration) => duration.as_nanos(),
         Err(err) => panic!("system time should be after unix epoch: {err}"),
     };
     let root = std::env::temp_dir().join(format!(
-        "vibeguard_runtime_profile_minimal_no_analysis_{}_{}",
+        "vibeguard_runtime_profile_{name}_{}_{}",
         std::process::id(),
         unique
     ));
@@ -18,13 +16,13 @@ fn command_approval_minimal_profile_skips_analysis_observation() {
         panic!("temp dir should be created: {err}");
     }
     let repo_dir = root.to_string_lossy().to_string();
-    if let Err(err) = fs::write(
-        Path::new(&repo_dir).join(".vibeguard.json"),
-        r#"{"profile":"minimal"}"#,
-    ) {
+    if let Err(err) = fs::write(root.join(".vibeguard.json"), policy) {
         panic!("project policy should be written: {err}");
     }
-    let hooks_dir = Path::new(&repo_dir).join("hooks");
+    if !pre_bash_hook {
+        return repo_dir;
+    }
+    let hooks_dir = root.join("hooks");
     if let Err(err) = fs::create_dir_all(&hooks_dir) {
         panic!("hooks dir should be created: {err}");
     }
@@ -37,13 +35,17 @@ printf '{"decision":"pass"}\n'
     ) {
         panic!("hook should be written: {err}");
     }
-    let mut strategy = match VibeGuardGateStrategy::new(&repo_dir, Some("guarded")) {
+    repo_dir
+}
+
+fn run_read_approvals(repo_dir: &str, thread_id: &str) -> (SessionState, String) {
+    let mut strategy = match VibeGuardGateStrategy::new(repo_dir, Some("guarded")) {
         Ok(strategy) => strategy,
         Err(err) => panic!("strategy should init: {err}"),
     };
     let mut state = SessionState::default();
     strategy.on_client_message(
-        &json!({"method": "thread/start", "params": {"threadId": "thread-minimal", "cwd": repo_dir}}),
+        &json!({"method": "thread/start", "params": {"threadId": thread_id, "cwd": repo_dir}}),
         &mut state,
     );
 
@@ -51,9 +53,9 @@ printf '{"decision":"pass"}\n'
     for i in 0..3 {
         let handled = strategy.handle_server_request(
             &json!({
-                "id": format!("req-minimal-{i}"),
+                "id": format!("req-{thread_id}-{i}"),
                 "method": "item/commandExecution/requestApproval",
-                "params": {"threadId": "thread-minimal", "command": "rg TODO src"}
+                "params": {"threadId": thread_id, "command": "rg TODO src"}
             }),
             &mut state,
             &mut |value| outputs.push(value),
@@ -61,7 +63,13 @@ printf '{"decision":"pass"}\n'
         assert!(!handled);
     }
 
-    let rendered = outputs.iter().map(Value::to_string).collect::<String>();
+    (state, outputs.iter().map(Value::to_string).collect())
+}
+
+#[test]
+fn command_approval_minimal_profile_skips_analysis_observation() {
+    let repo_dir = temp_profile_repo("minimal_no_analysis", r#"{"profile":"minimal"}"#, true);
+    let (state, rendered) = run_read_approvals(&repo_dir, "thread-minimal");
     let thread = match state.threads.get("thread-minimal") {
         Some(thread) => thread,
         None => panic!("thread should exist"),
@@ -76,50 +84,12 @@ printf '{"decision":"pass"}\n'
 
 #[test]
 fn command_approval_disabled_pre_bash_keeps_analysis_observation() {
-    let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(duration) => duration.as_nanos(),
-        Err(err) => panic!("system time should be after unix epoch: {err}"),
-    };
-    let root = std::env::temp_dir().join(format!(
-        "vibeguard_runtime_profile_disabled_pre_bash_analysis_{}_{}",
-        std::process::id(),
-        unique
-    ));
-    if let Err(err) = fs::create_dir_all(&root) {
-        panic!("temp dir should be created: {err}");
-    }
-    let repo_dir = root.to_string_lossy().to_string();
-    if let Err(err) = fs::write(
-        Path::new(&repo_dir).join(".vibeguard.json"),
+    let repo_dir = temp_profile_repo(
+        "disabled_pre_bash_analysis",
         r#"{"disabled_hooks":["pre-bash-guard"]}"#,
-    ) {
-        panic!("project policy should be written: {err}");
-    }
-    let mut strategy = match VibeGuardGateStrategy::new(&repo_dir, Some("guarded")) {
-        Ok(strategy) => strategy,
-        Err(err) => panic!("strategy should init: {err}"),
-    };
-    let mut state = SessionState::default();
-    strategy.on_client_message(
-        &json!({"method": "thread/start", "params": {"threadId": "thread-disabled-pre-bash", "cwd": repo_dir}}),
-        &mut state,
+        false,
     );
-
-    let mut outputs = Vec::new();
-    for i in 0..3 {
-        let handled = strategy.handle_server_request(
-            &json!({
-                "id": format!("req-disabled-pre-bash-{i}"),
-                "method": "item/commandExecution/requestApproval",
-                "params": {"threadId": "thread-disabled-pre-bash", "command": "rg TODO src"}
-            }),
-            &mut state,
-            &mut |value| outputs.push(value),
-        );
-        assert!(!handled);
-    }
-
-    let rendered = outputs.iter().map(Value::to_string).collect::<String>();
+    let (state, rendered) = run_read_approvals(&repo_dir, "thread-disabled-pre-bash");
     let thread = match state.threads.get("thread-disabled-pre-bash") {
         Some(thread) => thread,
         None => panic!("thread should exist"),

--- a/vibeguard-runtime/src/codex_app_server_profile_tests.rs
+++ b/vibeguard-runtime/src/codex_app_server_profile_tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn command_approval_minimal_profile_skips_analysis_observation() {
+    let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(err) => panic!("system time should be after unix epoch: {err}"),
+    };
+    let root = std::env::temp_dir().join(format!(
+        "vibeguard_runtime_profile_minimal_no_analysis_{}_{}",
+        std::process::id(),
+        unique
+    ));
+    if let Err(err) = fs::create_dir_all(&root) {
+        panic!("temp dir should be created: {err}");
+    }
+    let repo_dir = root.to_string_lossy().to_string();
+    if let Err(err) = fs::write(
+        Path::new(&repo_dir).join(".vibeguard.json"),
+        r#"{"profile":"minimal"}"#,
+    ) {
+        panic!("project policy should be written: {err}");
+    }
+    let hooks_dir = Path::new(&repo_dir).join("hooks");
+    if let Err(err) = fs::create_dir_all(&hooks_dir) {
+        panic!("hooks dir should be created: {err}");
+    }
+    if let Err(err) = fs::write(
+        hooks_dir.join("pre-bash-guard.sh"),
+        r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"pass"}\n'
+"#,
+    ) {
+        panic!("hook should be written: {err}");
+    }
+    let mut strategy = match VibeGuardGateStrategy::new(&repo_dir, Some("guarded")) {
+        Ok(strategy) => strategy,
+        Err(err) => panic!("strategy should init: {err}"),
+    };
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-minimal", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    for i in 0..3 {
+        let handled = strategy.handle_server_request(
+            &json!({
+                "id": format!("req-minimal-{i}"),
+                "method": "item/commandExecution/requestApproval",
+                "params": {"threadId": "thread-minimal", "command": "rg TODO src"}
+            }),
+            &mut state,
+            &mut |value| outputs.push(value),
+        );
+        assert!(!handled);
+    }
+
+    let rendered = outputs.iter().map(Value::to_string).collect::<String>();
+    let thread = match state.threads.get("thread-minimal") {
+        Some(thread) => thread,
+        None => panic!("thread should exist"),
+    };
+    assert_eq!(thread.research_streak, 0);
+    assert!(!rendered.contains("analysis paralysis warning"));
+
+    if let Err(err) = fs::remove_dir_all(&repo_dir) {
+        panic!("temp strategy dir should be removed: {err}");
+    }
+}

--- a/vibeguard-runtime/src/codex_app_server_strategies.rs
+++ b/vibeguard-runtime/src/codex_app_server_strategies.rs
@@ -156,6 +156,14 @@ impl CommandApprovalStrategy {
         if result.decision == "skip" {
             let text = primary_feedback_text("pre-bash-guard.sh", &result, "");
             emit_warning(write_to_server, text, thread_id.as_deref());
+            self.observe(
+                command,
+                thread_id.as_deref(),
+                cwd.as_deref(),
+                &env,
+                state,
+                write_to_server,
+            );
             return false;
         }
 

--- a/vibeguard-runtime/src/codex_app_server_strategies.rs
+++ b/vibeguard-runtime/src/codex_app_server_strategies.rs
@@ -5,6 +5,7 @@ use crate::codex_app_server_core::{
 use crate::codex_app_server_file_changes::{
     FileChangeApprovalStrategy, attach_vibeguard_feedback, params_thread_id, params_turn_id,
 };
+use crate::codex_app_server_policy::{HookPolicyDecision, evaluate_hook_policy};
 use regex::Regex;
 use serde_json::{Value, json};
 use std::path::Path;
@@ -141,7 +142,14 @@ impl CommandApprovalStrategy {
         if result.decision == "warn" {
             let text = primary_feedback_text("pre-bash-guard.sh", &result, "");
             emit_warning(write_to_server, text, thread_id.as_deref());
-            self.observe(command, thread_id.as_deref(), state, write_to_server);
+            self.observe(
+                command,
+                thread_id.as_deref(),
+                cwd.as_deref(),
+                &env,
+                state,
+                write_to_server,
+            );
             return false;
         }
 
@@ -190,6 +198,8 @@ impl CommandApprovalStrategy {
             self.observe(
                 &updated_command,
                 thread_id.as_deref(),
+                cwd.as_deref(),
+                &env,
                 state,
                 write_to_server,
             );
@@ -209,7 +219,14 @@ impl CommandApprovalStrategy {
             );
         }
 
-        self.observe(command, thread_id.as_deref(), state, write_to_server);
+        self.observe(
+            command,
+            thread_id.as_deref(),
+            cwd.as_deref(),
+            &env,
+            state,
+            write_to_server,
+        );
         false
     }
 
@@ -217,9 +234,23 @@ impl CommandApprovalStrategy {
         &self,
         command: &str,
         thread_id: Option<&str>,
+        cwd: Option<&str>,
+        env: &std::collections::HashMap<String, String>,
         state: &mut SessionState,
         write_to_server: &mut WriteServer<'_>,
     ) {
+        match evaluate_hook_policy("analysis-paralysis-guard.sh", cwd, env) {
+            HookPolicyDecision::Run { .. } => {}
+            HookPolicyDecision::Skip(_) => return,
+            HookPolicyDecision::Error(reason) => {
+                emit_warning(
+                    write_to_server,
+                    format!("analysis-paralysis-guard.sh: {reason}"),
+                    thread_id,
+                );
+                return;
+            }
+        }
         let thread = thread_id.map(|id| state.ensure_thread(id));
         self.analysis
             .observe_command(command, thread_id, thread, write_to_server);
@@ -391,6 +422,10 @@ impl GateStrategy for VibeGuardGateStrategy {
         attach_vibeguard_feedback(message, feedback)
     }
 }
+
+#[cfg(test)]
+#[path = "codex_app_server_profile_tests.rs"]
+mod profile_tests;
 
 #[cfg(test)]
 #[path = "codex_app_server_strategies_tests.rs"]

--- a/vibeguard-runtime/src/codex_app_server_strategies.rs
+++ b/vibeguard-runtime/src/codex_app_server_strategies.rs
@@ -145,9 +145,16 @@ impl CommandApprovalStrategy {
             return false;
         }
 
+        if result.decision == "skip" {
+            let text = primary_feedback_text("pre-bash-guard.sh", &result, "");
+            emit_warning(write_to_server, text, thread_id.as_deref());
+            self.observe(command, thread_id.as_deref(), state, write_to_server);
+            return false;
+        }
+
         if !matches!(
             result.decision.as_str(),
-            "pass" | "allow" | "block" | "hook_error"
+            "pass" | "allow" | "block" | "hook_error" | "skip"
         ) {
             if self.policy.blocks_enabled() {
                 write_to_server(json!({"id": msg_id, "result": {"decision": "decline"}}));

--- a/vibeguard-runtime/src/codex_app_server_strategies.rs
+++ b/vibeguard-runtime/src/codex_app_server_strategies.rs
@@ -148,7 +148,6 @@ impl CommandApprovalStrategy {
         if result.decision == "skip" {
             let text = primary_feedback_text("pre-bash-guard.sh", &result, "");
             emit_warning(write_to_server, text, thread_id.as_deref());
-            self.observe(command, thread_id.as_deref(), state, write_to_server);
             return false;
         }
 

--- a/vibeguard-runtime/src/codex_app_server_strategies_tests.rs
+++ b/vibeguard-runtime/src/codex_app_server_strategies_tests.rs
@@ -104,7 +104,10 @@ fn patch_update_records_pending_file_changes() {
 #[test]
 fn command_approval_skips_disabled_pre_bash_policy() {
     let repo_dir = temp_dir("disabled_pre_bash");
-    write_project_policy(&repo_dir, r#"{"disabled_hooks":["pre-bash-guard"]}"#);
+    write_project_policy(
+        &repo_dir,
+        r#"{"enforcement":"warn","disabled_hooks":["pre-bash-guard"]}"#,
+    );
     write_hook(
         &repo_dir,
         "pre-bash-guard.sh",
@@ -143,6 +146,39 @@ printf '{"decision":"block","reason":"should not run"}\n'
             .iter()
             .any(|value| value.to_string().contains("\"decision\":\"decline\""))
     );
+
+    let _ = fs::remove_dir_all(repo_dir);
+}
+
+#[test]
+fn command_policy_skip_does_not_emit_analysis_warnings() {
+    let repo_dir = temp_dir("policy_skip_no_analysis");
+    write_project_policy(&repo_dir, r#"{"enforcement":"off"}"#);
+    let mut strategy =
+        VibeGuardGateStrategy::new(&repo_dir, Some("guarded")).expect("strategy should init");
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-off", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    for i in 0..7 {
+        let handled = strategy.handle_server_request(
+            &json!({
+                "id": format!("req-off-{i}"),
+                "method": "item/commandExecution/requestApproval",
+                "params": {"threadId": "thread-off", "command": "rg TODO src"}
+            }),
+            &mut state,
+            &mut |value| outputs.push(value),
+        );
+        assert!(!handled);
+    }
+
+    let rendered = outputs.iter().map(Value::to_string).collect::<String>();
+    assert!(rendered.contains("enforcement=off"));
+    assert!(!rendered.contains("analysis paralysis warning"));
 
     let _ = fs::remove_dir_all(repo_dir);
 }

--- a/vibeguard-runtime/src/codex_app_server_strategies_tests.rs
+++ b/vibeguard-runtime/src/codex_app_server_strategies_tests.rs
@@ -23,6 +23,11 @@ fn write_hook(repo_dir: &str, name: &str, body: &str) {
     fs::write(hooks_dir.join(name), body).expect("hook should be written");
 }
 
+fn write_project_policy(repo_dir: &str, body: &str) {
+    fs::write(Path::new(repo_dir).join(".vibeguard.json"), body)
+        .expect("project policy should be written");
+}
+
 #[test]
 fn analysis_strategy_classifies_read_and_write_commands() {
     let analysis = AnalysisParalysisStrategy::new().expect("regexes should compile");
@@ -92,6 +97,180 @@ fn patch_update_records_pending_file_changes() {
 
     assert_eq!(thread.turn_id.as_deref(), Some("turn-2"));
     assert_eq!(patches[0].normalized_kind(), "update");
+
+    let _ = fs::remove_dir_all(repo_dir);
+}
+
+#[test]
+fn command_approval_skips_disabled_pre_bash_policy() {
+    let repo_dir = temp_dir("disabled_pre_bash");
+    write_project_policy(&repo_dir, r#"{"disabled_hooks":["pre-bash-guard"]}"#);
+    write_hook(
+        &repo_dir,
+        "pre-bash-guard.sh",
+        r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"block","reason":"should not run"}\n'
+"#,
+    );
+    let mut strategy =
+        VibeGuardGateStrategy::new(&repo_dir, Some("guarded")).expect("strategy should init");
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-policy", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    let handled = strategy.handle_server_request(
+        &json!({
+            "id": "req-policy",
+            "method": "item/commandExecution/requestApproval",
+            "params": {"threadId": "thread-policy", "command": "rm -rf /"}
+        }),
+        &mut state,
+        &mut |value| outputs.push(value),
+    );
+
+    assert!(!handled);
+    assert!(outputs.iter().any(|value| {
+        value
+            .to_string()
+            .contains("disabled_hooks contains pre-bash-guard")
+    }));
+    assert!(
+        !outputs
+            .iter()
+            .any(|value| value.to_string().contains("\"decision\":\"decline\""))
+    );
+
+    let _ = fs::remove_dir_all(repo_dir);
+}
+
+#[test]
+fn command_approval_fails_closed_when_required_pre_bash_missing() {
+    let repo_dir = temp_dir("missing_pre_bash");
+    fs::create_dir_all(Path::new(&repo_dir).join("hooks")).expect("hooks dir should be created");
+    let mut strategy =
+        VibeGuardGateStrategy::new(&repo_dir, Some("guarded")).expect("strategy should init");
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-missing", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    let handled = strategy.handle_server_request(
+        &json!({
+            "id": "req-missing",
+            "method": "item/commandExecution/requestApproval",
+            "params": {"threadId": "thread-missing", "command": "rm -rf /"}
+        }),
+        &mut state,
+        &mut |value| outputs.push(value),
+    );
+
+    assert!(handled);
+    assert!(outputs.iter().any(|value| {
+        value.get("id").and_then(Value::as_str) == Some("req-missing")
+            && value
+                .get("result")
+                .and_then(|v| v.get("decision"))
+                .and_then(Value::as_str)
+                == Some("decline")
+    }));
+    assert!(outputs.iter().any(|value| {
+        value
+            .to_string()
+            .contains("missing required hook pre-bash-guard.sh")
+    }));
+
+    let _ = fs::remove_dir_all(repo_dir);
+}
+
+#[test]
+fn command_approval_reports_invalid_project_policy() {
+    let repo_dir = temp_dir("invalid_policy");
+    write_project_policy(&repo_dir, "{");
+    write_hook(
+        &repo_dir,
+        "pre-bash-guard.sh",
+        r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"pass"}\n'
+"#,
+    );
+    let mut strategy =
+        VibeGuardGateStrategy::new(&repo_dir, Some("guarded")).expect("strategy should init");
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-invalid", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    let handled = strategy.handle_server_request(
+        &json!({
+            "id": "req-invalid",
+            "method": "item/commandExecution/requestApproval",
+            "params": {"threadId": "thread-invalid", "command": "cargo test"}
+        }),
+        &mut state,
+        &mut |value| outputs.push(value),
+    );
+
+    assert!(handled);
+    assert!(
+        outputs
+            .iter()
+            .any(|value| value.to_string().contains("project config invalid JSON"))
+    );
+
+    let _ = fs::remove_dir_all(repo_dir);
+}
+
+#[test]
+fn command_approval_downgrades_blocking_hook_in_project_warn_mode() {
+    let repo_dir = temp_dir("warn_policy");
+    write_project_policy(&repo_dir, r#"{"enforcement":"warn"}"#);
+    write_hook(
+        &repo_dir,
+        "pre-bash-guard.sh",
+        r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"block","reason":"dangerous command"}\n'
+"#,
+    );
+    let mut strategy =
+        VibeGuardGateStrategy::new(&repo_dir, Some("guarded")).expect("strategy should init");
+    let mut state = SessionState::default();
+    strategy.on_client_message(
+        &json!({"method": "thread/start", "params": {"threadId": "thread-warn", "cwd": repo_dir}}),
+        &mut state,
+    );
+
+    let mut outputs = Vec::new();
+    let handled = strategy.handle_server_request(
+        &json!({
+            "id": "req-warn",
+            "method": "item/commandExecution/requestApproval",
+            "params": {"threadId": "thread-warn", "command": "rm -rf /tmp/demo"}
+        }),
+        &mut state,
+        &mut |value| outputs.push(value),
+    );
+
+    assert!(!handled);
+    assert!(outputs.iter().any(|value| {
+        value
+            .to_string()
+            .contains("warn-mode advisory: dangerous command")
+    }));
+    assert!(
+        !outputs
+            .iter()
+            .any(|value| value.to_string().contains("\"decision\":\"decline\""))
+    );
 
     let _ = fs::remove_dir_all(repo_dir);
 }
@@ -408,6 +587,105 @@ printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext"
             .get("thread-declined")
             .expect("thread should exist");
         assert!(thread.pending_file_changes.is_empty());
+
+        let _ = fs::remove_dir_all(repo_dir);
+    }
+
+    #[test]
+    fn file_change_flow_honors_disabled_pre_and_post_hooks() {
+        let repo_dir = temp_dir("file_policy_disabled");
+        write_project_policy(
+            &repo_dir,
+            r#"{"disabled_hooks":["pre-write-guard","post-write-guard"]}"#,
+        );
+        write_hook(
+            &repo_dir,
+            "pre-write-guard.sh",
+            r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"block","reason":"pre should not run"}\n'
+"#,
+        );
+        write_hook(
+            &repo_dir,
+            "post-write-guard.sh",
+            r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"post should not run"}}\n'
+"#,
+        );
+        let mut strategy =
+            VibeGuardGateStrategy::new(&repo_dir, Some("guarded")).expect("strategy should init");
+        let mut state = SessionState::default();
+        strategy.on_client_message(
+            &json!({"method": "thread/start", "params": {"threadId": "thread-file-policy", "cwd": repo_dir}}),
+            &mut state,
+        );
+        strategy.on_server_notification(
+            json!({
+                "method": "item/started",
+                "params": {
+                    "threadId": "thread-file-policy",
+                    "turnId": "turn-file-policy",
+                    "item": {
+                        "id": "item-file-policy",
+                        "type": "fileChange",
+                        "changes": [{"path": "new.py", "kind": "add", "diff": "@@\n+print('x')\n"}]
+                    }
+                }
+            }),
+            &mut state,
+        );
+
+        let mut outputs = Vec::new();
+        let handled = strategy.handle_server_request(
+            &json!({
+                "id": "req-file-policy",
+                "method": "item/fileChange/requestApproval",
+                "params": {
+                    "threadId": "thread-file-policy",
+                    "turnId": "turn-file-policy",
+                    "itemId": "item-file-policy"
+                }
+            }),
+            &mut state,
+            &mut |value| outputs.push(value),
+        );
+
+        assert!(!handled);
+        assert!(outputs.iter().any(|value| {
+            value
+                .to_string()
+                .contains("disabled_hooks contains pre-write-guard")
+        }));
+        assert!(
+            !outputs
+                .iter()
+                .any(|value| value.to_string().contains("\"decision\":\"decline\""))
+        );
+
+        let completed = strategy.on_server_notification(
+            json!({
+                "method": "item/completed",
+                "params": {
+                    "threadId": "thread-file-policy",
+                    "turnId": "turn-file-policy",
+                    "item": {
+                        "id": "item-file-policy",
+                        "type": "fileChange",
+                        "status": "completed"
+                    }
+                }
+            }),
+            &mut state,
+        );
+
+        assert!(
+            completed
+                .to_string()
+                .contains("disabled_hooks contains post-write-guard")
+        );
+        assert!(!completed.to_string().contains("post should not run"));
 
         let _ = fs::remove_dir_all(repo_dir);
     }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -2,6 +2,7 @@ mod circuit_breaker;
 mod codex_app_server;
 mod codex_app_server_core;
 mod codex_app_server_file_changes;
+mod codex_app_server_policy;
 mod codex_app_server_strategies;
 mod codex_hooks;
 mod event_schema;


### PR DESCRIPTION
## Summary
- add a Rust-side app-server policy gate for `.vibeguard.json` disabled hooks, enforcement mode, profile skips, and invalid policy errors
- fail closed when required app-server pre-hooks are missing while preserving optional hook pass behavior
- add app-server regressions for disabled command/file hooks, missing required hooks, invalid policy, and warn-mode downgrade
- harden hook test helpers against silent telemetry drops and ambient `VIBEGUARD_WRITE_MODE` leakage

Fixes #372

## Validation
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --all -- --check
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/hooks/test_runtime_policy.sh
- bash tests/hooks/test_runtime_config.sh
- bash tests/test_codex_runtime.sh
- bash tests/test_hooks.sh
- bash scripts/ci/validate-manifest-contract.sh
- git diff --check