### PR TITLE
Add low-cardinality Prometheus export

### DIFF
--- a/scripts/metrics/metrics-exporter.sh
+++ b/scripts/metrics/metrics-exporter.sh
@@ -8,6 +8,7 @@
 # bash metrics-exporter.sh # Output to stdout
 # bash metrics-exporter.sh --push <gateway> # Push to Pushgateway
 # bash metrics-exporter.sh --file <path> # Write textfile
+# bash metrics-exporter.sh --project <path-or-hash> # Export one project's metrics
 
 set -euo pipefail
 
@@ -19,6 +20,7 @@ DAYS=7
 SINCE=""
 SCOPE="global"
 INPUT_FILE=""
+PROJECT=""
 
 resolve_runtime() {
   if [[ -n "${VIBEGUARD_RUNTIME:-}" ]]; then
@@ -54,6 +56,7 @@ while [[ $# -gt 0 ]]; do
     --since) SINCE="${2:?--since requires a value}"; shift 2 ;;
     --scope) SCOPE="${2:?--scope requires a value}"; shift 2 ;;
     --input-file) INPUT_FILE="${2:?--input-file requires a value}"; shift 2 ;;
+    --project) PROJECT="${2:?--project requires a value}"; shift 2 ;;
     *) printf 'Unknown option: %s\n' "$1" >&2; exit 2 ;;
   esac
 done
@@ -74,6 +77,10 @@ CMD=(
 
 if [[ -n "${INPUT_FILE}" ]]; then
   CMD+=(--input-file "${INPUT_FILE}")
+fi
+
+if [[ -n "${PROJECT}" ]]; then
+  CMD+=(--project "${PROJECT}")
 fi
 
 if [[ -n "${OUTPUT_FILE}" && -z "${PUSH_URL}" ]]; then

--- a/scripts/metrics/metrics-exporter.sh
+++ b/scripts/metrics/metrics-exporter.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # VibeGuard — Prometheus metrics export
 #
-# Read events.jsonl and output Prometheus text format indicators.
+# Export events.jsonl as Prometheus text format indicators.
 # Support pushing to Pushgateway or writing to textfile collector.
 #
 # Usage:
@@ -11,118 +11,77 @@
 
 set -euo pipefail
 
-LOG_DIR="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}"
-LOG_FILE="${LOG_DIR}/events.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 PUSH_URL=""
 OUTPUT_FILE=""
 DAYS=7
+SINCE=""
+SCOPE="global"
+INPUT_FILE=""
+
+resolve_runtime() {
+  if [[ -n "${VIBEGUARD_RUNTIME:-}" ]]; then
+    printf '%s\n' "${VIBEGUARD_RUNTIME}"
+    return 0
+  fi
+
+  local candidate
+  for candidate in \
+    "${REPO_DIR}/vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  if command -v vibeguard-runtime >/dev/null 2>&1; then
+    command -v vibeguard-runtime
+    return 0
+  fi
+
+  printf '%s\n' "vibeguard-runtime not found. Run cargo build --manifest-path vibeguard-runtime/Cargo.toml or setup.sh." >&2
+  return 2
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --push) PUSH_URL="$2"; shift 2 ;;
-    --file) OUTPUT_FILE="$2"; shift 2 ;;
-    --days) DAYS="$2"; shift 2 ;;
-    *) shift ;;
+    --push) PUSH_URL="${2:?--push requires a value}"; shift 2 ;;
+    --file) OUTPUT_FILE="${2:?--file requires a value}"; shift 2 ;;
+    --days) DAYS="${2:?--days requires a value}"; shift 2 ;;
+    --since) SINCE="${2:?--since requires a value}"; shift 2 ;;
+    --scope) SCOPE="${2:?--scope requires a value}"; shift 2 ;;
+    --input-file) INPUT_FILE="${2:?--input-file requires a value}"; shift 2 ;;
+    *) printf 'Unknown option: %s\n' "$1" >&2; exit 2 ;;
   esac
 done
 
-if [[ ! -f "$LOG_FILE" ]]; then
-  echo "# Log file does not exist: ${LOG_FILE}" >&2
-  exit 0
+if [[ -z "${SINCE}" ]]; then
+  SINCE="${DAYS}d"
 fi
 
