### PR TITLE
Route policy helper JSON through vibeguard-runtime

### DIFF
--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -42,6 +42,7 @@ vg_policy_check_hook() {
   VG_POLICY_REASON=""
   VG_POLICY_KIND=""
   VG_POLICY_ENFORCEMENT="block"
+  VG_POLICY_RUNTIME_PATH=""
   export VIBEGUARD_POLICY_ENFORCEMENT="block"
 
   if ! runtime_path="$(vg_policy_runtime_path)"; then
@@ -49,6 +50,7 @@ vg_policy_check_hook() {
     VG_POLICY_KIND="policy_error"
     return 20
   fi
+  VG_POLICY_RUNTIME_PATH="${runtime_path}"
 
   status=0
   output="$(
@@ -85,54 +87,23 @@ vg_policy_check_hook() {
 }
 
 vg_policy_downgrade_output() {
-  local output="$1"
+  local output="$1" runtime_path
   if [[ "${VIBEGUARD_POLICY_ENFORCEMENT:-}" != "warn" || -z "${output}" ]]; then
     printf '%s\n' "${output}"
     return 0
   fi
 
-  VG_POLICY_HOOK_OUTPUT="${output}" python3 - <<'PY' || printf '%s\n' "${output}"
-import json
-import os
-import sys
+  runtime_path="${VG_POLICY_RUNTIME_PATH:-}"
+  if [[ -z "${runtime_path}" ]] && ! runtime_path="$(vg_policy_runtime_path)"; then
+    printf 'VibeGuard policy error: vibeguard-runtime is required for warn-mode output downgrade.\n' >&2
+    printf '%s\n' "${output}"
+    return 0
+  fi
 
-raw = os.environ.get("VG_POLICY_HOOK_OUTPUT", "")
-try:
-    data = json.loads(raw)
-except json.JSONDecodeError:
-    sys.stdout.write(raw)
-    if raw and not raw.endswith("\n"):
-        sys.stdout.write("\n")
-    raise SystemExit(0)
-
-if not isinstance(data, dict):
-    print(json.dumps(data, ensure_ascii=False))
-    raise SystemExit(0)
-
-reason = data.get("reason")
-changed = False
-if data.get("decision") in {"block", "gate", "escalate"}:
-    data["decision"] = "warn"
-    changed = True
-if isinstance(reason, str) and reason and changed:
-    data["reason"] = f"VIBEGUARD warn-mode advisory: {reason}"
-
-hook_specific = data.get("hookSpecificOutput")
-if isinstance(hook_specific, dict):
-    if hook_specific.get("permissionDecision") == "deny":
-        message = hook_specific.pop("permissionDecisionReason", None)
-        hook_specific.pop("permissionDecision", None)
-        if isinstance(message, str) and message and "systemMessage" not in data:
-            data["systemMessage"] = f"VIBEGUARD warn-mode advisory: {message}"
-    decision = hook_specific.get("decision")
-    if isinstance(decision, dict) and decision.get("behavior") == "deny":
-        message = decision.get("message")
-        hook_specific.pop("decision", None)
-        if isinstance(message, str) and message and "systemMessage" not in data:
-            data["systemMessage"] = f"VIBEGUARD warn-mode advisory: {message}"
-
-print(json.dumps(data, ensure_ascii=False))
-PY
+  printf '%s' "${output}" | "${runtime_path}" runtime-policy-downgrade-output || {
+    printf 'VibeGuard policy error: runtime-policy-downgrade-output failed.\n' >&2
+    printf '%s\n' "${output}"
+  }
 }
 
 vg_policy_diag() {
@@ -141,65 +112,52 @@ vg_policy_diag() {
   diag_file="${VIBEGUARD_POLICY_DIAG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/policy.jsonl}"
   diag_dir="$(dirname "${diag_file}")"
   mkdir -p "${diag_dir}" 2>/dev/null || return 0
-  VIBEGUARD_POLICY_DIAG_HOOK="${hook_name}" \
-    VIBEGUARD_POLICY_DIAG_EVENT="${event_name}" \
-    VIBEGUARD_POLICY_DIAG_KIND="${kind}" \
-    VIBEGUARD_POLICY_DIAG_REASON="${reason}" \
-    VIBEGUARD_POLICY_DIAG_WRAPPER="${VIBEGUARD_WRAPPER:-unknown}" \
-    python3 - <<'PY' >>"${diag_file}" 2>/dev/null || true
-import json
-import os
-from datetime import datetime, timezone
-
-print(json.dumps({
-    "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "wrapper": os.environ.get("VIBEGUARD_POLICY_DIAG_WRAPPER", ""),
-    "hook": os.environ.get("VIBEGUARD_POLICY_DIAG_HOOK", ""),
-    "event": os.environ.get("VIBEGUARD_POLICY_DIAG_EVENT", ""),
-    "kind": os.environ.get("VIBEGUARD_POLICY_DIAG_KIND", ""),
-    "reason": os.environ.get("VIBEGUARD_POLICY_DIAG_REASON", ""),
-}, ensure_ascii=False))
-PY
+  local runtime_path
+  runtime_path="${VG_POLICY_RUNTIME_PATH:-}"
+  if [[ -z "${runtime_path}" ]] && ! runtime_path="$(vg_policy_runtime_path)"; then
+    return 0
+  fi
+  printf '%s' "${reason}" \
+    | "${runtime_path}" runtime-policy-diag \
+      "${diag_file}" \
+      "${hook_name}" \
+      "${event_name}" \
+      "${kind}" \
+      "${VIBEGUARD_WRAPPER:-unknown}" >/dev/null 2>/dev/null || true
 }
 
 vg_policy_codex_error_output() {
-  local event_name="$1" reason="$2"
-  VIBEGUARD_POLICY_EVENT="${event_name}" VIBEGUARD_POLICY_REASON="${reason}" python3 - <<'PY'
-import json
-import os
+  local event_name="$1" reason="$2" runtime_path
+  runtime_path="${VG_POLICY_RUNTIME_PATH:-}"
+  if [[ -z "${runtime_path}" ]] && ! runtime_path="$(vg_policy_runtime_path)"; then
+    vg_policy_codex_error_fallback "${event_name}"
+    return 0
+  fi
+  printf '%s' "${reason}" | "${runtime_path}" runtime-policy-codex-error "${event_name}" || {
+    vg_policy_codex_error_fallback "${event_name}"
+  }
+}
 
-event = os.environ.get("VIBEGUARD_POLICY_EVENT", "")
-reason = os.environ.get("VIBEGUARD_POLICY_REASON", "")
-if event == "PreToolUse":
-    payload = {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        }
-    }
-elif event == "PermissionRequest":
-    payload = {
-        "hookSpecificOutput": {
-            "hookEventName": "PermissionRequest",
-            "decision": {"behavior": "deny", "message": reason},
-        }
-    }
-elif event == "PostToolUse":
-    payload = {
-        "decision": "block",
-        "reason": reason,
-        "hookSpecificOutput": {
-            "hookEventName": "PostToolUse",
-            "additionalContext": reason,
-        },
-    }
-elif event == "Stop":
-    payload = {"stopReason": reason}
-else:
-    payload = {"systemMessage": reason}
-print(json.dumps(payload, ensure_ascii=False))
-PY
+vg_policy_codex_error_fallback() {
+  local event_name="$1"
+  local reason="VibeGuard policy error: vibeguard-runtime is required for Codex policy output."
+  case "${event_name}" in
+    PreToolUse)
+      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "${reason}"
+      ;;
+    PermissionRequest)
+      printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"%s"}}}\n' "${reason}"
+      ;;
+    PostToolUse)
+      printf '{"decision":"block","reason":"%s","hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "${reason}" "${reason}"
+      ;;
+    Stop)
+      printf '{"stopReason":"%s"}\n' "${reason}"
+      ;;
+    *)
+      printf '{"systemMessage":"%s"}\n' "${reason}"
+      ;;
+  esac
 }
 
 vg_policy_codex_gate() {

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -24,15 +24,33 @@ vg_policy_runtime_path() {
     "${wrapper_dir}/vibeguard-runtime" \
     "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
-      if VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
-        VIBEGUARD_USER_CONFIG_FILE="" \
-        "${candidate}" runtime-policy-check __vibeguard_policy_probe__ >/dev/null 2>&1; then
+      if vg_policy_runtime_supports "${candidate}"; then
         printf '%s\n' "${candidate}"
         return 0
       fi
     fi
   done
   return 1
+}
+
+vg_policy_runtime_supports() {
+  local candidate="$1" probe_diag downgrade_probe codex_probe
+  probe_diag="${TMPDIR:-/tmp}/vibeguard-policy-probe.$$.jsonl"
+  VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
+    VIBEGUARD_USER_CONFIG_FILE="" \
+    "${candidate}" runtime-policy-check __vibeguard_policy_probe__ >/dev/null 2>&1 || return 1
+  downgrade_probe="$(printf '{"decision":"block","reason":"probe"}' \
+    | "${candidate}" runtime-policy-downgrade-output 2>/dev/null)" || return 1
+  [[ "${downgrade_probe}" == *'"decision"'* && "${downgrade_probe}" == *'"warn"'* ]] || return 1
+  codex_probe="$(printf 'probe' \
+    | "${candidate}" runtime-policy-codex-error PreToolUse 2>/dev/null)" || return 1
+  [[ "${codex_probe}" == *'"permissionDecision"'* && "${codex_probe}" == *'"deny"'* ]] || return 1
+  rm -f "${probe_diag}" 2>/dev/null || true
+  printf 'probe' \
+    | "${candidate}" runtime-policy-diag "${probe_diag}" __vibeguard_policy_probe__ PreToolUse policy_error probe >/dev/null 2>&1 || return 1
+  [[ -s "${probe_diag}" ]] || return 1
+  rm -f "${probe_diag}" 2>/dev/null || true
+  return 0
 }
 
 vg_policy_check_hook() {

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -262,4 +262,7 @@ assert_contains "${bad_user_codex_out}" '"permissionDecision": "deny"' "Codex wr
 assert_contains "${bad_user_codex_out}" "VibeGuard runtime config invalid JSON" "Codex wrapper explains malformed runtime config"
 assert_contains "$(cat "${bad_user_home}/.vibeguard/policy.jsonl")" "config_parse_error" "runtime policy emits config_parse_error telemetry"
 
+header "runtime policy — no Python policy helpers"
+assert_not_contains "$(sed -n '1,240p' "${REPO_DIR}/hooks/_lib/policy.sh")" "python3" "policy helper no longer shells out to python3"
+
 hook_test_finish

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -110,7 +110,26 @@ codex_pretool_danger_input='{"hook_event_name":"PreToolUse","tool_input":{"comma
 
 header "runtime policy — runtime resolver"
 explicit_runtime="${WORK_DIR}/explicit-runtime"
-printf '#!/usr/bin/env bash\nexit 0\n' > "${explicit_runtime}"
+cat > "${explicit_runtime}" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  runtime-policy-check)
+    exit 0
+    ;;
+  runtime-policy-downgrade-output)
+    printf '{"decision":"warn","reason":"probe"}\n'
+    ;;
+  runtime-policy-codex-error)
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"probe"}}\n'
+    ;;
+  runtime-policy-diag)
+    printf '{"kind":"policy_error"}\n' >>"${2:?}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
 chmod +x "${explicit_runtime}"
 resolver_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_POLICY_RUNTIME="${explicit_runtime}" bash -c '
