### PR TITLE
Docs: plan Rust-only production path

### DIFF
--- a/docs/specs/rust-only-production-path.md
+++ b/docs/specs/rust-only-production-path.md
@@ -1,0 +1,268 @@
+# Spec: Rust-only production install and hook path
+
+- Status: Draft
+- Date: 2026-06-05
+- Owner: @majiayu000
+- Readiness: plan_first
+- Severity: P1
+- Related: `docs/specs/install-friction-reduction.md`, `scripts/setup/install.sh`, `scripts/setup/lib.sh`, `scripts/lib/install-state.sh`, `hooks/run-hook.sh`, `hooks/run-hook-codex.sh`, `hooks/_lib/policy.sh`, `hooks/_lib/codex_runner.sh`, `vibeguard-runtime/`
+
+## Issue Tracking
+
+- Umbrella: https://github.com/majiayu000/vibeguard/issues/371
+- P1 runtime policy/config: https://github.com/majiayu000/vibeguard/issues/381
+- P1 Codex normalization/adapters: https://github.com/majiayu000/vibeguard/issues/382
+- P1 configured hook path: https://github.com/majiayu000/vibeguard/issues/383
+- P2 setup/check/clean runtime migration: https://github.com/majiayu000/vibeguard/issues/384
+- P2 no-Python CI/docs gate: https://github.com/majiayu000/vibeguard/issues/385
+- Related app-server policy gate: https://github.com/majiayu000/vibeguard/issues/372
+
+## 1. Problem
+
+The release-binary install path removed the Rust/Cargo requirement for supported
+platforms, but the production install and configured hook paths still require
+Python. That keeps VibeGuard from being a single-runtime tool and preserves
+avoidable hook latency from Python process startup.
+
+This spec scopes the next migration target to a Python-free production path:
+
+- `setup.sh` / `setup.sh --check` / `setup.sh --clean` on supported release
+  targets.
+- Configured Claude Code and Codex hooks in supported profiles.
+- Runtime policy, config reads, Codex adaptation, apply_patch normalization,
+  logging/status, and hook checks needed by the installed production path.
+
+It does not require every repository script to be rewritten in Rust.
+
+## 2. Verified Facts
+
+Verified from the current `main` checkout on 2026-06-05:
+
+- The repo is on `900fd570807407133c0e2cc02bd756f84c7cd0a8`; the latest
+  release tag is `v1.1.2`.
+- `v1.1.2` publishes prebuilt `vibeguard-runtime` assets for macOS/Linux plus
+  `SHA256SUMS`.
+- `scripts/setup/install.sh` still fails if `python3` is unavailable.
+- `scripts/setup/lib.sh` shells out to Python helpers for Claude settings,
+  Codex hooks, Codex TOML config, manifest enumeration, and CLAUDE/AGENTS
+  injection.
+- `scripts/lib/install-state.sh` stores and checks install state through inline
+  Python.
+- `hooks/_lib/policy.sh` shells out to `hooks/_lib/policy.py` for runtime policy
+  and uses inline Python for output downgrade, diagnostics, and visible failure
+  payloads.
+- `hooks/_lib/codex_runner.sh` already prefers
+  `vibeguard-runtime codex-normalize-apply-patch`, but keeps
+  `hooks/_lib/codex_apply_patch_adapter.py` as fallback.
+- `hooks/pre-edit-guard.sh` already attempts `vibeguard-runtime pre-edit-check`
+  first, but still contains an inline Python implementation for the full path.
+- Current source inventory excluding `target`: 41 Rust files, 48 Python files,
+  and 223 shell files.
+
+The previous install-friction spec explicitly left single-runtime consolidation
+as roadmap work. This spec promotes that roadmap item into an executable design.
+
+## 3. Goals
+
+- G1: On supported release targets, install, check, and clean complete without a
+  `python3` executable in `PATH`.
+- G2: Configured Claude Code and Codex hook paths do not invoke Python for
+  policy, payload adaptation, apply_patch normalization, config reads, logging,
+  status, or first-party guard checks.
+- G3: Removing Python fallback is fail-closed. If the Rust runtime is missing,
+  stale, or lacks a required subcommand, hooks produce visible failure instead of
+  silently passing or falling back to a divergent implementation.
+- G4: Shell wrappers remain thin compatibility entry points only. Business logic
+  moves into `vibeguard-runtime`.
+- G5: App-server, shell-wrapper, and native Codex hook paths share one Rust
+  policy/config implementation.
+- G6: Release assets remain integrity verified and version pinned.
+
+## 4. Non-goals
+
+- Full repository Rust rewrite. Eval, benchmark, docs generation, CI-only
+  validators, and developer scripts may remain Python or shell.
+- Rewriting optional language guard packs that intentionally inspect Python
+  projects. Those may still require Python when the user enables or runs them.
+- Removing shell bootstrap entirely. `setup.sh` and hook shims may remain as
+  minimal launchers for portability.
+- Publishing npm, PyPI, Homebrew, or Docker packages.
+- Changing public Codex or Claude hook protocols.
+
+## 5. Design
+
+### 5.1 Production Path Definition
+
+For this spec, "production path" means code that runs during:
+
+- `bash setup.sh --yes`
+- `bash setup.sh --check`
+- `bash setup.sh --clean`
+- installed Claude Code hook execution
+- installed Codex hook execution
+- `vibeguard-runtime codex-app-server-wrapper`
+
+Python is allowed outside that path only for development, eval, CI, documentation,
+or optional language-specific guard tools.
+
+### 5.2 Runtime Modules and Commands
+
+Add Rust modules under `vibeguard-runtime/src/` for the remaining production
+responsibilities:
+
+- `runtime_config`: read user runtime config, project policy config, and
+  schema-specific project policy validation.
+- `runtime_policy`: mirror `hooks/_lib/policy.py` decisions, including disabled
+  hooks, enforcement mode, invalid-config handling, downgrade output, policy
+  diagnostics, and visible error output.
+- `install_state`: initialize, record, list, and drift-check
+  `~/.vibeguard/install-state.json`.
+- `setup_manifest`: enumerate install-module manifest links and rule labels now
+  served by `scripts/lib/vibeguard_manifest.py`.
+- `setup_home`: update Claude and Codex high-context files through structured,
+  idempotent operations.
+- `hook_pipeline`: optional follow-up command that runs normalization, policy,
+  hook check, adaptation, status, and logging in one runtime process.
+
+Expose them through stable CLI subcommands before deleting Python callers:
+
+```text
+vibeguard-runtime policy-check <hook-name>
+vibeguard-runtime policy-downgrade-output
+vibeguard-runtime policy-visible-failure <event-name>
+vibeguard-runtime policy-diag <hook> <event> <kind>
+vibeguard-runtime config-get <scope> <key> [default]
+vibeguard-runtime install-state <init|record-file|record-tree|check|list>
+vibeguard-runtime setup <install|check|clean>
+vibeguard-runtime active-constraints ...
+vibeguard-runtime hook-run <hook-name>
+```
+
+Command names can change during implementation, but each replacement must have a
+test before the Python call site is removed.
+
+### 5.3 Dependency Policy
+
+The current runtime intentionally has a small dependency surface:
+`serde_json`, `regex`, and `libc`. Rust-only setup needs structured parsing for
+TOML and checksums:
+
+- Allow `toml_edit` or an equivalent maintained TOML editing crate for
+  `~/.codex/config.toml`.
+- Allow `sha2` for install-state checksums if shelling out to `shasum` would
+  keep setup logic outside the runtime.
+- Do not add a general JSON Schema engine unless the project schema cannot be
+  represented as a small VibeGuard-specific validator.
+
+Any new dependency must be covered by `cargo test`, release build CI, and the
+existing release asset checksum flow.
+
+### 5.4 Migration Order
+
+1. Add Rust parity for policy/config and keep shell wrappers calling Rust.
+2. Remove Python fallback from Codex normalization and adapter helpers.
+3. Complete Rust parity for remaining configured hook Python snippets.
+4. Add Rust setup/check/clean implementation behind the existing `setup.sh`
+   bootstrap.
+5. Update `setup.sh` to download/verify runtime first, then delegate production
+   install/check/clean to Rust.
+6. Add no-Python install and hook-path CI sentinels.
+7. Optionally collapse multiple hook checks into `hook-run` for lower process
+   count after parity is proven.
+
+### 5.5 Fail-closed Rules
+
+- A missing runtime is a visible install/hook failure.
+- An unknown required runtime subcommand is a visible install/hook failure.
+- Invalid `.vibeguard.json` is a visible policy/config error.
+- A checksum mismatch aborts install.
+- Removing a Python fallback requires a targeted regression test that proves the
+  Rust behavior.
+
+### 5.6 Compatibility
+
+Existing shell commands remain valid:
+
+```bash
+bash setup.sh --yes
+bash setup.sh --check
+bash setup.sh --clean
+```
+
+The shell scripts become bootstraps, not alternate business-logic
+implementations. They may use POSIX/Bash, `git`, `curl` or `gh`, and checksum
+tools before the runtime is available, but not Python on supported release
+targets.
+
+## 6. Acceptance Criteria
+
+- AC1: In a test home with `python3` intentionally absent from `PATH`,
+  `bash setup.sh --yes --profile core` installs successfully on a supported
+  release target using the verified prebuilt runtime.
+- AC2: In that same environment, `bash setup.sh --check --strict` exits 0.
+- AC3: In that same environment, `bash setup.sh --clean` removes VibeGuard-owned
+  artifacts without Python.
+- AC4: Configured Claude Code and Codex hook paths in `minimal`, `core`, `full`,
+  and `strict` profiles do not execute `python3` for first-party runtime logic.
+- AC5: No configured hook has a Python fallback for a runtime-replaced module.
+- AC6: Existing Codex wrapper and app-server behavior tests still pass.
+- AC7: Invalid project policy config remains fail-visible in shell-wrapper and
+  app-server paths.
+- AC8: Docs distinguish "Python-free production path" from "Python-free whole
+  repository".
+
+## 7. Verification
+
+Required implementation checks:
+
+```bash
+cargo test --manifest-path vibeguard-runtime/Cargo.toml
+bash tests/test_setup.sh
+bash tests/test_setup_check.sh
+bash tests/test_codex_runtime.sh
+bash tests/test_hooks.sh
+bash scripts/ci/validate-manifest-contract.sh
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+```
+
+Add a dedicated no-Python test, likely in `tests/test_setup.sh` or a focused new
+test script, that shadows `python3` out of `PATH` while preserving the tools that
+the bootstrap legitimately needs.
+
+## 8. Risks and Open Questions
+
+- High-context writes: migrating `CLAUDE.md`, `AGENTS.md`, `settings.json`,
+  `hooks.json`, and `config.toml` must preserve dry-run diff behavior and
+  confirmation semantics.
+- TOML mutation: string editing would be fragile; use a structured Rust TOML
+  API or keep the operation out of scope.
+- Python guard packs: if users expect Python project guards during git hooks,
+  document that those optional language checks still require Python.
+- Release size and portability: new Rust dependencies may affect static Linux
+  builds and must pass release workflow tests.
+- App-server policy: this spec overlaps with the app-server policy-gate spec;
+  the Rust policy module should be shared, not duplicated.
+
+## 9. Routing Handoff
+
+```yaml
+handoff:
+  mode: fixflow
+  artifacts:
+    - docs/specs/rust-only-production-path.md
+    - plan/2026-06-05_22-28-rust-only-production-path.md
+    - plan/w20-rust-only-production-path-snapshot.md
+  runtime_pinning_snapshot: plan/w20-rust-only-production-path-snapshot.md
+  verification_owner: implementation owner
+  stop_conditions:
+    - A high-context file write cannot preserve dry-run diff and confirmation semantics.
+    - Rust policy/config behavior would intentionally diverge from existing wrapper behavior.
+    - A Python fallback is removed before equivalent Rust regression coverage exists.
+    - Release target builds fail after adding runtime dependencies.
+  lane_map:
+    runtime_policy_config: implementation owner
+    hook_path_consolidation: implementation owner
+    installer_consolidation: implementation owner
+    docs_and_ci_gates: implementation owner
+```

