### PR TITLE
Route runtime config reads through vibeguard-runtime

### DIFF
--- a/hooks/_lib/config.sh
+++ b/hooks/_lib/config.sh
@@ -15,14 +15,53 @@ if [[ -n "${_VG_CONFIG_SH_LOADED:-}" ]]; then
   return 0
 fi
 _VG_CONFIG_SH_LOADED=1
+_VG_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 _vg_config_file() {
   printf '%s' "${_VG_CONFIG_FILE:-${VIBEGUARD_CONFIG_FILE:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/config.json}}"
 }
 
+_vg_config_runtime_path() {
+  local wrapper_dir candidate
+  wrapper_dir="$(cd "${_VG_CONFIG_LIB_DIR}/.." && pwd)"
+  for candidate in \
+    "${_VIBEGUARD_RUNTIME:-}" \
+    "${VIBEGUARD_RUNTIME:-}" \
+    "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${wrapper_dir}/vibeguard-runtime"; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      if _vg_config_runtime_supports "${candidate}"; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+_vg_config_runtime_supports() {
+  local candidate="$1" probe_file int_probe str_probe
+  probe_file="${TMPDIR:-/tmp}/vibeguard-runtime-config-probe.$$.json"
+  printf '{"probe":{"int":19,"str":"probe-hit"}}\n' > "${probe_file}" || return 1
+  int_probe="$(
+    _VG_CONFIG_FILE="${probe_file}" VIBEGUARD_CONFIG_FILE="${probe_file}" \
+      "${candidate}" runtime-config-get-int __VIBEGUARD_CONFIG_PROBE_INT__ probe.int 17 2>/dev/null
+  )" || { rm -f "${probe_file}" 2>/dev/null || true; return 1; }
+  [[ "${int_probe}" == "19" ]] || { rm -f "${probe_file}" 2>/dev/null || true; return 1; }
+  str_probe="$(
+    _VG_CONFIG_FILE="${probe_file}" VIBEGUARD_CONFIG_FILE="${probe_file}" \
+      "${candidate}" runtime-config-get-str __VIBEGUARD_CONFIG_PROBE_STR__ probe.str probe-default 2>/dev/null
+  )" || { rm -f "${probe_file}" 2>/dev/null || true; return 1; }
+  [[ "${str_probe}" == "probe-hit" ]] || { rm -f "${probe_file}" 2>/dev/null || true; return 1; }
+  rm -f "${probe_file}" 2>/dev/null || true
+  return 0
+}
+
 vg_config_get_int() {
   local env_name="$1" json_path="$2" default_val="$3"
-  local val config_file
+  local val runtime_path config_file
 
   val="${!env_name:-}"
   if [[ -n "$val" && "$val" =~ ^[0-9]+$ ]]; then
@@ -31,33 +70,18 @@ vg_config_get_int() {
   fi
 
   config_file="$(_vg_config_file)"
-  if [[ -f "$config_file" ]]; then
-    val=$(python3 - "$config_file" "$json_path" <<'PY'
-import json
-import sys
-
-config_file, json_path = sys.argv[1:3]
-try:
-    with open(config_file, encoding="utf-8") as f:
-        node = json.load(f)
-except Exception:
-    raise SystemExit(1)
-
-for key in json_path.split("."):
-    if isinstance(node, dict) and key in node:
-        node = node[key]
-    else:
-        raise SystemExit(1)
-
-if isinstance(node, bool) or not isinstance(node, int):
-    raise SystemExit(1)
-print(node)
-PY
-    ) || val=""
+  if runtime_path="$(_vg_config_runtime_path)"; then
+    val="$(
+      _VG_CONFIG_FILE="${config_file}" VIBEGUARD_CONFIG_FILE="${config_file}" \
+        "${runtime_path}" runtime-config-get-int "$env_name" "$json_path" "$default_val" 2>/dev/null || true
+    )"
     if [[ -n "$val" && "$val" =~ ^[0-9]+$ ]]; then
       printf '%s' "$val"
       return 0
     fi
+  elif [[ -f "$config_file" ]]; then
+    printf 'VibeGuard runtime config read failed: vibeguard-runtime with runtime-config-get-int is required to read %s\n' "$config_file" >&2
+    return 2
   fi
 
   printf '%s' "$default_val"
@@ -65,7 +89,7 @@ PY
 
 vg_config_get_str() {
   local env_name="$1" json_path="$2" default_val="$3"
-  local val config_file
+  local val runtime_path config_file
 
   val="${!env_name:-}"
   if [[ -n "$val" ]]; then
@@ -74,33 +98,18 @@ vg_config_get_str() {
   fi
 
   config_file="$(_vg_config_file)"
-  if [[ -f "$config_file" ]]; then
-    val=$(python3 - "$config_file" "$json_path" <<'PY'
-import json
-import sys
-
-config_file, json_path = sys.argv[1:3]
-try:
-    with open(config_file, encoding="utf-8") as f:
-        node = json.load(f)
-except Exception:
-    raise SystemExit(1)
-
-for key in json_path.split("."):
-    if isinstance(node, dict) and key in node:
-        node = node[key]
-    else:
-        raise SystemExit(1)
-
-if not isinstance(node, str):
-    raise SystemExit(1)
-print(node)
-PY
-    ) || val=""
+  if runtime_path="$(_vg_config_runtime_path)"; then
+    val="$(
+      _VG_CONFIG_FILE="${config_file}" VIBEGUARD_CONFIG_FILE="${config_file}" \
+        "${runtime_path}" runtime-config-get-str "$env_name" "$json_path" "$default_val" 2>/dev/null || true
+    )"
     if [[ -n "$val" ]]; then
       printf '%s' "$val"
       return 0
     fi
+  elif [[ -f "$config_file" ]]; then
+    printf 'VibeGuard runtime config read failed: vibeguard-runtime with runtime-config-get-str is required to read %s\n' "$config_file" >&2
+    return 2
   fi
 
   printf '%s' "$default_val"

--- a/tests/hooks/test_runtime_config.sh
+++ b/tests/hooks/test_runtime_config.sh
@@ -255,4 +255,39 @@ got=$(vg_config_get_str VG_TEST_MODE write_mode block)
 [[ "$got" == "warn" ]] && green "vg_config_get_str env beats JSON" || { red "vg_config_get_str env (got: $got)"; FAIL=$((FAIL + 1)); }
 TOTAL=$((TOTAL + 1)); [[ "$got" == "warn" ]] && PASS=$((PASS + 1))
 
+partial_runtime="$WORK_DIR/partial-runtime"
+cat > "$partial_runtime" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "json-field" ]]; then
+  exit 0
+fi
+echo "missing helper: ${1:-}" >&2
+exit 2
+SH
+chmod +x "$partial_runtime"
+unset VG_TEST_X
+got=$(VIBEGUARD_RUNTIME="$partial_runtime" vg_config_get_int VG_TEST_X u16.limit 800)
+[[ "$got" == "1234" ]] && green "vg_config_get_int skips runtimes missing config helpers" || { red "vg_config_get_int stale runtime fallback (got: $got)"; FAIL=$((FAIL + 1)); }
+TOTAL=$((TOTAL + 1)); [[ "$got" == "1234" ]] && PASS=$((PASS + 1))
+
+default_only_runtime="$WORK_DIR/default-only-runtime"
+cat > "$default_only_runtime" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  runtime-config-get-int|runtime-config-get-str)
+    printf '%s\n' "${4:?}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$default_only_runtime"
+unset VG_TEST_MODE
+got=$(VIBEGUARD_RUNTIME="$default_only_runtime" vg_config_get_str VG_TEST_MODE write_mode warn)
+[[ "$got" == "block" ]] && green "vg_config_get_str rejects runtimes that cannot read JSON values" || { red "vg_config_get_str default-only runtime fallback (got: $got)"; FAIL=$((FAIL + 1)); }
+TOTAL=$((TOTAL + 1)); [[ "$got" == "block" ]] && PASS=$((PASS + 1))
+
+assert_not_contains "$(sed -n '1,180p' hooks/_lib/config.sh)" "python3" "runtime config helper no longer shells out to python3"
+
 hook_test_finish

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -171,6 +171,16 @@ static COMMANDS: &[Command] = &[
         handler: runtime_policy::runtime_policy_diag,
     },
     Command {
+        name: "runtime-config-get-int",
+        usage: "<env-name> <json-path> <default>  — read an integer from runtime config",
+        handler: runtime_config::runtime_config_get_int,
+    },
+    Command {
+        name: "runtime-config-get-str",
+        usage: "<env-name> <json-path> <default>  — read a string from runtime config",
+        handler: runtime_config::runtime_config_get_str,
+    },
+    Command {
         name: "pre-write-check",
         usage: "<base-limit> [warn-limit]  — classify PreToolUse(Write) input for hooks",
         handler: hook_checks::pre_write_check,

--- a/vibeguard-runtime/src/runtime_config.rs
+++ b/vibeguard-runtime/src/runtime_config.rs
@@ -1,5 +1,7 @@
+use crate::HandlerResult;
+use serde_json::Value;
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeConfigError {
@@ -55,4 +57,133 @@ pub fn validate_runtime_config_file(path_text: &str) -> Result<(), RuntimeConfig
     })?;
 
     Ok(())