@@ -135,6 +154,28 @@ resolver_out="$(
   '
 )"
 assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver honors VIBEGUARD_RUNTIME before installed binaries"
+
+partial_runtime="${WORK_DIR}/partial-runtime"
+cat > "${partial_runtime}" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "runtime-policy-check" ]]; then
+  exit 0
+fi
+echo "missing helper: ${1:-}" >&2
+exit 2
+SH
+chmod +x "${partial_runtime}"
+resolver_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${partial_runtime}" \
+  VIBEGUARD_RUNTIME="${RUNTIME_BIN}" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_runtime_path
+  '
+)"
+assert_not_contains "${resolver_out}" "${partial_runtime}" "runtime policy resolver rejects runtimes missing helper commands"
+assert_contains "${resolver_out}" "${RUNTIME_BIN}" "runtime policy resolver falls through to helper-capable runtime"
 
 header "runtime policy — disabled hooks"
 disabled_home="${WORK_DIR}/home-disabled"

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -156,6 +156,21 @@ static COMMANDS: &[Command] = &[
         handler: runtime_policy::runtime_policy_check,
     },
     Command {
+        name: "runtime-policy-downgrade-output",
+        usage: "  — downgrade stdin hook JSON to warn-mode advisory output",
+        handler: runtime_policy::runtime_policy_downgrade_output,
+    },
+    Command {
+        name: "runtime-policy-codex-error",
+        usage: "<event-name>  — emit Codex-visible policy error JSON from stdin reason",
+        handler: runtime_policy::runtime_policy_codex_error,
+    },
+    Command {
+        name: "runtime-policy-diag",
+        usage: "<diag-file> <hook-name> <event-name> <kind> <wrapper>  — append policy diagnostic JSONL from stdin reason",
+        handler: runtime_policy::runtime_policy_diag,
+    },
+    Command {
         name: "pre-write-check",
         usage: "<base-limit> [warn-limit]  — classify PreToolUse(Write) input for hooks",
         handler: hook_checks::pre_write_check,

--- a/vibeguard-runtime/src/runtime_policy.rs
+++ b/vibeguard-runtime/src/runtime_policy.rs
@@ -1,7 +1,12 @@
 use crate::HandlerResult;
 use crate::codex_app_server_policy::{HookPolicyDecision, evaluate_hook_policy};
 use crate::runtime_config::validate_runtime_config_file;
+use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
+use serde_json::{Value, json};
 use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::Path;
 use std::process;
 
 const ALLOW: i32 = 0;
@@ -39,6 +44,139 @@ pub fn runtime_policy_check(args: &[String]) -> HandlerResult {
     }
 }
 