--- a/docs/specs/rust-only-production-path.md
+++ b/docs/specs/rust-only-production-path.md
@@ -36,7 +36,8 @@ It does not require every repository script to be rewritten in Rust.
 
 ## 2. Verified Facts
 
-Verified from the current `main` checkout on 2026-06-05:
+Baseline captured from the `main` checkout on 2026-06-05 before this plan was
+opened:
 
 - The repo is on `900fd570807407133c0e2cc02bd756f84c7cd0a8`; the latest
   release tag is `v1.1.2`.

--- a/docs/specs/rust-only-production-path.md
+++ b/docs/specs/rust-only-production-path.md
@@ -36,7 +36,7 @@ It does not require every repository script to be rewritten in Rust.
 
 ## 2. Verified Facts
 
-Verified from the current `main` checkout on 2026-06-05:
+Verified from the baseline `main` checkout captured on 2026-06-05:
 
 - The repo is on `900fd570807407133c0e2cc02bd756f84c7cd0a8`; the latest
   release tag is `v1.1.2`.
@@ -56,7 +56,7 @@ Verified from the current `main` checkout on 2026-06-05:
   `hooks/_lib/codex_apply_patch_adapter.py` as fallback.
 - `hooks/pre-edit-guard.sh` already attempts `vibeguard-runtime pre-edit-check`
   first, but still contains an inline Python implementation for the full path.