-# Generate Prometheus metrics
-METRICS=$(python3 -c "
-import json, sys
-from collections import defaultdict
-from datetime import datetime, timezone, timedelta
+RUNTIME="$(resolve_runtime)"
+CMD=(
+  "${RUNTIME}"
+  observe
+  export
+  prometheus
+  --scope "${SCOPE}"
+  --since "${SINCE}"
+)
 
-log_file = '${LOG_FILE}'
-days = ${DAYS}
-cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+if [[ -n "${INPUT_FILE}" ]]; then
+  CMD+=(--input-file "${INPUT_FILE}")
+fi
 
-# counter
-hook_total = defaultdict(int)       # {(hook, decision): count}
-tool_total = defaultdict(int)       # {tool: count}
-duration_sum = defaultdict(float)   # {hook: sum_ms}
-duration_count = defaultdict(int)   # {hook: count}
-violation_total = defaultdict(int)  # {reason: count}
-
-total_events = 0
-
-with open(log_file, encoding='utf-8', errors='replace') as f:
-    for line in f:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        ts = event.get('ts', '')
-        try:
-            event_time = datetime.fromisoformat(ts.replace('Z', '+00:00'))
-            if event_time < cutoff:
-                continue
-        except (ValueError, AttributeError):
-            continue
-
-        total_events += 1
-        hook = event.get('hook', 'unknown')
-        tool = event.get('tool', 'unknown')
-        decision = event.get('decision', 'unknown')
-        reason = event.get('reason', '')
-        duration = event.get('duration_ms')
-
-        hook_total[(hook, decision)] += 1
-        tool_total[tool] += 1
-
-        if duration is not None:
-            duration_sum[hook] += float(duration) / 1000.0
-            duration_count[hook] += 1
-
-        if decision in ('warn', 'block', 'gate'):
-            violation_total[reason or 'unspecified'] += 1
-
-# Output Prometheus format
-print('# HELP vibeguard_hook_trigger_total Total hook triggers by hook and decision')
-print('# TYPE vibeguard_hook_trigger_total counter')
-for (hook, decision), count in sorted(hook_total.items()):
-    print(f'vibeguard_hook_trigger_total{{hook=\"{hook}\",decision=\"{decision}\"}} {count}')
-
-print()
-print('# HELP vibeguard_tool_total Total events by tool type')
-print('# TYPE vibeguard_tool_total counter')
-for tool, count in sorted(tool_total.items()):
-    print(f'vibeguard_tool_total{{tool=\"{tool}\"}} {count}')
-
-print()
-print('# HELP vibeguard_hook_duration_seconds Total hook execution duration in seconds')
-print('# TYPE vibeguard_hook_duration_seconds summary')
-for hook in sorted(duration_sum.keys()):
-    print(f'vibeguard_hook_duration_seconds_sum{{hook=\"{hook}\"}} {duration_sum[hook]:.3f}')
-    print(f'vibeguard_hook_duration_seconds_count{{hook=\"{hook}\"}} {duration_count[hook]}')
-
-print()
-print('# HELP vibeguard_guard_violation_total Total guard violations by reason')
-print('# TYPE vibeguard_guard_violation_total counter')
-for reason, count in sorted(violation_total.items()):
-    safe_reason = reason.replace('\"', '').replace('\\\\', '').replace('\n', ' ').replace('\r', '')[:80]
-    print(f'vibeguard_guard_violation_total{{reason=\"{safe_reason}\"}} {count}')
-
-print()
-print('# HELP vibeguard_events_total Total events in period')
-print('# TYPE vibeguard_events_total gauge')
-print(f'vibeguard_events_total {total_events}')
-")
-
-if [[ -n "$OUTPUT_FILE" ]]; then
-  echo "$METRICS" > "$OUTPUT_FILE"
+if [[ -n "${OUTPUT_FILE}" && -z "${PUSH_URL}" ]]; then
+  "${CMD[@]}" --file "${OUTPUT_FILE}"
   echo "Indicator written: ${OUTPUT_FILE}"
-elif [[ -n "$PUSH_URL" ]]; then
-  echo "$METRICS" | curl --silent --data-binary @- "${PUSH_URL}/metrics/job/vibeguard"
+elif [[ -n "${PUSH_URL}" ]]; then
+  "${CMD[@]}" | curl --silent --data-binary @- "${PUSH_URL}/metrics/job/vibeguard"
   echo "The indicator has been pushed to: ${PUSH_URL}"
 else
-  echo "$METRICS"
+  "${CMD[@]}"
 fi

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -40,6 +40,19 @@ assert_not_contains() {
   fi
 }
 
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 TMP_DIR="$(mktemp -d)"
 cleanup() {
   rm -rf "${TMP_DIR}"
@@ -150,6 +163,52 @@ assert_contains "${stats_out}" "Interception (block): 1 times" "Block count incl
 assert_contains "${stats_out}" "Warning: 1 times" "Warn count is correct"
 assert_contains "${stats_out}" "pre-bash-guard: 2 times" "Hook aggregation remains correct"
 assert_contains "${stats_out}" "post-edit-guard: 1 times" "Secondary hook aggregation remains correct"
+
+header "Prometheus exporter uses low-cardinality labels"
+RUNTIME="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+EXPORTER="${REPO_DIR}/scripts/metrics/metrics-exporter.sh"
+assert_cmd "vibeguard-runtime builds for exporter wrapper" \
+  cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml"
+
+mkdir -p "${TMP_DIR}/prom-log"
+python3 - "${TMP_DIR}/prom-log/events.jsonl" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+events = [
+    {
+        "ts": "2026-05-31T00:00:00Z",
+        "session": "secret-session",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "reason": "U-16 block for customer@example.com command cargo test -- --ignored",
+        "detail": "Edit /Users/alice/project/src/private_token.rs",
+        "duration_ms": 250,
+    }
+]
+with open(path, "w", encoding="utf-8") as f:
+    for event in events:
+        f.write(json.dumps(event) + "\n")
+PY
+
+prom_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-log" VIBEGUARD_RUNTIME="${RUNTIME}" bash "${EXPORTER}" --since all 2>&1)"
+assert_contains "${prom_out}" "vibeguard_event_total" "Prometheus event counter is emitted"
+assert_contains "${prom_out}" 'rule_id="U-16"' "Rule id is derived safely"
+assert_contains "${prom_out}" 'reason_code="rule_violation"' "Reason code is derived safely"
+assert_contains "${prom_out}" 'file_ext="rs"' "File extension is derived safely"
+assert_contains "${prom_out}" "vibeguard_hook_duration_seconds_sum" "Duration summary is emitted"
+assert_not_contains "${prom_out}" "secret-session" "Session id is not exported as a label"
+assert_not_contains "${prom_out}" "customer@example.com" "Raw reason content is absent"
+assert_not_contains "${prom_out}" "cargo test -- --ignored" "Raw command-like reason content is absent"
+assert_not_contains "${prom_out}" "/Users/alice" "Full path detail is absent"
+assert_not_contains "${prom_out}" "private_token" "Raw filename detail is absent"
+
+prom_file="${TMP_DIR}/metrics.prom"
+file_msg="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-log" VIBEGUARD_RUNTIME="${RUNTIME}" bash "${EXPORTER}" --since all --file "${prom_file}" 2>&1)"
+assert_contains "${file_msg}" "Indicator written: ${prom_file}" "Exporter --file still writes textfile output"
+assert_contains "$(cat "${prom_file}")" "vibeguard_guard_violation_total" "Textfile output contains metrics"
 
 echo
 echo "=============================="

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -238,6 +238,15 @@ assert_contains "${project_prom_out}" 'vibeguard_tool_total{tool="Bash"} 1' "Exp
 assert_contains "${project_prom_out}" 'reason_code="dangerous_command"' "Project exporter output preserves derived labels"
 assert_not_contains "${project_prom_out}" "git push --force" "Project exporter output avoids raw command detail"
 
+missing_prom_file="${TMP_DIR}/missing.prom"
+set +e
+missing_export_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-missing-log" VIBEGUARD_RUNTIME="${RUNTIME}" bash "${EXPORTER}" --since all --file "${missing_prom_file}" 2>&1)"
+missing_export_status=$?
+set -e
+assert_cmd "Exporter missing log exits nonzero" test "${missing_export_status}" -ne 0
+assert_contains "${missing_export_out}" "Log file does not exist" "Exporter missing log reports the missing log"
+assert_cmd "Exporter missing log does not create textfile output" test ! -e "${missing_prom_file}"
+
 echo
 echo "=============================="
 printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -211,6 +211,33 @@ file_msg="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-log" VIBEGUARD_RUNTIME="${RUNTIME
 assert_contains "${file_msg}" "Indicator written: ${prom_file}" "Exporter --file still writes textfile output"
 assert_contains "$(cat "${prom_file}")" "vibeguard_guard_violation_total" "Textfile output contains metrics"
 
+project_root="${TMP_DIR}/prom-project"
+project_log_dir="${TMP_DIR}/prom-project-log/projects/abcdef12"
+mkdir -p "${project_root}" "${project_log_dir}"
+printf '%s\n' "${project_root}" > "${project_log_dir}/.project-root"
+python3 - "${project_log_dir}/events.jsonl" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+event = {
+    "ts": "2026-05-31T00:00:00Z",
+    "hook": "pre-bash-guard",
+    "tool": "Bash",
+    "decision": "block",
+    "reason": "force push denied",
+    "detail": "git push --force",
+}
+with open(path, "w", encoding="utf-8") as f:
+    f.write(json.dumps(event) + "\n")
+PY
+
+project_prom_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-project-log" VIBEGUARD_RUNTIME="${RUNTIME}" bash "${EXPORTER}" --since all --project "${project_root}" 2>&1)"
+assert_contains "${project_prom_out}" "vibeguard_events_total 1" "Exporter --project reads mapped project log"
+assert_contains "${project_prom_out}" 'vibeguard_tool_total{tool="Bash"} 1' "Exporter --project forwards project to runtime"
+assert_contains "${project_prom_out}" 'reason_code="dangerous_command"' "Project exporter output preserves derived labels"
+assert_not_contains "${project_prom_out}" "git push --force" "Project exporter output avoids raw command detail"
+
 echo
 echo "=============================="
 printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -195,6 +195,7 @@ PY
 
 prom_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-log" VIBEGUARD_RUNTIME="${RUNTIME}" bash "${EXPORTER}" --since all 2>&1)"
 assert_contains "${prom_out}" "vibeguard_event_total" "Prometheus event counter is emitted"
+assert_contains "${prom_out}" 'vibeguard_tool_total{tool="Edit"} 1' "Legacy tool counter is preserved"
 assert_contains "${prom_out}" 'rule_id="U-16"' "Rule id is derived safely"
 assert_contains "${prom_out}" 'reason_code="rule_violation"' "Reason code is derived safely"
 assert_contains "${prom_out}" 'file_ext="rs"' "File extension is derived safely"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -184,7 +184,7 @@ events = [
         "tool": "Edit",
         "decision": "warn",
         "reason": "U-16 block for customer@example.com command cargo test -- --ignored",
-        "detail": "Edit /Users/alice/project/src/private_token.rs",
+        "detail": "Edit /var/tmp/vibeguard/project/src/private_token.rs",
         "duration_ms": 250,
     }
 ]