+pub fn runtime_policy_downgrade_output(args: &[String]) -> HandlerResult {
+    if !args.is_empty() {
+        return Err("Usage: vibeguard-runtime runtime-policy-downgrade-output".into());
+    }
+
+    let raw = read_stdin()?;
+    let Ok(mut value) = serde_json::from_str::<Value>(&raw) else {
+        print_raw_with_newline(&raw)?;
+        return Ok(());
+    };
+
+    let Some(object) = value.as_object_mut() else {
+        println!("{}", serde_json::to_string(&value)?);
+        return Ok(());
+    };
+
+    let mut changed = false;
+    if matches!(
+        object.get("decision").and_then(Value::as_str),
+        Some("block" | "gate" | "escalate")
+    ) {
+        object.insert("decision".to_string(), json!("warn"));
+        changed = true;
+    }
+
+    if changed
+        && let Some(reason) = object.get("reason").and_then(Value::as_str)
+        && !reason.is_empty()
+    {
+        object.insert(
+            "reason".to_string(),
+            json!(format!("VIBEGUARD warn-mode advisory: {reason}")),
+        );
+    }
+
+    let has_system_message = object.contains_key("systemMessage");
+    let mut advisory_message: Option<String> = None;
+    if let Some(hook_specific) = object
+        .get_mut("hookSpecificOutput")
+        .and_then(Value::as_object_mut)
+    {
+        if hook_specific
+            .get("permissionDecision")
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            let message = hook_specific
+                .remove("permissionDecisionReason")
+                .and_then(|value| value.as_str().map(str::to_string));
+            hook_specific.remove("permissionDecision");
+            if let Some(message) = message
+                && !message.is_empty()
+                && !has_system_message
+                && advisory_message.is_none()
+            {
+                advisory_message = Some(message);
+            }
+        }
+
+        if hook_specific
+            .get("decision")
+            .and_then(Value::as_object)
+            .and_then(|decision| decision.get("behavior"))
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            let message = hook_specific
+                .get("decision")
+                .and_then(Value::as_object)
+                .and_then(|decision| decision.get("message"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            hook_specific.remove("decision");
+            if let Some(message) = message
+                && !message.is_empty()
+                && !has_system_message
+                && advisory_message.is_none()
+            {
+                advisory_message = Some(message);
+            }
+        }
+    }
+    if let Some(message) = advisory_message {
+        object.insert(
+            "systemMessage".to_string(),
+            json!(format!("VIBEGUARD warn-mode advisory: {message}")),
+        );
+    }
+
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+
+pub fn runtime_policy_codex_error(args: &[String]) -> HandlerResult {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime runtime-policy-codex-error <event-name>".into());
+    }
+
+    let reason = read_stdin()?;
+    let payload = codex_error_payload(&args[0], &reason);
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+pub fn runtime_policy_diag(args: &[String]) -> HandlerResult {
+    if args.len() != 5 {
+        return Err("Usage: vibeguard-runtime runtime-policy-diag <diag-file> <hook-name> <event-name> <kind> <wrapper>".into());
+    }
+
+    let diag_file = Path::new(&args[0]);
+    if let Some(parent) = diag_file.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let reason = read_stdin()?;
+    let payload = json!({
+        "ts": format_unix_secs_utc(now_unix_secs()),
+        "wrapper": args[4],
+        "hook": args[1],
+        "event": args[2],
+        "kind": args[3],
+        "reason": reason,
+    });
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(diag_file)?;
+    writeln!(file, "{}", serde_json::to_string(&payload)?)?;
+    Ok(())
+}
+
 fn policy_error_exit_code(reason: &str) -> i32 {
     if reason.contains("project config invalid JSON")
         || reason.contains("project config invalid UTF-8")
@@ -46,6 +184,51 @@ fn policy_error_exit_code(reason: &str) -> i32 {
         CONFIG_PARSE_ERROR
     } else {
         POLICY_ERROR
+    }
+}
+
+fn read_stdin() -> io::Result<String> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    Ok(input)
+}
+
+fn print_raw_with_newline(raw: &str) -> io::Result<()> {
+    print!("{raw}");
+    if !raw.is_empty() && !raw.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
+fn codex_error_payload(event: &str, reason: &str) -> Value {
+    match event {
+        "PreToolUse" => json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }),
+        "PermissionRequest" => json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {
+                    "behavior": "deny",
+                    "message": reason,
+                },
+            }
+        }),
+        "PostToolUse" => json!({
+            "decision": "block",
+            "reason": reason,
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": reason,
+            },
+        }),
+        "Stop" => json!({ "stopReason": reason }),
+        _ => json!({ "systemMessage": reason }),
     }
 }
 

