### PR TITLE
Port shell policy path to vibeguard-runtime

### DIFF
--- a/hooks/_lib/config.sh
+++ b/hooks/_lib/config.sh
@@ -15,14 +15,33 @@ if [[ -n "${_VG_CONFIG_SH_LOADED:-}" ]]; then
   return 0
 fi
 _VG_CONFIG_SH_LOADED=1
+_VG_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 _vg_config_file() {
   printf '%s' "${_VG_CONFIG_FILE:-${VIBEGUARD_CONFIG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/config.json}}"
 }
 
+_vg_config_runtime_path() {
+  local candidate
+  for candidate in \
+    "${VIBEGUARD_RUNTIME:-}" \
+    "${_VIBEGUARD_RUNTIME:-}" \
+    "${_VG_CONFIG_LIB_DIR}/../../vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${_VG_CONFIG_LIB_DIR}/../../vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      if "${candidate}" runtime-config-get-int __VIBEGUARD_MISSING_ENV__ missing.path 0 "${TMPDIR:-/tmp}/vibeguard-missing-config-probe.json" >/dev/null 2>&1; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
 vg_config_get_int() {
   local env_name="$1" json_path="$2" default_val="$3"
-  local val config_file
+  local val config_file runtime_path
 
   val="${!env_name:-}"
   if [[ -n "$val" && "$val" =~ ^[0-9]+$ ]]; then
@@ -31,6 +50,16 @@ vg_config_get_int() {
   fi
 
   config_file="$(_vg_config_file)"
+  if runtime_path="$(_vg_config_runtime_path)"; then
+    if val=$("${runtime_path}" runtime-config-get-int "$env_name" "$json_path" "$default_val" "$config_file" 2>/dev/null); then
+      printf '%s' "$val"
+      return 0
+    fi
+    printf 'VibeGuard runtime config error: runtime-config-get-int failed; using default for %s\n' "$json_path" >&2
+    printf '%s' "$default_val"
+    return 0
+  fi
+
   if [[ -f "$config_file" ]]; then
     val=$(python3 - "$config_file" "$json_path" <<'PY'
 import json
@@ -65,7 +94,7 @@ PY
 
 vg_config_get_str() {
   local env_name="$1" json_path="$2" default_val="$3"
-  local val config_file
+  local val config_file runtime_path
 
   val="${!env_name:-}"
   if [[ -n "$val" ]]; then
@@ -74,6 +103,16 @@ vg_config_get_str() {
   fi
 
   config_file="$(_vg_config_file)"
+  if runtime_path="$(_vg_config_runtime_path)"; then
+    if val=$("${runtime_path}" runtime-config-get-str "$env_name" "$json_path" "$default_val" "$config_file" 2>/dev/null); then
+      printf '%s' "$val"
+      return 0
+    fi
+    printf 'VibeGuard runtime config error: runtime-config-get-str failed; using default for %s\n' "$json_path" >&2
+    printf '%s' "$default_val"
+    return 0
+  fi
+
   if [[ -f "$config_file" ]]; then
     val=$(python3 - "$config_file" "$json_path" <<'PY'
 import json

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -7,7 +7,27 @@ fi
 _VG_POLICY_SH_LOADED=1
 
 _VG_POLICY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_VG_POLICY_PY="${_VG_POLICY_LIB_DIR}/policy.py"
+
+vg_policy_runtime_path() {
+  local candidate
+  for candidate in \
+    "${VIBEGUARD_RUNTIME:-}" \
+    "${_VIBEGUARD_RUNTIME:-}" \
+    "${_VG_POLICY_LIB_DIR}/../../vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${_VG_POLICY_LIB_DIR}/../../vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${_VG_POLICY_LIB_DIR}/../vibeguard-runtime"; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      if VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
+          VIBEGUARD_USER_CONFIG_FILE="" \
+          "${candidate}" runtime-policy-check __vibeguard_policy_probe__ --cwd "${TMPDIR:-/tmp}" >/dev/null 2>&1; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
 
 vg_policy_user_config_file() {
   printf '%s' "${_VG_CONFIG_FILE:-${VIBEGUARD_CONFIG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/config.json}}"
@@ -15,20 +35,15 @@ vg_policy_user_config_file() {
 
 vg_policy_check_hook() {
   local hook_name="$1"
-  local output status
+  local output status runtime_path
 
   VG_POLICY_REASON=""
   VG_POLICY_KIND=""
   VG_POLICY_ENFORCEMENT="block"
   export VIBEGUARD_POLICY_ENFORCEMENT="block"
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    VG_POLICY_REASON="VibeGuard policy error: python3 is required for runtime policy checks."
-    VG_POLICY_KIND="policy_error"
-    return 20
-  fi
-  if [[ ! -f "${_VG_POLICY_PY}" ]]; then
-    VG_POLICY_REASON="VibeGuard policy error: policy helper missing at ${_VG_POLICY_PY}"
+  if ! runtime_path="$(vg_policy_runtime_path)"; then
+    VG_POLICY_REASON="VibeGuard policy error: vibeguard-runtime is required for runtime policy checks."
     VG_POLICY_KIND="policy_error"
     return 20
   fi
@@ -36,7 +51,7 @@ vg_policy_check_hook() {
   status=0
   output="$(
     VIBEGUARD_USER_CONFIG_FILE="$(vg_policy_user_config_file)" \
-      python3 "${_VG_POLICY_PY}" check "${hook_name}" 2>&1
+      "${runtime_path}" runtime-policy-check "${hook_name}" 2>&1
   )" || status=$?
 
   case "${status}" in
@@ -69,120 +84,75 @@ vg_policy_check_hook() {
 
 vg_policy_downgrade_output() {
   local output="$1"
+  local runtime_path runtime_output status
   if [[ "${VIBEGUARD_POLICY_ENFORCEMENT:-}" != "warn" || -z "${output}" ]]; then
     printf '%s\n' "${output}"
     return 0
   fi
 
-  VG_POLICY_HOOK_OUTPUT="${output}" python3 - <<'PY' || printf '%s\n' "${output}"
-import json
-import os
-import sys
-
-raw = os.environ.get("VG_POLICY_HOOK_OUTPUT", "")
-try:
-    data = json.loads(raw)
-except json.JSONDecodeError:
-    sys.stdout.write(raw)
-    if raw and not raw.endswith("\n"):
-        sys.stdout.write("\n")
-    raise SystemExit(0)
-
-if not isinstance(data, dict):
-    print(json.dumps(data, ensure_ascii=False))
-    raise SystemExit(0)
-
-reason = data.get("reason")
-changed = False
-if data.get("decision") in {"block", "gate", "escalate"}:
-    data["decision"] = "warn"
-    changed = True
-if isinstance(reason, str) and reason and changed:
-    data["reason"] = f"VIBEGUARD warn-mode advisory: {reason}"
-
-hook_specific = data.get("hookSpecificOutput")
-if isinstance(hook_specific, dict):
-    if hook_specific.get("permissionDecision") == "deny":
-        message = hook_specific.pop("permissionDecisionReason", None)
-        hook_specific.pop("permissionDecision", None)
-        if isinstance(message, str) and message and "systemMessage" not in data:
-            data["systemMessage"] = f"VIBEGUARD warn-mode advisory: {message}"
-    decision = hook_specific.get("decision")
-    if isinstance(decision, dict) and decision.get("behavior") == "deny":
-        message = decision.get("message")
-        hook_specific.pop("decision", None)
-        if isinstance(message, str) and message and "systemMessage" not in data:
-            data["systemMessage"] = f"VIBEGUARD warn-mode advisory: {message}"
-
-print(json.dumps(data, ensure_ascii=False))
-PY
+  if ! runtime_path="$(vg_policy_runtime_path)"; then
+    printf '%s\n' "VibeGuard policy error: vibeguard-runtime missing during warn-mode downgrade." >&2
+    printf '%s\n' "${output}"
+    return 0
+  fi
+  status=0
+  runtime_output="$(printf '%s' "${output}" | "${runtime_path}" runtime-policy-downgrade-output 2>/dev/null)" || status=$?
+  if [[ "${status}" -eq 0 ]]; then
+    printf '%s\n' "${runtime_output}"
+  else
+    printf '%s\n' "VibeGuard policy error: runtime-policy-downgrade-output failed." >&2
+    printf '%s\n' "${output}"
+  fi
 }
 
 vg_policy_diag() {
   local hook_name="$1" event_name="${2:-}" kind="$3" reason="$4"
-  local diag_file diag_dir
+  local diag_file diag_dir runtime_path
   diag_file="${VIBEGUARD_POLICY_DIAG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/policy.jsonl}"
   diag_dir="$(dirname "${diag_file}")"
   mkdir -p "${diag_dir}" 2>/dev/null || return 0
-  VIBEGUARD_POLICY_DIAG_HOOK="${hook_name}" \
-    VIBEGUARD_POLICY_DIAG_EVENT="${event_name}" \
-    VIBEGUARD_POLICY_DIAG_KIND="${kind}" \
-    VIBEGUARD_POLICY_DIAG_REASON="${reason}" \
-    VIBEGUARD_POLICY_DIAG_WRAPPER="${VIBEGUARD_WRAPPER:-unknown}" \
-    python3 - <<'PY' >>"${diag_file}" 2>/dev/null || true
-import json
-import os
-from datetime import datetime, timezone
+  runtime_path="$(vg_policy_runtime_path)" || return 0
+  printf '%s' "${reason}" \
+    | "${runtime_path}" runtime-policy-diag "${diag_file}" "${hook_name}" "${event_name}" "${kind}" "${VIBEGUARD_WRAPPER:-unknown}" \
+    >/dev/null 2>&1 || true
+}
 
-print(json.dumps({
-    "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "wrapper": os.environ.get("VIBEGUARD_POLICY_DIAG_WRAPPER", ""),
-    "hook": os.environ.get("VIBEGUARD_POLICY_DIAG_HOOK", ""),
-    "event": os.environ.get("VIBEGUARD_POLICY_DIAG_EVENT", ""),
-    "kind": os.environ.get("VIBEGUARD_POLICY_DIAG_KIND", ""),
-    "reason": os.environ.get("VIBEGUARD_POLICY_DIAG_REASON", ""),
-}, ensure_ascii=False))
-PY
+vg_policy_json_escape() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  text="${text//\"/\\\"}"
+  text="${text//$'\n'/\\n}"
+  text="${text//$'\r'/\\r}"
+  text="${text//$'\t'/\\t}"
+  printf '%s' "${text}"
 }
 
 vg_policy_codex_error_output() {
   local event_name="$1" reason="$2"
-  VIBEGUARD_POLICY_EVENT="${event_name}" VIBEGUARD_POLICY_REASON="${reason}" python3 - <<'PY'
-import json
-import os
-
-event = os.environ.get("VIBEGUARD_POLICY_EVENT", "")
-reason = os.environ.get("VIBEGUARD_POLICY_REASON", "")
-if event == "PreToolUse":
-    payload = {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        }
-    }
-elif event == "PermissionRequest":
-    payload = {
-        "hookSpecificOutput": {
-            "hookEventName": "PermissionRequest",
-            "decision": {"behavior": "deny", "message": reason},
-        }
-    }
-elif event == "PostToolUse":
-    payload = {
-        "decision": "block",
-        "reason": reason,
-        "hookSpecificOutput": {
-            "hookEventName": "PostToolUse",
-            "additionalContext": reason,
-        },
-    }
-elif event == "Stop":
-    payload = {"stopReason": reason}
-else:
-    payload = {"systemMessage": reason}
-print(json.dumps(payload, ensure_ascii=False))
-PY
+  local runtime_path escaped
+  if runtime_path="$(vg_policy_runtime_path)"; then
+    if printf '%s' "${reason}" | "${runtime_path}" runtime-policy-codex-error "${event_name}" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  escaped="$(vg_policy_json_escape "${reason}")"
+  case "${event_name}" in
+    PreToolUse)
+      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "${escaped}"
+      ;;
+    PermissionRequest)
+      printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"%s"}}}\n' "${escaped}"
+      ;;
+    PostToolUse)
+      printf '{"decision":"block","reason":"%s","hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "${escaped}" "${escaped}"
+      ;;
+    Stop)
+      printf '{"stopReason":"%s"}\n' "${escaped}"
+      ;;
+    *)
+      printf '{"systemMessage":"%s"}\n' "${escaped}"
+      ;;
+  esac
 }
 
 vg_policy_codex_gate() {

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -64,6 +64,7 @@ vg_is_source_file() {
 _VG_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _VIBEGUARD_RUNTIME=""
 for _candidate in \
+  "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
   "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime" \
   "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
   "${_VG_HOOK_DIR}/vibeguard-runtime"; do

--- a/scripts/lib/project_config.sh
+++ b/scripts/lib/project_config.sh
@@ -5,6 +5,21 @@ _VG_PROJECT_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _VG_PROJECT_CONFIG_VALIDATOR="${_VG_PROJECT_CONFIG_LIB_DIR}/project_config_validate.py"
 _VG_PROJECT_CONFIG_SCHEMA="${_VG_PROJECT_CONFIG_LIB_DIR}/../../schemas/vibeguard-project.schema.json"
 
+vg_project_config_runtime_path() {
+  local candidate
+  for candidate in \
+    "${VIBEGUARD_RUNTIME:-}" \
+    "${_VIBEGUARD_RUNTIME:-}"; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      if "${candidate}" project-config-value "${TMPDIR:-/tmp}/vibeguard-missing-project-probe.json" missing.path __default__ >/dev/null 2>&1; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
 vg_project_config_file() {
   if [[ -n "${VIBEGUARD_PROJECT_CONFIG:-}" ]]; then
     printf '%s\n' "${VIBEGUARD_PROJECT_CONFIG}"
@@ -33,6 +48,12 @@ vg_validate_project_config() {
     return 0
   fi
 
+  local runtime_path
+  if runtime_path="$(vg_project_config_runtime_path)"; then
+    "${runtime_path}" project-config-validate "$config_file"
+    return $?
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     printf 'VibeGuard project config invalid: python3 is required to validate %s\n' "$config_file" >&2
     return 1
@@ -55,13 +76,24 @@ vg_config_value() {
   local config_file
   config_file="$(vg_project_config_file)"
 
-  if [[ -z "$config_file" || ! -f "$config_file" ]] || ! command -v python3 >/dev/null 2>&1; then
+  if [[ -z "$config_file" || ! -f "$config_file" ]]; then
     printf '%s\n' "$default_value"
     return 0
   fi
 
   if ! vg_validate_project_config "$config_file"; then
     return 2
+  fi
+
+  local runtime_path
+  if runtime_path="$(vg_project_config_runtime_path)"; then
+    "${runtime_path}" project-config-value "$config_file" "$key_path" "$default_value"
+    return $?
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' "$default_value"
+    return 0
   fi
 
   python3 - "$config_file" "$key_path" "$default_value" <<'PY'

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -139,8 +139,362 @@ else:
     print(json.dumps(value))
 PY
     ;;
+  codex-event-name)
+    python3 - <<'PY'
+import json
+import sys
+
+try:
+    print(json.loads(sys.stdin.read()).get("hook_event_name", ""))
+except Exception:
+    print("")
+PY
+    ;;
+  codex-status-detail|codex-status-matcher|codex-status-from-output)
+    cat >/dev/null
+    ;;
+  codex-normalize-apply-patch)
+    shift || true
+    cat
+    ;;
+  codex-pretool-deny)
+    reason="$(cat)"
+    REASON="$reason" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": os.environ.get("REASON", "")}}, ensure_ascii=False))
+PY
+    ;;
+  codex-permission-deny)
+    reason="$(cat)"
+    REASON="$reason" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "deny", "message": os.environ.get("REASON", "")}}}, ensure_ascii=False))
+PY
+    ;;
+  codex-adapt-pretool)
+    python3 - <<'PY'
+import json
+import sys
+
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "VIBEGUARD hook failed: wrapped hook produced invalid JSON."}}, ensure_ascii=False))
+    raise SystemExit(3)
+
+decision = data.get("decision", "pass")
+reason = data.get("reason", "")
+hook_specific = data.get("hookSpecificOutput")
+native = isinstance(hook_specific, dict) or "systemMessage" in data
+if native and decision == "pass" and data.get("updatedInput") is None:
+    out = {}
+    if "systemMessage" in data:
+        out["systemMessage"] = data["systemMessage"]
+    if isinstance(hook_specific, dict):
+        out["hookSpecificOutput"] = dict(hook_specific)
+    if out:
+        print(json.dumps(out, ensure_ascii=False))
+elif decision == "block":
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}, ensure_ascii=False))
+elif decision == "warn" and reason:
+    print(json.dumps({"systemMessage": reason}, ensure_ascii=False))
+PY
+    ;;
+  codex-adapt-permission-request)
+    python3 - <<'PY'
+import json
+import sys
+
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "deny", "message": "VIBEGUARD hook failed: wrapped hook produced invalid JSON."}}}, ensure_ascii=False))
+    raise SystemExit(3)
+
+decision = data.get("decision", "pass")
+reason = data.get("reason", "")
+if decision == "block":
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "deny", "message": reason}}}, ensure_ascii=False))
+elif decision == "warn" and reason:
+    print(json.dumps({"systemMessage": reason}, ensure_ascii=False))
+PY
+    ;;
+  codex-adapt-posttool)
+    python3 - <<'PY'
+import json
+import sys
+
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    raise SystemExit(3)
+
+decision = data.get("decision", "pass")
+reason = data.get("reason", "")
+if decision in {"block", "escalate"}:
+    print(json.dumps({"decision": "block", "reason": reason, "hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": reason}}, ensure_ascii=False))
+elif decision == "warn" and reason:
+    print(json.dumps({"systemMessage": reason}, ensure_ascii=False))
+PY
+    ;;
   pkg-rewrite)
     cat >/dev/null