-- Current source inventory excluding `target`: 41 Rust files, 48 Python files,
+- Baseline source inventory excluding `target`: 41 Rust files, 48 Python files,
   and 223 shell files.
 
 The previous install-friction spec explicitly left single-runtime consolidation

--- a/plan/2026-06-05_22-28-rust-only-production-path.md
+++ b/plan/2026-06-05_22-28-rust-only-production-path.md
@@ -1,0 +1,329 @@
+# Rust-only production path execution plan
+
+- Planned version: v1
+- Applicable repository: `/Users/lifcc/Desktop/code/AI/tools/vibeguard`
+- Execution mode: Change each step -> Test now -> Update plan -> Next step
+- Routing readiness: `plan_first`
+- Primary spec: `docs/specs/rust-only-production-path.md`
+- GitHub umbrella: https://github.com/majiayu000/vibeguard/issues/371
+- GitHub child issues: #381, #382, #383, #384, #385
+
+## 0. Execution Constraints
+
+- Objective: make the installed production path Python-free while preserving
+  current hook behavior and fail-closed guarantees.
+- Compatibility: required for existing `setup.sh`, Claude Code hooks, Codex
+  hooks, and release binary install flow.
+- Submission strategy: milestone. Do not combine hook runtime migration and
+  installer migration into one large PR.
+- Non-goals: eval, docs generation, CI-only scripts, optional language guard
+  packs, package-manager publishing.
+- Test strategy:
+  - Step level: at least one directed regression test plus one health check per
+    step.
+  - Final: setup, Codex runtime, hook, Rust runtime, manifest, and doc validators.
+- Constraints:
+  - Search before adding files, functions, commands, tests, or rules.
+  - Do not remove a Python fallback until Rust parity is covered by tests.
+  - High-context file writes must keep dry-run diff and explicit confirmation.
+  - No silent degradation: missing runtime, invalid config, or unknown subcommand
+    must be visible.
+
+## 1. Analysis Results
+
+### Architecture Inventory Summary
+
+- Runtime command entry: `vibeguard-runtime/src/main.rs`
+- Runtime hook checks: `vibeguard-runtime/src/hook_checks*.rs`
+- Codex runtime protocol helpers: `vibeguard-runtime/src/codex_hooks.rs`
+- App-server guard proxy: `vibeguard-runtime/src/codex_app_server*.rs`
+- Shell hook wrappers: `hooks/run-hook.sh`, `hooks/run-hook-codex.sh`,
+  `hooks/_lib/*.sh`
+- Runtime policy shell/Python layer: `hooks/_lib/policy.sh`,
+  `hooks/_lib/policy.py`
+- Setup shell layer: `setup.sh`, `scripts/setup/*.sh`,
+  `scripts/setup/targets/*.sh`
+- Setup Python helpers: `scripts/lib/settings_json.py`,
+  `scripts/lib/codex_hooks_json.py`, `scripts/lib/codex_config_toml.py`,
+  `scripts/lib/vibeguard_manifest.py`, `scripts/lib/claude_md.py`,
+  `scripts/lib/project_config_validate.py`
+- Install-state shell/Python layer: `scripts/lib/install-state.sh`,
+  `scripts/lib/file_ops.py`
+
+### Redundant or Parallel Implementation Findings
+
+| id | category | files and symbols | evidence | impact | risk | convergence direction |
+|----|----------|-------------------|----------|--------|------|-----------------------|
+| F1 | runtime policy split | `hooks/_lib/policy.sh`, `hooks/_lib/policy.py`, app-server policy specs | Shell wrappers enforce policy through Python; app-server needs Rust-side policy parity. | high | high | Create one Rust `runtime_policy` module and have shell/app-server paths call it. |
+| F2 | apply_patch normalizer fallback | `hooks/_lib/codex_runner.sh`, `hooks/_lib/codex_apply_patch_adapter.py`, `vibeguard-runtime/src/codex_hooks.rs` | Runner already calls `codex-normalize-apply-patch`, then falls back to Python. | medium | medium | Delete fallback after runtime parity tests cover Add/Update/Delete/Move patch payloads. |
+| F3 | pre-edit duplicate path | `hooks/pre-edit-guard.sh`, `vibeguard-runtime/src/hook_checks.rs` | Shell hook calls Rust fast path, then keeps inline Python full implementation. | high | high | Extend Rust `pre-edit-check` until it owns the full behavior, then remove inline Python. |
+| F4 | setup config helpers in Python | `scripts/setup/lib.sh`, `scripts/setup/targets/*.sh`, `scripts/lib/*.py` | Setup writes JSON/TOML/Markdown high-context files via Python helpers. | high | high | Add Rust setup/check/clean commands with structured JSON/TOML/Markdown handling. |
+| F5 | install state in Python | `scripts/lib/install-state.sh`, `scripts/lib/file_ops.py` | Install-state init/record/check/list use inline Python and checksums. | medium | medium | Move install-state operations into Rust before setup can be no-Python. |
+| F6 | configured hook snippets still spawn Python | `hooks/count_active_constraints.sh`, `hooks/post-build-check.sh`, `hooks/learn-evaluator.sh`, `hooks/_lib/config.sh`, `hooks/_lib/log_redact.sh` | Full/strict profiles can still reach Python snippets outside pre-edit and policy. | medium | medium | Inventory configured profile hooks and migrate only first-party production snippets. |
+| F7 | low-value Python remains outside production path | `eval/*.py`, `scripts/precision-tracker.py`, CI-only validators | These do not run during install or normal hooks. | low | low | Keep out of scope; document as dev/eval tooling. |
+
+## 2. Detailed Steps
+
+### Step P0 Baseline and W-20 Snapshot
+
+- status: `completed`
+- Target: capture the execution baseline and freeze the scope before code edits.
+- Expected changes to files:
+  - `plan/w20-rust-only-production-path-snapshot.md`
+  - `docs/specs/rust-only-production-path.md`
+  - `plan/2026-06-05_22-28-rust-only-production-path.md`
+- Detailed changes:
+  - Record branch, commit, dirty state, tool versions, release assets, current
+    runtime version, and installed snapshot.
+  - Define production-path boundaries and explicit non-goals.
+  - Record the migration findings and step order.
+- step-level test command:
+  - `git status --short --branch`
+  - `bash workflows/plan-flow/scripts/redundancy_scan.sh vibeguard-runtime/src`
+  - `rg -n "python3|codex-normalize-apply-patch|policy.py|settings_json.py|codex_hooks_json.py|codex_config_toml.py|vibeguard_manifest.py|claude_md.py|project_config_validate.py" hooks scripts/setup scripts/lib vibeguard-runtime/src -g '!target'`
+- Completion judgment:
+  - Spec, plan, and W-20 snapshot exist.
+  - No implementation files are changed in this step.
+
+### Step P1 Runtime Policy and Config Canonicalization
+
+- status: `in_progress`
+- Issue: https://github.com/majiayu000/vibeguard/issues/381
+- Target: replace `hooks/_lib/policy.py` and project/user config Python reads
+  with Rust runtime commands.
+- Expected changes to files:
+  - `vibeguard-runtime/src/main.rs`
+  - `vibeguard-runtime/src/` planned module: runtime_config
+  - `vibeguard-runtime/src/` planned module: runtime_policy
+  - `vibeguard-runtime/tests/cli.rs`
+  - `hooks/_lib/policy.sh`
+  - `hooks/_lib/config.sh`
+  - `scripts/lib/project_config.sh`
+- Detailed changes:
+  - Add Rust project policy config validation for the fields used by hooks:
+    `disabled_hooks`, profile/enforcement, and related runtime policy keys.
+  - Add Rust user runtime config reads for thresholds and write mode.
+  - Add commands for policy check, downgrade output, visible failure output, and
+    policy diagnostics.
+  - Update shell wrappers to call the runtime command and fail visibly if it is
+    unavailable.
+- step-level test command:
+  - `cargo test --manifest-path vibeguard-runtime/Cargo.toml runtime_policy`
+  - `bash tests/hooks/test_runtime_policy.sh`
+  - `bash tests/test_codex_runtime.sh`
+- Completion judgment:
+  - Shell and app-server policy behavior share Rust logic.
+  - Invalid policy config remains visible.
+  - No `hooks/_lib/policy.py` production caller remains.
+
+### Step P2 Codex Normalizer and Adapter Fallback Removal
+
+- status: `pending`
+- Issue: https://github.com/majiayu000/vibeguard/issues/382
+- Target: make Codex wrapper normalization/adaptation Rust-only for configured
+  native hooks.
+- Expected changes to files:
+  - `hooks/_lib/codex_runner.sh`
+  - `hooks/_lib/codex_adapter.sh`
+  - `hooks/_lib/codex_diag.sh`
+  - `hooks/run-hook-codex.sh`
+  - `vibeguard-runtime/src/codex_hooks.rs`
+  - `vibeguard-runtime/tests/cli.rs`
+  - `tests/test_codex_runtime.sh`
+- Detailed changes:
+  - Remove `hooks/_lib/codex_apply_patch_adapter.py` from production fallback
+    after equivalent Rust coverage exists.
+  - Move remaining Codex visible-failure and status payload builders to runtime
+    commands.
+  - Keep shell wrapper as a dispatcher only.
+- step-level test command:
+  - `cargo test --manifest-path vibeguard-runtime/Cargo.toml codex`
+  - `bash tests/test_codex_runtime.sh`
+  - `bash scripts/ci/self-application/check-codex-wrapper-thin.sh`
+- Completion judgment:
+  - Apply-patch Add/Update/Delete/Move payloads normalize through Rust only.
+  - Wrapped hook output adaptation is fail-closed and Python-free.
+
+### Step P3 Remaining Configured Hook Python Snippets
+
+- status: `pending`
+- Issue: https://github.com/majiayu000/vibeguard/issues/383
+- Target: remove Python from first-party configured hook execution in
+  minimal/core/full/strict profiles.
+- Expected changes to files:
+  - `hooks/pre-edit-guard.sh`
+  - `hooks/pre-write-guard.sh`
+  - `hooks/post-build-check.sh`
+  - `hooks/count_active_constraints.sh`
+  - `hooks/learn-evaluator.sh`
+  - `hooks/_lib/post_edit_quality.sh`
+  - `hooks/_lib/post_edit_history.sh`
+  - `hooks/_lib/log_redact.sh`
+  - `hooks/_lib/log_timer.sh`
+  - `vibeguard-runtime/src/hook_checks.rs`
+  - `vibeguard-runtime/src/log_query.rs`
+  - `vibeguard-runtime/src/session_metrics/`
+  - `tests/test_hooks.sh`
+- Detailed changes:
+  - Extend existing Rust pre-edit/pre-write/post-write/log-query commands until
+    they cover the remaining inline Python branches.
+  - Add runtime output helpers for JSON payloads currently built with Python.
+  - Treat optional language guard scripts as out of scope unless they are run by
+    configured production hooks without a user-selected language pack.
+- step-level test command:
+  - `cargo test --manifest-path vibeguard-runtime/Cargo.toml hook_checks`
+  - `bash tests/test_hooks.sh`
+  - `bash tests/test_hook_status.sh`
+- Completion judgment:
+  - Configured first-party hooks do not spawn Python for runtime logic.
+  - Existing hook behavior tests still pass.
+
+### Step P4 Rust Setup, Check, Clean Core
+
+- status: `pending`
+- Issue: https://github.com/majiayu000/vibeguard/issues/384
+- Target: move setup/check/clean business logic from Python helpers into
+  `vibeguard-runtime`.
+- Expected changes to files:
+  - `vibeguard-runtime/src/main.rs`
+  - `vibeguard-runtime/src/` planned module: setup
+  - `vibeguard-runtime/src/` planned module: setup_manifest
+  - `vibeguard-runtime/src/` planned module: setup_home
+  - `vibeguard-runtime/src/` planned module: install_state
+  - `scripts/setup/lib.sh`
+  - `scripts/setup/install.sh`
+  - `scripts/setup/check.sh`
+  - `scripts/setup/clean.sh`
+  - `scripts/setup/targets/claude-home.sh`
+  - `scripts/setup/targets/codex-home.sh`
+  - `tests/test_setup.sh`
+  - `tests/test_setup_check.sh`
+- Detailed changes:
+  - Add Rust install-state init/record/tree/check/list.
+  - Add Rust manifest enumeration for skills and rules.
+  - Add Rust idempotent updates for Claude settings, Codex hooks JSON, Codex
+    config TOML, and AGENTS/CLAUDE rule blocks.
+  - Preserve dry-run diff and high-context confirmation semantics.
+- step-level test command:
+  - `cargo test --manifest-path vibeguard-runtime/Cargo.toml setup`
+  - `bash tests/test_setup.sh`
+  - `bash tests/test_setup_check.sh`
+  - `bash scripts/ci/validate-manifest-contract.sh`
+- Completion judgment:
+  - Setup/check/clean business logic has Rust coverage.
+  - Shell setup scripts no longer call Python helpers for production install.
+
+### Step P5 No-Python Install Gate and Documentation
+
+- status: `pending`
+- Issue: https://github.com/majiayu000/vibeguard/issues/385
+- Target: prove and document the Python-free production path.
+- Expected changes to files:
+  - `tests/test_setup.sh` or a focused new no-Python setup test
+  - `scripts/ci/self-application/check-u29-no-silent-degrade.sh`
+  - `README.md`
+  - `docs/README_CN.md`
+  - `docs/specs/rust-only-production-path.md`
+  - `.github/workflows/ci.yml`
+- Detailed changes:
+  - Add a test that removes `python3` from `PATH` while preserving required
+    bootstrap tools and verifies setup/check/clean on a supported release target.
+  - Add a CI sentinel that fails if configured production hook paths regain
+    Python fallback references for runtime-replaced modules.
+  - Update docs to state that production install/runtime is Python-free, while
+    eval/dev tools and optional Python guard packs may still require Python.
+- step-level test command:
+  - `bash tests/test_setup.sh`
+  - `bash scripts/ci/self-application/run-all.sh`
+  - `bash scripts/ci/validate-doc-paths.sh`
+  - `bash scripts/ci/validate-doc-command-paths.sh`
+- Completion judgment:
+  - No-Python install/check/clean is enforced by tests.
+  - Public docs match the actual dependency boundary.
+
+### Step P6 Optional Hook Pipeline Consolidation
+
+- status: `pending`
+- Target: reduce hook process count after Rust parity is stable.
+- Expected changes to files:
+  - `vibeguard-runtime/src/` planned module: hook_pipeline
+  - `vibeguard-runtime/src/main.rs`
+  - `hooks/run-hook.sh`
+  - `hooks/run-hook-codex.sh`
+  - `tests/bench_hook_latency.sh`
+  - `tests/test_hook_perf_contract.sh`
+- Detailed changes:
+  - Add `vibeguard-runtime hook-run <hook-name>` to combine policy, config,
+    normalization, check, output adaptation, status, and logging in one runtime
+    process where possible.
+  - Keep legacy shell entry points as compatibility wrappers.
+  - Compare latency before and after to ensure the extra abstraction pays for
+    itself.
+- step-level test command:
+  - `bash tests/bench_hook_latency.sh`
+  - `bash tests/test_hook_perf_contract.sh`
+  - `bash tests/test_codex_runtime.sh`
+- Completion judgment:
+  - Hook latency improves or remains neutral.
+  - No behavior regression in configured hooks.
+
+## 3. Regression Test Matrix
+
+- Rust runtime:
+  - `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
+  - `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
+- Setup:
+  - `bash tests/test_setup.sh`
+  - `bash tests/test_setup_check.sh`
+- Hooks:
+  - `bash tests/test_hooks.sh`
+  - `bash tests/test_codex_runtime.sh`
+  - `bash tests/test_hook_status.sh`
+  - `bash tests/test_hook_perf_contract.sh`
+- Contracts and docs:
+  - `bash scripts/ci/validate-manifest-contract.sh`
+  - `bash scripts/ci/validate-doc-paths.sh`
+  - `bash scripts/ci/validate-doc-command-paths.sh`
+  - `python3 workflows/plan-flow/scripts/plan_lint.py plan/2026-06-05_22-28-rust-only-production-path.md`
+
+## 4. Execution Log
+
+- 2026-06-05
+  - Step P0: `completed`
+    - Modified files:
+      - `docs/specs/rust-only-production-path.md`
+      - `plan/2026-06-05_22-28-rust-only-production-path.md`
+      - `plan/w20-rust-only-production-path-snapshot.md`
+    - Main changes:
+      - Captured baseline facts, production-path scope, non-goals, findings,
+        and phased execution plan.
+    - Execute tests:
+      - `git status --short --branch` -> pass; showed `main...origin/main`
+        and pre-existing untracked `docs/specs/observability-harness.md`.
+      - `bash workflows/plan-flow/scripts/redundancy_scan.sh vibeguard-runtime/src` -> pass; no duplicate exported type names found.
+      - `rg -n "python3|codex-normalize-apply-patch|policy.py|settings_json.py|codex_hooks_json.py|codex_config_toml.py|vibeguard_manifest.py|claude_md.py|project_config_validate.py" hooks scripts/setup scripts/lib vibeguard-runtime/src -g '!target'` -> pass; identified production Python surfaces for this plan.
+    - GitHub issue tracking:
+      - `#381`, `#382`, `#383`, `#384`, and `#385` opened under umbrella `#371`.
+
+## 5. Routing Handoff
+
+```yaml
+handoff:
+  mode: fixflow
+  artifacts:
+    - docs/specs/rust-only-production-path.md
+    - plan/2026-06-05_22-28-rust-only-production-path.md
+    - plan/w20-rust-only-production-path-snapshot.md
+  runtime_pinning_snapshot: plan/w20-rust-only-production-path-snapshot.md
+  verification_owner: implementation owner
+  stop_conditions:
+    - A high-context file write cannot preserve dry-run diff and confirmation semantics.
+    - Rust policy/config behavior would intentionally diverge from existing wrapper behavior.
+    - A Python fallback is removed before equivalent Rust regression coverage exists.
+    - Release target builds fail after adding runtime dependencies.
+  lane_map:
+    runtime_policy_config: implementation owner
+    hook_path_consolidation: implementation owner
+    installer_consolidation: implementation owner
+    docs_and_ci_gates: implementation owner
+```