@@ -202,7 +202,7 @@ assert_contains "${prom_out}" "vibeguard_hook_duration_seconds_sum" "Duration su
 assert_not_contains "${prom_out}" "secret-session" "Session id is not exported as a label"
 assert_not_contains "${prom_out}" "customer@example.com" "Raw reason content is absent"
 assert_not_contains "${prom_out}" "cargo test -- --ignored" "Raw command-like reason content is absent"
-assert_not_contains "${prom_out}" "/Users/alice" "Full path detail is absent"
+assert_not_contains "${prom_out}" "/var/tmp/vibeguard" "Full path detail is absent"
 assert_not_contains "${prom_out}" "private_token" "Raw filename detail is absent"
 
 prom_file="${TMP_DIR}/metrics.prom"

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -19,6 +19,7 @@ mod json_field;
 mod log_append;
 mod log_query;
 mod log_scope;
+mod observe;
 mod pkg_rewrite;
 mod runtime_config;
 mod runtime_policy;
@@ -96,6 +97,11 @@ static COMMANDS: &[Command] = &[
         name: "session-metrics",
         usage: "<session> <dir>  — emit session metrics and correction signals",
         handler: session_metrics::run,
+    },
+    Command {
+        name: "observe",
+        usage: "export prometheus [--scope project|global] [--project PATH_OR_HASH] [--since 7d|24h|3600s|all] [--file OUTPUT]  — export low-cardinality observability metrics",
+        handler: observe::run,
     },
     Command {
         name: "hook-status",

--- a/vibeguard-runtime/src/observe.rs
+++ b/vibeguard-runtime/src/observe.rs
@@ -229,12 +229,21 @@ impl Aggregates {
                 .or_default() += 1;
         }
 
-        if let Some(duration_ms) = event.get(field::DURATION_MS).and_then(Value::as_f64) {
-            if duration_ms >= 0.0 {
-                *self.duration_sum.entry(hook.clone()).or_default() += duration_ms / 1000.0;
-                *self.duration_count.entry(hook).or_default() += 1;
-            }
+        if let Some(duration_ms) = duration_ms_value(event) {
+            *self.duration_sum.entry(hook.clone()).or_default() += duration_ms / 1000.0;
+            *self.duration_count.entry(hook).or_default() += 1;
         }
+    }
+}
+
+fn duration_ms_value(event: &Value) -> Option<f64> {
+    match event.get(field::DURATION_MS)? {
+        Value::Number(value) => value.as_f64().filter(|duration_ms| *duration_ms >= 0.0),
+        Value::String(value) => value
+            .parse::<u64>()
+            .ok()
+            .map(|duration_ms| duration_ms as f64),
+        _ => None,
     }
 }
 
@@ -513,6 +522,13 @@ mod tests {
         render_prometheus(io::Cursor::new(input), Some(0)).unwrap()
     }
 