+    ;;
+  runtime-policy-check)
+    hook_name="${1:?runtime-policy-check requires hook name}"
+    python3 - "$hook_name" <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+hook_name = sys.argv[1]
+user_config = os.environ.get("VIBEGUARD_USER_CONFIG_FILE", "")
+if user_config and Path(user_config).is_file():
+    try:
+        json.loads(Path(user_config).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"VibeGuard runtime config invalid JSON: {user_config}: {exc}", file=sys.stderr)
+        raise SystemExit(30)
+
+def project_config_path() -> Path | None:
+    configured = os.environ.get("VIBEGUARD_PROJECT_CONFIG", "")
+    if configured and Path(configured).is_file():
+        return Path(configured)
+    try:
+        git_root = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).stdout.strip()
+    except OSError:
+        git_root = ""
+    if git_root and (Path(git_root) / ".vibeguard.json").is_file():
+        return Path(git_root) / ".vibeguard.json"
+    if Path(".vibeguard.json").is_file():
+        return Path(".vibeguard.json")
+    return None
+
+def canonical(name: str) -> str:
+    file_name = Path(name).name
+    if file_name.endswith(".sh"):
+        file_name = file_name[:-3]
+    if file_name.startswith("vibeguard-"):
+        file_name = file_name[len("vibeguard-"):]
+    return file_name.replace("_", "-")
+
+def profile_allows(profile: str, hook: str) -> bool:
+    if hook == "analysis-paralysis-guard":
+        return profile in {"core", "full", "strict"}
+    if hook == "count-active-constraints":
+        return profile == "strict"
+    if hook in {"post-build-check", "stop-guard", "learn-evaluator"}:
+        return profile in {"full", "strict"}
+    return True
+
+path = project_config_path()
+if path is None:
+    raise SystemExit(0)
+try:
+    config = json.loads(path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    print(f"VibeGuard project config invalid JSON: {path}: {exc}", file=sys.stderr)
+    raise SystemExit(30)
+if not isinstance(config, dict):
+    print(f"VibeGuard project config invalid: {path} must be a JSON object", file=sys.stderr)
+    raise SystemExit(20)
+
+allowed_hooks = {
+    "analysis-paralysis-guard",
+    "count-active-constraints",
+    "learn-evaluator",
+    "post-build-check",
+    "post-edit-guard",
+    "post-write-guard",
+    "pre-bash-guard",
+    "pre-commit-guard",
+    "pre-edit-guard",
+    "pre-write-guard",
+    "stop-guard",
+}
+disabled = config.get("disabled_hooks", [])
+if not isinstance(disabled, list) or any(not isinstance(item, str) for item in disabled):
+    print(f"VibeGuard project config invalid: {path} field disabled_hooks must contain only strings", file=sys.stderr)
+    raise SystemExit(20)
+for item in disabled:
+    if item not in allowed_hooks:
+        print(f"VibeGuard project config invalid: {path} disabled_hooks contains unsupported hook {item}", file=sys.stderr)
+        raise SystemExit(20)
+
+hook = canonical(hook_name)
+enforcement = config.get("enforcement", "block")
+if enforcement == "off":
+    print("VibeGuard policy skip: enforcement=off")
+    raise SystemExit(10)
+if hook in disabled:
+    print(f"VibeGuard policy skip: disabled_hooks contains {hook}")
+    raise SystemExit(10)
+profile = config.get("profile", "core")
+if isinstance(profile, str) and not profile_allows(profile, hook):
+    print(f"VibeGuard policy skip: profile={profile} excludes {hook}")
+    raise SystemExit(10)
+if enforcement == "warn":
+    print("VibeGuard policy warn: enforcement=warn")
+raise SystemExit(0)
+PY
+    ;;
+  runtime-policy-downgrade-output)
+    python3 - <<'PY'
+import json
+import sys
+
+raw = sys.stdin.read()
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    sys.stdout.write(raw)
+    if raw and not raw.endswith("\n"):
+        sys.stdout.write("\n")
+    raise SystemExit(0)
+
+if not isinstance(data, dict):
+    print(json.dumps(data, ensure_ascii=False))
+    raise SystemExit(0)
+
+reason = data.get("reason")
+changed = False
+if data.get("decision") in {"block", "gate", "escalate"}:
+    data["decision"] = "warn"
+    changed = True
+if isinstance(reason, str) and reason and changed:
+    data["reason"] = f"VIBEGUARD warn-mode advisory: {reason}"
+
+hook_specific = data.get("hookSpecificOutput")
+if isinstance(hook_specific, dict):
+    if hook_specific.get("permissionDecision") == "deny":
+        message = hook_specific.pop("permissionDecisionReason", None)
+        hook_specific.pop("permissionDecision", None)
+        if isinstance(message, str) and message and "systemMessage" not in data:
+            data["systemMessage"] = f"VIBEGUARD warn-mode advisory: {message}"
+    decision = hook_specific.get("decision")
+    if isinstance(decision, dict) and decision.get("behavior") == "deny":
+        message = decision.get("message")
+        hook_specific.pop("decision", None)
+        if isinstance(message, str) and message and "systemMessage" not in data:
+            data["systemMessage"] = f"VIBEGUARD warn-mode advisory: {message}"
+
+print(json.dumps(data, ensure_ascii=False))
+PY
+    ;;
+  runtime-policy-codex-error)
+    event_name="${1:-}"
+    reason="$(cat)"
+    EVENT_NAME="$event_name" REASON="$reason" python3 - <<'PY'
+import json
+import os
+
+event = os.environ.get("EVENT_NAME", "")
+reason = os.environ.get("REASON", "")
+if event == "PreToolUse":
+    payload = {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}
+elif event == "PermissionRequest":
+    payload = {"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "deny", "message": reason}}}
+elif event == "PostToolUse":
+    payload = {"decision": "block", "reason": reason, "hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": reason}}
+elif event == "Stop":
+    payload = {"stopReason": reason}
+else:
+    payload = {"systemMessage": reason}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+    ;;
+  runtime-policy-diag)
+    diag_file="${1:?diag path}"
+    hook_name="${2:-}"
+    event_name="${3:-}"
+    kind="${4:-}"
+    wrapper="${5:-}"
+    reason="$(cat)"
+    mkdir -p "$(dirname "$diag_file")"
+    DIAG_FILE="$diag_file" HOOK_NAME="$hook_name" EVENT_NAME="$event_name" KIND="$kind" WRAPPER="$wrapper" REASON="$reason" python3 - <<'PY'
+import datetime
+import json
+import os
+from pathlib import Path
+
+entry = {
+    "ts": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "wrapper": os.environ.get("WRAPPER", ""),
+    "hook": os.environ.get("HOOK_NAME", ""),
+    "event": os.environ.get("EVENT_NAME", ""),
+    "kind": os.environ.get("KIND", ""),
+    "reason": os.environ.get("REASON", ""),
+}
+path = Path(os.environ["DIAG_FILE"])
+with path.open("a", encoding="utf-8") as fh:
+    fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+PY
+    ;;
+  runtime-config-get-int)
+    env_name="${1:?env name}"
+    json_path="${2:?json path}"
+    default_val="${3:?default}"
+    config_file="${4:-}"
+    val="${!env_name:-}"
+    if [[ -n "$val" && "$val" =~ ^[0-9]+$ ]]; then
+      printf '%s\n' "$val"
+    else
+      python3 - "$config_file" "$json_path" "$default_val" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, json_path, default = sys.argv[1:4]
+try:
+    node = json.loads(Path(path).read_text(encoding="utf-8"))
+    for key in json_path.split("."):
+        node = node[key]
+    if isinstance(node, bool) or not isinstance(node, int) or node < 0:
+        raise ValueError
+    print(node)
+except Exception:
+    print(default)
+PY
+    fi
+    ;;
+  runtime-config-get-str)
+    env_name="${1:?env name}"
+    json_path="${2:?json path}"
+    default_val="${3:?default}"
+    config_file="${4:-}"
+    val="${!env_name:-}"
+    if [[ -n "$val" ]]; then
+      printf '%s\n' "$val"
+    else
+      python3 - "$config_file" "$json_path" "$default_val" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, json_path, default = sys.argv[1:4]
+try:
+    node = json.loads(Path(path).read_text(encoding="utf-8"))
+    for key in json_path.split("."):
+        node = node[key]
+    if not isinstance(node, str) or not node:
+        raise ValueError
+    print(node)
+except Exception:
+    print(default)
+PY
+    fi
     ;;
   pre-write-check)
     cat >/dev/null

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -208,6 +208,10 @@ fn load_project_config(path: &Path) -> Result<ProjectConfig, String> {
     })
 }
 
