### PR TITLE
fix: surface malformed PostToolUse input

### DIFF
--- a/tests/hooks/test_post_edit_guard_basic.sh
+++ b/tests/hooks/test_post_edit_guard_basic.sh
@@ -8,6 +8,9 @@ hook_test_init
 header "post-edit-guard.sh — quality warning"
 # =========================================================
 
+result=$(printf 'not-json' | bash hooks/post-edit-guard.sh)
+assert_contains "$result" "malformed PostToolUse(Edit)" "Malformed PostToolUse(Edit) input is visible"
+
 # Rust file added unwrap should warn
 result=$(echo '{"tool_input":{"file_path":"src/main.rs","new_string":"let val = data.unwrap();"}}' | bash hooks/post-edit-guard.sh)
 assert_contains "$result" "RS-03" "Detect Rust unwrap"

--- a/tests/hooks/test_post_write_guard.sh
+++ b/tests/hooks/test_post_write_guard.sh
@@ -8,6 +8,9 @@ hook_test_init
 header "post-write-guard.sh — duplicate detection"
 # =========================================================
 
+result=$(printf 'not-json' | bash hooks/post-write-guard.sh)
+assert_contains "$result" "malformed PostToolUse(Write)" "Malformed PostToolUse(Write) input is visible"
+
 # Non-source files (.md) should be allowed
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_test_readme.md","content":"# test"}}' | bash hooks/post-write-guard.sh)
 assert_not_contains "$result" "VIBEGUARD" "Non-source files (.md) are allowed"

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -427,7 +427,19 @@ pub fn post_edit_fast_check(args: &[String]) -> Result {
     let log_file = &args[3];
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
-        println!("SKIP");
+        let context = "VIBEGUARD ERROR: malformed PostToolUse(Edit) hook input. The edit result could not be inspected, so this warning is reported visibly instead of silently passing.";
+        if let Err(exc) = write_log_event(
+            log_file,
+            "post-edit-guard",
+            "Edit",
+            "warn",
+            "Malformed hook input",
+            "",
+        ) {
+            eprintln!("post-edit malformed input log failed: {exc}");
+        }
+        println!("FAST_OUTPUT");
+        println!("{}", hook_context_json("PostToolUse", context));
         return Ok(());
     };
 

--- a/vibeguard-runtime/src/hook_checks_write.rs
+++ b/vibeguard-runtime/src/hook_checks_write.rs
@@ -37,6 +37,18 @@ pub fn post_write_check(args: &[String]) -> Result {
     let log_file = &args[5];
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
+        let context = "VIBEGUARD ERROR: malformed PostToolUse(Write) hook input. The write result could not be inspected, so this warning is reported visibly instead of silently passing.";
+        if let Err(exc) = write_log_event(
+            log_file,
+            "post-write-guard",
+            "Write",
+            "warn",
+            "Malformed hook input",
+            "",
+        ) {
+            eprintln!("post-write malformed input log failed: {exc}");
+        }
+        println!("{}", post_write_context_output(context)?);
         return Ok(());
     };
 
@@ -288,10 +300,14 @@ fn u16_warning(
 }
 
 fn post_write_warning_output(warnings: &str) -> Result<String> {
+    post_write_context_output(&format!("VIBEGUARD duplicate detection:{warnings}"))
+}
+
+fn post_write_context_output(context: &str) -> Result<String> {
     Ok(serde_json::to_string(&json!({
         "hookSpecificOutput": {
             "hookEventName": "PostToolUse",
-            "additionalContext": format!("VIBEGUARD duplicate detection:{warnings}"),
+            "additionalContext": context,
         }
     }))?)
 }

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -399,6 +399,50 @@ fn run_post_write_check(input: &str, log_file: &std::path::Path) -> std::process
 }
 
 #[test]
+fn post_edit_fast_check_reports_malformed_json() {
+    let root = unique_temp_dir("post-edit-malformed");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let out = run_runtime_with_stdin(
+        &[
+            "post-edit-fast-check",
+            "400",
+            "test-session",
+            "codex",
+            log_file.to_string_lossy().as_ref(),
+        ],
+        "not-json",
+    );
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("FAST_OUTPUT"), "{stdout}");
+    assert!(stdout.contains("PostToolUse"), "{stdout}");
+    assert!(stdout.contains("malformed PostToolUse(Edit)"), "{stdout}");
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("Malformed hook input"), "{log_text}");
+    assert!(log_text.contains("\"decision\":\"warn\""), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_write_check_reports_malformed_json() {
+    let root = unique_temp_dir("post-write-malformed");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let out = run_post_write_check("not-json", &log_file);
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("PostToolUse"), "{stdout}");
+    assert!(stdout.contains("malformed PostToolUse(Write)"), "{stdout}");
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("Malformed hook input"), "{log_text}");
+    assert!(log_text.contains("\"decision\":\"warn\""), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn post_write_check_reports_duplicate_definition() {
     let root = unique_temp_dir("post-write-dup");
     fs::create_dir_all(root.join(".git")).unwrap();


### PR DESCRIPTION
## Summary
- Report malformed PostToolUse(Edit) payloads through the post-edit fast path instead of returning plain SKIP.
- Report malformed PostToolUse(Write) payloads from the runtime check instead of succeeding with empty output.
- Add runtime and shell-wrapper regressions while preserving valid non-file/no-op PostToolUse silence.

## Root cause
`post-edit-fast-check` treated JSON parse failures as `SKIP`, and `post-write-check` returned success without output on JSON parse failure. The shell wrappers interpreted both as successful no-ops, so malformed PostToolUse payloads could hide missed inspection.

## Validation
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --all -- --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash tests/test_hooks.sh`

Fixes #373