--- a/plan/2026-06-05_22-28-rust-only-production-path.md
+++ b/plan/2026-06-05_22-28-rust-only-production-path.md
@@ -1,7 +1,7 @@
 # Rust-only production path execution plan
 
 - Planned version: v1
-- Applicable repository: `/Users/lifcc/Desktop/code/AI/tools/vibeguard`
+- Applicable repository: `majiayu000/vibeguard`
 - Execution mode: Change each step -> Test now -> Update plan -> Next step
 - Routing readiness: `plan_first`
 - Primary spec: `docs/specs/rust-only-production-path.md`

--- a/plan/2026-06-05_22-28-rust-only-production-path.md
+++ b/plan/2026-06-05_22-28-rust-only-production-path.md
@@ -299,7 +299,7 @@
         and phased execution plan.
     - Execute tests:
       - `git status --short --branch` -> pass; showed `main...origin/main`
-        and pre-existing untracked `docs/specs/observability-harness.md`.
+        and a pre-existing unrelated untracked docs spec file.
       - `bash workflows/plan-flow/scripts/redundancy_scan.sh vibeguard-runtime/src` -> pass; no duplicate exported type names found.
       - `rg -n "python3|codex-normalize-apply-patch|policy.py|settings_json.py|codex_hooks_json.py|codex_config_toml.py|vibeguard_manifest.py|claude_md.py|project_config_validate.py" hooks scripts/setup scripts/lib vibeguard-runtime/src -g '!target'` -> pass; identified production Python surfaces for this plan.
     - GitHub issue tracking:

--- a/plan/2026-06-05_22-28-rust-only-production-path.md
+++ b/plan/2026-06-05_22-28-rust-only-production-path.md
@@ -297,6 +297,8 @@
     - Main changes:
       - Captured baseline facts, production-path scope, non-goals, findings,
         and phased execution plan.
+      - Captured the W-20 VibeGuard rule hash for `rules/claude-rules`:
+        `59ef8b07443f0103c85b4ad3d4f6400d37c5c47f2f9b953547268b2e09065437`.
     - Execute tests:
       - `git status --short --branch` -> pass; showed `main...origin/main`
         and a pre-existing unrelated untracked docs spec file.

--- a/plan/w20-rust-only-production-path-snapshot.md
+++ b/plan/w20-rust-only-production-path-snapshot.md
@@ -1,0 +1,69 @@
+# W-20 Runtime Pinning Snapshot: Rust-only production path
+
+- Captured at: 2026-06-05 22:28:03 CST
+- Repository: `/Users/lifcc/Desktop/code/AI/tools/vibeguard`
+- Branch: `main`
+- Commit: `900fd570807407133c0e2cc02bd756f84c7cd0a8`
+- Runtime version file: `vibeguard-runtime/VERSION` = `1.1.2`
+- Installed snapshot: `~/.vibeguard/installed/version` = `a15d69a`
+- Dirty state at capture: pre-existing untracked `docs/specs/observability-harness.md`
+- Latest release tag observed: `v1.1.2`
+- Release assets observed:
+  - `SHA256SUMS`
+  - `vibeguard-runtime-aarch64-apple-darwin`
+  - `vibeguard-runtime-aarch64-unknown-linux-musl`
+  - `vibeguard-runtime-x86_64-apple-darwin`
+  - `vibeguard-runtime-x86_64-unknown-linux-musl`
+
+## Tool Inventory
+
+- `rustc 1.95.0 (59807616e 2026-04-14) (Homebrew)`
+- `cargo 1.95.0 (f2d3ce0bd 2026-03-21) (Homebrew)`
+- `GNU bash, version 5.3.9(1)-release (aarch64-apple-darwin25.1.0)`
+- `Python 3.11.2`
+- `gh version 2.86.0 (2026-01-21)`
+
+## Current Runtime Dependency Surface
+
+`vibeguard-runtime/Cargo.toml` currently declares:
+
+- `serde_json = "1"`
+- `regex = "1"`
+- `libc = "0.2"`
+
+The Rust-only production path spec may require adding a structured TOML editing
+crate and a checksum crate. Any dependency addition must be validated against
+the release workflow.
+
+## Current Python Production Surfaces
+
+Representative surfaces captured before migration:
+
+- `hooks/_lib/policy.py`: 229 lines
+- `hooks/_lib/codex_apply_patch_adapter.py`: 170 lines
+- `scripts/lib/settings_json.py`: 594 lines
+- `scripts/lib/codex_hooks_json.py`: 524 lines
+- `scripts/lib/codex_config_toml.py`: 205 lines
+- `scripts/lib/vibeguard_manifest.py`: 724 lines
+- `scripts/lib/claude_md.py`: 148 lines
+- `scripts/lib/project_config_validate.py`: 163 lines
+- `scripts/lib/install-state.sh`: 235 lines
+- `hooks/pre-edit-guard.sh`: 275 lines
+- `hooks/_lib/codex_runner.sh`: 203 lines
+
+## Scope Boundaries
+
+- In scope: supported release-target install/check/clean and configured
+  first-party Claude/Codex hook execution.
+- Out of scope: eval, benchmarks, docs generation, CI-only scripts, optional
+  language guard packs, and full repository Rust rewrite.
+
+## Stop Conditions
+
+- A high-context file write cannot preserve existing dry-run diff and explicit
+  confirmation behavior.
+- Rust policy/config behavior would intentionally diverge from existing wrapper
+  behavior.
+- A Python fallback would be removed before equivalent Rust regression coverage
+  exists.
+- New runtime dependencies break release target builds or checksum publishing.

