### PR TITLE
Route hook policy checks through vibeguard-runtime

### DIFF
--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -7,28 +7,41 @@ fi
 _VG_POLICY_SH_LOADED=1
 
 _VG_POLICY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_VG_POLICY_PY="${_VG_POLICY_LIB_DIR}/policy.py"
 
 vg_policy_user_config_file() {
   printf '%s' "${_VG_CONFIG_FILE:-${VIBEGUARD_CONFIG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/config.json}}"
 }
 
+vg_policy_runtime_path() {
+  local helper_dir wrapper_dir candidate
+  helper_dir="${_VG_POLICY_LIB_DIR}"
+  wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
+  for candidate in \
+    "${VIBEGUARD_POLICY_RUNTIME:-}" \
+    "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${wrapper_dir}/vibeguard-runtime" \
+    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${VIBEGUARD_RUNTIME:-}"; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
 vg_policy_check_hook() {
   local hook_name="$1"
-  local output status
+  local output status runtime_path
 
   VG_POLICY_REASON=""
   VG_POLICY_KIND=""
   VG_POLICY_ENFORCEMENT="block"
   export VIBEGUARD_POLICY_ENFORCEMENT="block"
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    VG_POLICY_REASON="VibeGuard policy error: python3 is required for runtime policy checks."
-    VG_POLICY_KIND="policy_error"
-    return 20
-  fi
-  if [[ ! -f "${_VG_POLICY_PY}" ]]; then
-    VG_POLICY_REASON="VibeGuard policy error: policy helper missing at ${_VG_POLICY_PY}"
+  if ! runtime_path="$(vg_policy_runtime_path)"; then
+    VG_POLICY_REASON="VibeGuard policy error: vibeguard-runtime is required for runtime policy checks."
     VG_POLICY_KIND="policy_error"
     return 20
   fi
@@ -36,7 +49,7 @@ vg_policy_check_hook() {
   status=0
   output="$(
     VIBEGUARD_USER_CONFIG_FILE="$(vg_policy_user_config_file)" \
-      python3 "${_VG_POLICY_PY}" check "${hook_name}" 2>&1
+      "${runtime_path}" runtime-policy-check "${hook_name}" 2>&1
   )" || status=$?
 
   case "${status}" in

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -18,14 +18,18 @@ vg_policy_runtime_path() {
   wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
   for candidate in \
     "${VIBEGUARD_POLICY_RUNTIME:-}" \
+    "${VIBEGUARD_RUNTIME:-}" \
     "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
     "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
     "${wrapper_dir}/vibeguard-runtime" \
-    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
-    "${VIBEGUARD_RUNTIME:-}"; do
+    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return 0
+      if VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
+        VIBEGUARD_USER_CONFIG_FILE="" \
+        "${candidate}" runtime-policy-check __vibeguard_policy_probe__ >/dev/null 2>&1; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
     fi
   done
   return 1

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -8,6 +8,8 @@ hook_test_init
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
+RUNTIME_BIN="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
 
 make_home() {
   local home_dir="$1"
@@ -39,6 +41,7 @@ run_claude_wrapper() {
   cd "${project_dir}"
   printf '%s' "${input}" \
     | HOME="${home_dir}" VIBEGUARD_LOG_DIR="${home_dir}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
       bash "${REPO_DIR}/hooks/run-hook.sh" "${hook_name}"
 }
 
@@ -47,6 +50,7 @@ run_codex_wrapper() {
   cd "${project_dir}"
   printf '%s' "${input}" \
     | HOME="${home_dir}" VIBEGUARD_LOG_DIR="${home_dir}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
       bash "${REPO_DIR}/hooks/run-hook-codex.sh" "${hook_name}"
 }
 
@@ -62,6 +66,7 @@ const child = spawn('bash', [`${repoDir}/hooks/run-hook.sh`, hookName], {
     ...process.env,
     HOME: homeDir,
     VIBEGUARD_LOG_DIR: `${homeDir}/.vibeguard`,
+    VIBEGUARD_POLICY_RUNTIME: `${repoDir}/vibeguard-runtime/target/debug/vibeguard-runtime`,
   },
   stdio: ['pipe', 'pipe', 'pipe'],
 });
@@ -102,6 +107,18 @@ pretool_block_input='{"tool_input":{"command":"git push --force"}}'
 codex_pretool_input='{"hook_event_name":"PreToolUse","tool_input":{"command":"git push --force"}}'
 pretool_danger_input='{"tool_input":{"command":"git clean -f"}}'
 codex_pretool_danger_input='{"hook_event_name":"PreToolUse","tool_input":{"command":"git clean -f"}}'
+
+header "runtime policy — runtime resolver"
+explicit_runtime="${WORK_DIR}/explicit-runtime"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${explicit_runtime}"
+chmod +x "${explicit_runtime}"
+resolver_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_POLICY_RUNTIME="${explicit_runtime}" bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_runtime_path
+  '
+)"
+assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver honors explicit VIBEGUARD_POLICY_RUNTIME before checkout binaries"
 
 header "runtime policy — disabled hooks"
 disabled_home="${WORK_DIR}/home-disabled"
@@ -191,6 +208,7 @@ set +e
 bad_user_claude_out="$(
   cd "${bad_user_project}" && printf '%s' "${pretool_block_input}" \
     | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
       VIBEGUARD_CONFIG_FILE="${bad_user_config}" \
       bash "${REPO_DIR}/hooks/run-hook.sh" pre-bash-guard.sh 2>&1
 )"
@@ -210,6 +228,7 @@ set +e
 bad_user_codex_out="$(
   cd "${bad_user_project}" && printf '%s' "${codex_pretool_input}" \
     | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
       VIBEGUARD_CONFIG_FILE="${bad_user_config}" \
       bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh 2>&1
 )"

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -120,6 +120,22 @@ resolver_out="$(
 )"
 assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver honors explicit VIBEGUARD_POLICY_RUNTIME before checkout binaries"
 