+}
+
+pub fn runtime_config_get_int(args: &[String]) -> HandlerResult {
+    if args.len() != 3 {
+        return Err(
+            "Usage: vibeguard-runtime runtime-config-get-int <env-name> <json-path> <default>"
+                .into(),
+        );
+    }
+
+    let env_name = &args[0];
+    let json_path = &args[1];
+    let default_value = &args[2];
+
+    if let Some(value) = std::env::var(env_name)
+        .ok()
+        .filter(|value| is_nonnegative_digits(value))
+    {
+        println!("{value}");
+        return Ok(());
+    }
+
+    if let Some(value) = load_runtime_config_value(json_path) {
+        if let Some(number) = value.as_u64() {
+            println!("{number}");
+            return Ok(());
+        }
+    }
+
+    println!("{default_value}");
+    Ok(())
+}
+
+pub fn runtime_config_get_str(args: &[String]) -> HandlerResult {
+    if args.len() != 3 {
+        return Err(
+            "Usage: vibeguard-runtime runtime-config-get-str <env-name> <json-path> <default>"
+                .into(),
+        );
+    }
+
+    let env_name = &args[0];
+    let json_path = &args[1];
+    let default_value = &args[2];
+
+    if let Some(value) = std::env::var(env_name)
+        .ok()
+        .filter(|value| !value.is_empty())
+    {
+        println!("{value}");
+        return Ok(());
+    }
+
+    if let Some(value) = load_runtime_config_value(json_path) {
+        if let Some(text) = value.as_str().filter(|text| !text.is_empty()) {
+            println!("{text}");
+            return Ok(());
+        }
+    }
+
+    println!("{default_value}");
+    Ok(())
+}
+
+fn load_runtime_config_value(json_path: &str) -> Option<Value> {
+    let path = runtime_config_file();
+    if !path.is_file() {
+        return None;
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<Value>(&text).ok()?;
+    value_at_path(&value, json_path).cloned()
+}
+
+fn runtime_config_file() -> PathBuf {
+    if let Ok(path) = std::env::var("_VG_CONFIG_FILE") {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    if let Ok(path) = std::env::var("VIBEGUARD_CONFIG_FILE") {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    if let Ok(log_dir) = std::env::var("VIBEGUARD_LOG_DIR") {
+        if !log_dir.is_empty() {
+            return PathBuf::from(log_dir).join("config.json");
+        }
+    }
+    PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+        .join(".vibeguard")
+        .join("config.json")
+}
+
+fn is_nonnegative_digits(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn value_at_path<'a>(value: &'a Value, json_path: &str) -> Option<&'a Value> {
+    let mut node = value;
+    for key in json_path.split('.') {
+        let object = node.as_object()?;
+        node = object.get(key)?;
+    }
+    Some(node)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn nonnegative_digits_rejects_empty_signed_and_alpha_values() {
+        assert!(is_nonnegative_digits("0"));
+        assert!(is_nonnegative_digits("123"));
+        assert!(!is_nonnegative_digits(""));
+        assert!(!is_nonnegative_digits("-1"));
+        assert!(!is_nonnegative_digits("12x"));
+    }
+
+    #[test]
+    fn value_at_path_reads_nested_objects_only() {
+        let value = json!({"u16":{"limit":1234},"items":[1]});
+        assert_eq!(value_at_path(&value, "u16.limit"), Some(&json!(1234)));
+        assert_eq!(value_at_path(&value, "u16.missing"), None);
+        assert_eq!(value_at_path(&value, "items.0"), None);
+    }
 }

--- a/vibeguard-runtime/tests/runtime_config_cli.rs
+++ b/vibeguard-runtime/tests/runtime_config_cli.rs
@@ -1,0 +1,189 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+}
+
+fn runtime_config_temp_dir(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "vibeguard-runtime-config-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+#[test]
+fn runtime_config_get_int_preserves_env_json_default_order() {
+    let dir = runtime_config_temp_dir("int");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let config = dir.join("config.json");
+    fs::write(&config, r#"{"u16":{"limit":1234}}"#).expect("runtime config should be written");
+
+    let json = bin()
+        .arg("runtime-config-get-int")
+        .arg("VG_TEST_LIMIT")
+        .arg("u16.limit")
+        .arg("800")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env_remove("VG_TEST_LIMIT")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(json.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&json.stdout).trim(), "1234");
+
+    let env_override = bin()
+        .arg("runtime-config-get-int")
+        .arg("VG_TEST_LIMIT")
+        .arg("u16.limit")
+        .arg("800")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env("VG_TEST_LIMIT", "999")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(String::from_utf8_lossy(&env_override.stdout).trim(), "999");
+
+    let bad_env = bin()
+        .arg("runtime-config-get-int")
+        .arg("VG_TEST_LIMIT")
+        .arg("u16.limit")
+        .arg("800")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env("VG_TEST_LIMIT", "not-a-number")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(String::from_utf8_lossy(&bad_env.stdout).trim(), "1234");
+
+    let missing = bin()
+        .arg("runtime-config-get-int")
+        .arg("VG_TEST_LIMIT")
+        .arg("u16.missing")
+        .arg("800")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env_remove("VG_TEST_LIMIT")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(String::from_utf8_lossy(&missing.stdout).trim(), "800");
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn runtime_config_get_int_defaults_for_parse_errors_and_wrong_types() {
+    let dir = runtime_config_temp_dir("int_defaults");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let config = dir.join("config.json");
+
+    for body in [
+        r#"{"u16":{"limit":"oops"}}"#,
+        r#"{"u16":{"limit":true}}"#,
+        r#"{"u16":{"limit":-1}}"#,
+        r#"{"u16":{"limit":12.5}}"#,
+        r#"{"u16":{"limit":"#,
+    ] {
+        fs::write(&config, body).expect("runtime config should be written");
+        let output = bin()
+            .arg("runtime-config-get-int")
+            .arg("VG_TEST_LIMIT")
+            .arg("u16.limit")
+            .arg("800")
+            .env("VIBEGUARD_CONFIG_FILE", &config)
+            .env_remove("VG_TEST_LIMIT")
+            .output()
+            .expect("runtime config command should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "800");
+    }
+
+    fs::write(&config, r#"{"u16":{"limit":9223372036854775808}}"#)
+        .expect("runtime config should be written");
+    let output = bin()
+        .arg("runtime-config-get-int")
+        .arg("VG_TEST_LIMIT")
+        .arg("u16.limit")
+        .arg("800")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env_remove("VG_TEST_LIMIT")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "9223372036854775808"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn runtime_config_get_str_preserves_env_json_default_order() {
+    let dir = runtime_config_temp_dir("str");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let config = dir.join("config.json");
+    fs::write(&config, r#"{"write_mode":"block"}"#).expect("runtime config should be written");
+
+    let json = bin()
+        .arg("runtime-config-get-str")
+        .arg("VG_TEST_MODE")
+        .arg("write_mode")
+        .arg("warn")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env_remove("VG_TEST_MODE")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(json.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&json.stdout).trim(), "block");
+
+    let env_override = bin()
+        .arg("runtime-config-get-str")
+        .arg("VG_TEST_MODE")
+        .arg("write_mode")
+        .arg("warn")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env("VG_TEST_MODE", "warn")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(String::from_utf8_lossy(&env_override.stdout).trim(), "warn");
+
+    let missing = bin()
+        .arg("runtime-config-get-str")
+        .arg("VG_TEST_MODE")
+        .arg("missing")
+        .arg("warn")
+        .env("VIBEGUARD_CONFIG_FILE", &config)
+        .env_remove("VG_TEST_MODE")
+        .output()
+        .expect("runtime config command should run");
+    assert_eq!(String::from_utf8_lossy(&missing.stdout).trim(), "warn");
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn runtime_config_get_str_defaults_for_parse_errors_wrong_types_and_empty_strings() {
+    let dir = runtime_config_temp_dir("str_defaults");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let config = dir.join("config.json");
+
+    for body in [
+        r#"{"write_mode":""}"#,
+        r#"{"write_mode":true}"#,
+        r#"{"write_mode":12}"#,
+        r#"{"write_mode":"#,
+    ] {
+        fs::write(&config, body).expect("runtime config should be written");
+        let output = bin()
+            .arg("runtime-config-get-str")
+            .arg("VG_TEST_MODE")
+            .arg("write_mode")
+            .arg("warn")
+            .env("VIBEGUARD_CONFIG_FILE", &config)
+            .env_remove("VG_TEST_MODE")
+            .output()
+            .expect("runtime config command should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "warn");
+    }
+    let _ = fs::remove_dir_all(dir);
+}


### PR DESCRIPTION
## Summary

- add `runtime-config-get-int` and `runtime-config-get-str` commands to `vibeguard-runtime`
- route `hooks/_lib/config.sh` JSON reads through those runtime commands instead of inline Python
- reject runtimes that expose the commands but cannot read actual JSON values
- add Rust CLI parity tests and shell regressions for stale/default-only runtimes

Refs #381

## Verification

- `cargo build --manifest-path vibeguard-runtime/Cargo.toml --release`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test runtime_config_cli`
- `bash tests/hooks/test_runtime_config.sh`
- `bash tests/hooks/test_u16_config.sh`
- `bash tests/hooks/test_runtime_policy.sh`
- `bash tests/test_codex_runtime.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --all -- --check`
- `git diff --check`