--- a/plan/w20-rust-only-production-path-snapshot.md
+++ b/plan/w20-rust-only-production-path-snapshot.md
@@ -23,6 +23,14 @@
 - `Python 3.11.2`
 - `gh version 2.86.0 (2026-01-21)`
 
+## VibeGuard Rule Pin
+
+- Rules directory: `rules/claude-rules`
+- Rule file count: 18 markdown files
+- Rule hash: `59ef8b07443f0103c85b4ad3d4f6400d37c5c47f2f9b953547268b2e09065437`
+- Hash method: `guards/universal/check_runtime_drift.sh snapshot` with
+  `--rules-dir rules/claude-rules`, hashing sorted per-file SHA-256 entries.
+
 ## Current Runtime Dependency Surface
 
 `vibeguard-runtime/Cargo.toml` currently declares:

--- a/plan/w20-rust-only-production-path-snapshot.md
+++ b/plan/w20-rust-only-production-path-snapshot.md
@@ -6,7 +6,7 @@
 - Commit: `900fd570807407133c0e2cc02bd756f84c7cd0a8`
 - Runtime version file: `vibeguard-runtime/VERSION` = `1.1.2`
 - Installed snapshot: `~/.vibeguard/installed/version` = `a15d69a`
-- Dirty state at capture: pre-existing untracked `docs/specs/observability-harness.md`
+- Dirty state at capture: pre-existing unrelated untracked docs spec file
 - Latest release tag observed: `v1.1.2`
 - Release assets observed:
   - `SHA256SUMS`