+resolver_home="${WORK_DIR}/home-resolver"
+mkdir -p "${resolver_home}/.vibeguard/installed/bin"
+stale_installed_runtime="${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime"
+printf '#!/usr/bin/env bash\necho stale-installed-runtime >&2\nexit 2\n' > "${stale_installed_runtime}"
+chmod +x "${stale_installed_runtime}"
+resolver_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  HOME="${resolver_home}" \
+  VIBEGUARD_RUNTIME="${explicit_runtime}" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_runtime_path
+  '
+)"
+assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver honors VIBEGUARD_RUNTIME before installed binaries"
+
 header "runtime policy — disabled hooks"
 disabled_home="${WORK_DIR}/home-disabled"
 disabled_project="${WORK_DIR}/project-disabled"

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -135,10 +136,17 @@ struct ProjectConfig {
 
 fn load_project_config(path: &Path) -> Result<ProjectConfig, String> {
     let text = std::fs::read_to_string(path).map_err(|err| {
-        format!(
-            "VibeGuard project config cannot be read: {}: {err}",
-            path.display()
-        )
+        if err.kind() == ErrorKind::InvalidData {
+            format!(
+                "VibeGuard project config invalid UTF-8: {}: {err}",
+                path.display()
+            )
+        } else {
+            format!(
+                "VibeGuard project config cannot be read: {}: {err}",
+                path.display()
+            )
+        }
     })?;
     let value = serde_json::from_str::<Value>(&text).map_err(|err| {
         format!(
@@ -416,6 +424,7 @@ fn app_server_canonical_hook_name(hook_name: &str) -> String {
 fn profile_allows_hook(profile: &str, hook_name: &str) -> bool {
     match hook_name {
         "analysis-paralysis-guard" => matches!(profile, "core" | "full" | "strict"),
+        "count-active-constraints" => profile == "strict",
         "post-build-check" | "stop-guard" | "learn-evaluator" => {
             matches!(profile, "full" | "strict")
         }
@@ -539,6 +548,27 @@ mod tests {
 
         assert!(
             matches!(decision, HookPolicyDecision::Skip(reason) if reason.contains("profile=core excludes post-build-check"))
+        );
+        if let Err(err) = fs::remove_dir_all(&repo) {
+            panic!("temp policy dir should be removed: {err}");
+        }
+    }
+
+    #[test]
+    fn core_profile_excludes_strict_only_count_active_constraints() {
+        let repo = temp_policy_dir("core_count_active_constraints");
+        if let Err(err) = fs::write(repo.join(".vibeguard.json"), r#"{"profile":"core"}"#) {
+            panic!("project config should be written: {err}");
+        }
+
+        let decision = evaluate_hook_policy(
+            "count_active_constraints.sh",
+            repo.to_str(),
+            &HashMap::new(),
+        );
+
+        assert!(
+            matches!(decision, HookPolicyDecision::Skip(reason) if reason.contains("profile=core excludes count-active-constraints"))
         );
         if let Err(err) = fs::remove_dir_all(&repo) {
             panic!("temp policy dir should be removed: {err}");

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -18,6 +18,8 @@ mod json_field;
 mod log_append;
 mod log_query;
 mod pkg_rewrite;
+mod runtime_config;
+mod runtime_policy;
 mod session_metrics;
 mod time_utils;
 
@@ -147,6 +149,11 @@ static COMMANDS: &[Command] = &[
         name: "codex-normalize-apply-patch",
         usage: "<hook-name>  — normalize Codex apply_patch payloads for file hooks",
         handler: codex_hooks::normalize_apply_patch,
+    },
+    Command {
+        name: "runtime-policy-check",
+        usage: "<hook-name>  — evaluate runtime hook policy and config",
+        handler: runtime_policy::runtime_policy_check,
     },
     Command {
         name: "pre-write-check",

--- a/vibeguard-runtime/src/runtime_config.rs
+++ b/vibeguard-runtime/src/runtime_config.rs
@@ -1,0 +1,58 @@
+use std::io::ErrorKind;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfigError {
+    pub message: String,
+    pub exit_code: i32,
+}
+
+impl RuntimeConfigError {
+    fn config_parse_error(message: String) -> Self {
+        Self {
+            message,
+            exit_code: 30,
+        }
+    }
+
+    fn policy_error(message: String) -> Self {
+        Self {
+            message,
+            exit_code: 20,
+        }
+    }
+}
+
+pub fn validate_runtime_config_file(path_text: &str) -> Result<(), RuntimeConfigError> {
+    if path_text.is_empty() {
+        return Ok(());
+    }
+
+    let path = Path::new(path_text);
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let text = std::fs::read_to_string(path).map_err(|err| {
+        if err.kind() == ErrorKind::InvalidData {
+            RuntimeConfigError::config_parse_error(format!(
+                "VibeGuard runtime config invalid UTF-8: {}: {err}",
+                path.display()
+            ))
+        } else {
+            RuntimeConfigError::policy_error(format!(
+                "VibeGuard runtime config cannot be read: {}: {err}",
+                path.display()
+            ))
+        }
+    })?;
+
+    serde_json::from_str::<serde_json::Value>(&text).map_err(|err| {
+        RuntimeConfigError::config_parse_error(format!(
+            "VibeGuard runtime config invalid JSON: {}: {err}",
+            path.display()
+        ))
+    })?;
+
+    Ok(())
+}

--- a/vibeguard-runtime/src/runtime_policy.rs
+++ b/vibeguard-runtime/src/runtime_policy.rs
@@ -1,0 +1,83 @@
+use crate::HandlerResult;
+use crate::codex_app_server_policy::{HookPolicyDecision, evaluate_hook_policy};
+use crate::runtime_config::validate_runtime_config_file;
+use std::collections::HashMap;
+use std::process;
+
+const ALLOW: i32 = 0;
+const SKIP: i32 = 10;
+const POLICY_ERROR: i32 = 20;
+const CONFIG_PARSE_ERROR: i32 = 30;
+
+pub fn runtime_policy_check(args: &[String]) -> HandlerResult {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime runtime-policy-check <hook-name>".into());
+    }
+
+    let user_config = std::env::var("VIBEGUARD_USER_CONFIG_FILE").unwrap_or_default();
+    if let Err(err) = validate_runtime_config_file(&user_config) {
+        eprintln!("{}", err.message);
+        process::exit(err.exit_code);
+    }
+
+    let decision = evaluate_hook_policy(&args[0], None, &HashMap::new());
+    match decision {
+        HookPolicyDecision::Run { reason, .. } => {
+            if let Some(reason) = reason {
+                println!("{reason}");
+            }
+            process::exit(ALLOW);
+        }
+        HookPolicyDecision::Skip(reason) => {
+            println!("{reason}");
+            process::exit(SKIP);
+        }
+        HookPolicyDecision::Error(reason) => {
+            eprintln!("{reason}");
+            process::exit(policy_error_exit_code(&reason));
+        }
+    }
+}
+
+fn policy_error_exit_code(reason: &str) -> i32 {
+    if reason.contains("project config invalid JSON")
+        || reason.contains("project config invalid UTF-8")
+    {
+        CONFIG_PARSE_ERROR
+    } else {
+        POLICY_ERROR
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::policy_error_exit_code;
+
+    #[test]
+    fn runtime_policy_project_json_parse_errors_keep_config_parse_exit_code() {
+        assert_eq!(
+            policy_error_exit_code(
+                "VibeGuard project config invalid JSON: /tmp/.vibeguard.json: EOF"
+            ),
+            30
+        );
+    }
+
+    #[test]
+    fn runtime_policy_project_utf8_parse_errors_keep_config_parse_exit_code() {
+        assert_eq!(
+            policy_error_exit_code("VibeGuard project config invalid UTF-8: /tmp/.vibeguard.json"),
+            30
+        );
+    }
+
+    #[test]
+    fn runtime_policy_schema_errors_keep_policy_error_exit_code() {
+        assert_eq!(
+            policy_error_exit_code(
+                "VibeGuard project config invalid: /tmp/.vibeguard.json disabled_hooks contains unsupported hook missing-hook"
+            ),
+            20
+        );
+    }
+}

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -1,0 +1,152 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "vibeguard-runtime-policy-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn write_policy(repo: &Path, body: &str) {
+    fs::create_dir_all(repo).expect("repo temp dir should be created");
+    fs::write(repo.join(".vibeguard.json"), body).expect("project policy should be written");
+}
+
+fn run_runtime_policy(repo: &Path, hook_name: &str) -> std::process::Output {
+    bin()
+        .arg("runtime-policy-check")
+        .arg(hook_name)
+        .current_dir(repo)
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env_remove("VIBEGUARD_USER_CONFIG_FILE")
+        .output()
+        .expect("runtime policy command should run")
+}
+
+#[test]
+fn runtime_policy_check_allows_when_no_project_config_exists() {
+    let repo = unique_temp_dir("allow_no_config");
+    fs::create_dir_all(&repo).expect("repo temp dir should be created");
+
+    let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_skips_disabled_hook() {
+    let repo = unique_temp_dir("disabled_hook");
+    write_policy(&repo, r#"{"disabled_hooks":["pre-bash-guard"]}"#);
+
+    let output = run_runtime_policy(&repo, "vibeguard-pre-bash-guard.sh");
+
+    assert_eq!(output.status.code(), Some(10));
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("disabled_hooks contains pre-bash-guard")
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_reports_warn_enforcement() {
+    let repo = unique_temp_dir("warn_enforcement");
+    write_policy(&repo, r#"{"enforcement":"warn"}"#);
+
+    let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("enforcement=warn"));
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_validates_user_runtime_config_before_policy() {
+    let repo = unique_temp_dir("bad_user_config");
+    write_policy(&repo, r#"{}"#);
+    let user_config = repo.join("bad-config.json");
+    fs::write(&user_config, r#"{"write_mode":"#).expect("runtime config should be written");
+
+    let output = bin()
+        .arg("runtime-policy-check")
+        .arg("pre-bash-guard.sh")
+        .current_dir(&repo)
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env("VIBEGUARD_USER_CONFIG_FILE", &user_config)
+        .output()
+        .expect("runtime policy command should run");
+
+    assert_eq!(output.status.code(), Some(30));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("runtime config invalid JSON"));
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_reports_project_schema_errors_as_policy_errors() {
+    let repo = unique_temp_dir("bad_project_schema");
+    write_policy(&repo, r#"{"disabled_hooks":["missing-hook"]}"#);
+
+    let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
+
+    assert_eq!(output.status.code(), Some(20));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("disabled_hooks contains unsupported hook")
+    );
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_reports_project_json_parse_errors_as_config_parse_errors() {
+    let repo = unique_temp_dir("bad_project_json");
+    write_policy(&repo, r#"{"disabled_hooks":"#);
+
+    let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
+
+    assert_eq!(output.status.code(), Some(30));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("project config invalid JSON"));
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_reports_project_utf8_errors_as_config_parse_errors() {
+    let repo = unique_temp_dir("bad_project_utf8");
+    fs::create_dir_all(&repo).expect("repo temp dir should be created");
+    fs::write(repo.join(".vibeguard.json"), [0xff, 0xfe])
+        .expect("invalid utf8 project policy should be written");
+
+    let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
+
+    assert_eq!(output.status.code(), Some(30));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("project config invalid UTF-8"));
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_uses_shared_profile_filtering_for_strict_only_hooks() {
+    let repo = unique_temp_dir("strict_only");
+    write_policy(&repo, r#"{"profile":"core"}"#);
+
+    let output = run_runtime_policy(&repo, "count_active_constraints.sh");
+
+    assert_eq!(output.status.code(), Some(10));
+    assert!(
+        String::from_utf8_lossy(&output.stdout)
+            .contains("profile=core excludes count-active-constraints")
+    );
+    let _ = fs::remove_dir_all(repo);
+}


### PR DESCRIPTION
## Summary
- add `runtime-policy-check <hook-name>` to `vibeguard-runtime`
- reuse the existing `codex_app_server_policy::evaluate_hook_policy` for shell-wrapper policy checks
- make `hooks/_lib/policy.sh` use the runtime for the production policy decision path
- preserve policy exit semantics: allow `0`, skip `10`, policy error `20`, config parse error `30`
- add focused Rust CLI and shell-wrapper tests, including invalid project config UTF-8 parity

Refs #381. This is the first mergeable slice; Python still remains for warn-mode output downgrade, policy diagnostics JSONL, Codex-visible error JSON formatting, and generic config reads.

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --all -- --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml runtime_policy`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test runtime_policy_cli`
- `bash tests/hooks/test_runtime_policy.sh`
- `bash tests/hooks/test_runtime_config.sh`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/validate-manifest-contract.sh`
- `git diff --check`

## Review
- implemented in isolated #381 worktree
- independent reviewer lane found and verified the invalid UTF-8 exit-code fix
- no blocking findings remain