### PR TITLE
Fix malformed PostToolUse JSON visibility

### DIFF
--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -26,6 +26,20 @@ if [[ -n "${_VIBEGUARD_RUNTIME:-}" ]]; then
     2>/dev/null || true)
   _VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
   case "$_VG_FAST_STATUS" in
+    MALFORMED)
+      if ! vg_log "post-edit-guard" "Edit" "warn" "Malformed hook input" ""; then
+        printf 'VIBEGUARD ERROR: failed to log malformed post-edit hook input\n' >&2
+      fi
+      cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "VIBEGUARD ERROR: malformed PostToolUse(Edit) hook input. The edit result could not be validated, so VibeGuard is reporting visibly instead of treating it as a safe skip."
+  }
+}
+EOF
+      exit 0
+      ;;
     SKIP)
       exit 0
       ;;

--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -29,14 +29,32 @@ _vg_cleanup_runtime_err() {
 }
 trap _vg_cleanup_runtime_err EXIT
 
-if printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" post-write-check \
+if _VG_RUNTIME_OUTPUT=$(printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" post-write-check \
   "$_VG_U16_BASE_LIMIT" \
   "$_VG_U16_WARN_LIMIT" \
   "$_VG_SCAN_MAX_FILES" \
   "$_VG_SCAN_MAX_DEFS" \
   "$_VG_SCAN_MATCH_LIMIT" \
   "$VIBEGUARD_LOG_FILE" \
-  2>"$_VG_RUNTIME_ERR"; then
+  2>"$_VG_RUNTIME_ERR"); then
+  _VG_RUNTIME_STATUS="${_VG_RUNTIME_OUTPUT%%$'\n'*}"
+  if [[ "$_VG_RUNTIME_STATUS" == "MALFORMED" ]]; then
+    if ! vg_log "post-write-guard" "Write" "warn" "Malformed hook input" ""; then
+      printf 'VIBEGUARD ERROR: failed to log malformed post-write hook input\n' >&2
+    fi
+    cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "VIBEGUARD ERROR: malformed PostToolUse(Write) hook input. The write result could not be validated, so VibeGuard is reporting visibly instead of treating it as a safe skip."
+  }
+}
+EOF
+    exit 0
+  fi
+  if [[ -n "$_VG_RUNTIME_OUTPUT" ]]; then
+    printf '%s\n' "$_VG_RUNTIME_OUTPUT"
+  fi
   exit 0
 fi
 

--- a/tests/hooks/test_post_edit_guard_basic.sh
+++ b/tests/hooks/test_post_edit_guard_basic.sh
@@ -8,6 +8,20 @@ hook_test_init
 header "post-edit-guard.sh — quality warning"
 # =========================================================
 