--- a/plan/w20-rust-only-production-path-snapshot.md
+++ b/plan/w20-rust-only-production-path-snapshot.md
@@ -1,7 +1,7 @@
 # W-20 Runtime Pinning Snapshot: Rust-only production path
 
 - Captured at: 2026-06-05 22:28:03 CST
-- Repository: `/Users/lifcc/Desktop/code/AI/tools/vibeguard`
+- Repository: `majiayu000/vibeguard`
 - Branch: `main`
 - Commit: `900fd570807407133c0e2cc02bd756f84c7cd0a8`
 - Runtime version file: `vibeguard-runtime/VERSION` = `1.1.2`


### PR DESCRIPTION
## Summary

Adds the durable spec, execution plan, and W-20 runtime pinning snapshot for the Rust-only production install/hook path work.

Artifacts:

- `docs/specs/rust-only-production-path.md`
- `plan/2026-06-05_22-28-rust-only-production-path.md`
- `plan/w20-rust-only-production-path-snapshot.md`

Tracks umbrella #371 and child issues #381, #382, #383, #384, and #385. This PR does not close those implementation issues; it records the execution contract and lane map.

## Verification

```bash
python3 workflows/plan-flow/scripts/plan_lint.py plan/2026-06-05_22-28-rust-only-production-path.md
bash scripts/ci/validate-doc-paths.sh
bash scripts/ci/validate-doc-command-paths.sh
```