--- a/vibeguard-runtime/src/runtime_policy.rs
+++ b/vibeguard-runtime/src/runtime_policy.rs
@@ -69,14 +69,15 @@ pub fn runtime_policy_downgrade_output(args: &[String]) -> HandlerResult {
         changed = true;
     }
 
-    if changed
-        && let Some(reason) = object.get("reason").and_then(Value::as_str)
-        && !reason.is_empty()
-    {
-        object.insert(
-            "reason".to_string(),
-            json!(format!("VIBEGUARD warn-mode advisory: {reason}")),
-        );
+    if changed {
+        if let Some(reason) = object.get("reason").and_then(Value::as_str) {
+            if !reason.is_empty() {
+                object.insert(
+                    "reason".to_string(),
+                    json!(format!("VIBEGUARD warn-mode advisory: {reason}")),
+                );
+            }
+        }
     }
 
     let has_system_message = object.contains_key("systemMessage");
@@ -94,12 +95,10 @@ pub fn runtime_policy_downgrade_output(args: &[String]) -> HandlerResult {
                 .remove("permissionDecisionReason")
                 .and_then(|value| value.as_str().map(str::to_string));
             hook_specific.remove("permissionDecision");
-            if let Some(message) = message
-                && !message.is_empty()
-                && !has_system_message
-                && advisory_message.is_none()
-            {
-                advisory_message = Some(message);
+            if let Some(message) = message {
+                if !message.is_empty() && !has_system_message && advisory_message.is_none() {
+                    advisory_message = Some(message);
+                }
             }
         }
 
@@ -117,12 +116,10 @@ pub fn runtime_policy_downgrade_output(args: &[String]) -> HandlerResult {
                 .and_then(Value::as_str)
                 .map(str::to_string);
             hook_specific.remove("decision");
-            if let Some(message) = message
-                && !message.is_empty()
-                && !has_system_message
-                && advisory_message.is_none()
-            {
-                advisory_message = Some(message);
+            if let Some(message) = message {
+                if !message.is_empty() && !has_system_message && advisory_message.is_none() {
+                    advisory_message = Some(message);
+                }
             }
         }
     }
@@ -154,10 +151,10 @@ pub fn runtime_policy_diag(args: &[String]) -> HandlerResult {
     }
 
     let diag_file = Path::new(&args[0]);
-    if let Some(parent) = diag_file.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        fs::create_dir_all(parent)?;
+    if let Some(parent) = diag_file.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
     }
 
     let reason = read_stdin()?;

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -1,6 +1,7 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
@@ -20,6 +21,25 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 fn write_policy(repo: &Path, body: &str) {
     fs::create_dir_all(repo).expect("repo temp dir should be created");
     fs::write(repo.join(".vibeguard.json"), body).expect("project policy should be written");
+}
+
+fn run_runtime_with_stdin(args: &[&str], input: &str) -> std::process::Output {
+    let mut child = bin()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("runtime helper should spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(input.as_bytes())
+        .expect("runtime helper stdin should be written");
+    child
+        .wait_with_output()
+        .expect("runtime helper should finish")
 }
 
 fn run_runtime_policy(repo: &Path, hook_name: &str) -> std::process::Output {
@@ -148,5 +168,149 @@ fn runtime_policy_check_uses_shared_profile_filtering_for_strict_only_hooks() {
         String::from_utf8_lossy(&output.stdout)
             .contains("profile=core excludes count-active-constraints")
     );
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_downgrade_output_converts_block_to_warn() {
+    let output = run_runtime_with_stdin(
+        &["runtime-policy-downgrade-output"],
+        r#"{"decision":"block","reason":"dangerous command"}"#,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("downgraded output should be JSON");
+    assert_eq!(value["decision"], "warn");
+    assert_eq!(
+        value["reason"],
+        "VIBEGUARD warn-mode advisory: dangerous command"
+    );
+}
+
+#[test]
+fn runtime_policy_downgrade_output_removes_codex_pretool_denial() {
+    let output = run_runtime_with_stdin(
+        &["runtime-policy-downgrade-output"],
+        r#"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"blocked by policy"}}"#,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("downgraded output should be JSON");
+    assert_eq!(
+        value["systemMessage"],
+        "VIBEGUARD warn-mode advisory: blocked by policy"
+    );
+    assert!(value["hookSpecificOutput"]["permissionDecision"].is_null());
+    assert!(value["hookSpecificOutput"]["permissionDecisionReason"].is_null());
+}
+
+#[test]
+fn runtime_policy_downgrade_output_removes_codex_permission_denial() {
+    let output = run_runtime_with_stdin(
+        &["runtime-policy-downgrade-output"],
+        r#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"permission denied"}}}"#,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("downgraded output should be JSON");
+    assert_eq!(
+        value["systemMessage"],
+        "VIBEGUARD warn-mode advisory: permission denied"
+    );
+    assert!(value["hookSpecificOutput"]["decision"].is_null());
+}
+
+#[test]
+fn runtime_policy_downgrade_output_preserves_non_json_text() {
+    let output = run_runtime_with_stdin(&["runtime-policy-downgrade-output"], "not json");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "not json\n");
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+}
+
+#[test]
+fn runtime_policy_codex_error_outputs_event_specific_payloads() {
+    let pretool = run_runtime_with_stdin(
+        &["runtime-policy-codex-error", "PreToolUse"],
+        "project config invalid",
+    );
+    let pretool_value: serde_json::Value =
+        serde_json::from_slice(&pretool.stdout).expect("PreToolUse payload should be JSON");
+    assert_eq!(
+        pretool_value["hookSpecificOutput"]["permissionDecision"],
+        "deny"
+    );
+    assert_eq!(
+        pretool_value["hookSpecificOutput"]["permissionDecisionReason"],
+        "project config invalid"
+    );
+
+    let permission = run_runtime_with_stdin(
+        &["runtime-policy-codex-error", "PermissionRequest"],
+        "policy denied",
+    );
+    let permission_value: serde_json::Value = serde_json::from_slice(&permission.stdout)
+        .expect("PermissionRequest payload should be JSON");
+    assert_eq!(
+        permission_value["hookSpecificOutput"]["decision"]["behavior"],
+        "deny"
+    );
+    assert_eq!(
+        permission_value["hookSpecificOutput"]["decision"]["message"],
+        "policy denied"
+    );
+
+    let posttool = run_runtime_with_stdin(
+        &["runtime-policy-codex-error", "PostToolUse"],
+        "posttool denied",
+    );
+    let posttool_value: serde_json::Value =
+        serde_json::from_slice(&posttool.stdout).expect("PostToolUse payload should be JSON");
+    assert_eq!(posttool_value["decision"], "block");
+    assert_eq!(
+        posttool_value["hookSpecificOutput"]["additionalContext"],
+        "posttool denied"
+    );
+
+    let stop = run_runtime_with_stdin(&["runtime-policy-codex-error", "Stop"], "stop denied");
+    let stop_value: serde_json::Value =
+        serde_json::from_slice(&stop.stdout).expect("Stop payload should be JSON");
+    assert_eq!(stop_value["stopReason"], "stop denied");
+}
+
+#[test]
+fn runtime_policy_diag_appends_jsonl_event() {
+    let repo = unique_temp_dir("diag");
+    fs::create_dir_all(&repo).expect("diag dir should be created");
+    let diag_file = repo.join("policy.jsonl");
+
+    let output = run_runtime_with_stdin(
+        &[
+            "runtime-policy-diag",
+            diag_file.to_str().expect("diag path should be utf8"),
+            "pre-bash-guard.sh",
+            "PreToolUse",
+            "policy_error",
+            "run-hook-codex.sh",
+        ],
+        "runtime missing",
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let line = fs::read_to_string(&diag_file).expect("diag event should be written");
+    let value: serde_json::Value =
+        serde_json::from_str(line.trim()).expect("diag event should be JSON");
+    assert!(value["ts"].as_str().unwrap_or("").ends_with('Z'));
+    assert_eq!(value["wrapper"], "run-hook-codex.sh");
+    assert_eq!(value["hook"], "pre-bash-guard.sh");
+    assert_eq!(value["event"], "PreToolUse");
+    assert_eq!(value["kind"], "policy_error");
+    assert_eq!(value["reason"], "runtime missing");
     let _ = fs::remove_dir_all(repo);
 }


### PR DESCRIPTION
## Summary
- add runtime policy helper commands for warn-mode output downgrade, Codex-visible policy error payloads, and policy diagnostic JSONL
- replace the remaining inline Python helpers in `hooks/_lib/policy.sh` with `vibeguard-runtime` calls
- add Rust CLI coverage plus a shell sentinel that `policy.sh` no longer shells out to `python3`

Refs #381. This removes the remaining Python usage from `policy.sh`; `hooks/_lib/config.sh` and `scripts/lib/project_config.sh` are intentionally left for separate follow-up slices.

## Verification
- `bash -n hooks/_lib/policy.sh tests/hooks/test_runtime_policy.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --all -- --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml runtime_policy`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test runtime_policy_cli`
- `bash tests/hooks/test_runtime_policy.sh`
- `bash tests/test_codex_runtime.sh`
- `bash tests/hooks/test_runtime_config.sh`
- `bash scripts/ci/validate-manifest-contract.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash scripts/ci/validate-guards.sh`
- `bash scripts/ci/validate-hooks.sh`
- `git diff --check`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`