+    fn render_since(input: &str, cutoff_secs: u64) -> String {
+        match render_prometheus(io::Cursor::new(input), Some(cutoff_secs)) {
+            Ok(output) => output,
+            Err(err) => panic!("failed to render prometheus metrics: {err}"),
+        }
+    }
+
     #[test]
     fn prometheus_export_uses_safe_derived_labels() {
         let input = concat!(
@@ -566,5 +582,39 @@ mod tests {
         assert!(out.contains("file_ext=\"none\""));
         assert!(!out.contains("deploy-prod"));
         assert!(!out.contains("abc123"));
+    }
+
+    #[test]
+    fn selected_period_accepts_fractional_and_offset_timestamps() {
+        let input = concat!(
+            "{\"ts\":\"1970-01-01T00:01:00.123Z\",",
+            "\"hook\":\"fractional\",\"tool\":\"Bash\",\"decision\":\"pass\"}\n",
+            "{\"ts\":\"1970-01-01T01:01:00+01:00\",",
+            "\"hook\":\"offset\",\"tool\":\"Bash\",\"decision\":\"pass\"}\n",
+            "{\"ts\":\"1970-01-01T00:00:59.999Z\",",
+            "\"hook\":\"old\",\"tool\":\"Bash\",\"decision\":\"pass\"}\n"
+        );
+        let out = render_since(input, 60);
+
+        assert!(out.contains("vibeguard_events_total 2"));
+        assert!(out.contains("hook=\"fractional\""));
+        assert!(out.contains("hook=\"offset\""));
+        assert!(!out.contains("hook=\"old\""));
+    }
+
+    #[test]
+    fn duration_summary_counts_integer_string_duration_ms() {
+        let input = concat!(
+            "{\"ts\":\"2026-05-31T00:00:00Z\",",
+            "\"hook\":\"pre-bash-guard\",\"tool\":\"Bash\",\"decision\":\"pass\",",
+            "\"duration_ms\":250}\n",
+            "{\"ts\":\"2026-05-31T00:00:01Z\",",
+            "\"hook\":\"pre-bash-guard\",\"tool\":\"Bash\",\"decision\":\"pass\",",
+            "\"duration_ms\":\"750\"}\n"
+        );
+        let out = render(input);
+
+        assert!(out.contains("vibeguard_hook_duration_seconds_sum{hook=\"pre-bash-guard\"} 1.000"));
+        assert!(out.contains("vibeguard_hook_duration_seconds_count{hook=\"pre-bash-guard\"} 2"));
     }
 }

--- a/vibeguard-runtime/src/observe.rs
+++ b/vibeguard-runtime/src/observe.rs
@@ -84,6 +84,7 @@ impl ObserveArgs {
                 }
                 "--project" => {
                     project = Some(require_value(args, i, "--project")?);
+                    scope = LogScope::Project;
                     i += 2;
                 }
                 "--since" => {

--- a/vibeguard-runtime/src/observe.rs
+++ b/vibeguard-runtime/src/observe.rs
@@ -150,7 +150,9 @@ fn parse_since(value: &str) -> Result<Option<u64>> {
 fn render_prometheus_from_path(path: &Path, cutoff_secs: Option<u64>) -> Result<String> {
     match File::open(path) {
         Ok(file) => render_prometheus(file, cutoff_secs),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            Err(format!("Log file does not exist: {}", path.display()).into())
+        }
         Err(e) => Err(e.into()),
     }
 }

--- a/vibeguard-runtime/src/observe.rs
+++ b/vibeguard-runtime/src/observe.rs
@@ -519,7 +519,7 @@ mod tests {
             "{\"ts\":\"2026-05-31T00:00:00Z\",\"session\":\"secret-session\",",
             "\"hook\":\"post-edit-guard\",\"tool\":\"Edit\",\"decision\":\"warn\",",
             "\"reason\":\"U-16 block for customer@example.com command cargo test -- --ignored\",",
-            "\"detail\":\"Edit /Users/alice/project/src/private_token.rs\",",
+            "\"detail\":\"Edit /var/tmp/vibeguard/project/src/private_token.rs\",",
             "\"duration_ms\":250}\n"
         );
         let out = render(input);
@@ -533,7 +533,7 @@ mod tests {
             "secret-session",
             "customer@example.com",
             "cargo test -- --ignored",
-            "/Users/alice",
+            "/var/tmp/vibeguard",
             "private_token",
         ] {
             assert!(

--- a/vibeguard-runtime/src/observe.rs
+++ b/vibeguard-runtime/src/observe.rs
@@ -28,6 +28,7 @@ struct ObserveArgs {
 struct Aggregates {
     total_events: u64,
     hook_total: BTreeMap<(String, String), u64>,
+    tool_total: BTreeMap<String, u64>,
     event_total: BTreeMap<(String, String, String, String, String, String, String), u64>,
     violation_total: BTreeMap<(String, String, String, String, String, String), u64>,
     duration_sum: BTreeMap<String, f64>,
@@ -203,6 +204,7 @@ impl Aggregates {
             .hook_total
             .entry((hook.clone(), event_decision.clone()))
             .or_default() += 1;
+        *self.tool_total.entry(tool.clone()).or_default() += 1;
         *self
             .event_total
             .entry((
@@ -403,6 +405,22 @@ fn render_aggregates(aggr: &Aggregates) -> String {
     out.push('\n');
     push_header(
         &mut out,
+        "vibeguard_tool_total",
+        "Total events by tool type",
+        "counter",
+    );
+    for (tool, count) in &aggr.tool_total {
+        push_metric(
+            &mut out,
+            "vibeguard_tool_total",
+            &[("tool", tool)],
+            &count.to_string(),
+        );
+    }
+
+    out.push('\n');
+    push_header(
+        &mut out,
         "vibeguard_event_total",
         "Total VibeGuard events by low-cardinality labels",
         "counter",
@@ -542,6 +560,7 @@ mod tests {
         let out = render(input);
 
         assert!(out.contains("vibeguard_event_total"));
+        assert!(out.contains("vibeguard_tool_total{tool=\"Edit\"} 1"));
         assert!(out.contains("rule_id=\"U-16\""));
         assert!(out.contains("reason_code=\"rule_violation\""));
         assert!(out.contains("file_ext=\"rs\""));

--- a/vibeguard-runtime/src/observe.rs
+++ b/vibeguard-runtime/src/observe.rs
@@ -1,0 +1,570 @@
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::{self, BufRead, Read};
+use std::path::{Path, PathBuf};
+
+use crate::event_schema::{UNKNOWN, decision, field};
+use crate::log_scope::{LogScope, LogScopeOptions, parse_scope, resolve_log_file};
+use crate::time_utils;
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+const DEFAULT_SINCE_SECS: u64 = 7 * 24 * 60 * 60;
+const KNOWN_EXTS: &[&str] = &[
+    "rs", "py", "ts", "js", "mjs", "cjs", "tsx", "jsx", "go", "java", "kt", "swift", "rb", "sh",
+    "md", "json", "toml", "yaml", "yml", "txt", "lock",
+];
+
+struct ObserveArgs {
+    scope: LogScope,
+    project: Option<String>,
+    since_secs: Option<u64>,
+    output_file: Option<PathBuf>,
+    input_file: Option<PathBuf>,
+}
+
+#[derive(Default)]
+struct Aggregates {
+    total_events: u64,
+    hook_total: BTreeMap<(String, String), u64>,
+    event_total: BTreeMap<(String, String, String, String, String, String, String), u64>,
+    violation_total: BTreeMap<(String, String, String, String, String, String), u64>,
+    duration_sum: BTreeMap<String, f64>,
+    duration_count: BTreeMap<String, u64>,
+}
+
+pub fn run(args: &[String]) -> Result {
+    let opts = ObserveArgs::from_cli_args(args)?;
+    let input_path = match opts.input_file.clone() {
+        Some(path) => path,
+        None => {
+            resolve_log_file(&LogScopeOptions {
+                scope: opts.scope,
+                project: opts.project.clone(),
+                log_file: None,
+                allow_env_log_file: true,
+            })?
+            .path
+        }
+    };
+
+    let cutoff_secs = opts
+        .since_secs
+        .map(|secs| time_utils::now_unix_secs().saturating_sub(secs));
+    let metrics = render_prometheus_from_path(&input_path, cutoff_secs)?;
+
+    match opts.output_file {
+        Some(path) => fs::write(path, metrics)?,
+        None => {
+            print!("{metrics}");
+        }
+    }
+    Ok(())
+}
+
+impl ObserveArgs {
+    fn from_cli_args(args: &[String]) -> Result<Self> {
+        if args.len() < 2 || args[0] != "export" || args[1] != "prometheus" {
+            return Err("Usage: vibeguard-runtime observe export prometheus [--scope project|global] [--project PATH_OR_HASH] [--since 7d|24h|3600s|all] [--file OUTPUT] [--input-file EVENTS_JSONL]".into());
+        }
+
+        let mut scope = LogScope::Global;
+        let mut project = None;
+        let mut since_secs = Some(DEFAULT_SINCE_SECS);
+        let mut output_file = None;
+        let mut input_file = None;
+        let mut i = 2;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--scope" => {
+                    let value = require_value(args, i, "--scope")?;
+                    scope = parse_scope(&value)?;
+                    i += 2;
+                }
+                "--project" => {
+                    project = Some(require_value(args, i, "--project")?);
+                    i += 2;
+                }
+                "--since" => {
+                    let value = require_value(args, i, "--since")?;
+                    since_secs = parse_since(&value)?;
+                    i += 2;
+                }
+                "--file" => {
+                    output_file = Some(PathBuf::from(require_value(args, i, "--file")?));
+                    i += 2;
+                }
+                "--input-file" => {
+                    input_file = Some(PathBuf::from(require_value(args, i, "--input-file")?));
+                    i += 2;
+                }
+                other => {
+                    return Err(format!("Unknown observe export prometheus option: {other}").into());
+                }
+            }
+        }
+
+        Ok(Self {
+            scope,
+            project,
+            since_secs,
+            output_file,
+            input_file,
+        })
+    }
+}
+
+fn require_value(args: &[String], index: usize, flag: &str) -> Result<String> {
+    args.get(index + 1)
+        .filter(|value| !value.starts_with("--"))
+        .cloned()
+        .ok_or_else(|| format!("{flag} requires a value").into())
+}
+
+fn parse_since(value: &str) -> Result<Option<u64>> {
+    let trimmed = value.trim();
+    if trimmed == "all" {
+        return Ok(None);
+    }
+    if trimmed.is_empty() {
+        return Err("--since cannot be empty".into());
+    }
+
+    let (digits, multiplier) = match trimmed.as_bytes().last().copied() {
+        Some(b'd') => (&trimmed[..trimmed.len() - 1], 24 * 60 * 60),
+        Some(b'h') => (&trimmed[..trimmed.len() - 1], 60 * 60),
+        Some(b'm') => (&trimmed[..trimmed.len() - 1], 60),
+        Some(b's') => (&trimmed[..trimmed.len() - 1], 1),
+        Some(_) => (trimmed, 1),
+        None => return Err("--since cannot be empty".into()),
+    };
+    let amount: u64 = digits
+        .parse()
+        .map_err(|_| "--since must be an integer duration such as 7d, 24h, 30m, or 3600s")?;
+    Ok(Some(amount.saturating_mul(multiplier)))
+}
+
+fn render_prometheus_from_path(path: &Path, cutoff_secs: Option<u64>) -> Result<String> {
+    match File::open(path) {
+        Ok(file) => render_prometheus(file, cutoff_secs),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn render_prometheus(reader: impl Read, cutoff_secs: Option<u64>) -> Result<String> {
+    let mut aggr = Aggregates::default();
+    let mut reader = io::BufReader::new(reader);
+    let mut bytes = Vec::new();
+
+    while reader.read_until(b'\n', &mut bytes)? != 0 {
+        let line = String::from_utf8_lossy(&bytes);
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            if let Ok(event) = serde_json::from_str::<Value>(trimmed) {
+                if event_in_selected_period(&event, cutoff_secs) {
+                    aggr.record_event(&event);
+                }
+            }
+        }
+        bytes.clear();
+    }
+
+    Ok(render_aggregates(&aggr))
+}
+
+fn event_in_selected_period(event: &Value, cutoff_secs: Option<u64>) -> bool {
+    let Some(cutoff_secs) = cutoff_secs else {
+        return true;
+    };
+    event
+        .get(field::TS)
+        .and_then(Value::as_str)
+        .and_then(time_utils::parse_iso_ts)
+        .is_some_and(|event_secs| event_secs >= cutoff_secs)
+}
+
+impl Aggregates {
+    fn record_event(&mut self, event: &Value) {
+        let hook = safe_label(field_str(event, field::HOOK), UNKNOWN);
+        let tool = safe_label(field_str(event, field::TOOL), UNKNOWN);
+        let event_decision = safe_label(field_str(event, field::DECISION), UNKNOWN);
+        let raw_reason = field_str(event, field::REASON);
+        let raw_detail = field_str(event, field::DETAIL);
+        let rule_id = derive_rule_id(raw_reason);
+        let reason_code = derive_reason_code(raw_reason, &rule_id);
+        let severity = derive_severity(&event_decision, &rule_id);
+        let file_ext = derive_file_ext(raw_detail);
+
+        self.total_events += 1;
+        *self
+            .hook_total
+            .entry((hook.clone(), event_decision.clone()))
+            .or_default() += 1;
+        *self
+            .event_total
+            .entry((
+                hook.clone(),
+                tool,
+                event_decision.clone(),
+                rule_id.clone(),
+                reason_code.clone(),
+                severity.clone(),
+                file_ext.clone(),
+            ))
+            .or_default() += 1;
+
+        if is_violation_decision(&event_decision) {
+            *self
+                .violation_total
+                .entry((
+                    hook.clone(),
+                    event_decision,
+                    rule_id,
+                    reason_code,
+                    severity,
+                    file_ext,
+                ))
+                .or_default() += 1;
+        }
+
+        if let Some(duration_ms) = event.get(field::DURATION_MS).and_then(Value::as_f64) {
+            if duration_ms >= 0.0 {
+                *self.duration_sum.entry(hook.clone()).or_default() += duration_ms / 1000.0;
+                *self.duration_count.entry(hook).or_default() += 1;
+            }
+        }
+    }
+}
+
+fn field_str<'a>(event: &'a Value, key: &str) -> &'a str {
+    event.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn is_violation_decision(value: &str) -> bool {
+    matches!(
+        value,
+        decision::WARN
+            | decision::BLOCK
+            | decision::GATE
+            | decision::ESCALATE
+            | decision::CORRECTION
+    )
+}
+
+fn safe_label(value: &str, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return fallback.to_string();
+    }
+    if trimmed.len() > 64 {
+        return "other".to_string();
+    }
+    if trimmed
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+    {
+        trimmed.to_string()
+    } else {
+        "other".to_string()
+    }
+}
+
+fn derive_rule_id(reason: &str) -> String {
+    for token in reason.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-')) {
+        let upper = token.to_ascii_uppercase();
+        if valid_rule_id(&upper) {
+            return upper;
+        }
+    }
+    "none".to_string()
+}
+
+fn valid_rule_id(token: &str) -> bool {
+    let Some((prefix, tail)) = token.split_once('-') else {
+        return false;
+    };
+    matches!(
+        prefix,
+        "U" | "W" | "SEC" | "RS" | "PY" | "TS" | "GO" | "PERF"
+    ) && !tail.is_empty()
+        && tail.len() <= 3
+        && tail.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn derive_reason_code(reason: &str, rule_id: &str) -> String {
+    let lower = reason.to_ascii_lowercase();
+    let code = if lower.trim().is_empty() {
+        "unspecified"
+    } else if lower.contains("malformed") || lower.contains("invalid json") {
+        "malformed_input"
+    } else if lower.contains("duplicate definition") {
+        "duplicate_definition"
+    } else if lower.contains("same-name") || lower.contains("same name") {
+        "same_name_duplicate"
+    } else if lower.contains("unwrap") || lower.contains("expect") {
+        "unsafe_unwrap"
+    } else if lower.contains("console.log") || lower.contains("debug") {
+        "debug_output"
+    } else if lower.contains("hardcoded")
+        || lower.contains("credential")
+        || lower.contains("secret")
+    {
+        "sensitive_literal"
+    } else if lower.contains("force push")
+        || lower.contains("checkout/restore")
+        || lower.contains("rm -rf")
+        || lower.contains("dangerous")
+    {
+        "dangerous_command"
+    } else if lower.contains("timeout") {
+        "timeout"
+    } else if lower.contains("build fail") {
+        "build_failed"
+    } else if lower.contains("pre-commit") {
+        "precommit_failed"
+    } else if lower.contains("analysis paralysis") {
+        "analysis_paralysis"
+    } else if lower.contains("test infrastructure") {
+        "test_integrity"
+    } else if lower.contains("package manager") || lower.contains("pnpm") || lower.contains("uv") {
+        "package_manager"
+    } else if rule_id != "none" {
+        "rule_violation"
+    } else {
+        "other"
+    };
+    code.to_string()
+}
+
+fn derive_severity(decision_value: &str, rule_id: &str) -> String {
+    if rule_id.starts_with("SEC-") {
+        return "critical".to_string();
+    }
+    match decision_value {
+        decision::BLOCK | decision::GATE | decision::ESCALATE => "strict",
+        decision::WARN | decision::CORRECTION => "guideline",
+        decision::PASS | decision::COMPLETE => "info",
+        _ => UNKNOWN,
+    }
+    .to_string()
+}
+
+fn derive_file_ext(detail: &str) -> String {
+    for token in
+        detail.split(|c: char| c.is_whitespace() || matches!(c, '|' | ',' | '"' | '\'' | '(' | ')'))
+    {
+        let token = token.trim_matches(|c: char| matches!(c, ':' | ';' | '[' | ']' | '{' | '}'));
+        let Some(basename) = token.rsplit('/').next() else {
+            continue;
+        };
+        let Some((_, ext)) = basename.rsplit_once('.') else {
+            continue;
+        };
+        let ext = ext.to_ascii_lowercase();
+        if KNOWN_EXTS.contains(&ext.as_str()) {
+            return ext;
+        }
+        if !ext.is_empty() && ext.len() <= 12 && ext.bytes().all(|b| b.is_ascii_alphanumeric()) {
+            return "other".to_string();
+        }
+    }
+    "none".to_string()
+}
+
+fn render_aggregates(aggr: &Aggregates) -> String {
+    let mut out = String::new();
+    push_header(
+        &mut out,
+        "vibeguard_hook_trigger_total",
+        "Total hook triggers by hook and decision",
+        "counter",
+    );
+    for ((hook, event_decision), count) in &aggr.hook_total {
+        push_metric(
+            &mut out,
+            "vibeguard_hook_trigger_total",
+            &[("hook", hook), ("decision", event_decision)],
+            &count.to_string(),
+        );
+    }
+
+    out.push('\n');
+    push_header(
+        &mut out,
+        "vibeguard_event_total",
+        "Total VibeGuard events by low-cardinality labels",
+        "counter",
+    );
+    for ((hook, tool, event_decision, rule_id, reason_code, severity, file_ext), count) in
+        &aggr.event_total
+    {
+        push_metric(
+            &mut out,
+            "vibeguard_event_total",
+            &[
+                ("hook", hook),
+                ("tool", tool),
+                ("decision", event_decision),
+                ("rule_id", rule_id),
+                ("reason_code", reason_code),
+                ("severity", severity),
+                ("file_ext", file_ext),
+            ],
+            &count.to_string(),
+        );
+    }
+
+    out.push('\n');
+    push_header(
+        &mut out,
+        "vibeguard_hook_duration_seconds",
+        "Hook execution duration in seconds",
+        "summary",
+    );
+    for (hook, sum) in &aggr.duration_sum {
+        push_metric(
+            &mut out,
+            "vibeguard_hook_duration_seconds_sum",
+            &[("hook", hook)],
+            &format!("{sum:.3}"),
+        );
+        let count = aggr.duration_count.get(hook).copied().unwrap_or(0);
+        push_metric(
+            &mut out,
+            "vibeguard_hook_duration_seconds_count",
+            &[("hook", hook)],
+            &count.to_string(),
+        );
+    }
+
+    out.push('\n');
+    push_header(
+        &mut out,
+        "vibeguard_guard_violation_total",
+        "Total guard violations by low-cardinality derived labels",
+        "counter",
+    );
+    for ((hook, event_decision, rule_id, reason_code, severity, file_ext), count) in
+        &aggr.violation_total
+    {
+        push_metric(
+            &mut out,
+            "vibeguard_guard_violation_total",
+            &[
+                ("hook", hook),
+                ("decision", event_decision),
+                ("rule_id", rule_id),
+                ("reason_code", reason_code),
+                ("severity", severity),
+                ("file_ext", file_ext),
+            ],
+            &count.to_string(),
+        );
+    }
+
+    out.push('\n');
+    push_header(
+        &mut out,
+        "vibeguard_events_total",
+        "Total events in the selected period",
+        "gauge",
+    );
+    out.push_str(&format!("vibeguard_events_total {}\n", aggr.total_events));
+    out
+}
+
+fn push_header(out: &mut String, name: &str, help: &str, metric_type: &str) {
+    out.push_str(&format!("# HELP {name} {help}\n"));
+    out.push_str(&format!("# TYPE {name} {metric_type}\n"));
+}
+
+fn push_metric(out: &mut String, name: &str, labels: &[(&str, &String)], value: &str) {
+    out.push_str(name);
+    out.push('{');
+    for (index, (label, label_value)) in labels.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str(label);
+        out.push_str("=\"");
+        out.push_str(&prometheus_escape(label_value));
+        out.push('"');
+    }
+    out.push_str("} ");
+    out.push_str(value);
+    out.push('\n');
+}
+
+fn prometheus_escape(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    fn render(input: &str) -> String {
+        render_prometheus(io::Cursor::new(input), Some(0)).unwrap()
+    }
+
+    #[test]
+    fn prometheus_export_uses_safe_derived_labels() {
+        let input = concat!(
+            "{\"ts\":\"2026-05-31T00:00:00Z\",\"session\":\"secret-session\",",
+            "\"hook\":\"post-edit-guard\",\"tool\":\"Edit\",\"decision\":\"warn\",",
+            "\"reason\":\"U-16 block for customer@example.com command cargo test -- --ignored\",",
+            "\"detail\":\"Edit /Users/alice/project/src/private_token.rs\",",
+            "\"duration_ms\":250}\n"
+        );
+        let out = render(input);
+
+        assert!(out.contains("vibeguard_event_total"));
+        assert!(out.contains("rule_id=\"U-16\""));
+        assert!(out.contains("reason_code=\"rule_violation\""));
+        assert!(out.contains("file_ext=\"rs\""));
+        assert!(out.contains("vibeguard_hook_duration_seconds_sum"));
+        for raw in [
+            "secret-session",
+            "customer@example.com",
+            "cargo test -- --ignored",
+            "/Users/alice",
+            "private_token",
+        ] {
+            assert!(
+                !out.contains(raw),
+                "raw value leaked in metrics: {raw}\n{out}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_since_supports_units_and_all() {
+        assert_eq!(parse_since("7d").unwrap(), Some(604800));
+        assert_eq!(parse_since("2h").unwrap(), Some(7200));
+        assert_eq!(parse_since("30m").unwrap(), Some(1800));
+        assert_eq!(parse_since("15s").unwrap(), Some(15));
+        assert_eq!(parse_since("42").unwrap(), Some(42));
+        assert_eq!(parse_since("all").unwrap(), None);
+    }
+
+    #[test]
+    fn unknown_freeform_reason_uses_other_code() {
+        let input = concat!(
+            "{\"ts\":\"2026-05-31T00:00:00Z\",",
+            "\"hook\":\"pre-bash-guard\",\"tool\":\"Bash\",\"decision\":\"block\",",
+            "\"reason\":\"user typed deploy-prod --token abc123\",",
+            "\"detail\":\"deploy-prod --token abc123\"}\n"
+        );
+        let out = render(input);
+        assert!(out.contains("reason_code=\"other\""));
+        assert!(out.contains("file_ext=\"none\""));
+        assert!(!out.contains("deploy-prod"));
+        assert!(!out.contains("abc123"));
+    }
+}

--- a/vibeguard-runtime/src/time_utils.rs
+++ b/vibeguard-runtime/src/time_utils.rs
@@ -18,15 +18,13 @@ pub(crate) fn now_unix_millis() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
-/// Parse ISO 8601 UTC timestamp (YYYY-MM-DDTHH:MM:SSZ or +00:00) to Unix seconds.
+/// Parse ISO 8601 timestamp to Unix seconds.
 /// Returns None if the string cannot be parsed.
 pub(crate) fn parse_iso_ts(ts: &str) -> Option<u64> {
-    let s = ts.trim_end_matches('Z');
-    let s = s.strip_suffix("+00:00").unwrap_or(s);
+    let s = ts.trim();
     let (date_part, time_part) = s.split_once('T')?;
     let dp: Vec<&str> = date_part.split('-').collect();
-    let tp: Vec<&str> = time_part.split(':').collect();
-    if dp.len() < 3 || tp.len() < 3 {
+    if dp.len() != 3 {
         return None;
     }
     let year: i64 = dp[0].parse().ok()?;
@@ -35,9 +33,26 @@ pub(crate) fn parse_iso_ts(ts: &str) -> Option<u64> {
     if month < 1 || month > 12 {
         return None;
     }
+    let (time_part, offset_secs) = split_iso_time_and_offset(time_part)?;
+    let tp: Vec<&str> = time_part.split(':').collect();
+    if tp.len() != 3 {
+        return None;
+    }
     let hour: i64 = tp[0].parse().ok()?;
     let min: i64 = tp[1].parse().ok()?;
-    let sec: i64 = tp[2].trim_end_matches('Z').parse().ok()?;
+    let sec_part = match tp[2].split_once('.') {
+        Some((whole, fraction)) => {
+            if whole.is_empty()
+                || fraction.is_empty()
+                || !fraction.bytes().all(|b| b.is_ascii_digit())
+            {
+                return None;
+            }
+            whole
+        }
+        None => tp[2],
+    };
+    let sec: i64 = sec_part.parse().ok()?;
     if hour < 0 || hour > 23 || min < 0 || min > 59 || sec < 0 || sec > 59 {
         return None;
     }
@@ -53,23 +68,43 @@ pub(crate) fn parse_iso_ts(ts: &str) -> Option<u64> {
         return None;
     }
 
-    let mut days: i64 = 0;
-    for y in 1970..year {
-        days += if is_leap(y) { 366 } else { 365 };
-    }
-    for m in 1..month {
-        days += month_days[(m - 1) as usize];
-        if m == 2 && is_leap(year) {
-            days += 1;
-        }
-    }
-    days += day - 1;
-
-    let total = days * 86400 + hour * 3600 + min * 60 + sec;
+    let total =
+        days_from_civil(year, month, day) * 86400 + hour * 3600 + min * 60 + sec - offset_secs;
     if total < 0 {
         return None;
     }
     Some(total as u64)
+}
+
+fn split_iso_time_and_offset(time_part: &str) -> Option<(&str, i64)> {
+    if let Some(stripped) = time_part.strip_suffix('Z') {
+        return Some((stripped, 0));
+    }
+    if time_part.len() >= 6 {
+        let offset_start = time_part.len() - 6;
+        let sign = time_part.as_bytes()[offset_start];
+        if matches!(sign, b'+' | b'-') && time_part.as_bytes()[offset_start + 3] == b':' {
+            let hours: i64 = time_part[offset_start + 1..offset_start + 3].parse().ok()?;
+            let mins: i64 = time_part[offset_start + 4..offset_start + 6].parse().ok()?;
+            if hours > 23 || mins > 59 {
+                return None;
+            }
+            let offset = hours * 3600 + mins * 60;
+            let signed_offset = if sign == b'+' { offset } else { -offset };
+            return Some((&time_part[..offset_start], signed_offset));
+        }
+    }
+    Some((time_part, 0))
+}
+
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let y = year - if month <= 2 { 1 } else { 0 };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let m = month + if month > 2 { -3 } else { 9 };
+    let doy = (153 * m + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
 }
 
 pub(crate) fn format_unix_secs_utc(secs: u64) -> String {

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -122,6 +122,10 @@ fn observe_export_prometheus_omits_raw_sensitive_labels() {
     assert_eq!(out.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("vibeguard_event_total"), "{stdout}");
+    assert!(
+        stdout.contains("vibeguard_tool_total{tool=\"Edit\"} 1"),
+        "{stdout}"
+    );
     assert!(stdout.contains("rule_id=\"U-16\""), "{stdout}");
     assert!(
         stdout.contains("reason_code=\"rule_violation\""),

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -64,6 +64,7 @@ fn help_lists_all_commands() {
         "pkg-rewrite",
         "pre-bash-check",
         "session-metrics",
+        "observe",
         "codex-event-name",
         "codex-status-detail",
         "codex-status-matcher",
@@ -86,6 +87,121 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+#[test]
+fn observe_export_prometheus_omits_raw_sensitive_labels() {
+    let root = unique_temp_dir("observe-prometheus");
+    fs::create_dir_all(&root).unwrap();
+    let input = root.join("events.jsonl");
+    let output_file = root.join("metrics.prom");
+    fs::write(
+        &input,
+        concat!(
+            "{\"ts\":\"2026-05-31T00:00:00Z\",\"session\":\"secret-session\",",
+            "\"hook\":\"post-edit-guard\",\"tool\":\"Edit\",\"decision\":\"warn\",",
+            "\"reason\":\"U-16 block for customer@example.com command cargo test -- --ignored\",",
+            "\"detail\":\"Edit /Users/alice/project/src/private_token.rs\",",
+            "\"duration_ms\":250}\n"
+        ),
+    )
+    .unwrap();
+
+    let out = bin()
+        .args([
+            "observe",
+            "export",
+            "prometheus",
+            "--since",
+            "all",
+            "--input-file",
+        ])
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("vibeguard_event_total"), "{stdout}");
+    assert!(stdout.contains("rule_id=\"U-16\""), "{stdout}");
+    assert!(
+        stdout.contains("reason_code=\"rule_violation\""),
+        "{stdout}"
+    );
+    assert!(stdout.contains("file_ext=\"rs\""), "{stdout}");
+    for raw in [
+        "secret-session",
+        "customer@example.com",
+        "cargo test -- --ignored",
+        "/Users/alice",
+        "private_token",
+    ] {
+        assert!(!stdout.contains(raw), "raw value leaked: {raw}\n{stdout}");
+    }
+
+    let file_out = bin()
+        .args([
+            "observe",
+            "export",
+            "prometheus",
+            "--since",
+            "all",
+            "--input-file",
+        ])
+        .arg(&input)
+        .args(["--file"])
+        .arg(&output_file)
+        .output()
+        .unwrap();
+    assert_eq!(file_out.status.code(), Some(0));
+    assert!(file_out.stdout.is_empty());
+    let file_metrics = fs::read_to_string(&output_file).unwrap();
+    assert!(file_metrics.contains("vibeguard_guard_violation_total"));
+    assert!(!file_metrics.contains("customer@example.com"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn observe_export_prometheus_project_scope_reads_project_log_dir() {
+    let root = unique_temp_dir("observe-project-scope");
+    let project_root = root.join("repo");
+    let log_root = root.join("logs");
+    let project_log_dir = log_root.join("projects").join("abcdef12");
+    fs::create_dir_all(&project_root).unwrap();
+    fs::create_dir_all(&project_log_dir).unwrap();
+    fs::write(
+        project_log_dir.join(".project-root"),
+        project_root.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+    fs::write(
+        project_log_dir.join("events.jsonl"),
+        "{\"hook\":\"pre-bash-guard\",\"tool\":\"Bash\",\"decision\":\"block\",\"reason\":\"force push denied\",\"detail\":\"git push --force\"}\n",
+    )
+    .unwrap();
+
+    let out = bin()
+        .args([
+            "observe",
+            "export",
+            "prometheus",
+            "--scope",
+            "project",
+            "--project",
+        ])
+        .arg(&project_root)
+        .args(["--since", "all"])
+        .env("VIBEGUARD_LOG_DIR", &log_root)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("vibeguard_events_total 1"), "{stdout}");
+    assert!(
+        stdout.contains("reason_code=\"dangerous_command\""),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("git push --force"), "{stdout}");
+    let _ = fs::remove_dir_all(root);
 }
 
 fn run_runtime_with_stdin(args: &[&str], input: &str) -> std::process::Output {

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -180,14 +180,7 @@ fn observe_export_prometheus_project_scope_reads_project_log_dir() {
     .unwrap();
 
     let out = bin()
-        .args([
-            "observe",
-            "export",
-            "prometheus",
-            "--scope",
-            "project",
-            "--project",
-        ])
+        .args(["observe", "export", "prometheus", "--project"])
         .arg(&project_root)
         .args(["--since", "all"])
         .env("VIBEGUARD_LOG_DIR", &log_root)

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -201,6 +201,39 @@ fn observe_export_prometheus_project_scope_reads_project_log_dir() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[test]
+fn observe_export_prometheus_missing_log_reports_error_without_output_file() {
+    let root = unique_temp_dir("observe-missing-log");
+    fs::create_dir_all(&root).unwrap();
+    let missing = root.join("missing-events.jsonl");
+    let output_file = root.join("metrics.prom");
+
+    let out = bin()
+        .args([
+            "observe",
+            "export",
+            "prometheus",
+            "--since",
+            "all",
+            "--input-file",
+        ])
+        .arg(&missing)
+        .args(["--file"])
+        .arg(&output_file)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Log file does not exist"), "{stderr}");
+    assert!(
+        stderr.contains(&missing.to_string_lossy().to_string()),
+        "{stderr}"
+    );
+    assert!(!output_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
 fn run_runtime_with_stdin(args: &[&str], input: &str) -> std::process::Output {
     let mut child = bin()
         .args(args)


### PR DESCRIPTION
## Summary
- add `vibeguard-runtime observe export prometheus` with safe low-cardinality labels
- derive `rule_id`, `reason_code`, `severity`, and `file_ext` without exporting raw reason/detail/path/command/session values
- keep `scripts/metrics/metrics-exporter.sh` as a compatibility wrapper for stdout, `--file`, `--push`, `--days`, `--since`, and `--scope`

## Validation
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_hook_health.sh`
- `bash tests/test_stats.sh`
- `bash scripts/ci/validate-hook-perf.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check && git diff --check`

Closes #397