+pub fn validate_project_config_path(path: &Path) -> Result<(), String> {
+    crate::project_config_validation::validate_path(path)
+}
+
 fn validate_known_properties(
     path: &Path,
     object: &serde_json::Map<String, Value>,
@@ -344,7 +348,7 @@ fn validate_disabled_rules(
     Ok(())
 }
 
-fn valid_disabled_rule_id(rule: &str) -> bool {
+pub(crate) fn valid_disabled_rule_id(rule: &str) -> bool {
     let Some((prefix, suffix)) = rule.split_once('-') else {
         return false;
     };
@@ -416,6 +420,7 @@ fn app_server_canonical_hook_name(hook_name: &str) -> String {
 fn profile_allows_hook(profile: &str, hook_name: &str) -> bool {
     match hook_name {
         "analysis-paralysis-guard" => matches!(profile, "core" | "full" | "strict"),
+        "count-active-constraints" => profile == "strict",
         "post-build-check" | "stop-guard" | "learn-evaluator" => {
             matches!(profile, "full" | "strict")
         }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -18,6 +18,9 @@ mod json_field;
 mod log_append;
 mod log_query;
 mod pkg_rewrite;
+mod project_config_validation;
+mod runtime_config;
+mod runtime_policy_cli;
 mod session_metrics;
 mod time_utils;
 
@@ -147,6 +150,46 @@ static COMMANDS: &[Command] = &[
         name: "codex-normalize-apply-patch",
         usage: "<hook-name>  — normalize Codex apply_patch payloads for file hooks",
         handler: codex_hooks::normalize_apply_patch,
+    },
+    Command {
+        name: "runtime-policy-check",
+        usage: "<hook-name> [--cwd DIR] [--user-config PATH]  — evaluate VibeGuard project policy for a hook",
+        handler: runtime_policy_cli::check,
+    },
+    Command {
+        name: "runtime-policy-downgrade-output",
+        usage: "  — downgrade a hook JSON payload for project enforcement=warn",
+        handler: runtime_policy_cli::downgrade_output,
+    },
+    Command {
+        name: "runtime-policy-codex-error",
+        usage: "<event-name>  — emit a Codex-visible policy error payload from stdin",
+        handler: runtime_policy_cli::codex_error,
+    },
+    Command {
+        name: "runtime-policy-diag",
+        usage: "<diag-file> <hook> <event> <kind> <wrapper>  — append runtime policy telemetry",
+        handler: runtime_policy_cli::diag,
+    },
+    Command {
+        name: "project-config-validate",
+        usage: "<config-file>  — validate a project-level .vibeguard.json",
+        handler: runtime_policy_cli::project_config_validate,
+    },
+    Command {
+        name: "project-config-value",
+        usage: "<config-file> <json-path> <default>  — read a validated project config value",
+        handler: runtime_policy_cli::project_config_value,
+    },
+    Command {
+        name: "runtime-config-get-int",
+        usage: "<env-name> <json-path> <default> [config-file]  — resolve a runtime config integer",
+        handler: runtime_config::get_int,
+    },
+    Command {
+        name: "runtime-config-get-str",
+        usage: "<env-name> <json-path> <default> [config-file]  — resolve a runtime config string",
+        handler: runtime_config::get_str,
     },
     Command {
         name: "pre-write-check",

--- a/vibeguard-runtime/src/project_config_validation.rs
+++ b/vibeguard-runtime/src/project_config_validation.rs
@@ -1,0 +1,245 @@
+use serde_json::Value;
+use std::path::Path;
+
+use crate::codex_app_server_policy::valid_disabled_rule_id;
+
+pub fn validate_path(path: &Path) -> Result<(), String> {
+    let text = std::fs::read_to_string(path).map_err(|err| {
+        format!(
+            "VibeGuard project config invalid: {}: cannot read file ({err})",
+            path.display()
+        )
+    })?;
+    let value = serde_json::from_str::<Value>(&text).map_err(|err| {
+        format!(
+            "VibeGuard project config invalid: {}: invalid JSON: {err}",
+            path.display()
+        )
+    })?;
+    let Some(object) = value.as_object() else {
+        return Err(format!(
+            "VibeGuard project config invalid: {}\n  $: expected object",
+            path.display()
+        ));
+    };
+
+    let errors = collect_project_config_errors(object);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "VibeGuard project config invalid: {}\n  {}",
+            path.display(),
+            errors.join("\n  ")
+        ))
+    }
+}
+
+fn collect_project_config_errors(object: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut errors = Vec::new();
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "profile"
+                | "enforcement"
+                | "languages"
+                | "disabled_hooks"
+                | "disabled_rules"
+                | "disabled_guards"
+                | "gc"
+        ) {
+            errors.push(unknown_property_error(&[key.as_str()]));
+        }
+    }
+
+    collect_string_enum(
+        object,
+        "profile",
+        &["core", "full", "minimal", "strict"],
+        &mut errors,
+    );
+    collect_string_enum(
+        object,
+        "enforcement",
+        &["block", "off", "warn"],
+        &mut errors,
+    );
+    collect_string_array_enum(
+        object,
+        "languages",
+        &["go", "javascript", "python", "rust", "typescript"],
+        &mut errors,
+    );
+    collect_string_array_enum(
+        object,
+        "disabled_hooks",
+        &[
+            "analysis-paralysis-guard",
+            "count-active-constraints",
+            "learn-evaluator",
+            "post-build-check",
+            "post-edit-guard",
+            "post-write-guard",
+            "pre-bash-guard",
+            "pre-commit-guard",
+            "pre-edit-guard",
+            "pre-write-guard",
+            "stop-guard",
+        ],
+        &mut errors,
+    );
+    collect_string_array_enum(
+        object,
+        "disabled_guards",
+        &[
+            "check_any_abuse",
+            "check_circular_deps",
+            "check_code_slop",
+            "check_component_duplication",
+            "check_console_residual",
+            "check_dead_shims",
+            "check_declaration_execution_gap",
+            "check_defer_in_loop",
+            "check_dependency_layers",
+            "check_duplicate_constants",
+            "check_duplicate_types",
+            "check_duplicates",
+            "check_error_handling",
+            "check_goroutine_leak",
+            "check_naming_convention",
+            "check_nested_locks",
+            "check_semantic_effect",
+            "check_single_source_of_truth",
+            "check_taste_invariants",
+            "check_test_integrity",
+            "check_unwrap_in_prod",
+            "check_workspace_consistency",
+        ],
+        &mut errors,
+    );
+    collect_disabled_rules(object, &mut errors);
+    collect_gc_errors(object, &mut errors);
+    errors
+}
+
+fn collect_string_enum(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    allowed: &[&str],
+    errors: &mut Vec<String>,
+) {
+    let Some(value) = object.get(field) else {
+        return;
+    };
+    let path = format!(".{field}");
+    let Some(text) = value.as_str() else {
+        errors.push(format!("{path}: expected string"));
+        return;
+    };
+    if !allowed.iter().any(|allowed| allowed == &text) {
+        errors.push(format!(
+            "{path}: unsupported value {text:?}; expected one of {allowed:?}"
+        ));
+    }
+}
+
+fn collect_string_array_enum(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    allowed: &[&str],
+    errors: &mut Vec<String>,
+) {
+    let Some(value) = object.get(field) else {
+        return;
+    };
+    let Some(items) = value.as_array() else {
+        errors.push(format!(".{field}: expected array"));
+        return;
+    };
+    for (index, item) in items.iter().enumerate() {
+        let path = format!(".{field}.{index}");
+        let Some(text) = item.as_str() else {
+            errors.push(format!("{path}: expected string"));
+            continue;
+        };
+        if !allowed.iter().any(|allowed| allowed == &text) {
+            errors.push(format!(
+                "{path}: unsupported value {text:?}; expected one of {allowed:?}"
+            ));
+        }
+    }
+}
+
+fn collect_disabled_rules(object: &serde_json::Map<String, Value>, errors: &mut Vec<String>) {
+    let Some(value) = object.get("disabled_rules") else {
+        return;
+    };
+    let Some(items) = value.as_array() else {
+        errors.push(".disabled_rules: expected array".into());
+        return;
+    };
+    for (index, item) in items.iter().enumerate() {
+        let path = format!(".disabled_rules.{index}");
+        let Some(rule) = item.as_str() else {
+            errors.push(format!("{path}: expected string"));
+            continue;
+        };
+        if !valid_disabled_rule_id(rule) {
+            errors.push(format!(
+                "{path}: does not match ^(SEC|RS|GO|TS|PY|U|W|TASTE)-[A-Za-z0-9-]+$"
+            ));
+        }
+    }
+}
+
+fn collect_gc_errors(object: &serde_json::Map<String, Value>, errors: &mut Vec<String>) {
+    let Some(value) = object.get("gc") else {
+        return;
+    };
+    let Some(gc) = value.as_object() else {
+        errors.push(".gc: expected object".into());
+        return;
+    };
+    let allowed = [
+        "log_threshold_mb",
+        "archive_retain_months",
+        "worktree_max_days",
+        "session_metrics_retain_days",
+        "learning_window_days",
+        "gc_log_max_kb",
+    ];
+    for key in gc.keys() {
+        if !allowed.iter().any(|allowed| allowed == &key.as_str()) {
+            errors.push(unknown_property_error(&["gc", key.as_str()]));
+        }
+    }
+    for (key, value) in gc {
+        if !allowed.iter().any(|allowed| allowed == &key.as_str()) {
+            continue;
+        }
+        if value.is_boolean() || value.as_i64().filter(|number| *number >= 1).is_none() {
+            errors.push(format!(".gc.{key}: expected integer >= 1"));
+        }
+    }
+}
+
+fn unknown_property_error(path: &[&str]) -> String {
+    let label = format!(".{}", path.join("."));
+    let hint = match path {
+        ["write_mode"] => {
+            Some("write_mode belongs in ~/.vibeguard/config.json, not .vibeguard.json")
+        }
+        ["u16"] => Some("u16.* belongs in ~/.vibeguard/config.json, not .vibeguard.json"),
+        ["circuit_breaker"] => {
+            Some("circuit_breaker.* belongs in ~/.vibeguard/config.json, not .vibeguard.json")
+        }
+        ["paralysis"] => {
+            Some("paralysis.* belongs in ~/.vibeguard/config.json, not .vibeguard.json")
+        }
+        _ => None,
+    };
+    match hint {
+        Some(hint) => format!("{label}: unknown property; {hint}"),
+        None => format!("{label}: unknown property"),
+    }
+}

--- a/vibeguard-runtime/src/runtime_config.rs
+++ b/vibeguard-runtime/src/runtime_config.rs
@@ -1,0 +1,88 @@
+use serde_json::Value;
+
+pub fn get_int(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    if args.len() < 3 || args.len() > 4 {
+        return Err(
+            "runtime-config-get-int requires <env-name> <json-path> <default> [config-file]".into(),
+        );
+    }
+    let env_name = &args[0];
+    let json_path = &args[1];
+    let default_value = &args[2];
+    let config_file = args.get(3).map(String::as_str).unwrap_or("");
+
+    if let Ok(value) = std::env::var(env_name) {
+        if is_unsigned_integer(&value) {
+            println!("{value}");
+            return Ok(());
+        }
+    }
+
+    if let Some(value) = read_config_value(config_file, json_path) {
+        if let Some(number) = value.as_i64().filter(|number| *number >= 0) {
+            println!("{number}");
+            return Ok(());
+        }
+    }
+
+    println!("{default_value}");
+    Ok(())
+}
+
+pub fn get_str(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    if args.len() < 3 || args.len() > 4 {
+        return Err(
+            "runtime-config-get-str requires <env-name> <json-path> <default> [config-file]".into(),
+        );
+    }
+    let env_name = &args[0];
+    let json_path = &args[1];
+    let default_value = &args[2];
+    let config_file = args.get(3).map(String::as_str).unwrap_or("");
+
+    if let Ok(value) = std::env::var(env_name) {
+        if !value.is_empty() {
+            println!("{value}");
+            return Ok(());
+        }
+    }
+
+    if let Some(value) = read_config_value(config_file, json_path) {
+        if let Some(text) = value.as_str().filter(|text| !text.is_empty()) {
+            println!("{text}");
+            return Ok(());
+        }
+    }
+
+    println!("{default_value}");
+    Ok(())
+}
+
+fn read_config_value(config_file: &str, json_path: &str) -> Option<Value> {
+    if config_file.is_empty() {
+        return None;
+    }
+    let text = std::fs::read_to_string(config_file).ok()?;
+    let mut value = serde_json::from_str::<Value>(&text).ok()?;
+    for key in json_path.split('.') {
+        value = value.as_object()?.get(key)?.clone();
+    }
+    Some(value)
+}
+
+fn is_unsigned_integer(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsigned_integer_rejects_empty_and_signed_values() {
+        assert!(is_unsigned_integer("0"));
+        assert!(is_unsigned_integer("123"));
+        assert!(!is_unsigned_integer(""));
+        assert!(!is_unsigned_integer("-1"));
+    }
+}

--- a/vibeguard-runtime/src/runtime_policy_cli.rs
+++ b/vibeguard-runtime/src/runtime_policy_cli.rs
@@ -1,0 +1,297 @@
+use crate::codex_app_server_policy::{
+    HookPolicyDecision, evaluate_hook_policy, validate_project_config_path,
+};
+use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::path::Path;
+
+const SKIP: i32 = 10;
+const POLICY_ERROR: i32 = 20;
+const CONFIG_PARSE_ERROR: i32 = 30;
+
+pub fn check(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let mut hook_name: Option<String> = None;
+    let mut cwd: Option<String> = None;
+    let mut user_config: Option<String> = std::env::var("VIBEGUARD_USER_CONFIG_FILE").ok();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--cwd" => {
+                index += 1;
+                cwd = args.get(index).cloned();
+            }
+            "--user-config" => {
+                index += 1;
+                user_config = args.get(index).cloned();
+            }
+            value if hook_name.is_none() => hook_name = Some(value.to_string()),
+            other => return Err(format!("unexpected argument: {other}").into()),
+        }
+        index += 1;
+    }
+
+    let hook_name = hook_name.ok_or("runtime-policy-check requires a hook name")?;
+    if let Some(path) = user_config.as_deref().filter(|path| !path.is_empty()) {
+        if let Err(reason) = validate_runtime_config(path) {
+            eprintln!("{reason}");
+            std::process::exit(CONFIG_PARSE_ERROR);
+        }
+    }
+
+    match evaluate_hook_policy(&hook_name, cwd.as_deref(), &HashMap::new()) {
+        HookPolicyDecision::Run {
+            reason: Some(reason),
+            ..
+        } => {
+            println!("{reason}");
+            Ok(())
+        }
+        HookPolicyDecision::Run { .. } => Ok(()),
+        HookPolicyDecision::Skip(reason) => {
+            println!("{reason}");
+            std::process::exit(SKIP);
+        }
+        HookPolicyDecision::Error(reason) => {
+            eprintln!("{reason}");
+            if is_config_parse_error(&reason) {
+                std::process::exit(CONFIG_PARSE_ERROR);
+            }
+            std::process::exit(POLICY_ERROR);
+        }
+    }
+}
+
+pub fn downgrade_output(_args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw)?;
+    let Ok(mut data) = serde_json::from_str::<Value>(&raw) else {
+        print_with_newline(&raw);
+        return Ok(());
+    };
+    let Some(object) = data.as_object_mut() else {
+        println!("{}", serde_json::to_string(&data)?);
+        return Ok(());
+    };
+
+    let mut changed = false;
+    if object
+        .get("decision")
+        .and_then(Value::as_str)
+        .is_some_and(|decision| matches!(decision, "block" | "gate" | "escalate"))
+    {
+        object.insert("decision".into(), Value::String("warn".into()));
+        changed = true;
+    }
+    if changed {
+        if let Some(reason) = object.get("reason").and_then(Value::as_str) {
+            if !reason.is_empty() {
+                object.insert(
+                    "reason".into(),
+                    Value::String(format!("VIBEGUARD warn-mode advisory: {reason}")),
+                );
+            }
+        }
+    }
+
+    let had_system_message = object.get("systemMessage").is_some();
+    let mut system_message: Option<String> = None;
+    if let Some(hook_specific) = object
+        .get_mut("hookSpecificOutput")
+        .and_then(Value::as_object_mut)
+    {
+        if hook_specific
+            .get("permissionDecision")
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            let message = hook_specific
+                .remove("permissionDecisionReason")
+                .and_then(|value| value.as_str().map(str::to_string));
+            hook_specific.remove("permissionDecision");
+            if !had_system_message {
+                system_message = message
+                    .filter(|message| !message.is_empty())
+                    .map(|message| format!("VIBEGUARD warn-mode advisory: {message}"));
+            }
+        }
+
+        let deny_message = hook_specific
+            .get("decision")
+            .and_then(Value::as_object)
+            .filter(|decision| {
+                decision
+                    .get("behavior")
+                    .and_then(Value::as_str)
+                    .is_some_and(|behavior| behavior == "deny")
+            })
+            .and_then(|decision| decision.get("message"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if deny_message.is_some() {
+            hook_specific.remove("decision");
+            if !had_system_message && system_message.is_none() {
+                system_message = deny_message
+                    .filter(|message| !message.is_empty())
+                    .map(|message| format!("VIBEGUARD warn-mode advisory: {message}"));
+            }
+        }
+    }
+    if let Some(message) = system_message {
+        object.insert("systemMessage".into(), Value::String(message));
+    }
+
+    println!("{}", serde_json::to_string_pretty(&data)?);
+    Ok(())
+}
+
+pub fn codex_error(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let event = args
+        .first()
+        .ok_or("runtime-policy-codex-error requires an event")?;
+    let mut reason = String::new();
+    std::io::stdin().read_to_string(&mut reason)?;
+    let reason = reason.trim_end_matches('\n');
+    let payload = match event.as_str() {
+        "PreToolUse" => json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }),
+        "PermissionRequest" => json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {"behavior": "deny", "message": reason},
+            }
+        }),
+        "PostToolUse" => json!({
+            "decision": "block",
+            "reason": reason,
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": reason,
+            },
+        }),
+        "Stop" => json!({"stopReason": reason}),
+        _ => json!({"systemMessage": reason}),
+    };
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+pub fn diag(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    if args.len() != 5 {
+        return Err(
+            "runtime-policy-diag requires <diag-file> <hook> <event> <kind> <wrapper>".into(),
+        );
+    }
+    let mut reason = String::new();
+    std::io::stdin().read_to_string(&mut reason)?;
+    let diag_file = Path::new(&args[0]);
+    if let Some(parent) = diag_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let entry = json!({
+        "ts": format_unix_secs_utc(now_unix_secs()),
+        "wrapper": args[4],
+        "hook": args[1],
+        "event": args[2],
+        "kind": args[3],
+        "reason": reason.trim_end_matches('\n'),
+    });
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(diag_file)?;
+    writeln!(file, "{}", serde_json::to_string(&entry)?)?;
+    Ok(())
+}
+
+pub fn project_config_validate(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let path = args
+        .first()
+        .ok_or("project-config-validate requires <config-file>")?;
+    match validate_project_config_path(Path::new(path)) {
+        Ok(()) => Ok(()),
+        Err(reason) => {
+            eprintln!("{reason}");
+            if is_config_parse_error(&reason) {
+                std::process::exit(CONFIG_PARSE_ERROR);
+            }
+            std::process::exit(POLICY_ERROR);
+        }
+    }
+}
+
+pub fn project_config_value(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    if args.len() != 3 {
+        return Err("project-config-value requires <config-file> <json-path> <default>".into());
+    }
+    let path = Path::new(&args[0]);
+    let default_value = &args[2];
+    if !path.is_file() {
+        println!("{default_value}");
+        return Ok(());
+    }
+    if let Err(reason) = validate_project_config_path(path) {
+        eprintln!("{reason}");
+        if is_config_parse_error(&reason) {
+            std::process::exit(CONFIG_PARSE_ERROR);
+        }
+        std::process::exit(POLICY_ERROR);
+    }
+    let text = std::fs::read_to_string(path)?;
+    let mut value = serde_json::from_str::<Value>(&text)?;
+    for key in args[1].split('.') {
+        let Some(next) = value.as_object().and_then(|object| object.get(key)) else {
+            println!("{default_value}");
+            return Ok(());
+        };
+        value = next.clone();
+    }
+    match value {
+        Value::Bool(_) | Value::Null => println!("{default_value}"),
+        Value::String(text) => println!("{text}"),
+        Value::Number(number) => println!("{number}"),
+        other => println!("{}", serde_json::to_string(&other)?),
+    }
+    Ok(())
+}
+
+fn validate_runtime_config(path: &str) -> Result<(), String> {
+    let path = Path::new(path);
+    if !path.is_file() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(path).map_err(|err| {
+        format!(
+            "VibeGuard runtime config cannot be read: {}: {err}",
+            path.display()
+        )
+    })?;
+    serde_json::from_str::<Value>(&text)
+        .map(|_| ())
+        .map_err(|err| {
+            format!(
+                "VibeGuard runtime config invalid JSON: {}: {err}",
+                path.display()
+            )
+        })
+}
+
+fn is_config_parse_error(reason: &str) -> bool {
+    reason.contains("invalid JSON")
+        || reason.contains("invalid UTF-8")
+        || reason.contains("cannot be read")
+}
+
+fn print_with_newline(raw: &str) {
+    print!("{raw}");
+    if !raw.is_empty() && !raw.ends_with('\n') {
+        println!();
+    }
+}

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -74,6 +74,14 @@ fn help_lists_all_commands() {
         "codex-adapt-posttool",
         "codex-adapt-permission-request",
         "codex-normalize-apply-patch",
+        "runtime-policy-check",
+        "runtime-policy-downgrade-output",
+        "runtime-policy-codex-error",
+        "runtime-policy-diag",
+        "project-config-validate",
+        "project-config-value",
+        "runtime-config-get-int",
+        "runtime-config-get-str",
         "pre-write-check",
         "pre-edit-check",
         "post-edit-fast-check",
@@ -86,6 +94,142 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+#[test]
+fn runtime_policy_check_reports_skip_and_warn_modes() {
+    let repo = unique_temp_dir("runtime-policy-check");
+    fs::create_dir_all(&repo).unwrap();
+
+    fs::write(
+        repo.join(".vibeguard.json"),
+        r#"{"disabled_hooks":["pre-bash-guard"]}"#,
+    )
+    .unwrap();
+    let disabled = bin()
+        .arg("runtime-policy-check")
+        .arg("vibeguard-pre-bash-guard.sh")
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    assert_eq!(disabled.status.code(), Some(10));
+    assert!(
+        String::from_utf8_lossy(&disabled.stdout)
+            .contains("disabled_hooks contains pre-bash-guard")
+    );
+
+    fs::write(repo.join(".vibeguard.json"), r#"{"enforcement":"warn"}"#).unwrap();
+    let warn = bin()
+        .arg("runtime-policy-check")
+        .arg("pre-bash-guard.sh")
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    assert_eq!(warn.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&warn.stdout).contains("enforcement=warn"));
+
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_validates_user_runtime_config() {
+    let root = unique_temp_dir("runtime-policy-user-config");
+    fs::create_dir_all(&root).unwrap();
+    let config = root.join("bad-config.json");
+    fs::write(&config, r#"{"write_mode":"#).unwrap();
+
+    let out = bin()
+        .arg("runtime-policy-check")
+        .arg("pre-bash-guard.sh")
+        .env("VIBEGUARD_USER_CONFIG_FILE", &config)
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(30));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("VibeGuard runtime config invalid JSON"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn runtime_policy_downgrade_output_rewrites_block_payloads() {
+    let out = run_runtime_with_stdin(
+        &["runtime-policy-downgrade-output"],
+        r#"{"decision":"block","reason":"danger"}"#,
+    );
+    assert_eq!(out.status.code(), Some(0));
+    let payload: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(payload["decision"], "warn");
+    assert!(
+        payload["reason"]
+            .as_str()
+            .unwrap()
+            .contains("warn-mode advisory")
+    );
+}
+
+#[test]
+fn runtime_config_helpers_resolve_env_json_and_defaults() {
+    let root = unique_temp_dir("runtime-config-helper");
+    fs::create_dir_all(&root).unwrap();
+    let config = root.join("config.json");
+    fs::write(&config, r#"{"u16":{"limit":1234},"write_mode":"block"}"#).unwrap();
+
+    let int_from_json = bin()
+        .args([
+            "runtime-config-get-int",
+            "VG_TEST_X",
+            "u16.limit",
+            "800",
+            config.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(int_from_json.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&int_from_json.stdout), "1234\n");
+
+    let str_from_env = bin()
+        .args([
+            "runtime-config-get-str",
+            "VG_TEST_MODE",
+            "write_mode",
+            "warn",
+            config.to_str().unwrap(),
+        ])
+        .env("VG_TEST_MODE", "warn")
+        .output()
+        .unwrap();
+    assert_eq!(str_from_env.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&str_from_env.stdout), "warn\n");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn project_config_validate_reports_field_path_errors() {
+    let root = unique_temp_dir("project-config-validate");
+    fs::create_dir_all(&root).unwrap();
+    let config = root.join("bad-vibeguard.json");
+    fs::write(
+        &config,
+        r#"{"profile":"strictest","gc":{"log_threshold_mb":0,"unexpected_gc_key":1},"write_mode":"block"}"#,
+    )
+    .unwrap();
+
+    let out = bin()
+        .arg("project-config-validate")
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(20));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(".profile: unsupported value"));
+    assert!(stderr.contains(".gc.log_threshold_mb: expected integer >= 1"));
+    assert!(stderr.contains(".gc.unexpected_gc_key: unknown property"));
+    assert!(stderr.contains(".write_mode: unknown property"));
+    assert!(stderr.contains("write_mode belongs in ~/.vibeguard/config.json"));
+
+    let _ = fs::remove_dir_all(root);
 }
 
 fn run_runtime_with_stdin(args: &[&str], input: &str) -> std::process::Output {


### PR DESCRIPTION
## Summary
- Move shell-wrapper runtime policy checks, warn-mode downgrades, Codex error payloads, and policy telemetry onto vibeguard-runtime CLI commands.
- Add runtime config CLI helpers for hook config lookups and validated project config CLI access for explicit runtime callers.
- Expand runtime CLI and hook wrapper tests to cover policy/config parity paths.

Closes #381

## Validation
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/hooks/test_runtime_policy.sh
- bash tests/hooks/test_runtime_config.sh
- bash tests/test_codex_runtime.sh
- bash tests/test_gc_config.sh
- bash tests/test_manifest_contract.sh
- bash scripts/ci/validate-manifest-contract.sh
- bash tests/test_setup.sh