+# Malformed PostToolUse input must be visible, not a silent SKIP
+malformed_log_dir="$(mktemp -d)"
+result=$(printf '%s' 'not-json' | VIBEGUARD_LOG_DIR="$malformed_log_dir" bash hooks/post-edit-guard.sh)
+assert_contains "$result" "hookSpecificOutput" "Malformed PostToolUse(Edit) emits hook context"
+assert_contains "$result" "malformed PostToolUse(Edit)" "Malformed PostToolUse(Edit) explains validation failure"
+malformed_log_file="$(find "$malformed_log_dir" -name events.jsonl -print -quit)"
+assert_contains "$(cat "$malformed_log_file" 2>/dev/null || true)" "Malformed hook input" "Malformed PostToolUse(Edit) writes hook log"
+rm -rf "$malformed_log_dir"
+
+# Valid non-file PostToolUse events remain silent
+result=$(echo '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"echo ok"}}' | bash hooks/post-edit-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "Non-file PostToolUse(Edit) event is silent"
+assert_not_contains "$result" "hookSpecificOutput" "Non-file PostToolUse(Edit) event emits no hook context"
+
 # Rust file added unwrap should warn
 result=$(echo '{"tool_input":{"file_path":"src/main.rs","new_string":"let val = data.unwrap();"}}' | bash hooks/post-edit-guard.sh)
 assert_contains "$result" "RS-03" "Detect Rust unwrap"

--- a/tests/hooks/test_post_write_guard.sh
+++ b/tests/hooks/test_post_write_guard.sh
@@ -8,6 +8,20 @@ hook_test_init
 header "post-write-guard.sh — duplicate detection"
 # =========================================================
 
+# Malformed PostToolUse input must be visible, not an empty success
+malformed_log_dir="$(mktemp -d)"
+result=$(printf '%s' 'not-json' | VIBEGUARD_LOG_DIR="$malformed_log_dir" bash hooks/post-write-guard.sh)
+assert_contains "$result" "hookSpecificOutput" "Malformed PostToolUse(Write) emits hook context"
+assert_contains "$result" "malformed PostToolUse(Write)" "Malformed PostToolUse(Write) explains validation failure"
+malformed_log_file="$(find "$malformed_log_dir" -name events.jsonl -print -quit)"
+assert_contains "$(cat "$malformed_log_file" 2>/dev/null || true)" "Malformed hook input" "Malformed PostToolUse(Write) writes hook log"
+rm -rf "$malformed_log_dir"
+
+# Valid non-file PostToolUse events remain silent
+result=$(echo '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"echo ok"}}' | bash hooks/post-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "Non-file PostToolUse(Write) event is silent"
+assert_not_contains "$result" "hookSpecificOutput" "Non-file PostToolUse(Write) event emits no hook context"
+
 # Non-source files (.md) should be allowed
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_test_readme.md","content":"# test"}}' | bash hooks/post-write-guard.sh)
 assert_not_contains "$result" "VIBEGUARD" "Non-source files (.md) are allowed"

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -427,7 +427,7 @@ pub fn post_edit_fast_check(args: &[String]) -> Result {
     let log_file = &args[3];
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
-        println!("SKIP");
+        println!("MALFORMED");
         return Ok(());
     };
 

--- a/vibeguard-runtime/src/hook_checks_write.rs
+++ b/vibeguard-runtime/src/hook_checks_write.rs
@@ -37,6 +37,7 @@ pub fn post_write_check(args: &[String]) -> Result {
     let log_file = &args[5];
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
+        println!("MALFORMED");
         return Ok(());
     };
 

--- a/vibeguard-runtime/tests/posttool_malformed.rs
+++ b/vibeguard-runtime/tests/posttool_malformed.rs
@@ -1,0 +1,131 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn posttool_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+}
+
+fn posttool_temp_dir(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "vibeguard-runtime-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn run_posttool_runtime(args: &[&str], input: &str) -> Output {
+    let mut child = posttool_bin()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn run_posttool_write_check(input: &str, log_file: &Path) -> Output {
+    run_posttool_runtime(
+        &[
+            "post-write-check",
+            "800",
+            "400",
+            "5000",
+            "20",
+            "5",
+            log_file.to_string_lossy().as_ref(),
+        ],
+        input,
+    )
+}
+
+#[test]
+fn post_edit_fast_check_reports_malformed_input() {
+    let root = posttool_temp_dir("post-edit-malformed");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let log_path = log_file.to_string_lossy().into_owned();
+
+    let out = run_posttool_runtime(
+        &["post-edit-fast-check", "400", "session", "codex", &log_path],
+        "not-json",
+    );
+
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "MALFORMED\n");
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_keeps_non_file_events_silent_for_shell() {
+    let root = posttool_temp_dir("post-edit-non-file");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let log_path = log_file.to_string_lossy().into_owned();
+    let input = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "echo ok"
+        }
+    })
+    .to_string();
+
+    let out = run_posttool_runtime(
+        &["post-edit-fast-check", "400", "session", "codex", &log_path],
+        &input,
+    );
+
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "SKIP\n");
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_write_check_reports_malformed_input() {
+    let root = posttool_temp_dir("post-write-malformed");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+
+    let out = run_posttool_write_check("not-json", &log_file);
+
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "MALFORMED\n");
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_write_check_keeps_non_file_events_silent() {
+    let root = posttool_temp_dir("post-write-non-file");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "echo ok"
+        }
+    })
+    .to_string();
+
+    let out = run_posttool_write_check(&input, &log_file);
+
+    assert_eq!(out.status.code(), Some(0));
+    assert!(out.stdout.is_empty());
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary
- make `post-edit-fast-check` return `MALFORMED` for malformed PostToolUse JSON instead of silent `SKIP`
- make `post-write-check` return `MALFORMED` instead of empty success on malformed JSON
- surface malformed post-edit/post-write input through hook `additionalContext` and warn logs
- add runtime and shell-hook regression coverage while keeping valid non-file PostToolUse events silent

Closes #373

## Verification
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash tests/hooks/test_post_edit_guard_basic.sh`
- `bash tests/hooks/test_post_write_guard.sh`
- `git diff --check`
- malformed runtime reproductions now print `MALFORMED`
- wrapper malformed output parses as valid PostToolUse JSON; valid non-file PostToolUse emits 0 bytes

## Review
- implemented in an isolated worktree via worker lane
- independent reviewer lane found no blocking issues