### PR TITLE
Move setup helpers into Rust runtime

### DIFF
--- a/docs/specs/rust-only-production-path.md
+++ b/docs/specs/rust-only-production-path.md
@@ -1,9 +1,9 @@
 # Spec: Rust-only production install and hook path
 
-- Status: Draft
+- Status: Implemented
 - Date: 2026-06-05
 - Owner: @majiayu000
-- Readiness: plan_first
+- Readiness: execute_direct
 - Severity: P1
 - Related: `docs/specs/install-friction-reduction.md`, `scripts/setup/install.sh`, `scripts/setup/lib.sh`, `scripts/lib/install-state.sh`, `hooks/run-hook.sh`, `hooks/run-hook-codex.sh`, `hooks/_lib/policy.sh`, `hooks/_lib/codex_runner.sh`, `vibeguard-runtime/`
 
@@ -16,6 +16,23 @@
 - P2 setup/check/clean runtime migration: https://github.com/majiayu000/vibeguard/issues/384
 - P2 no-Python CI/docs gate: https://github.com/majiayu000/vibeguard/issues/385
 - Related app-server policy gate: https://github.com/majiayu000/vibeguard/issues/372
+
+## Implementation Status
+
+The production boundary in this spec is now enforced by tests:
+
+- `tests/test_setup.sh` builds the debug runtime before creating fake release
+  assets, so setup-flow release tests exercise real Rust setup commands.
+- `tests/setup/install_flow_tests.sh` shadows `python3` and `python` with
+  failing stubs and proves `setup.sh --yes --profile core`,
+  `setup.sh --check --strict`, and `setup.sh --clean` complete without Python.
+- `scripts/ci/self-application/check-hook-production-python-free.sh` remains
+  the hook-path CI sentinel and is run by `scripts/ci/self-application/run-all.sh`
+  in GitHub Actions.
+
+This is a Python-free production path, not a Python-free repository. Eval,
+documentation generation, developer validators, tests, and optional
+language-specific guard tools may still use Python.
 
 ## 1. Problem
 
@@ -103,8 +120,8 @@ For this spec, "production path" means code that runs during:
 - installed Codex hook execution
 - `vibeguard-runtime codex-app-server-wrapper`
 
-Python is allowed outside that path only for development, eval, CI, documentation,
-or optional language-specific guard tools.
+Python is allowed outside that path only for tests, development, eval, CI,
+documentation generation, or optional language-specific guard tools.
 
 ### 5.2 Runtime Modules and Commands
 
@@ -144,14 +161,13 @@ test before the Python call site is removed.
 
 ### 5.3 Dependency Policy
 
-The current runtime intentionally has a small dependency surface:
-`serde_json`, `regex`, and `libc`. Rust-only setup needs structured parsing for
-TOML and checksums:
+The runtime intentionally keeps a small dependency surface. The setup migration
+added `toml_edit` for structured `~/.codex/config.toml` mutation and kept
+checksums local to the runtime instead of shelling out through Python. Future
+setup dependencies must stay specific and justified:
 
-- Allow `toml_edit` or an equivalent maintained TOML editing crate for
-  `~/.codex/config.toml`.
-- Allow `sha2` for install-state checksums if shelling out to `shasum` would
-  keep setup logic outside the runtime.
+- A checksum crate may be added only if the local implementation becomes a
+  maintenance risk.
 - Do not add a general JSON Schema engine unless the project schema cannot be
   represented as a small VibeGuard-specific validator.
 
@@ -199,37 +215,40 @@ targets.
 
 - AC1: In a test home with `python3` intentionally absent from `PATH`,
   `bash setup.sh --yes --profile core` installs successfully on a supported
-  release target using the verified prebuilt runtime.
+  release target using the verified prebuilt runtime. Enforced by
+  `tests/setup/install_flow_tests.sh`.
 - AC2: In that same environment, `bash setup.sh --check --strict` exits 0.
+  Enforced by `tests/setup/install_flow_tests.sh`.
 - AC3: In that same environment, `bash setup.sh --clean` removes VibeGuard-owned
-  artifacts without Python.
+  artifacts without Python. Enforced by `tests/setup/install_flow_tests.sh`.
 - AC4: Configured Claude Code and Codex hook paths in `minimal`, `core`, `full`,
   and `strict` profiles do not execute `python3` for first-party runtime logic.
+  Enforced by `scripts/ci/self-application/check-hook-production-python-free.sh`.
 - AC5: No configured hook has a Python fallback for a runtime-replaced module.
-- AC6: Existing Codex wrapper and app-server behavior tests still pass.
+  Enforced by `scripts/ci/self-application/check-hook-production-python-free.sh`.
+- AC6: Existing Codex wrapper and app-server behavior tests still pass. Enforced
+  by `tests/test_codex_runtime.sh`.
 - AC7: Invalid project policy config remains fail-visible in shell-wrapper and
-  app-server paths.
+  app-server paths. Enforced by setup and runtime config regression tests.
 - AC8: Docs distinguish "Python-free production path" from "Python-free whole
-  repository".
+  repository". Enforced by this section.
 
 ## 7. Verification
 
 Required implementation checks:
 
 ```bash
+cargo check --manifest-path vibeguard-runtime/Cargo.toml
 cargo test --manifest-path vibeguard-runtime/Cargo.toml
 bash tests/test_setup.sh
 bash tests/test_setup_check.sh
 bash tests/test_codex_runtime.sh
 bash tests/test_hooks.sh
-bash scripts/ci/validate-manifest-contract.sh
+bash tests/test_manifest_contract.sh
 bash scripts/ci/validate-doc-paths.sh
 bash scripts/ci/validate-doc-command-paths.sh
+bash scripts/ci/self-application/check-hook-production-python-free.sh
 ```
-
-Add a dedicated no-Python test, likely in `tests/test_setup.sh` or a focused new
-test script, that shadows `python3` out of `PATH` while preserving the tools that
-the bootstrap legitimately needs.
 
 ## 8. Risks and Open Questions
 

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -3,6 +3,10 @@
 
 codex_runtime_path() {
   local helper_dir wrapper_dir candidate
+  if [[ -n "${CODEX_RUNTIME_PATH_CACHE:-}" && -x "${CODEX_RUNTIME_PATH_CACHE}" ]]; then
+    printf '%s\n' "${CODEX_RUNTIME_PATH_CACHE}"
+    return 0
+  fi
   helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
   for candidate in \
@@ -12,6 +16,7 @@ codex_runtime_path() {
     "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
     "${wrapper_dir}/vibeguard-runtime"; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      CODEX_RUNTIME_PATH_CACHE="${candidate}"
       printf '%s\n' "${candidate}"
       return 0
     fi
@@ -113,10 +118,23 @@ codex_diag() {
 codex_hook_timeout_ms() {
   local hook_name="$1"
   case "${hook_name}" in
-    *post-build-check*) printf '%s\n' "30000" ;;
-    *pre-*|*post-edit*|*post-write*) printf '%s\n' "10000" ;;
+    *post-build-check*) printf '%s\n' "35000" ;;
+    *stop-guard*|*learn-evaluator*) printf '%s\n' "15000" ;;
+    *pre-*|*post-edit*|*post-write*) printf '%s\n' "15000" ;;
     *) printf '%s\n' "" ;;
   esac
+}
+
+codex_hook_status_info() {
+  local input="$1" parsed
+  if parsed=$(codex_runtime_stdin "codex-status-info" "${input}" 2>/dev/null); then
+    printf '%s\n' "${parsed}"
+    return 0
+  fi
+  printf '%s\t%s\t%s\n' \
+    "$(codex_raw_event_name "${input}")" \
+    "$(codex_hook_status_matcher "${input}" 2>/dev/null || true)" \
+    "$(codex_hook_status_detail "${input}" 2>/dev/null || true)"
 }
 
 codex_hook_status_detail() {
@@ -146,15 +164,22 @@ codex_hook_status() {
 
 codex_hook_status_from_output() {
   local hook_name="$1" event_name="$2" matcher="$3" hook_output="$4" detail="${5:-}" timeout_ms="${6:-}"
-  local parsed hook_status hook_reason
-  if ! parsed=$(codex_runtime_stdin "codex-status-from-output" "${hook_output}" 2>/dev/null); then
-    parsed=$'hook_error\truntime-unavailable'
+  local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
+  local runtime_path parsed hook_status hook_reason
+  if runtime_path="$(codex_runtime_path 2>/dev/null)" \
+    && printf '%s' "${hook_output}" | "${runtime_path}" codex-hook-status-from-output \
+      "${diag_file}" "${hook_name}" "${event_name}" "${matcher}" "${detail}" "${timeout_ms}" 2>/dev/null; then
+    return 0
   fi
-  hook_status="${parsed%%$'\t'*}"
-  hook_reason="${parsed#*$'\t'}"
-  if [[ "${hook_status}" == "${parsed}" ]]; then
-    hook_reason=""
+  if parsed=$(codex_runtime_stdin "codex-status-from-output" "${hook_output}" 2>/dev/null); then
+    hook_status="${parsed%%$'\t'*}"
+    hook_reason="${parsed#*$'\t'}"
+    if [[ "${hook_status}" == "${parsed}" ]]; then
+      hook_reason=""
+    fi
+    [[ -n "${hook_status}" ]] || hook_status="hook_error"
+    codex_hook_status "${hook_name}" "${event_name}" "${matcher}" "${hook_status}" "${hook_reason}" "${detail}" "${timeout_ms}"
+    return 0
   fi
-  [[ -n "${hook_status}" ]] || hook_status="hook_error"
-  codex_hook_status "${hook_name}" "${event_name}" "${matcher}" "${hook_status}" "${hook_reason}" "${detail}" "${timeout_ms}"
+  codex_hook_status "${hook_name}" "${event_name}" "${matcher}" "hook_error" "runtime-unavailable" "${detail}" "${timeout_ms}"
 }

--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -28,6 +28,11 @@ _codex_write_normalized_inputs() {
   local hook_name="$1" input="$2" normalized_file="$3"
   local status=0 stderr_file stderr_text
 
+  if ! _codex_input_looks_apply_patch "${input}"; then
+    printf '%s\n' "${input}" >"${normalized_file}"
+    return 0
+  fi
+
   if stderr_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-normalizer.XXXXXX")"; then
     if _codex_normalize_apply_patch_runtime "${hook_name}" "${input}" >"${normalized_file}" 2>"${stderr_file}"; then
       rm -f "${stderr_file}" 2>/dev/null || true
@@ -40,19 +45,12 @@ _codex_write_normalized_inputs() {
 
     if [[ "${status}" -ne 0 ]]; then
       codex_diag "${hook_name}" "${EVENT_NAME}" "normalizer-failed" "${stderr_text:-runtime exit ${status}}"
-      if _codex_input_looks_apply_patch "${input}"; then
-        return 1
-      fi
-      printf '%s\n' "${input}" >"${normalized_file}"
-      return 0
+      return 1
     fi
   fi
 
   codex_diag "${hook_name}" "${EVENT_NAME}" "normalizer-failed" "runtime unavailable"
-  if _codex_input_looks_apply_patch "${input}"; then
-    return 1
-  fi
-  printf '%s\n' "${input}" >"${normalized_file}"
+  return 1
 }
 
 codex_run_hook() {
@@ -76,17 +74,48 @@ codex_run_hook() {
 
     hook_err_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-hook.XXXXXX")"
     event_name=$(codex_event_name "${normalized_input}")
-    local hook_matcher hook_detail hook_timeout_ms
-    hook_matcher="$(codex_hook_status_matcher "${normalized_input}" 2>/dev/null || true)"
-    hook_detail="$(codex_hook_status_detail "${normalized_input}" 2>/dev/null || true)"
+    local hook_matcher hook_detail hook_timeout_ms hook_status_info
+    local hook_timeout_seconds
+    if declare -F codex_hook_status_info >/dev/null 2>&1; then
+      hook_status_info="$(codex_hook_status_info "${normalized_input}" 2>/dev/null || true)"
+      event_name="${hook_status_info%%$'\t'*}"
+      hook_status_info="${hook_status_info#*$'\t'}"
+      hook_matcher="${hook_status_info%%$'\t'*}"
+      hook_detail="${hook_status_info#*$'\t'}"
+      if [[ "${hook_matcher}" == "${hook_status_info}" ]]; then
+        hook_detail=""
+      fi
+    else
+      event_name=$(codex_event_name "${normalized_input}")
+      hook_matcher="$(codex_hook_status_matcher "${normalized_input}" 2>/dev/null || true)"
+      hook_detail="$(codex_hook_status_detail "${normalized_input}" 2>/dev/null || true)"
+    fi
+    [[ -n "${event_name}" ]] || event_name=$(codex_event_name "${normalized_input}")
     hook_timeout_ms="$(codex_hook_timeout_ms "${hook_name}" 2>/dev/null || true)"
     codex_hook_status "${hook_name}" "${event_name}" "${hook_matcher}" "running" "" "${hook_detail}" "${hook_timeout_ms}"
 
     hook_output=""
     hook_exit=0
-    hook_output=$(printf '%s' "${normalized_input}" | bash "${hook_path}" "$@" 2>"${hook_err_file}") || hook_exit=$?
+    hook_timeout_seconds=""
+    if [[ "${hook_timeout_ms}" =~ ^[0-9]+$ && "${hook_timeout_ms}" -gt 0 ]]; then
+      hook_timeout_seconds=$(( (hook_timeout_ms + 999) / 1000 ))
+    fi
+    if [[ -n "${hook_timeout_seconds}" ]] && declare -F vg_run_with_timeout >/dev/null 2>&1; then
+      hook_output=$(printf '%s' "${normalized_input}" | vg_run_with_timeout "${hook_timeout_seconds}" bash "${hook_path}" "$@" 2>"${hook_err_file}") || hook_exit=$?
+    else
+      hook_output=$(printf '%s' "${normalized_input}" | bash "${hook_path}" "$@" 2>"${hook_err_file}") || hook_exit=$?
+    fi
     hook_err="$(cat "${hook_err_file}" 2>/dev/null || true)"
     rm -f "${hook_err_file}" 2>/dev/null || true
+
+    if [[ ${hook_exit} -eq 124 ]]; then
+      local timeout_reason="wrapped hook timeout after ${hook_timeout_seconds:-?}s"
+      codex_hook_status "${hook_name}" "${event_name}" "${hook_matcher}" "timeout" "${timeout_reason}" "${hook_detail}" "${hook_timeout_ms}"
+      codex_diag "${hook_name}" "${event_name}" "wrapped-hook-timeout" "${timeout_reason}"
+      rm -f "${normalized_file}" 2>/dev/null || true
+      codex_visible_failure_raw "${event_name}" "VIBEGUARD hook timed out after ${hook_timeout_seconds:-?}s."
+      return 0
+    fi
 
     if [[ ${hook_exit} -ne 0 ]]; then
       codex_diag "${hook_name}" "${event_name}" "wrapped-hook-nonzero" "${hook_err:-${hook_output}}"

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -14,6 +14,10 @@ vg_policy_user_config_file() {
 
 vg_policy_runtime_path() {
   local helper_dir wrapper_dir candidate
+  if [[ -n "${VG_POLICY_RUNTIME_PATH_CACHE:-}" && -x "${VG_POLICY_RUNTIME_PATH_CACHE}" ]]; then
+    printf '%s\n' "${VG_POLICY_RUNTIME_PATH_CACHE}"
+    return 0
+  fi
   helper_dir="${_VG_POLICY_LIB_DIR}"
   wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
   for candidate in \
@@ -25,6 +29,7 @@ vg_policy_runtime_path() {
     "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
       if vg_policy_runtime_supports "${candidate}"; then
+        VG_POLICY_RUNTIME_PATH_CACHE="${candidate}"
         printf '%s\n' "${candidate}"
         return 0
       fi

--- a/hooks/_lib/timeout.sh
+++ b/hooks/_lib/timeout.sh
@@ -24,7 +24,11 @@ vg_run_with_timeout() {
   "$@" &
   pid=$!
   (
-    sleep "${seconds}" 2>/dev/null || sleep 1
+    local sleep_pid
+    sleep "${seconds}" 2>/dev/null &
+    sleep_pid=$!
+    trap 'kill "${sleep_pid}" 2>/dev/null || true; exit 0' TERM INT
+    wait "${sleep_pid}" 2>/dev/null || true
     if kill -0 "${pid}" 2>/dev/null; then
       printf 'timeout\n' >"${flag}" 2>/dev/null || true
       kill -TERM "${pid}" 2>/dev/null || true

--- a/hooks/learn-evaluator.sh
+++ b/hooks/learn-evaluator.sh
@@ -30,6 +30,33 @@ vg_learn_stop_hook_active_fast() {
   [[ "$active" == "true" ]]
 }
 
+vg_learn_recent_events() {
+  local log_file="$1" tail_bytes="$2"
+  [[ -f "$log_file" ]] || return 0
+  if [[ "$tail_bytes" =~ ^[0-9]+$ && "$tail_bytes" -gt 0 ]]; then
+    tail -c "$tail_bytes" "$log_file" 2>/dev/null || cat "$log_file" 2>/dev/null || true
+  else
+    cat "$log_file" 2>/dev/null || true
+  fi
+}
+
+vg_learn_log_truncation_once() {
+  local log_file="$1" tail_bytes="$2"
+  [[ -f "$log_file" ]] || return 0
+  [[ "$tail_bytes" =~ ^[0-9]+$ && "$tail_bytes" -gt 0 ]] || return 0
+
+  local size_bytes session_key flag_file
+  size_bytes="$(wc -c < "$log_file" 2>/dev/null | tr -d ' ' || echo 0)"
+  [[ "$size_bytes" =~ ^[0-9]+$ && "$size_bytes" -gt "$tail_bytes" ]] || return 0
+  session_key="$(printf '%s' "${VIBEGUARD_SESSION_ID:-unknown}" | tr -c 'A-Za-z0-9_.-' '_')"
+  flag_file="${VIBEGUARD_LOG_DIR}/.learn_metrics_truncated_${session_key}"
+  [[ -f "$flag_file" ]] && return 0
+  : > "$flag_file" 2>/dev/null || true
+  vg_log "learn-evaluator" "Stop" "warn" \
+    "metrics input truncated to ${tail_bytes} bytes before 30-minute filter; increase VIBEGUARD_LEARN_METRICS_TAIL_BYTES for very busy sessions" \
+    "$log_file"
+}
+
 # CI guard: skip in automated environments
 vg_learn_is_ci && exit 0
 
@@ -42,11 +69,13 @@ if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
   exit 0
 fi
 
-# Collect session metrics for the last 30 minutes of the current project + correct signal detection
-# Pass the full log file — the 30-minute cutoff is enforced inside vibeguard-runtime,
-# so tail-limiting here would under-count events on busy sessions (>1000 events/30 min).
-LEARN_SUGGESTION=$("$_VIBEGUARD_RUNTIME" session-metrics "$VIBEGUARD_SESSION_ID" "$VIBEGUARD_PROJECT_LOG_DIR" \
-  < "$VIBEGUARD_LOG_FILE" 2>/dev/null || true)
+# Collect session metrics for the last 30 minutes of the current project. Bound
+# the input before the runtime filter so old logs cannot make every Stop hook
+# linearly slower as events.jsonl grows.
+LEARN_TAIL_BYTES="$(vg_config_get_int VIBEGUARD_LEARN_METRICS_TAIL_BYTES learn.metrics_tail_bytes 5242880)"
+vg_learn_log_truncation_once "$VIBEGUARD_LOG_FILE" "$LEARN_TAIL_BYTES"
+LEARN_SUGGESTION=$(vg_learn_recent_events "$VIBEGUARD_LOG_FILE" "$LEARN_TAIL_BYTES" \
+  | "$_VIBEGUARD_RUNTIME" session-metrics "$VIBEGUARD_SESSION_ID" "$VIBEGUARD_PROJECT_LOG_DIR" 2>/dev/null || true)
 
 # If a correction signal is detected, output suggestions (not blocking)
 if [[ "$LEARN_SUGGESTION" == LEARN_SUGGESTED* ]]; then

--- a/hooks/manifest.json
+++ b/hooks/manifest.json
@@ -52,7 +52,7 @@
         "enabled": true,
         "support": "native",
         "script": "vibeguard-pre-bash-guard.sh",
-        "timeout": 10,
+        "timeout": 15,
         "entries": [
           {"event": "PreToolUse", "matcher": "Bash"},
           {"event": "PermissionRequest", "matcher": "Bash"}
@@ -78,7 +78,7 @@
         "enabled": true,
         "support": "native",
         "script": "vibeguard-pre-edit-guard.sh",
-        "timeout": 10,
+        "timeout": 15,
         "entries": [
           {"event": "PreToolUse", "matcher": "Edit"},
           {"event": "PermissionRequest", "matcher": "Edit"}
@@ -104,7 +104,7 @@
         "enabled": true,
         "support": "native",
         "script": "vibeguard-pre-write-guard.sh",
-        "timeout": 10,
+        "timeout": 15,
         "entries": [
           {"event": "PreToolUse", "matcher": "Write"},
           {"event": "PermissionRequest", "matcher": "Write"}
@@ -132,7 +132,7 @@
         "event": "PostToolUse",
         "matcher": "Edit",
         "script": "vibeguard-post-edit-guard.sh",
-        "timeout": 10
+        "timeout": 15
       }
     },
     {
@@ -156,7 +156,7 @@
         "event": "PostToolUse",
         "matcher": "Write",
         "script": "vibeguard-post-write-guard.sh",
-        "timeout": 10
+        "timeout": 15
       }
     },
     {
@@ -212,7 +212,7 @@
         "enabled": true,
         "support": "native",
         "script": "vibeguard-post-build-check.sh",
-        "timeout": 30,
+        "timeout": 35,
         "entries": [
           {"event": "PostToolUse", "matcher": "Bash"},
           {"event": "PostToolUse", "matcher": "Edit|Write"}
@@ -249,7 +249,8 @@
         "support": "native",
         "event": "Stop",
         "matcher": null,
-        "script": "vibeguard-stop-guard.sh"
+        "script": "vibeguard-stop-guard.sh",
+        "timeout": 15
       }
     },
     {
@@ -272,7 +273,8 @@
         "support": "native",
         "event": "Stop",
         "matcher": null,
-        "script": "vibeguard-learn-evaluator.sh"
+        "script": "vibeguard-learn-evaluator.sh",
+        "timeout": 15
       }
     },
     {

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -72,6 +72,9 @@ fi
 RUNNER_PATH="${WRAPPER_DIR}/_lib/codex_runner.sh"
 [[ -f "${RUNNER_PATH}" || ! -f "${INSTALLED_DIR}/_lib/codex_runner.sh" ]] || RUNNER_PATH="${INSTALLED_DIR}/_lib/codex_runner.sh"
 
+TIMEOUT_PATH="${WRAPPER_DIR}/_lib/timeout.sh"
+[[ -f "${TIMEOUT_PATH}" || ! -f "${INSTALLED_DIR}/_lib/timeout.sh" ]] || TIMEOUT_PATH="${INSTALLED_DIR}/_lib/timeout.sh"
+
 if [[ ! -d "$INSTALLED_DIR" ]]; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ ! -f "$REPO_PATH_FILE" ]]; then
@@ -86,6 +89,9 @@ if [[ ! -d "$INSTALLED_DIR" ]]; then
   fi
   if [[ ! -f "${RUNNER_PATH}" && -f "${REPO_DIR}/hooks/_lib/codex_runner.sh" ]]; then
     RUNNER_PATH="${REPO_DIR}/hooks/_lib/codex_runner.sh"
+  fi
+  if [[ ! -f "${TIMEOUT_PATH}" && -f "${REPO_DIR}/hooks/_lib/timeout.sh" ]]; then
+    TIMEOUT_PATH="${REPO_DIR}/hooks/_lib/timeout.sh"
   fi
 fi
 
@@ -117,6 +123,11 @@ source "${ADAPTER_PATH}"
 # Adapter delegates: codex_event_name codex_pretool_deny codex_adapt_pretool codex_adapt_posttool.
 if ! declare -F codex_permission_deny >/dev/null 2>&1; then codex_permission_deny() { codex_permission_deny_raw "$1"; }; fi
 if ! declare -F codex_adapt_permission_request >/dev/null 2>&1; then codex_adapt_permission_request() { codex_permission_deny "VIBEGUARD install incomplete: missing PermissionRequest adapter."; }; fi
+
+if [[ -f "${TIMEOUT_PATH}" ]]; then
+  # shellcheck source=hooks/_lib/timeout.sh
+  source "${TIMEOUT_PATH}"
+fi
 
 if [[ ! -f "${RUNNER_PATH}" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-runner" "${RUNNER_PATH}"

--- a/scripts/gc/gc-scheduled.sh
+++ b/scripts/gc/gc-scheduled.sh
@@ -17,27 +17,97 @@ source "${SCRIPT_DIR}/../lib/project_config.sh"
 
 LOG_DIR="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}"
 GC_LOG="${LOG_DIR}/gc-cron.log"
+GC_STATE_FILE="${LOG_DIR}/gc-last-success"
+GC_ATTEMPT_FILE="${LOG_DIR}/gc-last-attempt"
 SESSION_METRICS_RETAIN_DAYS="$(vg_config_positive_int VIBEGUARD_GC_SESSION_METRICS_RETAIN_DAYS gc.session_metrics_retain_days 90)"
 LEARNING_WINDOW_DAYS="$(vg_config_positive_int VIBEGUARD_GC_LEARNING_WINDOW_DAYS gc.learning_window_days 7)"
 GC_LOG_MAX_KB="$(vg_config_positive_int VIBEGUARD_GC_LOG_MAX_KB gc.gc_log_max_kb 1024)"
+GC_LOG_THRESHOLD_MB="$(vg_config_positive_int VIBEGUARD_GC_LOG_THRESHOLD_MB gc.log_threshold_mb 10)"
+GC_CATCHUP_INTERVAL_HOURS="$(vg_config_positive_int VIBEGUARD_GC_CATCHUP_INTERVAL_HOURS gc.catchup_interval_hours 168)"
+SCHEDULED=false
+GC_FAILED=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scheduled) SCHEDULED=true; shift ;;
+    *) shift ;;
+  esac
+done
 
 mkdir -p "${LOG_DIR}"
 
+log_file_size_mb() {
+  local file="$1"
+  [[ -f "$file" ]] || { printf '%s\n' "0"; return 0; }
+  du -m "$file" 2>/dev/null | cut -f1
+}
+
+find_oversized_logs() {
+  local file size
+  file="${LOG_DIR}/events.jsonl"
+  if [[ -f "$file" ]]; then
+    size="$(log_file_size_mb "$file")"
+    [[ "$size" =~ ^[0-9]+$ && "$size" -ge "$GC_LOG_THRESHOLD_MB" ]] && printf '%s\t%s\n' "$size" "$file"
+  fi
+  for file in "${LOG_DIR}"/projects/*/events.jsonl; do
+    [[ -f "$file" ]] || continue
+    size="$(log_file_size_mb "$file")"
+    [[ "$size" =~ ^[0-9]+$ && "$size" -ge "$GC_LOG_THRESHOLD_MB" ]] && printf '%s\t%s\n' "$size" "$file"
+  done
+}
+
+scheduled_run_due() {
+  [[ "$SCHEDULED" == "true" ]] || return 0
+  if [[ -n "$(find_oversized_logs)" ]]; then
+    return 0
+  fi
+  [[ -f "$GC_STATE_FILE" ]] || return 0
+
+  local last_success now max_age
+  last_success="$(cat "$GC_STATE_FILE" 2>/dev/null || true)"
+  [[ "$last_success" =~ ^[0-9]+$ ]] || return 0
+  now="$(date +%s)"
+  max_age=$((GC_CATCHUP_INTERVAL_HOURS * 3600))
+  [[ $((now - last_success)) -ge "$max_age" ]]
+}
+
+if ! scheduled_run_due; then
+  exit 0
+fi
+
 run_gc_log_archive() {
   echo "--- Log archive ---"
-  bash "${SCRIPT_DIR}/gc-logs.sh" 2>&1 || echo "[ERROR] gc-logs failed"
+  if ! bash "${SCRIPT_DIR}/gc-logs.sh" 2>&1; then
+    echo "[ERROR] gc-logs failed"
+    GC_FAILED=1
+  fi
+  local oversized=""
+  oversized="$(find_oversized_logs)"
+  if [[ -n "$oversized" ]]; then
+    while IFS=$'\t' read -r size file; do
+      [[ -n "$file" ]] || continue
+      echo "[WARN] log remains above threshold after GC: ${file} (${size}MB >= ${GC_LOG_THRESHOLD_MB}MB)"
+    done <<< "$oversized"
+    GC_FAILED=1
+  fi
   echo
 }
 
 run_worktree_cleanup() {
   echo "--- Worktree Cleanup ---"
-  bash "${SCRIPT_DIR}/gc-worktrees.sh" 2>&1 || echo "[ERROR] gc-worktrees failed"
+  if ! bash "${SCRIPT_DIR}/gc-worktrees.sh" 2>&1; then
+    echo "[ERROR] gc-worktrees failed"
+    GC_FAILED=1
+  fi
   echo
 }
 
 run_rule_budget_gc() {
   echo "--- Rule Budget GC (U-32) ---"
-  bash "${SCRIPT_DIR}/gc-rule-budget.sh" "${REPO_ROOT}" 2>&1 || echo "[ERROR] gc-rule-budget failed"
+  if ! bash "${SCRIPT_DIR}/gc-rule-budget.sh" "${REPO_ROOT}" 2>&1; then
+    echo "[ERROR] gc-rule-budget failed"
+    GC_FAILED=1
+  fi
   echo
 }
 
@@ -48,8 +118,11 @@ run_session_metrics_cleanup() {
     || date -d "${SESSION_METRICS_RETAIN_DAYS} days ago" '+%Y-%m-%dT' 2>/dev/null \
     || echo "")
   if [[ -n "${cutoff}" ]]; then
-    _GC_LOG_DIR="${LOG_DIR}" _GC_CUTOFF="${cutoff}" \
-      python3 "${SCRIPT_DIR}/session_metrics_cleanup.py" 2>/dev/null || true
+    if ! _GC_LOG_DIR="${LOG_DIR}" _GC_CUTOFF="${cutoff}" \
+      python3 "${SCRIPT_DIR}/session_metrics_cleanup.py" 2>/dev/null; then
+      echo "[ERROR] session-metrics cleanup failed"
+      GC_FAILED=1
+    fi
   else
     echo "Skip (cannot calculate date)"
   fi
@@ -58,18 +131,24 @@ run_session_metrics_cleanup() {
 
 run_learning_digest() {
   echo "--- Regular learning (event log + code scanning unified signal source) ---"
-  _GC_LOG_DIR="${LOG_DIR}" \
+  if ! _GC_LOG_DIR="${LOG_DIR}" \
     _GC_VIBEGUARD_DIR="${REPO_ROOT}" \
     _GC_LEARNING_WINDOW_DAYS="${LEARNING_WINDOW_DAYS}" \
-    python3 "${SCRIPT_DIR}/learn_digest.py" 2>&1 || echo "[ERROR] learn-digest failed"
+    python3 "${SCRIPT_DIR}/learn_digest.py" 2>&1; then
+    echo "[ERROR] learn-digest failed"
+    GC_FAILED=1
+  fi
   echo
 }
 
 run_reflection_digest() {
   echo "---Session Quality Reflection (Reflection Automation) ---"
   local reflection_file="${LOG_DIR}/reflection-digest.md"
-  _GC_LOG_DIR="${LOG_DIR}" _GC_REFLECTION_FILE="${reflection_file}" \
-    python3 "${SCRIPT_DIR}/reflection_digest.py" 2>&1 || echo "[ERROR] reflection failed"
+  if ! _GC_LOG_DIR="${LOG_DIR}" _GC_REFLECTION_FILE="${reflection_file}" \
+    python3 "${SCRIPT_DIR}/reflection_digest.py" 2>&1; then
+    echo "[ERROR] reflection failed"
+    GC_FAILED=1
+  fi
   echo
 }
 
@@ -96,7 +175,18 @@ trim_gc_log() {
   run_learning_digest
   run_reflection_digest
 
-  echo "GC completed"
+  if [[ "$GC_FAILED" -eq 0 ]]; then
+    echo "GC completed"
+  else
+    echo "GC completed with errors"
+  fi
 } >> "${GC_LOG}" 2>&1
+
+date +%s > "${GC_ATTEMPT_FILE}"
+chmod 600 "${GC_ATTEMPT_FILE}" 2>/dev/null || true
+if [[ "$GC_FAILED" -eq 0 ]]; then
+  date +%s > "${GC_STATE_FILE}"
+  chmod 600 "${GC_STATE_FILE}" 2>/dev/null || true
+fi
 
 trim_gc_log

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -241,14 +241,8 @@ def timeout_findings(path: Path, home: Path) -> list[dict[str, str]]:
     data = load_hooks(path)
     findings: list[dict[str, str]] = []
     for event, matcher_text, hook in _iter_hook_records(data):
-        # VibeGuard's managed Stop entries intentionally have no timeout because
-        # Codex's Stop output surface is non-blocking and historically rejected
-        # spurious Stop timeouts in check-vibeguard. External Stop hooks are
-        # still reported so their owner can make an explicit timeout decision.
         matcher = None if matcher_text == "<none>" else matcher_text
         identity = _identity_for_hook(event, matcher, hook)
-        if event == "Stop" and identity.is_managed:
-            continue
         command = hook.get("command")
         if not isinstance(command, str) or not command:
             continue
@@ -373,7 +367,7 @@ def _has_entry(
             if hook.get("type") != "command":
                 continue
             # timeout must be present-and-matching when the spec demands it,
-            # and absent when the spec has none (Stop entries).
+            # and absent when the spec has none.
             if expected_timeout is not None:
                 if hook.get("timeout") != expected_timeout:
                     continue

--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -26,67 +26,57 @@ STATE_VERSION=1
 STATE_FILE="${HOME}/.vibeguard/install-state.json"
 INSTALL_STATE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+state_runtime_path() {
+  local repo_root candidate
+  repo_root="$(cd "${INSTALL_STATE_LIB_DIR}/../.." && pwd)"
+  for candidate in \
+    "${VIBEGUARD_SETUP_RUNTIME:-}" \
+    "${_INSTALL_TMP:-}/bin/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${repo_root}/vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${repo_root}/vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "vibeguard-runtime"; do
+    [[ -n "${candidate}" ]] || continue
+    if [[ "${candidate}" == */* ]]; then
+      if [[ -x "${candidate}" ]] && state_runtime_supports "${candidate}"; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    elif command -v "${candidate}" >/dev/null 2>&1; then
+      candidate="$(command -v "${candidate}")"
+      if state_runtime_supports "${candidate}"; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+state_runtime_supports() {
+  local runtime="$1" probe_state="${TMPDIR:-/tmp}/vibeguard-runtime-probe.$$.json"
+  "${runtime}" setup-state-list-symlinks-under "${probe_state}" "${TMPDIR:-/tmp}" >/dev/null 2>&1
+}
+
+state_runtime() {
+  local runtime
+  runtime="$(state_runtime_path)" || {
+    printf 'ERROR: vibeguard-runtime not found for install-state operation\n' >&2
+    return 127
+  }
+  "${runtime}" "$@"
+}
+
 # Initialize or load state
 state_init() {
   local profile="${1:-core}" languages="${2:-}"
-  local repo_dir
-  repo_dir="$(cat "${HOME}/.vibeguard/repo-path" 2>/dev/null || true)"
-
-  python3 - "$INSTALL_STATE_LIB_DIR" "$STATE_FILE" "$STATE_VERSION" "$profile" "$languages" "$repo_dir" <<'PY'
-import datetime
-import sys
-from pathlib import Path
-
-lib_dir, state_file, state_version, profile, languages, repo_dir = sys.argv[1:7]
-sys.path.insert(0, lib_dir)
-from file_ops import write_json_atomic
-
-state = {
-    'version': int(state_version),
-    'installed_at': datetime.datetime.now().astimezone().isoformat(),
-    'profile': profile,
-    'languages': languages.split(',') if languages else [],
-    'repo_dir': repo_dir,
-    'files': {}
-}
-write_json_atomic(Path(state_file), state)
-PY
+  state_runtime setup-state-init "$STATE_FILE" "$profile" "$languages"
 }
 
 # Record a file installation
 state_record_file() {
   local dest="$1" source="$2" install_type="${3:-copy}"
-
-  python3 - "$INSTALL_STATE_LIB_DIR" "$STATE_FILE" "$STATE_VERSION" "$dest" "$source" "$install_type" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-lib_dir, state_file, state_version, dest, source, install_type = sys.argv[1:7]
-sys.path.insert(0, lib_dir)
-from file_ops import sha256_file, write_json_atomic
-
-expected_version = int(state_version)
-state_path = Path(state_file)
-dest_path = Path(dest)
-
-try:
-    with state_path.open(encoding='utf-8') as f:
-        state = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    state = {'version': expected_version, 'files': {}}
-
-version = state.get('version', expected_version)
-if version != expected_version:
-    raise SystemExit(f'unsupported install-state version: {version} (expected {expected_version})')
-
-entry = {'source': source, 'type': install_type}
-if install_type != 'symlink' and dest_path.is_file():
-    entry['checksum'] = 'sha256:' + sha256_file(dest_path)
-state.setdefault('files', {})[dest] = entry
-
-write_json_atomic(state_path, state)
-PY
+  state_runtime setup-state-record-file "$STATE_FILE" "$dest" "$source" "$install_type"
 }
 
 # Record all files (regular or symlink) under a directory as installed artifacts.
@@ -111,55 +101,7 @@ state_check_drift() {
     return 0
   fi
 
-  python3 - "$INSTALL_STATE_LIB_DIR" "$STATE_FILE" "$STATE_VERSION" 2>/dev/null <<'PY'
-import json, os
-import sys
-from pathlib import Path
-
-lib_dir, state_file, state_version = sys.argv[1], sys.argv[2], int(sys.argv[3])
-sys.path.insert(0, lib_dir)
-from file_ops import sha256_file
-
-with open(state_file, encoding='utf-8') as f:
-    state = json.load(f)
-
-version = state.get('version', 1)
-if version != state_version:
-    print(f'UNSUPPORTED_STATE_VERSION: {version} (expected {state_version})')
-    raise SystemExit(0)
-
-files = state.get('files', {})
-drift_count = 0
-missing_count = 0
-
-for dest, info in files.items():
-    expanded = os.path.expanduser(dest)
-    if info['type'] == 'symlink':
-        if not os.path.islink(expanded):
-            if not os.path.exists(expanded):
-                print(f'MISSING: {dest}')
-                missing_count += 1
-            else:
-                print(f'DRIFT: {dest} (was symlink, now regular file)')
-                drift_count += 1
-    elif info['type'] == 'copy':
-        if not os.path.exists(expanded):
-            print(f'MISSING: {dest}')
-            missing_count += 1
-        elif 'checksum' in info:
-            actual = 'sha256:' + sha256_file(Path(expanded))
-            if actual != info['checksum']:
-                print(f'DRIFT: {dest} (checksum mismatch)')
-                drift_count += 1
-
-total = len(files)
-print(f'---')
-print(f'Total tracked: {total}, Missing: {missing_count}, Drifted: {drift_count}')
-if drift_count + missing_count == 0:
-    print('STATUS: CLEAN')
-else:
-    print(f'STATUS: DRIFT ({drift_count} drifted, {missing_count} missing)')
-PY
+  state_runtime setup-state-check-drift "$STATE_FILE" 2>/dev/null
 }
 
 # List all tracked files
@@ -169,64 +111,14 @@ state_list() {
     return 1
   fi
 
-  python3 - "$STATE_FILE" "$STATE_VERSION" <<'PY'
-import json
-import sys
-
-state_file, expected_version = sys.argv[1], int(sys.argv[2])
-
-with open(state_file, encoding='utf-8') as f:
-    state = json.load(f)
-version = state.get('version', 1)
-if version != expected_version:
-    raise SystemExit(f'Unsupported install-state version: {version} (expected {expected_version})')
-print(f'Profile: {state.get("profile", "unknown")}')
-print(f'Installed: {state.get("installed_at", "unknown")}')
-langs = state.get('languages', [])
-if langs:
-    print(f'Languages: {", ".join(langs)}')
-print(f'Tracked files: {len(state.get("files", {}))}')
-print()
-for dest, info in sorted(state.get('files', {}).items()):
-    t = info.get('type', '?')
-    print(f'  [{t:7s}] {dest}')
-PY
+  state_runtime setup-state-list "$STATE_FILE"
 }
 
 state_list_tracked_symlinks_under() {
   local dest_dir="$1"
   [[ -f "$STATE_FILE" ]] || return 0
 
-  python3 - "$STATE_FILE" "$dest_dir" "$STATE_VERSION" <<'PY'
-import json
-import os
-import sys
-
-state_file, dest_dir, expected_version = sys.argv[1], sys.argv[2], int(sys.argv[3])
-dest_dir = os.path.abspath(os.path.expanduser(dest_dir))
-
-try:
-    with open(state_file, encoding="utf-8") as f:
-        state = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    raise SystemExit(0)
-
-version = state.get("version", expected_version)
-if version != expected_version:
-    print(
-        f"WARN: unsupported install-state version: {version} (expected {expected_version}); "
-        "skipping tracked symlink cleanup",
-        file=sys.stderr,
-    )
-    raise SystemExit(0)
-
-for dest, info in sorted(state.get("files", {}).items()):
-    if info.get("type") != "symlink":
-        continue
-    expanded = os.path.abspath(os.path.expanduser(dest))
-    if expanded == dest_dir or expanded.startswith(dest_dir + os.sep):
-        print(expanded)
-PY
+  state_runtime setup-state-list-symlinks-under "$STATE_FILE" "$dest_dir"
 }
 
 # Remove state file (used by clean.sh)

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -93,6 +93,12 @@ if [[ "${JSON}" -eq 1 && "${INSTALL}" -eq 1 ]]; then
   exit 64
 fi
 
+if ! ensure_setup_runtime_available >/dev/null 2>&1; then
+  if [[ "${JSON}" -ne 1 ]]; then
+    yellow "[WARN] vibeguard-runtime unavailable for setup helper checks; run: bash setup.sh --yes"
+  fi
+fi
+
 _check_repo_git_hook() {
   local hook_name="$1"
   local expected_target="$2"
@@ -321,53 +327,17 @@ run_legacy_checks() {
   echo "Guard Script Portability"
   echo "------------------------------"
   _awk_violations=$(create_tmpfile 2>/dev/null || mktemp)
-  # Detect non-POSIX regex shortcuts only in awk command contexts. Python
-  # heredocs and quoted Python regexes may legitimately use \s, \d, \w, or \b.
-  python3 - <<'PY' "${REPO_DIR}/guards" > "$_awk_violations" 2>/dev/null || true
-from __future__ import annotations
-
-import re
-import sys
-from pathlib import Path
-
-root = Path(sys.argv[1])
-awk_word = re.compile(r"\b(?:awk|gawk|mawk|nawk)\b")
-non_posix = re.compile(r"/[^/\"']*\\[sdwb][^/\"']*/")
-
-for path in sorted(root.rglob("*.sh")):
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        continue
-
-    in_awk_program = False
-    quote = ""
-    for line_no, line in enumerate(lines, 1):
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-
-        inspect_line = False
-        if in_awk_program:
-            inspect_line = True
-            if quote and quote in line:
-                in_awk_program = False
-                quote = ""
-        elif awk_word.search(line):
-            inspect_line = True
-            after_awk = awk_word.split(line, maxsplit=1)[1]
-            single_count = after_awk.count("'")
-            double_count = after_awk.count('"')
-            if single_count % 2 == 1:
-                in_awk_program = True
-                quote = "'"
-            elif double_count % 2 == 1:
-                in_awk_program = True
-                quote = '"'
-
-        if inspect_line and non_posix.search(line):
-            print(f"{path}:{line_no}:{line}")
-PY
+  while IFS= read -r _guard_file; do
+    _line_no=0
+    while IFS= read -r _guard_line || [[ -n "${_guard_line}" ]]; do
+      _line_no=$((_line_no + 1))
+      [[ "${_guard_line}" =~ ^[[:space:]]*# ]] && continue
+      [[ "${_guard_line}" =~ (^|[^A-Za-z0-9_])(awk|gawk|mawk|nawk)([^A-Za-z0-9_]|$) ]] || continue
+      if [[ "${_guard_line}" =~ /[^/\"\']*\\[sdwb][^/\"\']*/ ]]; then
+        printf '%s:%s:%s\n' "${_guard_file}" "${_line_no}" "${_guard_line}" >> "$_awk_violations"
+      fi
+    done < "${_guard_file}"
+  done < <(find "${REPO_DIR}/guards" -type f -name "*.sh" 2>/dev/null | sort)
   if [[ -s "$_awk_violations" ]]; then
     count=$(wc -l < "$_awk_violations" | tr -d ' ')
     red "[FAIL] ${count} awk line(s) use non-POSIX regex (\\s \\d \\w \\b — breaks on BSD awk):"

--- a/scripts/setup/clean.sh
+++ b/scripts/setup/clean.sh
@@ -9,6 +9,8 @@ source "${SCRIPT_DIR}/targets/codex-home.sh"
 
 echo "Cleaning VibeGuard installation..."
 
+ensure_setup_runtime_available >/dev/null 2>&1 || true
+
 clean_claude_home_installation
 clean_codex_home_installation
 

--- a/scripts/setup/com.vibeguard.gc.plist
+++ b/scripts/setup/com.vibeguard.gc.plist
@@ -8,6 +8,7 @@
     <array>
         <string>/bin/bash</string>
         <string>__VIBEGUARD_DIR__/scripts/gc/gc-scheduled.sh</string>
+        <string>--scheduled</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>
@@ -18,11 +19,13 @@
         <key>Minute</key>
         <integer>0</integer>
     </dict>
+    <key>StartInterval</key>
+    <integer>21600</integer>
     <key>StandardOutPath</key>
     <string>__HOME__/.vibeguard/gc-launchd.log</string>
     <key>StandardErrorPath</key>
     <string>__HOME__/.vibeguard/gc-launchd.log</string>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
 </dict>
 </plist>

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -361,9 +361,8 @@ stage_install_snapshot() {
   trap cleanup_install_temps EXIT
   cp -r "${REPO_DIR}/hooks" "${_INSTALL_TMP}/"
   cp -r "${REPO_DIR}/guards" "${_INSTALL_TMP}/"
-  mkdir -p "${_INSTALL_TMP}/schemas" "${_INSTALL_TMP}/scripts/lib"
+  mkdir -p "${_INSTALL_TMP}/schemas"
   cp "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${_INSTALL_TMP}/schemas/"
-  cp "${REPO_DIR}/scripts/lib/project_config_validate.py" "${_INSTALL_TMP}/scripts/lib/"
   printf '%s' "$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')" > "${_INSTALL_TMP}/version"
 
   # Runtime must be prepared before project config validation, but the staged
@@ -403,6 +402,7 @@ if [[ -n "${project_config_file}" && -f "${project_config_file}" ]]; then
 fi
 
 if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
+  stage_install_snapshot
   configure_claude_home_runtime
   inject_claude_home_rules
   inject_codex_home_rules
@@ -412,10 +412,6 @@ fi
 
 # 1. Make sure the directory exists
 echo "Step 1: Prepare directories"
-if ! command -v python3 &>/dev/null; then
-  red "  ERROR: python3 not found. VibeGuard hooks require Python 3."
-  exit 1
-fi
 mkdir -p "${CLAUDE_DIR}"
 green "  ~/.claude/ ready"
 #Write repo path + install hook wrapper (compatible with all platforms, no symlink dependencies)

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -19,61 +19,255 @@ green() { printf '\033[32m%s\033[0m\n' "$1"; }
 yellow() { printf '\033[33m%s\033[0m\n' "$1"; }
 red() { printf '\033[31m%s\033[0m\n' "$1"; }
 
+setup_runtime_path() {
+  local candidate
+  for candidate in \
+    "${VIBEGUARD_SETUP_RUNTIME:-}" \
+    "${_INSTALL_TMP:-}/bin/vibeguard-runtime" \
+    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${REPO_DIR}/vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "vibeguard-runtime"; do
+    [[ -n "${candidate}" ]] || continue
+    if [[ "${VIBEGUARD_SETUP_SKIP_REPO_RUNTIME:-0}" == "1" && "${candidate}" == "${REPO_DIR}/vibeguard-runtime/target/"* ]]; then
+      continue
+    fi
+    if [[ "${candidate}" == */* ]]; then
+      if [[ -x "${candidate}" ]] && setup_runtime_supports "${candidate}"; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    elif command -v "${candidate}" >/dev/null 2>&1; then
+      candidate="$(command -v "${candidate}")"
+      if setup_runtime_supports "${candidate}"; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+setup_runtime_supports() {
+  local runtime="$1" probe_state="${TMPDIR:-/tmp}/vibeguard-runtime-probe.$$.json"
+  "${runtime}" setup-state-list-symlinks-under "${probe_state}" "${TMPDIR:-/tmp}" >/dev/null 2>&1 || return 1
+
+  local command probe_out
+  for command in \
+    setup-manifest-skill-links \
+    setup-md-remove \
+    setup-settings-check-stale \
+    setup-codex-config-check-hooks \
+    setup-codex-hooks-check-stale; do
+    probe_out="$("${runtime}" "${command}" 2>&1 || true)"
+    if printf '%s\n' "${probe_out}" | grep -q "Unknown command"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+setup_runtime() {
+  local runtime
+  runtime="$(setup_runtime_path)" || {
+    red "  ERROR: vibeguard-runtime not found; run setup with --build-from-source or install a release binary." >&2
+    return 127
+  }
+  "${runtime}" "$@"
+}
+
+setup_runtime_release_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}:${arch}" in
+    Darwin:arm64|Darwin:aarch64)
+      printf 'aarch64-apple-darwin' ;;
+    Darwin:x86_64|Darwin:amd64)
+      printf 'x86_64-apple-darwin' ;;
+    Linux:x86_64|Linux:amd64)
+      printf 'x86_64-unknown-linux-musl' ;;
+    Linux:aarch64|Linux:arm64)
+      printf 'aarch64-unknown-linux-musl' ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+setup_runtime_release_tag() {
+  local version version_file
+  version="${VIBEGUARD_SETUP_RUNTIME_VERSION:-}"
+  if [[ -z "${version}" ]]; then
+    version_file="${REPO_DIR}/vibeguard-runtime/VERSION"
+    [[ -f "${version_file}" ]] || return 1
+    version="$(tr -d '[:space:]' < "${version_file}")"
+  fi
+  [[ -n "${version}" ]] || return 1
+  case "${version}" in
+    v*) printf '%s' "${version}" ;;
+    *) printf 'v%s' "${version}" ;;
+  esac
+}
+
+setup_runtime_sha256_file() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+setup_download_prebuilt_runtime_quiet() {
+  local target="$1" tag="$2" dest="$3"
+  local asset="vibeguard-runtime-${target}"
+  local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
+  local download_dir downloaded expected actual
+
+  download_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-runtime-download_XXXXXX")"
+  downloaded=0
+
+  if command -v gh >/dev/null 2>&1; then
+    if gh release download "${tag}" \
+      --repo "${release_repo}" \
+      --pattern "${asset}" \
+      --pattern "SHA256SUMS" \
+      --dir "${download_dir}" >/dev/null 2>&1; then
+      downloaded=1
+    fi
+  fi
+
+  if [[ "${downloaded}" != "1" ]] && command -v curl >/dev/null 2>&1; then
+    local base_url="https://github.com/${release_repo}/releases/download/${tag}"
+    if curl -fsSL -o "${download_dir}/${asset}" "${base_url}/${asset}" >/dev/null 2>&1 \
+      && curl -fsSL -o "${download_dir}/SHA256SUMS" "${base_url}/SHA256SUMS" >/dev/null 2>&1; then
+      downloaded=1
+    fi
+  fi
+
+  if [[ "${downloaded}" != "1" || ! -f "${download_dir}/${asset}" || ! -f "${download_dir}/SHA256SUMS" ]]; then
+    rm -rf "${download_dir}"
+    return 1
+  fi
+
+  expected="$(awk -v file="${asset}" '($2 == file || $2 == "*" file) { print $1; exit }' "${download_dir}/SHA256SUMS")"
+  if [[ -z "${expected}" ]]; then
+    rm -rf "${download_dir}"
+    return 1
+  fi
+  if ! actual="$(setup_runtime_sha256_file "${download_dir}/${asset}")" || [[ "${actual}" != "${expected}" ]]; then
+    rm -rf "${download_dir}"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "${dest}")"
+  cp "${download_dir}/${asset}" "${dest}"
+  chmod +x "${dest}"
+  rm -rf "${download_dir}"
+}
+
+setup_runtime_bootstrap_cleanup() {
+  if [[ -n "${VIBEGUARD_SETUP_RUNTIME_BOOTSTRAP_TMP:-}" ]]; then
+    rm -rf "${VIBEGUARD_SETUP_RUNTIME_BOOTSTRAP_TMP}" 2>/dev/null || true
+  fi
+}
+
+ensure_setup_runtime_available() {
+  local target tag tmp dest
+  if setup_runtime_path >/dev/null 2>&1; then
+    return 0
+  fi
+  target="$(setup_runtime_release_target)" || return 1
+  tag="$(setup_runtime_release_tag)" || return 1
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-runtime-bootstrap_XXXXXX")"
+  dest="${tmp}/vibeguard-runtime"
+  if ! setup_download_prebuilt_runtime_quiet "${target}" "${tag}" "${dest}"; then
+    rm -rf "${tmp}"
+    return 1
+  fi
+  export VIBEGUARD_SETUP_RUNTIME="${dest}"
+  export VIBEGUARD_SETUP_RUNTIME_BOOTSTRAP_TMP="${tmp}"
+  trap setup_runtime_bootstrap_cleanup EXIT
+  setup_runtime_path >/dev/null 2>&1
+}
+
 settings_check() {
   local settings_file="$1" target="$2"
   [[ -f "${settings_file}" ]] || return 1
-  python3 "${SETTINGS_HELPER}" check --settings-file "${settings_file}" --target "${target}" >/dev/null 2>&1
+  setup_runtime setup-settings-check "${REPO_DIR}" "${settings_file}" "${target}" >/dev/null 2>&1
 }
 
 settings_stale_hooks_report() {
   local settings_file="$1"
   [[ -f "${settings_file}" ]] || return 0
-  python3 "${SETTINGS_HELPER}" check-stale-hooks --settings-file "${settings_file}"
+  setup_runtime setup-settings-check-stale "${settings_file}"
 }
 
 settings_upsert() {
   local settings_file="$1" profile="$2"
-  local args=(upsert-vibeguard --settings-file "${settings_file}" --repo-dir "${REPO_DIR}" --profile "${profile}")
+  local args=(setup-settings-upsert "${REPO_DIR}" "${settings_file}" "${profile}")
   if [[ "${VIBEGUARD_SETUP_FORCE_OVERWRITE}" == "1" ]]; then
     args+=(--force-overwrite)
   fi
-  python3 "${SETTINGS_HELPER}" "${args[@]}"
+  setup_runtime "${args[@]}"
 }
 
 settings_upsert_diff() {
   local settings_file="$1" profile="$2"
-  local args=(upsert-vibeguard --dry-run --settings-file "${settings_file}" --repo-dir "${REPO_DIR}" --profile "${profile}")
+  local args=(setup-settings-upsert "${REPO_DIR}" "${settings_file}" "${profile}" --dry-run)
   if [[ "${VIBEGUARD_SETUP_FORCE_OVERWRITE}" == "1" ]]; then
     args+=(--force-overwrite)
   fi
-  python3 "${SETTINGS_HELPER}" "${args[@]}"
+  setup_runtime "${args[@]}"
 }
 
 settings_remove() {
   local settings_file="$1"
-  python3 "${SETTINGS_HELPER}" remove-vibeguard --settings-file "${settings_file}"
+  setup_runtime setup-settings-remove "${REPO_DIR}" "${settings_file}"
 }
 
 manifest_skill_links() {
   local target="$1"
-  python3 "${MANIFEST_HELPER}" skill-links --target "${target}"
+  if [[ "${MANIFEST_HELPER}" != "${REPO_DIR}/scripts/lib/vibeguard_manifest.py" ]]; then
+    python3 "${MANIFEST_HELPER}" skill-links --target "${target}"
+    return
+  fi
+  setup_runtime setup-manifest-skill-links "${REPO_DIR}" "${target}"
 }
 
 manifest_rule_links() {
   local languages="${1:-}"
+  if [[ "${MANIFEST_HELPER}" != "${REPO_DIR}/scripts/lib/vibeguard_manifest.py" ]]; then
+    if [[ -n "${languages}" ]]; then
+      python3 "${MANIFEST_HELPER}" rule-links --languages "${languages}"
+    else
+      python3 "${MANIFEST_HELPER}" rule-links
+    fi
+    return
+  fi
   if [[ -n "${languages}" ]]; then
-    python3 "${MANIFEST_HELPER}" rule-links --languages "${languages}"
+    setup_runtime setup-manifest-rule-links "${REPO_DIR}" "${languages}"
   else
-    python3 "${MANIFEST_HELPER}" rule-links
+    setup_runtime setup-manifest-rule-links "${REPO_DIR}"
   fi
 }
 
 manifest_rule_labels() {
   local languages="${1:-}"
+  if [[ "${MANIFEST_HELPER}" != "${REPO_DIR}/scripts/lib/vibeguard_manifest.py" ]]; then
+    if [[ -n "${languages}" ]]; then
+      python3 "${MANIFEST_HELPER}" rule-labels --languages "${languages}"
+    else
+      python3 "${MANIFEST_HELPER}" rule-labels
+    fi
+    return
+  fi
   if [[ -n "${languages}" ]]; then
-    python3 "${MANIFEST_HELPER}" rule-labels --languages "${languages}"
+    setup_runtime setup-manifest-rule-labels "${REPO_DIR}" "${languages}"
   else
-    python3 "${MANIFEST_HELPER}" rule-labels
+    setup_runtime setup-manifest-rule-labels "${REPO_DIR}"
   fi
 }
 
@@ -250,7 +444,7 @@ inject_vibeguard_rules() {
 
   rule_count=$(claude_rule_count_for_banner)
   mkdir -p "$(dirname "${target_file}")"
-  if ! rules_diff=$(python3 "${CLAUDE_MD_HELPER}" diff-inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
+  if ! rules_diff=$(setup_runtime setup-md-diff-inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
     red "  Failed to compute ${display_label} diff"
     return 1
   fi
@@ -269,7 +463,7 @@ inject_vibeguard_rules() {
     echo
     return 0
   fi
-  if result=$(python3 "${CLAUDE_MD_HELPER}" inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
+  if result=$(setup_runtime setup-md-inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>&1); then
     if [[ -f "${target_file}" ]]; then
       state_record_file "${target_file}" "${state_source}" "copy"
     fi

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -487,7 +487,7 @@ check_claude_home_installation() {
 clean_claude_home_installation() {
   if [[ -f "${CLAUDE_DIR}/CLAUDE.md" ]]; then
     local result
-    result=$(python3 "${CLAUDE_MD_HELPER}" remove "${CLAUDE_DIR}/CLAUDE.md" 2>/dev/null || echo "ERROR")
+    result=$(setup_runtime setup-md-remove "${CLAUDE_DIR}/CLAUDE.md" 2>/dev/null || echo "ERROR")
     case "${result}" in
       REMOVED|REMOVED_LEGACY) yellow "Removed VibeGuard rules from ~/.claude/CLAUDE.md" ;;
       NOT_FOUND) yellow "No VibeGuard rules found in ~/.claude/CLAUDE.md" ;;

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -17,17 +17,19 @@ install_codex_home_assets() {
   mkdir -p "${HOME}/.vibeguard/_lib"
   cp "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${HOME}/.vibeguard/_lib/codex_diag.sh"
   cp "${REPO_DIR}/hooks/_lib/codex_runner.sh" "${HOME}/.vibeguard/_lib/codex_runner.sh"
+  cp "${REPO_DIR}/hooks/_lib/timeout.sh" "${HOME}/.vibeguard/_lib/timeout.sh"
   chmod +x "${HOME}/.vibeguard/run-hook-codex.sh"
   state_record_file "${HOME}/.vibeguard/run-hook-codex.sh" "hooks/run-hook-codex.sh" "copy"
   state_record_file "${HOME}/.vibeguard/_lib/codex_diag.sh" "hooks/_lib/codex_diag.sh" "copy"
   state_record_file "${HOME}/.vibeguard/_lib/codex_runner.sh" "hooks/_lib/codex_runner.sh" "copy"
+  state_record_file "${HOME}/.vibeguard/_lib/timeout.sh" "hooks/_lib/timeout.sh" "copy"
   green "  ~/.vibeguard/run-hook-codex.sh ready"
 
   # Merge VibeGuard hooks into ~/.codex/hooks.json (do not overwrite existing hooks)
   local wrapper="${HOME}/.vibeguard/run-hook-codex.sh"
   local hooks_file="${CODEX_DIR}/hooks.json"
   local hooks_result
-  hooks_result=$(python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${hooks_file}" --wrapper "${wrapper}" 2>/dev/null || echo "ERROR")
+  hooks_result=$(setup_runtime setup-codex-hooks-upsert "${REPO_DIR}" "${hooks_file}" "${wrapper}" 2>/dev/null || echo "ERROR")
   if [[ "${hooks_result}" == "CHANGED" || "${hooks_result}" == "SKIP" ]]; then
     state_record_file "${hooks_file}" "generated/codex-hooks.json" "copy"
     green "  ~/.codex/hooks.json merged (VibeGuard hooks upserted)"
@@ -73,7 +75,7 @@ install_codex_skill_copy() {
 _enable_codex_hooks_feature() {
   local config="${CODEX_DIR}/config.toml"
   local result
-  if ! result=$(python3 "${CODEX_CONFIG_HELPER}" enable-hooks --config-file "${config}" 2>/dev/null); then
+  if ! result=$(setup_runtime setup-codex-config-enable-hooks "${config}" 2>/dev/null); then
     red "  Failed to enable hooks feature in config.toml"
     return 1
   fi
@@ -93,7 +95,7 @@ _enable_codex_hooks_feature() {
 
 _remove_legacy_codex_mcp_config() {
   local config="${CODEX_DIR}/config.toml"
-  python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${config}"
+  setup_runtime setup-codex-config-remove-legacy-mcp "${config}"
 }
 
 _has_legacy_codex_mcp_config() {
@@ -156,23 +158,17 @@ check_codex_home_installation() {
   if [[ -f "${CODEX_DIR}/hooks.json" ]]; then
     local wrapper="${HOME}/.vibeguard/run-hook-codex.sh"
     local hook_count
-    hook_count=$(python3 -c "
-import json
-with open('${CODEX_DIR}/hooks.json') as f:
-    data = json.load(f)
-total = sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list))
-print(total)
-" 2>/dev/null || echo "?")
+    hook_count=$(setup_runtime setup-codex-hooks-count "${CODEX_DIR}/hooks.json" 2>/dev/null || echo "?")
     green "[OK] Codex hooks.json present (${hook_count} total entries)"
 
-    if python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${CODEX_DIR}/hooks.json" --wrapper "${wrapper}" >/dev/null 2>&1; then
+    if setup_runtime setup-codex-hooks-check "${REPO_DIR}" "${CODEX_DIR}/hooks.json" "${wrapper}" >/dev/null 2>&1; then
       green "[OK] VibeGuard hooks merged in ~/.codex/hooks.json"
     else
       yellow "[MISSING] VibeGuard hooks not fully configured in ~/.codex/hooks.json"
     fi
 
     local stale_hooks_report
-    if stale_hooks_report="$(python3 "${CODEX_HOOKS_HELPER}" check-stale-hooks --hooks-file "${CODEX_DIR}/hooks.json" 2>&1)"; then
+    if stale_hooks_report="$(setup_runtime setup-codex-hooks-check-stale "${CODEX_DIR}/hooks.json" 2>&1)"; then
       :
     else
       while IFS= read -r line; do
@@ -181,7 +177,7 @@ print(total)
     fi
 
     local timeout_hooks_report
-    if timeout_hooks_report="$(python3 "${CODEX_HOOKS_HELPER}" check-timeouts --hooks-file "${CODEX_DIR}/hooks.json" 2>&1)"; then
+    if timeout_hooks_report="$(setup_runtime setup-codex-hooks-check-timeouts "${REPO_DIR}" "${CODEX_DIR}/hooks.json" 2>&1)"; then
       :
     else
       while IFS= read -r line; do
@@ -209,7 +205,7 @@ print(total)
   local config="${CODEX_DIR}/config.toml"
   local codex_hooks_status="MISSING"
   if [[ -f "${config}" ]]; then
-    codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-hooks --config-file "${config}" 2>/dev/null || true)"
+    codex_hooks_status="$(setup_runtime setup-codex-config-check-hooks "${config}" 2>/dev/null || true)"
   fi
   if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] hooks feature enabled in config.toml"
@@ -236,7 +232,7 @@ codex_semantic_drift_message() {
   if [[ "${path}" == "${config}" ]]; then
     local codex_hooks_status="MISSING"
     if [[ -f "${config}" ]]; then
-      codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-hooks --config-file "${config}" 2>/dev/null || true)"
+      codex_hooks_status="$(setup_runtime setup-codex-config-check-hooks "${config}" 2>/dev/null || true)"
     fi
     if [[ "${codex_hooks_status}" == "OK" ]] && ! _has_legacy_codex_mcp_config; then
       printf '%s\n' "${path} (checksum drift; Codex config semantics OK)"
@@ -246,7 +242,7 @@ codex_semantic_drift_message() {
 
   if [[ "${path}" == "${hooks_file}" ]]; then
     local wrapper="${HOME}/.vibeguard/run-hook-codex.sh"
-    if [[ -f "${hooks_file}" ]] && python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${hooks_file}" --wrapper "${wrapper}" >/dev/null 2>&1; then
+    if [[ -f "${hooks_file}" ]] && setup_runtime setup-codex-hooks-check "${REPO_DIR}" "${hooks_file}" "${wrapper}" >/dev/null 2>&1; then
       printf '%s\n' "${path} (checksum drift; VibeGuard hook semantics OK)"
       return 0
     fi
@@ -326,7 +322,7 @@ print_codex_status() {
   local wrapper="${HOME}/.vibeguard/run-hook-codex.sh"
   if [[ -f "${hooks_file}" ]]; then
     green "[OK] Codex hooks.json present"
-    if python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${hooks_file}" --wrapper "${wrapper}" >/dev/null 2>&1; then
+    if setup_runtime setup-codex-hooks-check "${REPO_DIR}" "${hooks_file}" "${wrapper}" >/dev/null 2>&1; then
       green "[OK] VibeGuard-managed Codex hooks semantic check passed"
     else
       yellow "[WARN] VibeGuard-managed Codex hooks semantic check failed (repair: bash setup.sh --yes)"
@@ -346,7 +342,7 @@ print_codex_status() {
   local config="${CODEX_DIR}/config.toml"
   local codex_hooks_status="MISSING"
   if [[ -f "${config}" ]]; then
-    codex_hooks_status="$(python3 "${CODEX_CONFIG_HELPER}" check-hooks --config-file "${config}" 2>/dev/null || true)"
+    codex_hooks_status="$(setup_runtime setup-codex-config-check-hooks "${config}" 2>/dev/null || true)"
   fi
   if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] hooks feature enabled"
@@ -466,7 +462,7 @@ check_codex_agents_hygiene() {
 clean_codex_home_installation() {
   if [[ -f "${CODEX_DIR}/AGENTS.md" ]]; then
     local agents_md_result
-    agents_md_result=$(python3 "${CLAUDE_MD_HELPER}" remove "${CODEX_DIR}/AGENTS.md" 2>/dev/null || echo "ERROR")
+    agents_md_result=$(setup_runtime setup-md-remove "${CODEX_DIR}/AGENTS.md" 2>/dev/null || echo "ERROR")
     case "${agents_md_result}" in
       REMOVED|REMOVED_LEGACY) yellow "Removed VibeGuard rules from ~/.codex/AGENTS.md" ;;
       NOT_FOUND) yellow "No VibeGuard rules found in ~/.codex/AGENTS.md" ;;
@@ -484,7 +480,7 @@ clean_codex_home_installation() {
 
   # Remove only VibeGuard-managed entries from hooks.json (do not delete third-party hooks)
   local hooks_cleanup_result
-  hooks_cleanup_result=$(python3 "${CODEX_HOOKS_HELPER}" remove-vibeguard --hooks-file "${CODEX_DIR}/hooks.json" 2>/dev/null || echo "ERROR")
+  hooks_cleanup_result=$(setup_runtime setup-codex-hooks-remove "${REPO_DIR}" "${CODEX_DIR}/hooks.json" 2>/dev/null || echo "ERROR")
   case "${hooks_cleanup_result}" in
     CHANGED)
       yellow "Removed VibeGuard hook entries from ~/.codex/hooks.json"
@@ -500,6 +496,7 @@ clean_codex_home_installation() {
   rm -f "${HOME}/.vibeguard/run-hook-codex.sh"
   rm -f "${HOME}/.vibeguard/_lib/codex_diag.sh"
   rm -f "${HOME}/.vibeguard/_lib/codex_runner.sh"
+  rm -f "${HOME}/.vibeguard/_lib/timeout.sh"
   rmdir "${HOME}/.vibeguard/_lib" 2>/dev/null || true
   yellow "Removed Codex hook wrapper"
 

--- a/tests/codex_runtime/protocol_helper_tests.sh
+++ b/tests/codex_runtime/protocol_helper_tests.sh
@@ -25,17 +25,19 @@ SH
 chmod +x "${NO_PYTHON_BIN}/python3"
 
 protocol_helper_out="$(
-  WRAPPER_DIR="${REPO_DIR}/hooks" PATH="${NO_PYTHON_BIN}:${PATH}" bash -c '
+  WRAPPER_DIR="${REPO_DIR}/hooks" PATH="${NO_PYTHON_BIN}:${PATH}" VIBEGUARD_CODEX_DIAG_FILE="${TMP_DIR}/protocol-codex-wrapper.jsonl" bash -c '
     set -euo pipefail
     source "$1"
     source "$2"
     payload="{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cargo test\"}}"
     printf "raw_event=%s\n" "$(codex_raw_event_name "${payload}")"
     printf "adapter_event=%s\n" "$(codex_event_name "${payload}")"
+    printf "status_info=%s\n" "$(codex_hook_status_info "${payload}")"
     printf "matcher=%s\n" "$(codex_hook_status_matcher "${payload}")"
     printf "detail=%s\n" "$(codex_hook_status_detail "${payload}")"
     codex_hook_status() { printf "status=%s reason=%s\n" "$4" "$5"; }
     codex_hook_status_from_output "vibeguard-pre-bash-guard.sh" "PreToolUse" "Bash" "{\"hookSpecificOutput\":{\"decision\":{\"behavior\":\"deny\",\"message\":\"stop\"}}}"
+    printf "status_json=%s\n" "$(cat "${VIBEGUARD_CODEX_DIAG_FILE}")"
     printf "pretool_deny_start\n"; codex_pretool_deny "blocked without python"; printf "pretool_deny_end\n"
     printf "permission_deny_start\n"; codex_permission_deny "permission blocked without python"; printf "permission_deny_end\n"
     printf "pretool_adapt_start\n"; codex_adapt_pretool "{\"decision\":\"block\",\"reason\":\"adapted without python\"}"; printf "pretool_adapt_end\n"
@@ -45,14 +47,87 @@ protocol_helper_out="$(
 )"
 assert_contains "${protocol_helper_out}" "raw_event=PreToolUse" "codex_raw_event_name works without python3"
 assert_contains "${protocol_helper_out}" "adapter_event=PreToolUse" "codex_event_name works without python3"
+assert_contains "${protocol_helper_out}" $'status_info=PreToolUse\tBash\tcargo test' "codex_hook_status_info works without python3"
 assert_contains "${protocol_helper_out}" "matcher=Bash" "codex_hook_status_matcher works without python3"
 assert_contains "${protocol_helper_out}" "detail=cargo test" "codex_hook_status_detail works without python3"
-assert_contains "${protocol_helper_out}" "status=block reason=" "codex_hook_status_from_output works without python3"
+assert_contains "${protocol_helper_out}" '"status":"block"' "codex_hook_status_from_output works without python3"
 assert_contains "${protocol_helper_out}" "blocked without python" "codex_pretool_deny works without python3"
 assert_contains "${protocol_helper_out}" "permission blocked without python" "codex_permission_deny works without python3"
 assert_contains "${protocol_helper_out}" "adapted without python" "codex_adapt_pretool works without python3"
 assert_contains "${protocol_helper_out}" "posttool without python" "codex_adapt_posttool works without python3"
 assert_contains "${protocol_helper_out}" "permission adapted without python" "codex_adapt_permission_request works without python3"
+
+timeout_defaults_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" bash -c '
+    set -euo pipefail
+    source "$1"
+    printf "pre_bash=%s\n" "$(codex_hook_timeout_ms vibeguard-pre-bash-guard.sh)"
+    printf "post_build=%s\n" "$(codex_hook_timeout_ms vibeguard-post-build-check.sh)"
+    printf "stop=%s\n" "$(codex_hook_timeout_ms vibeguard-stop-guard.sh)"
+  ' -- "${REPO_DIR}/hooks/_lib/codex_diag.sh"
+)"
+assert_contains "${timeout_defaults_out}" "pre_bash=15000" "Codex pre hooks use manifest timeout"
+assert_contains "${timeout_defaults_out}" "post_build=35000" "Codex post-build hook uses manifest timeout"
+assert_contains "${timeout_defaults_out}" "stop=15000" "Codex stop hook uses manifest timeout"
+
+OLD_STATUS_RUNTIME="${TMP_DIR}/old-status-runtime"
+OLD_STATUS_DIAG="${TMP_DIR}/old-status-diag.jsonl"
+cat > "${OLD_STATUS_RUNTIME}" <<'SH'
+#!/usr/bin/env bash
+cmd="$1"
+shift
+case "$cmd" in
+  codex-status-info|codex-hook-status-from-output)
+    printf 'Unknown command: %s\n' "$cmd" >&2
+    exit 2
+    ;;
+  codex-event-name)
+    cat >/dev/null
+    printf 'PreToolUse\n'
+    ;;
+  codex-status-matcher)
+    cat >/dev/null
+    printf 'Bash\n'
+    ;;
+  codex-status-detail)
+    cat >/dev/null
+    printf 'cargo test\n'
+    ;;
+  codex-status-from-output)
+    cat >/dev/null
+    printf 'block\told-runtime-block\n'
+    ;;
+  codex-hook-status)
+    diag_file="$1"
+    hook_name="$2"
+    event_name="$3"
+    matcher="$4"
+    status="$5"
+    reason="$6"
+    detail="$7"
+    timeout_ms="$8"
+    printf '{"hook":"%s","event":"%s","matcher":"%s","status":"%s","reason":"%s","detail":"%s","timeout_ms":%s}\n' \
+      "$hook_name" "$event_name" "$matcher" "$status" "$reason" "$detail" "$timeout_ms" >> "$diag_file"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${OLD_STATUS_RUNTIME}"
+old_status_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_RUNTIME="${OLD_STATUS_RUNTIME}" VIBEGUARD_CODEX_DIAG_FILE="${OLD_STATUS_DIAG}" bash -c '
+    set -euo pipefail
+    source "$1"
+    payload="{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cargo test\"}}"
+    printf "old_status_info=%s\n" "$(codex_hook_status_info "${payload}")"
+    codex_hook_status_from_output "vibeguard-pre-bash-guard.sh" "PreToolUse" "Bash" "{\"decision\":\"block\",\"reason\":\"fallback\"}" "cargo test" "10000"
+    printf "old_status_diag=%s\n" "$(cat "${VIBEGUARD_CODEX_DIAG_FILE}")"
+  ' -- "${REPO_DIR}/hooks/_lib/codex_diag.sh"
+)"
+assert_contains "${old_status_out}" $'old_status_info=PreToolUse\tBash\tcargo test' "codex_hook_status_info falls back to old runtime helpers"
+assert_contains "${old_status_out}" '"status":"block"' "codex_hook_status_from_output falls back to old runtime helpers"
+assert_not_contains "${old_status_out}" "runtime-unavailable" "old runtime status fallback does not create false hook_error"
 
 BROKEN_RUNTIME="${TMP_DIR}/broken-vibeguard-runtime"
 cat > "${BROKEN_RUNTIME}" <<'SH'
@@ -123,6 +198,38 @@ no_python_patch_out="$(
 )"
 assert_contains "${no_python_patch_out}" '"permissionDecision": "deny"' "codex_run_hook apply_patch normalizer works without python3"
 assert_contains "${no_python_patch_out}" 'apply_patch normalized without python' "codex_run_hook apply_patch path reaches normalized Write hook without python3"
+
+TMP_FAKE_REPO_TIMEOUT="${TMP_DIR}/fake-repo-timeout"
+mkdir -p "${TMP_FAKE_REPO_TIMEOUT}/hooks"
+cat > "${TMP_FAKE_REPO_TIMEOUT}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+sleep 5
+printf '{"decision":"pass"}\n'
+HOOK
+chmod +x "${TMP_FAKE_REPO_TIMEOUT}/hooks/vibeguard-pre-bash-guard.sh"
+timeout_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_RUNTIME="${VIBEGUARD_RUNTIME}" bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    source "$3"
+    source "$4"
+    EVENT_NAME=PreToolUse
+    codex_diag() { printf "diag=%s:%s\n" "$3" "$4"; }
+    codex_hook_status() { printf "status=%s reason=%s timeout=%s\n" "$4" "$5" "$7"; }
+    codex_hook_timeout_ms() { printf "100\n"; }
+    codex_run_hook "vibeguard-pre-bash-guard.sh" "$5" "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sleep 5\"}}"
+  ' -- \
+    "${REPO_DIR}/hooks/_lib/codex_diag.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_adapter.sh" \
+    "${REPO_DIR}/hooks/_lib/timeout.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_runner.sh" \
+    "${TMP_FAKE_REPO_TIMEOUT}/hooks/vibeguard-pre-bash-guard.sh"
+)"
+assert_contains "${timeout_out}" "status=timeout" "codex_run_hook enforces wrapped hook timeout"
+assert_contains "${timeout_out}" "wrapped-hook-timeout" "codex_run_hook records timeout diagnostic"
+assert_contains "${timeout_out}" "VIBEGUARD hook timed out" "codex_run_hook emits visible timeout failure"
 
 old_normalizer_runtime="${TMP_DIR}/old-normalizer-runtime"
 cat > "${old_normalizer_runtime}" <<'SH'

--- a/tests/codex_runtime/protocol_helper_tests.sh
+++ b/tests/codex_runtime/protocol_helper_tests.sh
@@ -231,6 +231,32 @@ assert_contains "${timeout_out}" "status=timeout" "codex_run_hook enforces wrapp
 assert_contains "${timeout_out}" "wrapped-hook-timeout" "codex_run_hook records timeout diagnostic"
 assert_contains "${timeout_out}" "VIBEGUARD hook timed out" "codex_run_hook emits visible timeout failure"
 
+timeout_fast_started="$(date +%s)"
+timeout_fast_out="$(
+  bash -c '
+    set -euo pipefail
+    source "$1"
+    vg_run_with_timeout 3 bash -c "exit 0"
+  ' -- "${REPO_DIR}/hooks/_lib/timeout.sh"
+)"
+timeout_fast_elapsed=$(( $(date +%s) - timeout_fast_started ))
+TOTAL=$((TOTAL + 1))
+if [[ "${timeout_fast_elapsed}" -lt 3 ]]; then
+  green "timeout fallback returns before the deadline for fast commands"
+  PASS=$((PASS + 1))
+else
+  red "timeout fallback returns before the deadline for fast commands"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if [[ -z "${timeout_fast_out}" ]]; then
+  green "timeout fallback keeps fast command stdout empty"
+  PASS=$((PASS + 1))
+else
+  red "timeout fallback keeps fast command stdout empty"
+  FAIL=$((FAIL + 1))
+fi
+
 old_normalizer_runtime="${TMP_DIR}/old-normalizer-runtime"
 cat > "${old_normalizer_runtime}" <<'SH'
 #!/usr/bin/env bash

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -296,6 +296,46 @@ set -e
 assert_cmd "source-to-download switch remains healthy under --check --strict" test "${switch_check_rc}" -eq 0
 assert_not_contains "${switch_check_out}" "[BROKEN]" "source-to-download switch does not report BROKEN"
 
+no_python_home="${TMP_HOME}/no-python-install-home"
+no_python_bin="${TMP_HOME}/no-python-bin"
+mkdir -p "${no_python_home}" "${no_python_bin}"
+cat > "${no_python_bin}/python3" <<'SH'
+#!/usr/bin/env bash
+printf 'python3 unexpectedly executed: %s\n' "$*" >&2
+exit 127
+SH
+chmod +x "${no_python_bin}/python3"
+ln -sf "${no_python_bin}/python3" "${no_python_bin}/python"
+no_python_path="${no_python_bin}:${PATH}"
+no_python_install_out="$(HOME="${no_python_home}" PATH="${no_python_path}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core 2>&1)"
+assert_contains "${no_python_install_out}" "Setup complete! All components installed." "no-Python setup install succeeds"
+assert_contains "${no_python_install_out}" "vibeguard-runtime downloaded and verified" "no-Python setup uses verified prebuilt runtime"
+assert_not_contains "${no_python_install_out}" "python3 unexpectedly executed" "no-Python setup install does not execute python3"
+
+fresh_no_python_home="${TMP_HOME}/fresh-no-python-home"
+mkdir -p "${fresh_no_python_home}"
+set +e
+fresh_no_python_check_out="$(HOME="${fresh_no_python_home}" PATH="${no_python_path}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1 bash "${REPO_DIR}/setup.sh" --check --strict 2>&1)"
+fresh_no_python_check_rc=$?
+set -e
+assert_cmd "fresh no-Python setup --check --strict exits broken but runs" test "${fresh_no_python_check_rc}" -eq 2
+assert_contains "${fresh_no_python_check_out}" "VibeGuard Installation Status" "fresh no-Python setup --check emits status"
+assert_not_contains "${fresh_no_python_check_out}" "python3 unexpectedly executed" "fresh no-Python setup --check does not execute python3"
+fresh_no_python_clean_out="$(HOME="${fresh_no_python_home}" PATH="${no_python_path}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1 bash "${REPO_DIR}/setup.sh" --clean 2>&1)"
+assert_contains "${fresh_no_python_clean_out}" "VibeGuard cleaned." "fresh no-Python setup --clean succeeds without installed runtime"
+assert_not_contains "${fresh_no_python_clean_out}" "python3 unexpectedly executed" "fresh no-Python setup --clean does not execute python3"
+
+set +e
+no_python_check_out="$(HOME="${no_python_home}" PATH="${no_python_path}" bash "${REPO_DIR}/setup.sh" --check --strict 2>&1)"
+no_python_check_rc=$?
+set -e
+assert_cmd "no-Python setup --check --strict exits 0" test "${no_python_check_rc}" -eq 0
+assert_not_contains "${no_python_check_out}" "python3 unexpectedly executed" "no-Python setup --check does not execute python3"
+no_python_clean_out="$(HOME="${no_python_home}" PATH="${no_python_path}" bash "${REPO_DIR}/setup.sh" --clean 2>&1)"
+assert_contains "${no_python_clean_out}" "VibeGuard cleaned." "no-Python setup --clean succeeds"
+assert_not_contains "${no_python_clean_out}" "python3 unexpectedly executed" "no-Python setup --clean does not execute python3"
+assert_cmd "no-Python setup --clean removes install state" test ! -e "${no_python_home}/.vibeguard/install-state.json"
+
 install_out="$(VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
 assert_contains "${install_out}" "vibeguard-runtime downloaded and verified" "default setup uses verified prebuilt runtime without cargo"
@@ -307,7 +347,9 @@ assert_cmd "setup install removes tracked retired Codex skill" test ! -L "${HOME
 assert_cmd "vg shortcut commands are installed after setup" test -L "${HOME}/.claude/commands/vg"
 assert_cmd "vibeguard-runtime binary installed after setup" test -x "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
 assert_cmd "runtime policy project schema installed after setup" test -f "${HOME}/.vibeguard/installed/schemas/vibeguard-project.schema.json"
-assert_cmd "runtime policy project validator installed after setup" test -f "${HOME}/.vibeguard/installed/scripts/lib/project_config_validate.py"
+printf '{"profile":"core"}\n' > "${TMP_HOME}/valid-project-config.json"
+assert_cmd "runtime policy project validator moved into runtime" "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" project-config-validate "${TMP_HOME}/valid-project-config.json"
+assert_cmd "runtime policy Python project validator not installed after setup" test ! -e "${HOME}/.vibeguard/installed/scripts/lib/project_config_validate.py"
 assert_contains "${install_out}" "[OK] Installed hooks+guards snapshot matches repo HEAD" "setup install reports current installed snapshot"
 assert_contains "${install_out}" "~/.vibeguard/config.json present (preserved)" "setup preserves seeded runtime config during install"
 assert_cmd "pre-push wrapper is installed after setup" test -x "${HOME}/.vibeguard/pre-push"

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -20,6 +20,27 @@ force_settings_out="$(bash "${REPO_DIR}/setup.sh" --yes --force-overwrite 2>&1)"
 assert_contains "${force_settings_out}" "Mode: force-overwrite" "--force-overwrite mode is visible"
 assert_cmd "--force-overwrite restores canonical hook command" bash -c "! grep -q 'flock /tmp/vibeguard.lock' '${HOME}/.claude/settings.json'"
 
+python3 - <<'PY' "${HOME}/.claude/settings.json"
+import json
+import sys
+from pathlib import Path
+
+settings = Path(sys.argv[1])
+data = json.loads(settings.read_text(encoding="utf-8"))
+for entry in data["hooks"]["PreToolUse"]:
+    if entry.get("matcher") == "Bash":
+        entry["hooks"].append({"type": "command", "command": "bash /tmp/third-party-pre-bash.sh"})
+        break
+else:
+    raise SystemExit(1)
+settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+mixed_clean_out="$(bash "${REPO_DIR}/setup.sh" --clean 2>&1)"
+assert_contains "${mixed_clean_out}" "VibeGuard cleaned." "setup --clean succeeds with mixed Claude hook entry"
+assert_cmd "setup --clean preserves third-party Claude hook in mixed entry" grep -q "/tmp/third-party-pre-bash.sh" "${HOME}/.claude/settings.json"
+assert_cmd "setup --clean removes VibeGuard hook from mixed entry" bash -c "! grep -q 'pre-bash-guard.sh' '${HOME}/.claude/settings.json'"
+bash "${REPO_DIR}/setup.sh" --yes >/dev/null
+
 _CUSTOM_RULE="${HOME}/.claude/rules/vibeguard/common/security.md"
 rm -f "${_CUSTOM_RULE}"
 printf 'local custom security rule\n' > "${_CUSTOM_RULE}"
@@ -31,15 +52,16 @@ assert_contains "${rule_force_out}" "FORCE: replacing local rule copy" "--force-
 assert_cmd "--force-overwrite restores rule symlink" test -L "${_CUSTOM_RULE}"
 
 header "codex config helper failure propagates"
-_ORIG_CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
-_BACKUP_CODEX_CONFIG_HELPER="${TMP_HOME}/codex_config_toml.py.backup"
-cp "${_ORIG_CODEX_CONFIG_HELPER}" "${_BACKUP_CODEX_CONFIG_HELPER}"
-cat > "${_ORIG_CODEX_CONFIG_HELPER}" <<'PY'
-#!/usr/bin/env python3
-raise SystemExit(42)
-PY
-fail_install_out="$(bash "${REPO_DIR}/setup.sh" --yes 2>&1 || true)"
-cp "${_BACKUP_CODEX_CONFIG_HELPER}" "${_ORIG_CODEX_CONFIG_HELPER}"
+_FAILING_CODEX_CONFIG_RUNTIME="${TMP_HOME}/failing-codex-config-runtime"
+cat > "${_FAILING_CODEX_CONFIG_RUNTIME}" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "setup-codex-config-enable-hooks" ]]; then
+  exit 42
+fi
+exec "${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime" "\$@"
+EOF
+chmod +x "${_FAILING_CODEX_CONFIG_RUNTIME}"
+fail_install_out="$(VIBEGUARD_SETUP_RUNTIME="${_FAILING_CODEX_CONFIG_RUNTIME}" bash "${REPO_DIR}/setup.sh" --yes 2>&1 || true)"
 assert_contains "${fail_install_out}" "Failed to enable hooks feature in config.toml" "setup reports hooks helper failure"
 assert_cmd "setup exits before reporting success when hooks helper fails" bash -c "! grep -q 'Setup complete! All components installed.' <<< '${fail_install_out}'"
 
@@ -218,7 +240,7 @@ assert_cmd "check-vibeguard rejects stale entry missing type field" bash -c "! p
 # After upsert the entry must be repaired and check must pass.
 python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}" >/dev/null
 assert_cmd "upsert repairs stale entry; check-vibeguard then passes" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${_STALE_HOOKS}" --wrapper "${_STALE_WRAPPER}"
-# Write a Stop entry with correct command but a spurious timeout (Stop spec has none).
+# Write a Stop entry with correct command but the wrong timeout.
 python3 -c "
 import json
 data = {
@@ -231,7 +253,7 @@ data = {
 with open('${_STALE_HOOKS}', 'w') as f:
     json.dump(data, f, indent=2)
 "
-assert_cmd "check-vibeguard rejects Stop entry with spurious timeout" bash -c "! python3 '${CODEX_HOOKS_HELPER}' check-vibeguard --hooks-file '${_STALE_HOOKS}' --wrapper '${_STALE_WRAPPER}'"
+assert_cmd "check-vibeguard rejects Stop entry with wrong timeout" bash -c "! python3 '${CODEX_HOOKS_HELPER}' check-vibeguard --hooks-file '${_STALE_HOOKS}' --wrapper '${_STALE_WRAPPER}'"
 # Write a Stop entry with correct command+type but a spurious matcher (Stop spec has none).
 python3 -c "
 import json

--- a/tests/test_gc_scheduled.sh
+++ b/tests/test_gc_scheduled.sh
@@ -92,6 +92,77 @@ assert_contains "$metrics_after" "$today" "current session metric remains"
 assert_not_contains "$metrics_after" "2020-01-01" "expired session metric is removed"
 assert_contains "$reflection" "VibeGuard Weekly Reflection Report" "reflection report is generated"
 
+header "gc-scheduled.sh catch-up mode"
+
+skip_log_before="$(wc -l < "${log_dir}/gc-cron.log" | tr -d ' ')"
+VIBEGUARD_LOG_DIR="$log_dir" VIBEGUARD_PROJECT_CONFIG="$cfg" bash scripts/gc/gc-scheduled.sh --scheduled
+skip_log_after="$(wc -l < "${log_dir}/gc-cron.log" | tr -d ' ')"
+assert_cmd "scheduled mode skips when last success is fresh and logs are below threshold" test "$skip_log_before" = "$skip_log_after"
+
+python3 - "${log_dir}/events.jsonl" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+with path.open("w", encoding="utf-8") as f:
+    for index in range(20000):
+        f.write(json.dumps({
+            "ts": "2024-01-01T00:00:00Z",
+            "session": "oversized",
+            "hook": "pre-bash-guard",
+            "tool": "Bash",
+            "decision": "pass",
+            "detail": "x" * 80,
+            "index": index,
+        }) + "\n")
+    f.write(json.dumps({
+        "ts": "2099-01-01T00:00:00Z",
+        "session": "current",
+        "hook": "pre-bash-guard",
+        "tool": "Bash",
+        "decision": "pass",
+        "detail": "current",
+    }) + "\n")
+PY
+
+VIBEGUARD_LOG_DIR="$log_dir" VIBEGUARD_PROJECT_CONFIG="$cfg" VIBEGUARD_GC_LOG_THRESHOLD_MB=1 \
+  VIBEGUARD_GC_ARCHIVE_RETAIN_MONTHS=1200 \
+  bash scripts/gc/gc-scheduled.sh --scheduled
+
+assert_cmd "scheduled mode catches up when global log exceeds threshold" test -f "${log_dir}/archive/events-2024-01.jsonl.gz"
+assert_contains "$(cat "${log_dir}/events.jsonl")" "current" "catch-up retains current log events"
+assert_contains "$(cat "${log_dir}/gc-cron.log")" "--- Log archive ---" "catch-up records archive section"
+
+printf '%s\n' "123" > "${log_dir}/gc-last-success"
+python3 - "${log_dir}/events.jsonl" "$(date -u '+%Y-%m-01T00:00:00Z')" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+ts = sys.argv[2]
+with path.open("w", encoding="utf-8") as f:
+    for index in range(20000):
+        f.write(json.dumps({
+            "ts": ts,
+            "session": "current-oversized",
+            "hook": "pre-bash-guard",
+            "tool": "Bash",
+            "decision": "pass",
+            "detail": "y" * 80,
+            "index": index,
+        }) + "\n")
+PY
+
+VIBEGUARD_LOG_DIR="$log_dir" VIBEGUARD_PROJECT_CONFIG="$cfg" VIBEGUARD_GC_LOG_THRESHOLD_MB=1 \
+  bash scripts/gc/gc-scheduled.sh --scheduled
+
+assert_cmd "failed scheduled GC records an attempt" test -f "${log_dir}/gc-last-attempt"
+assert_contains "$(cat "${log_dir}/gc-last-success")" "123" "failed scheduled GC does not update last-success"
+assert_contains "$(cat "${log_dir}/gc-cron.log")" "GC completed with errors" "failed scheduled GC is visible in cron log"
+
 printf '\n==============================\n'
 printf 'Total: %s  Pass: \033[32m%s\033[0m  Fail: \033[31m%s\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
 printf '==============================\n'

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -457,6 +457,7 @@ export PATH="${TMP_HOME}/bin:${PATH}"
 
 TEST_RELEASE_DIR="${TMP_HOME}/release-assets"
 mkdir -p "${TEST_RELEASE_DIR}"
+cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
 : > "${TEST_RELEASE_DIR}/SHA256SUMS"
 for target in \
   aarch64-apple-darwin \
@@ -464,9 +465,13 @@ for target in \
   x86_64-unknown-linux-musl \
   aarch64-unknown-linux-musl; do
   asset="${TEST_RELEASE_DIR}/vibeguard-runtime-${target}"
-  cat > "${asset}" <<SH
+cat > "${asset}" <<SH
 #!/usr/bin/env bash
 set -euo pipefail
+REAL_RUNTIME="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+if [[ -x "\${REAL_RUNTIME}" ]]; then
+  exec "\${REAL_RUNTIME}" "\$@"
+fi
 case "\${1:-}" in
   project-config-validate)
     if [[ \$# -ne 2 ]]; then

--- a/vibeguard-runtime/Cargo.lock
+++ b/vibeguard-runtime/Cargo.lock
@@ -12,6 +12,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +152,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +188,16 @@ dependencies = [
  "libc",
  "regex",
  "serde_json",
+ "toml_edit",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/vibeguard-runtime/Cargo.toml
+++ b/vibeguard-runtime/Cargo.toml
@@ -8,6 +8,7 @@ description = "VibeGuard runtime — fast JSON/JSONL ops, hook metrics, and Code
 serde_json = "1"
 regex = "1"
 libc = "0.2"
+toml_edit = "0.22"
 
 [profile.release]
 opt-level = "z"

--- a/vibeguard-runtime/src/codex_hooks.rs
+++ b/vibeguard-runtime/src/codex_hooks.rs
@@ -43,6 +43,10 @@ fn codex_status_detail(data: &Value) -> String {
     String::new()
 }
 
+fn shell_status_field(value: &str) -> String {
+    value.replace(['\t', '\n', '\r'], " ")
+}
+
 fn codex_status_from_output(data: &Value) -> (String, String) {
     let Some(object) = data.as_object() else {
         return ("hook_error".to_string(), "invalid-json".to_string());
@@ -406,6 +410,24 @@ pub fn status_matcher(args: &[String]) -> Result {
     Ok(())
 }
 
+pub fn status_info(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-status-info")?;
+    let data = read_json_tolerant()?;
+    let event_name = data.as_ref().map(codex_event_name).unwrap_or("");
+    let matcher = data.as_ref().map(codex_status_matcher).unwrap_or("");
+    let detail = data
+        .as_ref()
+        .map(codex_status_detail)
+        .unwrap_or_else(String::new);
+    println!(
+        "{}\t{}\t{}",
+        shell_status_field(event_name),
+        shell_status_field(matcher),
+        shell_status_field(&detail)
+    );
+    Ok(())
+}
+
 pub fn status_from_output(args: &[String]) -> Result {
     ensure_no_args(args, "Usage: vibeguard-runtime codex-status-from-output")?;
     let input = read_stdin()?;
@@ -620,6 +642,14 @@ mod tests {
     fn status_matcher_reads_tool_name() {
         assert_eq!(codex_status_matcher(&json!({"tool_name": "Bash"})), "Bash");
         assert_eq!(codex_status_matcher(&json!({"tool_name": null})), "");
+    }
+
+    #[test]
+    fn shell_status_field_removes_line_breaks_and_tabs() {
+        assert_eq!(
+            shell_status_field("one\ttwo\nthree\rfour"),
+            "one two three four"
+        );
     }
 
     #[test]

--- a/vibeguard-runtime/src/codex_hooks_diag.rs
+++ b/vibeguard-runtime/src/codex_hooks_diag.rs
@@ -94,6 +94,80 @@ pub fn hook_status(args: &[String]) -> Result {
     append_codex_jsonl(&args[0], entry)
 }
 
+fn status_from_hook_output(data: &Value) -> (String, String) {
+    let Some(object) = data.as_object() else {
+        return ("hook_error".to_string(), "invalid-json".to_string());
+    };
+
+    let decision = object
+        .get("decision")
+        .and_then(Value::as_str)
+        .unwrap_or("pass");
+    let reason = object
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .replace(['\t', '\n'], " ");
+
+    let mut status = "pass";
+    if matches!(
+        decision,
+        "warn" | "block" | "gate" | "escalate" | "correction"
+    ) {
+        status = decision;
+    } else if decision == "skip" {
+        status = "skipped";
+    } else if let Some(hook_specific) = object.get("hookSpecificOutput").and_then(Value::as_object)
+    {
+        if hook_specific
+            .get("permissionDecision")
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            status = "block";
+        }
+        if hook_specific
+            .get("decision")
+            .and_then(Value::as_object)
+            .and_then(|decision| decision.get("behavior"))
+            .and_then(Value::as_str)
+            == Some("deny")
+        {
+            status = "block";
+        }
+    }
+
+    (status.to_string(), truncate_chars(&reason, 300))
+}
+
+pub fn hook_status_from_output(args: &[String]) -> Result {
+    if args.len() != 6 {
+        return Err(
+            "Usage: vibeguard-runtime codex-hook-status-from-output <diag-file> <hook-name> <event-name> <matcher> <detail> <timeout-ms>"
+                .into(),
+        );
+    }
+    let input = read_stdin()?;
+    let (status, reason) = match serde_json::from_str::<Value>(&input) {
+        Ok(data) => status_from_hook_output(&data),
+        Err(_) => ("hook_error".to_string(), "invalid-json".to_string()),
+    };
+    let mut entry = json!({
+        "ts": codex_ts(),
+        "cli": "codex",
+        "hook": clean_hook_name(&args[1]),
+        "event": args[2],
+        "matcher": args[3],
+        "status": status,
+        "reason": reason,
+        "detail": truncate_chars(&args[4], 300),
+    });
+    if let Ok(timeout_ms) = args[5].parse::<u64>() {
+        entry["timeout_ms"] = json!(timeout_ms);
+    }
+    append_codex_jsonl(&args[0], entry)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +204,29 @@ mod tests {
             "pre-bash-guard"
         );
         assert_eq!(clean_hook_name("custom-hook"), "custom-hook");
+    }
+
+    #[test]
+    fn status_from_hook_output_maps_nested_denies() {
+        assert_eq!(
+            status_from_hook_output(&json!({"decision": "warn", "reason": "a\tb\nc"})),
+            ("warn".to_string(), "a b c".to_string())
+        );
+        assert_eq!(
+            status_from_hook_output(&json!({"decision": "skip"})),
+            ("skipped".to_string(), String::new())
+        );
+        assert_eq!(
+            status_from_hook_output(&json!({
+                "hookSpecificOutput": {"permissionDecision": "deny"}
+            })),
+            ("block".to_string(), String::new())
+        );
+        assert_eq!(
+            status_from_hook_output(&json!({
+                "hookSpecificOutput": {"decision": {"behavior": "deny"}}
+            })),
+            ("block".to_string(), String::new())
+        );
     }
 }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -28,6 +28,12 @@ mod project_config;
 mod runtime_config;
 mod runtime_policy;
 mod session_metrics;
+mod setup_codex_config;
+mod setup_codex_hooks;
+mod setup_install_state;
+mod setup_manifest;
+mod setup_markdown;
+mod setup_support;
 mod time_utils;
 
 use std::env;
@@ -148,6 +154,11 @@ static COMMANDS: &[Command] = &[
         handler: codex_hooks::status_detail,
     },
     Command {
+        name: "codex-status-info",
+        usage: "  — extract Codex event, matcher, and status detail from stdin",
+        handler: codex_hooks::status_info,
+    },
+    Command {
         name: "codex-status-matcher",
         usage: "  — extract Codex hook status matcher from stdin",
         handler: codex_hooks::status_matcher,
@@ -181,6 +192,11 @@ static COMMANDS: &[Command] = &[
         name: "codex-hook-status",
         usage: "<diag-file> <hook-name> <event-name> <matcher> <status> <reason> <detail> <timeout-ms>  — append a Codex hook status JSONL event",
         handler: codex_hooks_diag::hook_status,
+    },
+    Command {
+        name: "codex-hook-status-from-output",
+        usage: "<diag-file> <hook-name> <event-name> <matcher> <detail> <timeout-ms>  — classify wrapped hook output and append Codex status JSONL",
+        handler: codex_hooks_diag::hook_status_from_output,
     },
     Command {
         name: "codex-adapt-pretool",
@@ -276,6 +292,126 @@ static COMMANDS: &[Command] = &[
         name: "codex-app-server-wrapper",
         usage: "[--repo-dir DIR] [--strategy vibeguard|noop] [--codex-command CMD]  — run the Rust Codex app-server guard proxy",
         handler: codex_app_server::run,
+    },
+    Command {
+        name: "setup-manifest-skill-links",
+        usage: "<repo-dir> <target>  — list manifest skill links",
+        handler: setup_manifest::skill_links,
+    },
+    Command {
+        name: "setup-manifest-rule-links",
+        usage: "<repo-dir> [languages]  — list manifest rule links",
+        handler: setup_manifest::rule_links,
+    },
+    Command {
+        name: "setup-manifest-rule-labels",
+        usage: "<repo-dir> [languages]  — list manifest rule labels",
+        handler: setup_manifest::rule_labels,
+    },
+    Command {
+        name: "setup-md-diff-inject",
+        usage: "<target-file> <rules-file> <repo-dir> <rule-count>  — render managed Markdown diff",
+        handler: setup_markdown::diff_inject,
+    },
+    Command {
+        name: "setup-md-inject",
+        usage: "<target-file> <rules-file> <repo-dir> <rule-count>  — inject managed Markdown block",
+        handler: setup_markdown::inject,
+    },
+    Command {
+        name: "setup-md-remove",
+        usage: "<target-file>  — remove managed Markdown block",
+        handler: setup_markdown::remove,
+    },
+    Command {
+        name: "setup-settings-check",
+        usage: "<repo-dir> <settings-file> <pre-hooks|post-hooks|full-hooks>  — check Claude settings",
+        handler: setup_markdown::settings_check,
+    },
+    Command {
+        name: "setup-settings-upsert",
+        usage: "<repo-dir> <settings-file> <profile> [--dry-run] [--force-overwrite]  — upsert Claude settings",
+        handler: setup_markdown::settings_upsert,
+    },
+    Command {
+        name: "setup-settings-remove",
+        usage: "<repo-dir> <settings-file>  — remove VibeGuard Claude settings",
+        handler: setup_markdown::settings_remove,
+    },
+    Command {
+        name: "setup-settings-check-stale",
+        usage: "<settings-file>  — detect stale Claude hook commands",
+        handler: setup_markdown::settings_check_stale,
+    },
+    Command {
+        name: "setup-state-init",
+        usage: "<state-file> <profile> <languages>  — initialize install state",
+        handler: setup_install_state::init,
+    },
+    Command {
+        name: "setup-state-record-file",
+        usage: "<state-file> <dest> <source> <type>  — record install-state file",
+        handler: setup_install_state::record_file,
+    },
+    Command {
+        name: "setup-state-check-drift",
+        usage: "<state-file>  — check install-state drift",
+        handler: setup_install_state::check_drift,
+    },
+    Command {
+        name: "setup-state-list",
+        usage: "<state-file>  — list install-state files",
+        handler: setup_install_state::list,
+    },
+    Command {
+        name: "setup-state-list-symlinks-under",
+        usage: "<state-file> <dest-dir>  — list tracked symlinks under a directory",
+        handler: setup_install_state::list_tracked_symlinks_under,
+    },
+    Command {
+        name: "setup-codex-config-enable-hooks",
+        usage: "<config-file>  — enable Codex hooks feature",
+        handler: setup_codex_config::enable_hooks,
+    },
+    Command {
+        name: "setup-codex-config-check-hooks",
+        usage: "<config-file>  — check Codex hooks feature",
+        handler: setup_codex_config::check_hooks,
+    },
+    Command {
+        name: "setup-codex-config-remove-legacy-mcp",
+        usage: "<config-file>  — remove legacy VibeGuard Codex MCP config",
+        handler: setup_codex_config::remove_legacy_mcp,
+    },
+    Command {
+        name: "setup-codex-hooks-upsert",
+        usage: "<repo-dir> <hooks-file> <wrapper>  — upsert Codex hooks",
+        handler: setup_codex_hooks::codex_hooks_upsert,
+    },
+    Command {
+        name: "setup-codex-hooks-remove",
+        usage: "<repo-dir> <hooks-file>  — remove VibeGuard Codex hooks",
+        handler: setup_codex_hooks::codex_hooks_remove,
+    },
+    Command {
+        name: "setup-codex-hooks-check",
+        usage: "<repo-dir> <hooks-file> <wrapper>  — check Codex hooks",
+        handler: setup_codex_hooks::codex_hooks_check,
+    },
+    Command {
+        name: "setup-codex-hooks-count",
+        usage: "<hooks-file>  — count Codex hook entries",
+        handler: setup_codex_hooks::codex_hooks_count,
+    },
+    Command {
+        name: "setup-codex-hooks-check-stale",
+        usage: "<hooks-file>  — detect stale Codex hook commands",
+        handler: setup_codex_hooks::codex_hooks_check_stale,
+    },
+    Command {
+        name: "setup-codex-hooks-check-timeouts",
+        usage: "<repo-dir> <hooks-file>  — detect Codex hooks without timeout",
+        handler: setup_codex_hooks::codex_hooks_check_timeouts,
     },
 ];
 

--- a/vibeguard-runtime/src/setup_codex_config.rs
+++ b/vibeguard-runtime/src/setup_codex_config.rs
@@ -1,0 +1,220 @@
+use crate::setup_support::{SetupResult, write_text_atomic};
+use std::path::Path;
+use toml_edit::{DocumentMut, Item, Table, value};
+
+pub fn enable_hooks(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-config-enable-hooks <config-file>".into(),
+        );
+    }
+    let path = Path::new(&args[0]);
+    let old = if path.exists() {
+        std::fs::read_to_string(path)?
+    } else {
+        String::new()
+    };
+    let (new, changed) = ensure_hooks_enabled(&old)?;
+    if changed || !path.exists() {
+        write_text_atomic(path, &new)?;
+        println!("CHANGED");
+    } else {
+        println!("SKIP");
+    }
+    Ok(())
+}
+
+pub fn check_hooks(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-codex-config-check-hooks <config-file>".into());
+    }
+    let path = Path::new(&args[0]);
+    if !path.exists() {
+        println!("MISSING");
+        std::process::exit(1);
+    }
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(_) => {
+            println!("INVALID");
+            std::process::exit(1);
+        }
+    };
+    match check_hooks_status(&text) {
+        ConfigStatus::Ok => {
+            println!("OK");
+            Ok(())
+        }
+        ConfigStatus::Legacy => {
+            println!("LEGACY");
+            std::process::exit(1);
+        }
+        ConfigStatus::Missing => {
+            println!("MISSING");
+            std::process::exit(1);
+        }
+        ConfigStatus::Invalid => {
+            println!("INVALID");
+            std::process::exit(1);
+        }
+    }
+}
+
+pub fn remove_legacy_mcp(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-config-remove-legacy-mcp <config-file>".into(),
+        );
+    }
+    let path = Path::new(&args[0]);
+    if !path.exists() {
+        println!("SKIP");
+        return Ok(());
+    }
+    let old = std::fs::read_to_string(path)?;
+    let (new, changed) = remove_legacy_vibeguard_mcp(&old)?;
+    if !changed {
+        println!("SKIP");
+        return Ok(());
+    }
+    if new.is_empty() {
+        std::fs::remove_file(path)?;
+    } else {
+        write_text_atomic(path, &new)?;
+    }
+    println!("CHANGED");
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ConfigStatus {
+    Ok,
+    Legacy,
+    Missing,
+    Invalid,
+}
+
+fn ensure_hooks_enabled(text: &str) -> SetupResult<(String, bool)> {
+    let mut doc = parse_document(text)?;
+    let before = normalized_doc_string(&doc);
+    ensure_table(&mut doc, "features")?;
+    let features = doc["features"]
+        .as_table_mut()
+        .ok_or("config.toml [features] must be a table")?;
+    features.remove("codex_hooks");
+    features["hooks"] = value(true);
+    let after = normalized_doc_string(&doc);
+    Ok((after.clone(), after != before))
+}
+
+fn remove_legacy_vibeguard_mcp(text: &str) -> SetupResult<(String, bool)> {
+    let mut doc = parse_document(text)?;
+    let before = normalized_doc_string(&doc);
+    let mut remove_mcp_servers = false;
+    if let Some(mcp_servers) = doc.get_mut("mcp_servers") {
+        let table = mcp_servers
+            .as_table_mut()
+            .ok_or("config.toml [mcp_servers] must be a table")?;
+        table.remove("vibeguard");
+        remove_mcp_servers = table.is_empty();
+    }
+    if remove_mcp_servers {
+        doc.as_table_mut().remove("mcp_servers");
+    }
+    let after = normalized_doc_string(&doc);
+    Ok((after.clone(), after != before))
+}
+
+fn check_hooks_status(text: &str) -> ConfigStatus {
+    let Ok(doc) = parse_document(text) else {
+        return ConfigStatus::Invalid;
+    };
+    let Some(features) = doc.get("features").and_then(Item::as_table) else {
+        return ConfigStatus::Missing;
+    };
+    if features.get("codex_hooks").is_some() {
+        return ConfigStatus::Legacy;
+    }
+    let hooks_true = features
+        .get("hooks")
+        .and_then(Item::as_value)
+        .and_then(|item| item.as_bool())
+        .unwrap_or(false);
+    if hooks_true {
+        ConfigStatus::Ok
+    } else {
+        ConfigStatus::Missing
+    }
+}
+
+fn parse_document(text: &str) -> SetupResult<DocumentMut> {
+    Ok(text.parse::<DocumentMut>()?)
+}
+
+fn ensure_table(doc: &mut DocumentMut, key: &str) -> SetupResult<()> {
+    if !doc.as_table().contains_key(key) {
+        doc[key] = Item::Table(Table::new());
+    }
+    if doc[key].as_table().is_none() {
+        return Err(format!("config.toml [{key}] must be a table").into());
+    }
+    Ok(())
+}
+
+fn normalized_doc_string(doc: &DocumentMut) -> String {
+    let mut text = doc.to_string();
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enables_hooks_in_existing_features() -> SetupResult<()> {
+        let (text, changed) = ensure_hooks_enabled("[features]\ncodex_hooks = true\nx = 1\n")?;
+        assert!(changed);
+        assert!(text.contains("hooks = true"));
+        assert!(!text.contains("codex_hooks"));
+        Ok(())
+    }
+
+    #[test]
+    fn detects_invalid_table() {
+        assert_eq!(
+            check_hooks_status("[features\nhooks = true\n"),
+            ConfigStatus::Invalid
+        );
+    }
+
+    #[test]
+    fn detects_invalid_bare_key() {
+        assert_eq!(
+            check_hooks_status("not valid toml =\n[features]\nhooks = true\n"),
+            ConfigStatus::Invalid
+        );
+    }
+
+    #[test]
+    fn preserves_hash_inside_strings() -> SetupResult<()> {
+        let text = "title = \"a # b\"\n[features]\nhooks = false # old\n";
+        let (updated, changed) = ensure_hooks_enabled(text)?;
+        assert!(changed);
+        assert!(updated.contains("title = \"a # b\""));
+        assert_eq!(check_hooks_status(&updated), ConfigStatus::Ok);
+        Ok(())
+    }
+
+    #[test]
+    fn removes_legacy_mcp_structurally() -> SetupResult<()> {
+        let text = "[mcp_servers.vibeguard]\ncommand = \"node\"\n\n[mcp_servers.other]\ncommand = \"keep\"\n";
+        let (updated, changed) = remove_legacy_vibeguard_mcp(text)?;
+        assert!(changed);
+        assert!(!updated.contains("vibeguard"));
+        assert!(updated.contains("[mcp_servers.other]"));
+        Ok(())
+    }
+}

--- a/vibeguard-runtime/src/setup_codex_hooks.rs
+++ b/vibeguard-runtime/src/setup_codex_hooks.rs
@@ -1,0 +1,556 @@
+use crate::setup_support::{
+    SetupResult, basename, display_home_path, home_dir, read_json_object, shell_quote, shell_split,
+    write_json_atomic,
+};
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CodexSpec {
+    event: String,
+    matcher: Option<String>,
+    script: String,
+    timeout: Option<i64>,
+}
+
+const CODEX_LEGACY_MARKERS: &[&str] = &[
+    "pre-bash-guard.sh",
+    "post-build-check.sh",
+    "stop-guard.sh",
+    "learn-evaluator.sh",
+    "post-guard-check.sh",
+    "session-tagger.sh",
+    "cognitive-reminder.sh",
+];
+
+pub fn codex_hooks_upsert(args: &[String]) -> SetupResult<()> {
+    if args.len() != 3 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-hooks-upsert <repo-dir> <hooks-file> <wrapper>"
+                .into(),
+        );
+    }
+    let repo_dir = Path::new(&args[0]);
+    let hooks_path = Path::new(&args[1]);
+    let wrapper = &args[2];
+    let mut data = Value::Object(read_json_object(hooks_path, true)?);
+    let before = serde_json::to_string(&data)?;
+    ensure_hooks_root(&mut data)?;
+    codex_prune_managed(&mut data, repo_dir);
+    codex_prune_stale(&mut data);
+    ensure_hooks_root(&mut data)?;
+    let hooks = data["hooks"]
+        .as_object_mut()
+        .ok_or("hooks.json hooks must be an object")?;
+    for spec in codex_specs(repo_dir)? {
+        let entries = hooks.entry(spec.event.clone()).or_insert_with(|| json!([]));
+        if !entries.is_array() {
+            *entries = json!([]);
+        }
+        let entries_arr = entries.as_array_mut().expect("entries are array");
+        let command = format!("bash {} {}", shell_quote(wrapper), spec.script);
+        if !codex_has_entry(
+            entries_arr,
+            repo_dir,
+            &command,
+            spec.matcher.as_deref(),
+            spec.timeout,
+        ) {
+            entries_arr.push(codex_build_entry(wrapper, &spec));
+        }
+    }
+    if serde_json::to_string(&data)? != before {
+        write_json_atomic(hooks_path, &data)?;
+        println!("CHANGED");
+    } else {
+        println!("SKIP");
+    }
+    Ok(())
+}
+
+pub fn codex_hooks_remove(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-hooks-remove <repo-dir> <hooks-file>".into(),
+        );
+    }
+    let hooks_path = Path::new(&args[1]);
+    if !hooks_path.exists() {
+        println!("SKIP");
+        return Ok(());
+    }
+    let mut data = Value::Object(read_json_object(hooks_path, false)?);
+    let before = serde_json::to_string(&data)?;
+    codex_prune_managed(&mut data, Path::new(&args[0]));
+    if serde_json::to_string(&data)? == before {
+        println!("SKIP");
+    } else {
+        if data.as_object().is_some_and(|object| object.is_empty()) {
+            std::fs::remove_file(hooks_path)?;
+        } else {
+            write_json_atomic(hooks_path, &data)?;
+        }
+        println!("CHANGED");
+    }
+    Ok(())
+}
+
+pub fn codex_hooks_check(args: &[String]) -> SetupResult<()> {
+    if args.len() != 3 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-hooks-check <repo-dir> <hooks-file> <wrapper>"
+                .into(),
+        );
+    }
+    let repo_dir = Path::new(&args[0]);
+    let data = Value::Object(read_json_object(Path::new(&args[1]), false)?);
+    let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
+        std::process::exit(1);
+    };
+    for spec in codex_specs(repo_dir)? {
+        let Some(entries) = hooks.get(&spec.event).and_then(Value::as_array) else {
+            std::process::exit(1);
+        };
+        let command = format!("bash {} {}", shell_quote(&args[2]), spec.script);
+        if !codex_has_entry(
+            entries,
+            repo_dir,
+            &command,
+            spec.matcher.as_deref(),
+            spec.timeout,
+        ) {
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}
+
+pub fn codex_hooks_count(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-codex-hooks-count <hooks-file>".into());
+    }
+    let path = Path::new(&args[0]);
+    if !path.exists() {
+        println!("0");
+        return Ok(());
+    }
+    let data = Value::Object(read_json_object(path, false)?);
+    let total = data
+        .get("hooks")
+        .and_then(Value::as_object)
+        .map(|hooks| {
+            hooks
+                .values()
+                .filter_map(Value::as_array)
+                .map(Vec::len)
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+    println!("{total}");
+    Ok(())
+}
+
+pub fn codex_hooks_check_stale(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-codex-hooks-check-stale <hooks-file>".into());
+    }
+    let hooks_path = Path::new(&args[0]);
+    if !hooks_path.exists() {
+        return Ok(());
+    }
+    let data = Value::Object(read_json_object(hooks_path, false)?);
+    let findings = codex_stale_findings(&data, hooks_path);
+    for finding in &findings {
+        println!("{finding}");
+    }
+    if !findings.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+pub fn codex_hooks_check_timeouts(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-hooks-check-timeouts <repo-dir> <hooks-file>"
+                .into(),
+        );
+    }
+    let repo_dir = Path::new(&args[0]);
+    let hooks_path = Path::new(&args[1]);
+    if !hooks_path.exists() {
+        return Ok(());
+    }
+    let data = Value::Object(read_json_object(hooks_path, false)?);
+    let mut findings = Vec::new();
+    for (event, matcher, hook) in codex_hook_records(&data) {
+        let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+        if command.is_empty()
+            || hook
+                .get("timeout")
+                .and_then(Value::as_i64)
+                .is_some_and(|v| v > 0)
+        {
+            continue;
+        }
+        let managed = codex_command_is_managed(repo_dir, command);
+        let state = if managed { "managed" } else { "unmanaged" };
+        let repair = if managed {
+            "bash setup.sh --yes"
+        } else {
+            "add timeout or consult hook owner"
+        };
+        findings.push(format!(
+            "{state} Codex hook without timeout: config={} event={event} matcher={matcher} command={command} repair={repair}",
+            display_home_path(hooks_path)
+        ));
+    }
+    for finding in &findings {
+        println!("{finding}");
+    }
+    if !findings.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn codex_specs(repo_dir: &Path) -> SetupResult<Vec<CodexSpec>> {
+    let text = std::fs::read_to_string(repo_dir.join("hooks/manifest.json"))?;
+    let manifest: Value = serde_json::from_str(&text)?;
+    let hooks = manifest
+        .get("hooks")
+        .and_then(Value::as_array)
+        .ok_or("hooks manifest must contain a hooks array")?;
+    let mut specs = Vec::new();
+    for item in hooks {
+        let Some(item_obj) = item.as_object() else {
+            return Err("each hook manifest entry must be an object".into());
+        };
+        let Some(codex) = item_obj.get("codex").and_then(Value::as_object) else {
+            continue;
+        };
+        if codex.get("enabled").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        if let Some(entries) = codex.get("entries").and_then(Value::as_array) {
+            for entry in entries {
+                let entry = entry
+                    .as_object()
+                    .ok_or("codex.entries must contain objects")?;
+                specs.push(CodexSpec {
+                    event: json_string(entry, "event")?,
+                    matcher: entry
+                        .get("matcher")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    script: entry
+                        .get("script")
+                        .or_else(|| codex.get("script"))
+                        .and_then(Value::as_str)
+                        .ok_or("codex entry script missing")?
+                        .to_string(),
+                    timeout: entry
+                        .get("timeout")
+                        .or_else(|| codex.get("timeout"))
+                        .and_then(Value::as_i64),
+                });
+            }
+        } else {
+            specs.push(CodexSpec {
+                event: json_string(codex, "event")?,
+                matcher: codex
+                    .get("matcher")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                script: json_string(codex, "script")?,
+                timeout: codex.get("timeout").and_then(Value::as_i64),
+            });
+        }
+    }
+    Ok(specs)
+}
+
+fn json_string(object: &serde_json::Map<String, Value>, key: &str) -> SetupResult<String> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| format!("missing string field: {key}").into())
+}
+
+fn ensure_hooks_root(data: &mut Value) -> SetupResult<()> {
+    if data.get("hooks").and_then(Value::as_object).is_none() {
+        data.as_object_mut()
+            .ok_or("hooks.json root must be an object")?
+            .insert("hooks".to_string(), json!({}));
+    }
+    Ok(())
+}
+
+fn codex_prune_managed(data: &mut Value, repo_dir: &Path) {
+    let Some(hooks) = data.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for entries in hooks.values_mut() {
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        let mut next_entries = Vec::new();
+        for entry in std::mem::take(entries) {
+            let Some(entry_obj) = entry.as_object() else {
+                next_entries.push(entry);
+                continue;
+            };
+            let Some(hook_entries) = entry_obj.get("hooks").and_then(Value::as_array) else {
+                next_entries.push(entry);
+                continue;
+            };
+            let kept: Vec<Value> = hook_entries
+                .iter()
+                .filter(|hook| {
+                    let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+                    !codex_command_is_managed(repo_dir, command)
+                })
+                .cloned()
+                .collect();
+            if kept.len() == hook_entries.len() {
+                next_entries.push(entry);
+            } else if !kept.is_empty() {
+                let mut next = entry_obj.clone();
+                next.insert("hooks".to_string(), Value::Array(kept));
+                next_entries.push(Value::Object(next));
+            }
+        }
+        *entries = next_entries;
+    }
+    hooks.retain(|_, value| value.as_array().is_some_and(|items| !items.is_empty()));
+    if hooks.is_empty() {
+        data.as_object_mut().expect("object").remove("hooks");
+    }
+}
+
+fn codex_prune_stale(data: &mut Value) {
+    let Some(hooks) = data.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for entries in hooks.values_mut() {
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        let mut next_entries = Vec::new();
+        for entry in std::mem::take(entries) {
+            let Some(entry_obj) = entry.as_object() else {
+                next_entries.push(entry);
+                continue;
+            };
+            let Some(hook_entries) = entry_obj.get("hooks").and_then(Value::as_array) else {
+                next_entries.push(entry);
+                continue;
+            };
+            let kept: Vec<Value> = hook_entries
+                .iter()
+                .filter(|hook| {
+                    let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+                    codex_direct_installed_hook_target(command).is_none()
+                        && codex_hook_target(command).is_none_or(|target| target.exists())
+                })
+                .cloned()
+                .collect();
+            if kept.len() == hook_entries.len() {
+                next_entries.push(entry);
+            } else if !kept.is_empty() {
+                let mut next = entry_obj.clone();
+                next.insert("hooks".to_string(), Value::Array(kept));
+                next_entries.push(Value::Object(next));
+            }
+        }
+        *entries = next_entries;
+    }
+}
+
+fn codex_build_entry(wrapper: &str, spec: &CodexSpec) -> Value {
+    let mut hook = serde_json::Map::new();
+    hook.insert("type".to_string(), Value::String("command".to_string()));
+    hook.insert(
+        "command".to_string(),
+        Value::String(format!("bash {} {}", shell_quote(wrapper), spec.script)),
+    );
+    if let Some(timeout) = spec.timeout {
+        hook.insert("timeout".to_string(), Value::Number(timeout.into()));
+    }
+    let mut entry = serde_json::Map::new();
+    entry.insert("hooks".to_string(), Value::Array(vec![Value::Object(hook)]));
+    if let Some(matcher) = &spec.matcher {
+        if !matcher.is_empty() {
+            entry.insert("matcher".to_string(), Value::String(matcher.clone()));
+        }
+    }
+    Value::Object(entry)
+}
+
+fn codex_has_entry(
+    entries: &[Value],
+    repo_dir: &Path,
+    command: &str,
+    matcher: Option<&str>,
+    timeout: Option<i64>,
+) -> bool {
+    entries.iter().any(|entry| {
+        let Some(entry_obj) = entry.as_object() else {
+            return false;
+        };
+        if entry_obj.get("matcher").and_then(Value::as_str) != matcher {
+            return false;
+        }
+        let Some(hooks) = entry_obj.get("hooks").and_then(Value::as_array) else {
+            return false;
+        };
+        hooks.iter().any(|hook| {
+            let hook_command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+            codex_command_is_managed(repo_dir, hook_command)
+                && hook_command == command
+                && hook.get("type").and_then(Value::as_str) == Some("command")
+                && match timeout {
+                    Some(expected) => hook.get("timeout").and_then(Value::as_i64) == Some(expected),
+                    None => hook.get("timeout").is_none(),
+                }
+        })
+    })
+}
+
+fn codex_command_is_managed(repo_dir: &Path, command: &str) -> bool {
+    let scripts = codex_managed_scripts(repo_dir);
+    let parts = shell_split(command);
+    for (idx, token) in parts.iter().enumerate() {
+        if basename(token) == "run-hook-codex.sh" {
+            if let Some(next) = parts.get(idx + 1) {
+                if scripts.contains(basename(next)) {
+                    return true;
+                }
+            }
+        }
+        let base = basename(token);
+        if scripts.contains(base) || CODEX_LEGACY_MARKERS.contains(&base) {
+            return true;
+        }
+    }
+    false
+}
+
+fn codex_managed_scripts(repo_dir: &Path) -> BTreeSet<String> {
+    let mut scripts = CODEX_LEGACY_MARKERS
+        .iter()
+        .map(|item| (*item).to_string())
+        .collect::<BTreeSet<_>>();
+    if let Ok(specs) = codex_specs(repo_dir) {
+        scripts.extend(specs.into_iter().map(|spec| spec.script));
+    }
+    if let Ok(text) = std::fs::read_to_string(repo_dir.join("hooks/manifest.json")) {
+        if let Ok(value) = serde_json::from_str::<Value>(&text) {
+            if let Some(hooks) = value.get("hooks").and_then(Value::as_array) {
+                for item in hooks {
+                    if let Some(script) = item.get("script").and_then(Value::as_str) {
+                        scripts.insert(script.to_string());
+                    }
+                }
+            }
+        }
+    }
+    scripts
+}
+
+fn codex_hook_records(data: &Value) -> Vec<(String, String, serde_json::Map<String, Value>)> {
+    let mut records = Vec::new();
+    let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
+        return records;
+    };
+    for (event, entries) in hooks {
+        let Some(entries) = entries.as_array() else {
+            continue;
+        };
+        for entry in entries {
+            let Some(entry_obj) = entry.as_object() else {
+                continue;
+            };
+            let matcher = entry_obj
+                .get("matcher")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("<none>")
+                .to_string();
+            let Some(hook_entries) = entry_obj.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for hook in hook_entries {
+                if let Some(hook_obj) = hook.as_object() {
+                    records.push((event.clone(), matcher.clone(), hook_obj.clone()));
+                }
+            }
+        }
+    }
+    records
+}
+
+fn codex_stale_findings(data: &Value, config: &Path) -> Vec<String> {
+    codex_hook_records(data)
+        .into_iter()
+        .filter_map(|(event, matcher, hook)| {
+            let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+            let target = if let Some(target) = codex_direct_installed_hook_target(command) {
+                target
+            } else {
+                let target = codex_hook_target(command)?;
+                if target.exists() {
+                    return None;
+                }
+                target
+            };
+            Some(format!(
+                "stale Codex hook command: config={} event={event} matcher={matcher} command_path={} repair=bash setup.sh --yes",
+                display_home_path(config),
+                target.display()
+            ))
+        })
+        .collect()
+}
+
+fn codex_direct_installed_hook_target(command: &str) -> Option<PathBuf> {
+    let home = home_dir()?;
+    shell_split(command).into_iter().find_map(|token| {
+        let path = codex_expand_path(&token, &home)?;
+        path.to_string_lossy()
+            .contains("/.vibeguard/installed/hooks/")
+            .then_some(path)
+    })
+}
+
+fn codex_hook_target(command: &str) -> Option<PathBuf> {
+    let home = home_dir()?;
+    let parts = shell_split(command);
+    for (idx, token) in parts.iter().enumerate() {
+        let path = codex_expand_path(token, &home)?;
+        if path
+            .to_string_lossy()
+            .ends_with("/.vibeguard/run-hook-codex.sh")
+        {
+            let script = parts.get(idx + 1)?;
+            if !script.contains('/') {
+                let installed = path.parent()?.join("installed/hooks").join(script);
+                if installed.parent().is_some_and(Path::exists) {
+                    return Some(installed);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn codex_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
+    token
+        .strip_prefix("~/")
+        .map(|tail| home.join(tail))
+        .or_else(|| token.strip_prefix("$HOME/").map(|tail| home.join(tail)))
+        .or_else(|| token.strip_prefix("${HOME}/").map(|tail| home.join(tail)))
+        .or_else(|| token.starts_with('/').then(|| PathBuf::from(token)))
+}

--- a/vibeguard-runtime/src/setup_codex_hooks.rs
+++ b/vibeguard-runtime/src/setup_codex_hooks.rs
@@ -554,3 +554,90 @@ fn codex_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
         .or_else(|| token.strip_prefix("${HOME}/").map(|tail| home.join(tail)))
         .or_else(|| token.starts_with('/').then(|| PathBuf::from(token)))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_managed_keeps_third_party_hooks_in_mixed_entry() {
+        let repo_dir = Path::new("/tmp/vibeguard-test-repo");
+        let mut data = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "bash /tmp/run-hook-codex.sh pre-bash-guard.sh"
+                            },
+                            {
+                                "type": "command",
+                                "command": "bash /tmp/third-party.sh"
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        codex_prune_managed(&mut data, repo_dir);
+
+        let hooks = data
+            .pointer("/hooks/PreToolUse/0/hooks")
+            .and_then(Value::as_array);
+        assert_eq!(hooks.map(Vec::len), Some(1));
+        assert_eq!(
+            hooks.and_then(|items| items.first())
+                .and_then(|hook| hook.get("command"))
+                .and_then(Value::as_str),
+            Some("bash /tmp/third-party.sh")
+        );
+    }
+
+    #[test]
+    fn built_entries_preserve_matcher_and_timeout() {
+        let spec = CodexSpec {
+            event: "Stop".to_string(),
+            matcher: None,
+            script: "vibeguard-stop-guard.sh".to_string(),
+            timeout: Some(15),
+        };
+
+        let entry = codex_build_entry("/tmp/run-hook-codex.sh", &spec);
+        assert_eq!(entry.get("matcher"), None);
+        let hook = entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .and_then(|items| items.first());
+        assert_eq!(
+            hook.and_then(|value| value.get("command"))
+                .and_then(Value::as_str),
+            Some("bash /tmp/run-hook-codex.sh vibeguard-stop-guard.sh")
+        );
+        assert_eq!(
+            hook.and_then(|value| value.get("timeout"))
+                .and_then(Value::as_i64),
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn managed_entry_check_requires_expected_timeout() {
+        let repo_dir = Path::new("/tmp/vibeguard-test-repo");
+        let command = "bash /tmp/run-hook-codex.sh stop-guard.sh";
+        let entries = vec![json!({
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": command,
+                    "timeout": 99
+                }
+            ]
+        })];
+
+        assert!(!codex_has_entry(&entries, repo_dir, command, None, Some(15)));
+        assert!(codex_has_entry(&entries, repo_dir, command, None, Some(99)));
+    }
+}

--- a/vibeguard-runtime/src/setup_install_state.rs
+++ b/vibeguard-runtime/src/setup_install_state.rs
@@ -285,3 +285,69 @@ fn setup_absolute_path(path: &Path) -> PathBuf {
             .join(path)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn unique_temp_dir(name: &str) -> SetupResult<PathBuf> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        path.push(format!(
+            "vibeguard-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path)?;
+        Ok(path)
+    }
+
+    #[test]
+    fn record_file_stores_checksum_for_regular_files() -> SetupResult<()> {
+        let dir = unique_temp_dir("install-state-record")?;
+        let state_file = dir.join("install-state.json");
+        let tracked = dir.join("tracked.txt");
+        fs::write(&tracked, "hello")?;
+
+        record_file(&[
+            state_file.display().to_string(),
+            tracked.display().to_string(),
+            "generated/tracked.txt".to_string(),
+            "copy".to_string(),
+        ])?;
+
+        let state = read_state(&state_file)?;
+        let entry = state
+            .get("files")
+            .and_then(Value::as_object)
+            .and_then(|files| files.get(&tracked.display().to_string()));
+        assert_eq!(
+            entry
+                .and_then(|value| value.get("type"))
+                .and_then(Value::as_str),
+            Some("copy")
+        );
+        assert_eq!(
+            entry
+                .and_then(|value| value.get("checksum"))
+                .and_then(Value::as_str),
+            Some("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        );
+
+        let _ = fs::remove_dir_all(dir);
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_state_version_is_rejected() {
+        let state = json!({"version": 2, "files": {}});
+        assert!(ensure_state_version(&state).is_err());
+    }
+
+    #[test]
+    fn installed_timestamp_is_epoch_seconds() {
+        let timestamp = now_timestamp();
+        assert!(timestamp.len() >= 10);
+        assert!(timestamp.chars().all(|ch| ch.is_ascii_digit()));
+    }
+}

--- a/vibeguard-runtime/src/setup_install_state.rs
+++ b/vibeguard-runtime/src/setup_install_state.rs
@@ -1,0 +1,287 @@
+use crate::setup_support::{SetupResult, home_dir, sha256_file, write_json_atomic};
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const STATE_VERSION: i64 = 1;
+
+pub fn init(args: &[String]) -> SetupResult<()> {
+    if args.len() != 3 {
+        return Err(
+            "Usage: vibeguard-runtime setup-state-init <state-file> <profile> <languages>".into(),
+        );
+    }
+    let state_file = Path::new(&args[0]);
+    let repo_dir = repo_dir_from_home();
+    let languages: Vec<Value> = if args[2].is_empty() {
+        Vec::new()
+    } else {
+        args[2]
+            .split(',')
+            .map(|item| Value::String(item.to_string()))
+            .collect()
+    };
+    let state = json!({
+        "version": STATE_VERSION,
+        "installed_at": now_timestamp(),
+        "profile": args[1],
+        "languages": languages,
+        "repo_dir": repo_dir,
+        "files": {}
+    });
+    write_json_atomic(state_file, &state)?;
+    Ok(())
+}
+
+pub fn record_file(args: &[String]) -> SetupResult<()> {
+    if args.len() != 4 {
+        return Err(
+            "Usage: vibeguard-runtime setup-state-record-file <state-file> <dest> <source> <type>"
+                .into(),
+        );
+    }
+    let state_file = Path::new(&args[0]);
+    let mut state = read_state_or_empty(state_file)?;
+    ensure_state_version(&state)?;
+    let mut entry = serde_json::Map::new();
+    entry.insert("source".to_string(), Value::String(args[2].clone()));
+    entry.insert("type".to_string(), Value::String(args[3].clone()));
+    if args[3] != "symlink" && Path::new(&args[1]).is_file() {
+        entry.insert(
+            "checksum".to_string(),
+            Value::String(format!("sha256:{}", sha256_file(Path::new(&args[1]))?)),
+        );
+    }
+    state
+        .as_object_mut()
+        .expect("state is object")
+        .entry("files")
+        .or_insert_with(|| json!({}));
+    state["files"]
+        .as_object_mut()
+        .ok_or("install-state files must be an object")?
+        .insert(args[1].clone(), Value::Object(entry));
+    write_json_atomic(state_file, &state)?;
+    Ok(())
+}
+
+pub fn check_drift(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-state-check-drift <state-file>".into());
+    }
+    let state_file = Path::new(&args[0]);
+    if !state_file.exists() {
+        println!("NO_STATE");
+        return Ok(());
+    }
+    let state = read_state(state_file)?;
+    let version = state
+        .get("version")
+        .and_then(Value::as_i64)
+        .unwrap_or(STATE_VERSION);
+    if version != STATE_VERSION {
+        println!("UNSUPPORTED_STATE_VERSION: {version} (expected {STATE_VERSION})");
+        return Ok(());
+    }
+    let files = state
+        .get("files")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut missing_count = 0usize;
+    let mut drift_count = 0usize;
+    for (dest, info) in &files {
+        let dest_path = expand_home(dest);
+        let install_type = info.get("type").and_then(Value::as_str).unwrap_or("");
+        if install_type == "symlink" {
+            match std::fs::symlink_metadata(&dest_path) {
+                Ok(meta) if meta.file_type().is_symlink() => {}
+                Ok(_) => {
+                    println!("DRIFT: {dest} (was symlink, now regular file)");
+                    drift_count += 1;
+                }
+                Err(_) => {
+                    println!("MISSING: {dest}");
+                    missing_count += 1;
+                }
+            }
+        } else if !dest_path.exists() {
+            println!("MISSING: {dest}");
+            missing_count += 1;
+        } else if let Some(expected) = info.get("checksum").and_then(Value::as_str) {
+            let actual = format!("sha256:{}", sha256_file(&dest_path)?);
+            if actual != expected {
+                println!("DRIFT: {dest} (checksum mismatch)");
+                drift_count += 1;
+            }
+        }
+    }
+    println!("---");
+    println!(
+        "Total tracked: {}, Missing: {missing_count}, Drifted: {drift_count}",
+        files.len()
+    );
+    if missing_count + drift_count == 0 {
+        println!("STATUS: CLEAN");
+    } else {
+        println!("STATUS: DRIFT ({drift_count} drifted, {missing_count} missing)");
+    }
+    Ok(())
+}
+
+pub fn list(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-state-list <state-file>".into());
+    }
+    let state_file = Path::new(&args[0]);
+    if !state_file.exists() {
+        return Err("No install state found. Run setup.sh first.".into());
+    }
+    let state = read_state(state_file)?;
+    ensure_state_version(&state)?;
+    println!(
+        "Profile: {}",
+        state
+            .get("profile")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    );
+    println!(
+        "Installed: {}",
+        state
+            .get("installed_at")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    );
+    if let Some(languages) = state.get("languages").and_then(Value::as_array) {
+        if !languages.is_empty() {
+            let text = languages
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("Languages: {text}");
+        }
+    }
+    let files = state
+        .get("files")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    println!("Tracked files: {}", files.len());
+    println!();
+    for (dest, info) in files {
+        let kind = info.get("type").and_then(Value::as_str).unwrap_or("?");
+        println!("  [{kind:7}] {dest}");
+    }
+    Ok(())
+}
+
+pub fn list_tracked_symlinks_under(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-state-list-symlinks-under <state-file> <dest-dir>"
+                .into(),
+        );
+    }
+    let state_file = Path::new(&args[0]);
+    if !state_file.exists() {
+        return Ok(());
+    }
+    let state = match read_state(state_file) {
+        Ok(state) => state,
+        Err(_) => return Ok(()),
+    };
+    if state
+        .get("version")
+        .and_then(Value::as_i64)
+        .unwrap_or(STATE_VERSION)
+        != STATE_VERSION
+    {
+        eprintln!("WARN: unsupported install-state version; skipping tracked symlink cleanup");
+        return Ok(());
+    }
+    let dest_dir = setup_absolute_path(&expand_home(&args[1]));
+    let files = state
+        .get("files")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (dest, info) in files {
+        if info.get("type").and_then(Value::as_str) != Some("symlink") {
+            continue;
+        }
+        let expanded = setup_absolute_path(&expand_home(&dest));
+        if expanded == dest_dir || expanded.starts_with(&dest_dir) {
+            println!("{}", expanded.display());
+        }
+    }
+    Ok(())
+}
+
+fn read_state(path: &Path) -> SetupResult<Value> {
+    let text = std::fs::read_to_string(path)?;
+    let value: Value = serde_json::from_str(&text)?;
+    if !value.is_object() {
+        return Err("install-state root must be an object".into());
+    }
+    Ok(value)
+}
+
+fn read_state_or_empty(path: &Path) -> SetupResult<Value> {
+    if !path.exists() {
+        return Ok(json!({"version": STATE_VERSION, "files": {}}));
+    }
+    read_state(path)
+}
+
+fn ensure_state_version(state: &Value) -> SetupResult<()> {
+    let version = state
+        .get("version")
+        .and_then(Value::as_i64)
+        .unwrap_or(STATE_VERSION);
+    if version != STATE_VERSION {
+        return Err(format!(
+            "Unsupported install-state version: {version} (expected {STATE_VERSION})"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn repo_dir_from_home() -> String {
+    let Some(home) = home_dir() else {
+        return String::new();
+    };
+    std::fs::read_to_string(home.join(".vibeguard/repo-path"))
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn now_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("{seconds}")
+}
+
+fn expand_home(path: &str) -> PathBuf {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(stripped);
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn setup_absolute_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    }
+}

--- a/vibeguard-runtime/src/setup_manifest.rs
+++ b/vibeguard-runtime/src/setup_manifest.rs
@@ -1,0 +1,280 @@
+use crate::setup_support::SetupResult;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::{Component, Path};
+
+const MANIFEST_REL: &str = "schemas/install-modules.json";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RuleLink {
+    source: String,
+    dest_rel: String,
+    label: String,
+}
+
+pub fn skill_links(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-manifest-skill-links <repo-dir> <target>".into(),
+        );
+    }
+    for (source, skill) in manifest_skill_links(Path::new(&args[0]), &args[1])? {
+        println!("{source}\t{skill}");
+    }
+    Ok(())
+}
+
+pub fn rule_links(args: &[String]) -> SetupResult<()> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-manifest-rule-links <repo-dir> [languages]".into(),
+        );
+    }
+    let languages = args.get(1).map(String::as_str).unwrap_or("");
+    for link in manifest_rule_links(Path::new(&args[0]), languages)? {
+        println!("{}\t{}\t{}", link.source, link.dest_rel, link.label);
+    }
+    Ok(())
+}
+
+pub fn rule_labels(args: &[String]) -> SetupResult<()> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-manifest-rule-labels <repo-dir> [languages]".into(),
+        );
+    }
+    let languages = args.get(1).map(String::as_str).unwrap_or("");
+    let mut seen = BTreeSet::new();
+    for link in manifest_rule_links(Path::new(&args[0]), languages)? {
+        if seen.insert(link.label.clone()) {
+            println!("{}", link.label);
+        }
+    }
+    Ok(())
+}
+
+pub fn manifest_skill_links(repo_dir: &Path, target: &str) -> SetupResult<Vec<(String, String)>> {
+    let manifest = load_manifest(repo_dir)?;
+    let modules = manifest
+        .get("modules")
+        .and_then(Value::as_array)
+        .ok_or("manifest modules must be a list")?;
+    let mut links = Vec::new();
+    for module in modules {
+        let Some(object) = module.as_object() else {
+            return Err("manifest module entry is not an object".into());
+        };
+        if object.get("kind").and_then(Value::as_str) != Some("skills")
+            || object.get("target").and_then(Value::as_str) != Some(target)
+        {
+            continue;
+        }
+        let module_id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let paths = object
+            .get("paths")
+            .and_then(Value::as_array)
+            .ok_or_else(|| format!("module {module_id}: paths must be a list"))?;
+        for path in paths {
+            let Some(path_text) = path.as_str() else {
+                return Err(format!("module {module_id}: non-string path entry").into());
+            };
+            let source = normalize_skill_source(path_text, module_id)?;
+            let skill = Path::new(&source)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| {
+                    format!(
+                        "module {module_id}: skill path must name a skill directory: {path_text}"
+                    )
+                })?
+                .to_string();
+            links.push((source, skill));
+        }
+    }
+    Ok(links)
+}
+
+fn manifest_rule_links(repo_dir: &Path, languages: &str) -> SetupResult<Vec<RuleLink>> {
+    let manifest = load_manifest(repo_dir)?;
+    let selected = language_filter(languages);
+    let modules = manifest
+        .get("modules")
+        .and_then(Value::as_array)
+        .ok_or("manifest modules must be a list")?;
+    let mut links = Vec::new();
+    for module in modules {
+        let Some(object) = module.as_object() else {
+            return Err("manifest module entry is not an object".into());
+        };
+        if object.get("kind").and_then(Value::as_str) != Some("rules") {
+            continue;
+        }
+        let module_id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let module_languages = module_languages(object, module_id)?;
+        if !selected.is_empty()
+            && !module_languages.is_empty()
+            && selected.is_disjoint(&module_languages)
+        {
+            continue;
+        }
+        let paths = object
+            .get("paths")
+            .and_then(Value::as_array)
+            .ok_or_else(|| format!("module {module_id}: paths must be a list"))?;
+        for path in paths {
+            let Some(path_text) = path.as_str() else {
+                return Err(format!("module {module_id}: non-string rule path").into());
+            };
+            let link = normalize_rule_source(repo_dir, path_text, module_id)?;
+            links.push(link);
+        }
+    }
+    Ok(links)
+}
+
+fn load_manifest(repo_dir: &Path) -> SetupResult<Value> {
+    let text = std::fs::read_to_string(repo_dir.join(MANIFEST_REL))?;
+    let value: Value = serde_json::from_str(&text)?;
+    if !value.is_object() {
+        return Err("manifest root must be an object".into());
+    }
+    Ok(value)
+}
+
+fn language_filter(languages: &str) -> BTreeSet<String> {
+    languages
+        .split(',')
+        .filter_map(|part| {
+            let normalized = normalize_language(part);
+            (!normalized.is_empty()).then_some(normalized)
+        })
+        .collect()
+}
+
+fn module_languages(
+    module: &serde_json::Map<String, Value>,
+    module_id: &str,
+) -> SetupResult<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    let Some(value) = module.get("languages") else {
+        return Ok(out);
+    };
+    let Some(items) = value.as_array() else {
+        return Err(format!("module {module_id}: languages must be a list").into());
+    };
+    for item in items {
+        let Some(text) = item.as_str() else {
+            return Err(format!("module {module_id}: non-string language entry").into());
+        };
+        let normalized = normalize_language(text);
+        if !normalized.is_empty() {
+            out.insert(normalized);
+        }
+    }
+    Ok(out)
+}
+
+fn normalize_language(value: &str) -> String {
+    let language = value.trim().to_ascii_lowercase();
+    if language == "golang" {
+        "go".to_string()
+    } else {
+        language
+    }
+}
+
+fn normalize_skill_source(path_text: &str, module_id: &str) -> SetupResult<String> {
+    let source = path_text.trim_end_matches('/');
+    if source.is_empty() || source.contains('\\') || source.starts_with('/') {
+        return Err(
+            format!("module {module_id}: skill path must be repo-relative: {path_text}").into(),
+        );
+    }
+    if has_parent_component(source) {
+        return Err(
+            format!("module {module_id}: skill path must not contain '..': {path_text}").into(),
+        );
+    }
+    if Path::new(source).file_name().is_none() {
+        return Err(format!(
+            "module {module_id}: skill path must name a skill directory: {path_text}"
+        )
+        .into());
+    }
+    Ok(source.to_string())
+}
+
+fn normalize_rule_source(
+    repo_dir: &Path,
+    path_text: &str,
+    module_id: &str,
+) -> SetupResult<RuleLink> {
+    let source = path_text.trim_end_matches('/');
+    if source.is_empty() || source.contains('\\') || source.starts_with('/') {
+        return Err(
+            format!("module {module_id}: rule path must be repo-relative: {path_text}").into(),
+        );
+    }
+    if has_parent_component(source) {
+        return Err(
+            format!("module {module_id}: rule path must not contain '..': {path_text}").into(),
+        );
+    }
+    if !source.ends_with(".md") {
+        return Err(
+            format!("module {module_id}: rule path must be a Markdown file: {path_text}").into(),
+        );
+    }
+    let prefix = "rules/claude-rules/";
+    let Some(dest_rel) = source.strip_prefix(prefix) else {
+        return Err(format!(
+            "module {module_id}: rule path must live under rules/claude-rules/: {path_text}"
+        )
+        .into());
+    };
+    let label = dest_rel
+        .split('/')
+        .next()
+        .filter(|part| !part.is_empty())
+        .ok_or_else(|| {
+            format!("module {module_id}: rule path must include a rule subdirectory: {path_text}")
+        })?;
+    if !repo_dir.join(source).is_file() {
+        return Err(format!("module {module_id}: missing rule path {source}").into());
+    }
+    Ok(RuleLink {
+        source: source.to_string(),
+        dest_rel: dest_rel.to_string(),
+        label: label.to_string(),
+    })
+}
+
+fn has_parent_component(path_text: &str) -> bool {
+    Path::new(path_text)
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_filter_normalizes_golang() {
+        let filter = language_filter("rust,golang, python");
+        assert!(filter.contains("rust"));
+        assert!(filter.contains("go"));
+        assert!(filter.contains("python"));
+    }
+
+    #[test]
+    fn rejects_parent_skill_path() {
+        assert!(normalize_skill_source("../skills/vibeguard", "x").is_err());
+    }
+}

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -1,0 +1,660 @@
+use crate::setup_support::{
+    SetupResult, basename, display_home_path, home_dir, read_json_object, shell_split,
+    simple_unified_diff, write_json_atomic, write_text_atomic,
+};
+use regex::Regex;
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+const START: &str = "<!-- vibeguard-start -->";
+const END: &str = "<!-- vibeguard-end -->";
+const RULE_COUNT_PLACEHOLDER: &str = "__VIBEGUARD_RULE_COUNT__";
+
+pub fn diff_inject(args: &[String]) -> SetupResult<()> {
+    if args.len() != 4 {
+        return Err("Usage: vibeguard-runtime setup-md-diff-inject <target-file> <rules-file> <repo-dir> <rule-count>".into());
+    }
+    let (action, original, content) =
+        render_injected(Path::new(&args[0]), Path::new(&args[1]), &args[2], &args[3])?;
+    if original == content {
+        println!("SKIP");
+    } else {
+        print!(
+            "{}",
+            simple_unified_diff(Path::new(&args[0]), &original, &content)
+        );
+        println!("{action}");
+    }
+    Ok(())
+}
+
+pub fn inject(args: &[String]) -> SetupResult<()> {
+    if args.len() != 4 {
+        return Err("Usage: vibeguard-runtime setup-md-inject <target-file> <rules-file> <repo-dir> <rule-count>".into());
+    }
+    let (action, _original, content) =
+        render_injected(Path::new(&args[0]), Path::new(&args[1]), &args[2], &args[3])?;
+    write_text_atomic(Path::new(&args[0]), &content)?;
+    println!("{action}");
+    Ok(())
+}
+
+pub fn remove(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-md-remove <target-file>".into());
+    }
+    let path = Path::new(&args[0]);
+    if !path.exists() {
+        println!("NOT_FOUND");
+        return Ok(());
+    }
+
+    let original = std::fs::read_to_string(path)?;
+    if let Some((start, end_after)) = marker_range(&original) {
+        let before = original[..start].trim_end();
+        let after = original[end_after..].trim_start_matches('\n');
+        let mut content = before.to_string();
+        if !after.is_empty() {
+            if !content.is_empty() {
+                content.push_str("\n\n");
+            }
+            content.push_str(after);
+        }
+        content = content.trim_end().to_string() + "\n";
+        write_text_atomic(path, &content)?;
+        println!("REMOVED");
+        return Ok(());
+    }
+
+    if let Some(index) = original.find("\n# VibeGuard") {
+        let content = original[..index].trim_end().to_string() + "\n";
+        write_text_atomic(path, &content)?;
+        println!("REMOVED_LEGACY");
+    } else {
+        println!("NOT_FOUND");
+    }
+    Ok(())
+}
+
+fn render_injected(
+    target_file: &Path,
+    rules_file: &Path,
+    repo_dir: &str,
+    rule_count: &str,
+) -> SetupResult<(String, String, String)> {
+    if rule_count.parse::<u64>().is_err() {
+        return Err(format!("Invalid rule count: {rule_count}").into());
+    }
+    let rules = std::fs::read_to_string(rules_file)?
+        .replace("__VIBEGUARD_DIR__", repo_dir)
+        .replace(RULE_COUNT_PLACEHOLDER, rule_count);
+    let original = std::fs::read_to_string(target_file).unwrap_or_default();
+
+    if marker_range(&original).is_some() {
+        let content = replace_managed_block(&original, &rules);
+        return Ok(("UPDATED".to_string(), original, content));
+    }
+    let legacy_re = Regex::new(r"\n# VibeGuard").expect("legacy regex compiles");
+    let base = legacy_re
+        .find(&original)
+        .map(|found| &original[..found.start()])
+        .unwrap_or(&original)
+        .trim_end();
+    let content = if base.is_empty() {
+        format!("{}\n", rules.trim())
+    } else {
+        format!("{base}\n\n{}\n", rules.trim())
+    };
+    Ok(("APPENDED".to_string(), original, content))
+}
+
+fn replace_managed_block(original: &str, rules: &str) -> String {
+    let Some((start, end_after)) = marker_range(original) else {
+        return original.to_string();
+    };
+    let before = original[..start].trim_end();
+    let after = original[end_after..].trim_start_matches('\n');
+    let mut content = String::new();
+    if !before.is_empty() {
+        content.push_str(before);
+        content.push_str("\n\n");
+    }
+    content.push_str(rules.trim());
+    content.push('\n');
+    if !after.is_empty() {
+        content.push('\n');
+        content.push_str(after);
+    }
+    content
+}
+
+fn marker_range(text: &str) -> Option<(usize, usize)> {
+    let start = text.find(START)?;
+    let end = text[start..].find(END)? + start;
+    Some((start, end + END.len()))
+}
+
+#[derive(Clone, Debug)]
+struct ClaudeSpec {
+    event: String,
+    matcher: String,
+    script: String,
+}
+
+const CLAUDE_LEGACY_SCRIPTS: &[&str] = &[
+    "post-guard-check.sh",
+    "session-tagger.sh",
+    "cognitive-reminder.sh",
+];
+
+pub fn settings_check(args: &[String]) -> SetupResult<()> {
+    if args.len() != 3 {
+        return Err("Usage: vibeguard-runtime setup-settings-check <repo-dir> <settings-file> <pre-hooks|post-hooks|full-hooks>".into());
+    }
+    let repo_dir = Path::new(&args[0]);
+    let data = Value::Object(read_json_object(Path::new(&args[1]), false)?);
+    let ok = match args[2].as_str() {
+        "pre-hooks" => settings_has_pre_hooks(repo_dir, &data)?,
+        "post-hooks" => settings_has_post_hooks(repo_dir, &data)?,
+        "full-hooks" => settings_has_full_hooks(repo_dir, &data)?,
+        _ => false,
+    };
+    if ok {
+        Ok(())
+    } else {
+        std::process::exit(1);
+    }
+}
+
+pub fn settings_upsert(args: &[String]) -> SetupResult<()> {
+    if args.len() < 3 {
+        return Err("Usage: vibeguard-runtime setup-settings-upsert <repo-dir> <settings-file> <profile> [--dry-run] [--force-overwrite]".into());
+    }
+    let repo_dir = Path::new(&args[0]);
+    let settings_path = Path::new(&args[1]);
+    let profile = &args[2];
+    let dry_run = args.iter().any(|arg| arg == "--dry-run");
+    let force = args.iter().any(|arg| arg == "--force-overwrite");
+    let before_text = std::fs::read_to_string(settings_path).unwrap_or_default();
+    let mut data = Value::Object(read_json_object(settings_path, true)?);
+    let mut changed = false;
+    changed |= settings_remove_legacy_mcp(&mut data);
+    changed |= settings_remove_legacy_hooks(&mut data, repo_dir)?;
+    changed |= settings_remove_stale_installed(&mut data);
+    if data.get("hooks").and_then(Value::as_object).is_none() {
+        data.as_object_mut()
+            .expect("object")
+            .insert("hooks".to_string(), json!({}));
+        changed = true;
+    }
+    let desired = claude_specs(repo_dir, Some(profile))?;
+    for spec in &desired {
+        changed |= settings_upsert_hook(&mut data, spec, force);
+    }
+    let desired_pairs: BTreeSet<(String, String)> = desired
+        .iter()
+        .map(|spec| (spec.event.clone(), spec.script.clone()))
+        .collect();
+    for spec in claude_specs(repo_dir, None)? {
+        if !desired_pairs.contains(&(spec.event.clone(), spec.script.clone())) {
+            changed |= settings_remove_hook(&mut data, &spec.event, &spec.script);
+        }
+    }
+    if dry_run {
+        if changed {
+            let after = serde_json::to_string_pretty(&data)? + "\n";
+            print!(
+                "{}",
+                simple_unified_diff(settings_path, &before_text, &after)
+            );
+            println!("CHANGED");
+        } else {
+            println!("SKIP");
+        }
+        return Ok(());
+    }
+    if changed {
+        write_json_atomic(settings_path, &data)?;
+        println!("CHANGED");
+    } else {
+        println!("SKIP");
+    }
+    Ok(())
+}
+
+pub fn settings_remove(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-settings-remove <repo-dir> <settings-file>".into(),
+        );
+    }
+    let settings_path = Path::new(&args[1]);
+    if !settings_path.exists() {
+        println!("SKIP");
+        return Ok(());
+    }
+    let repo_dir = Path::new(&args[0]);
+    let mut data = Value::Object(read_json_object(settings_path, false)?);
+    let before = serde_json::to_string(&data)?;
+    settings_remove_legacy_mcp(&mut data);
+    settings_remove_legacy_hooks(&mut data, repo_dir)?;
+    for script in claude_managed_scripts(repo_dir)? {
+        for event in [
+            "PreToolUse",
+            "PostToolUse",
+            "Stop",
+            "SessionStart",
+            "PreCompact",
+            "UserPromptSubmit",
+        ] {
+            settings_remove_hook(&mut data, event, &script);
+        }
+    }
+    if serde_json::to_string(&data)? == before {
+        println!("SKIP");
+    } else {
+        write_json_atomic(settings_path, &data)?;
+        println!("CHANGED");
+    }
+    Ok(())
+}
+
+pub fn settings_check_stale(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-settings-check-stale <settings-file>".into());
+    }
+    let settings_path = Path::new(&args[0]);
+    if !settings_path.exists() {
+        return Ok(());
+    }
+    let data = Value::Object(read_json_object(settings_path, false)?);
+    let findings = settings_stale_findings(&data, settings_path);
+    for finding in &findings {
+        println!("{finding}");
+    }
+    if !findings.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn claude_specs(repo_dir: &Path, profile: Option<&str>) -> SetupResult<Vec<ClaudeSpec>> {
+    let text = std::fs::read_to_string(repo_dir.join("hooks/manifest.json"))?;
+    let manifest: Value = serde_json::from_str(&text)?;
+    let hooks = manifest
+        .get("hooks")
+        .and_then(Value::as_array)
+        .ok_or("hooks manifest must contain a hooks array")?;
+    let mut specs = Vec::new();
+    for item in hooks {
+        let item = item
+            .as_object()
+            .ok_or("each hook manifest entry must be an object")?;
+        let Some(claude) = item.get("claude").and_then(Value::as_object) else {
+            continue;
+        };
+        if claude.get("enabled").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        let profiles = claude
+            .get("profiles")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        if let Some(profile) = profile {
+            if !profiles.iter().any(|value| value.as_str() == Some(profile)) {
+                continue;
+            }
+        }
+        let matchers = claude
+            .get("matchers")
+            .and_then(Value::as_array)
+            .ok_or("claude.matchers must be an array")?;
+        for matcher in matchers {
+            specs.push(ClaudeSpec {
+                event: claude
+                    .get("event")
+                    .and_then(Value::as_str)
+                    .ok_or("claude.event missing")?
+                    .to_string(),
+                matcher: matcher.as_str().unwrap_or("").to_string(),
+                script: item
+                    .get("script")
+                    .and_then(Value::as_str)
+                    .ok_or("hook script missing")?
+                    .to_string(),
+            });
+        }
+    }
+    Ok(specs)
+}
+
+fn settings_has_pre_hooks(repo_dir: &Path, data: &Value) -> SetupResult<bool> {
+    Ok(claude_specs(repo_dir, Some("minimal"))?
+        .iter()
+        .filter(|spec| spec.event == "PreToolUse")
+        .all(|spec| settings_has_spec(data, spec)))
+}
+
+fn settings_has_post_hooks(repo_dir: &Path, data: &Value) -> SetupResult<bool> {
+    Ok(claude_specs(repo_dir, Some("minimal"))?
+        .iter()
+        .filter(|spec| spec.event == "PostToolUse")
+        .all(|spec| settings_has_spec(data, spec)))
+}
+
+fn settings_has_full_hooks(repo_dir: &Path, data: &Value) -> SetupResult<bool> {
+    let core_scripts: BTreeSet<String> = claude_specs(repo_dir, Some("core"))?
+        .into_iter()
+        .map(|spec| spec.script)
+        .collect();
+    Ok(settings_has_post_hooks(repo_dir, data)?
+        && claude_specs(repo_dir, Some("full"))?
+            .iter()
+            .filter(|spec| !core_scripts.contains(&spec.script))
+            .all(|spec| settings_has_spec(data, spec)))
+}
+
+fn settings_has_spec(data: &Value, spec: &ClaudeSpec) -> bool {
+    let Some(entries) = data
+        .get("hooks")
+        .and_then(Value::as_object)
+        .and_then(|hooks| hooks.get(&spec.event))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    entries.iter().any(|entry| {
+        let matcher = entry.get("matcher").and_then(Value::as_str).unwrap_or("");
+        if matcher != spec.matcher {
+            return false;
+        }
+        settings_entry_has_script(entry, &spec.script)
+    })
+}
+
+fn settings_upsert_hook(data: &mut Value, spec: &ClaudeSpec, force: bool) -> bool {
+    let desired = format!(
+        "bash {}/.vibeguard/run-hook.sh {}",
+        home_dir().unwrap_or_default().display(),
+        spec.script
+    );
+    let hooks = data["hooks"].as_object_mut().expect("hooks object");
+    let entries = hooks.entry(spec.event.clone()).or_insert_with(|| json!([]));
+    if !entries.is_array() {
+        *entries = json!([]);
+    }
+    let entries = entries.as_array_mut().expect("entries array");
+    let mut changed = false;
+    let mut found = false;
+    for entry in entries.iter_mut() {
+        let matcher = entry.get("matcher").and_then(Value::as_str).unwrap_or("");
+        if matcher != spec.matcher {
+            continue;
+        }
+        let Some(hook_entries) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+            entry.as_object_mut().expect("entry object").insert(
+                "hooks".to_string(),
+                json!([{"type":"command","command":desired}]),
+            );
+            found = true;
+            changed = true;
+            continue;
+        };
+        for hook in hook_entries.iter_mut() {
+            if !settings_hook_is_script(hook, &spec.script) {
+                continue;
+            }
+            found = true;
+            if hook.get("type").and_then(Value::as_str) != Some("command") {
+                hook.as_object_mut()
+                    .expect("hook object")
+                    .insert("type".to_string(), Value::String("command".to_string()));
+                changed = true;
+            }
+            let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+            if command != desired {
+                if force || settings_is_canonical(command, &spec.script) {
+                    hook.as_object_mut()
+                        .expect("hook object")
+                        .insert("command".to_string(), Value::String(desired.clone()));
+                    changed = true;
+                } else {
+                    eprintln!(
+                        "WARN: preserving customized VibeGuard hook command for {}; use --force-overwrite to replace it",
+                        spec.script
+                    );
+                }
+            }
+        }
+    }
+    if !found {
+        let mut entry = json!({"hooks":[{"type":"command","command":desired}]});
+        if !spec.matcher.is_empty() {
+            entry
+                .as_object_mut()
+                .expect("entry object")
+                .insert("matcher".to_string(), Value::String(spec.matcher.clone()));
+        }
+        entries.push(entry);
+        changed = true;
+    }
+    changed
+}
+
+fn settings_remove_hook(data: &mut Value, event: &str, script: &str) -> bool {
+    let Some(entries) = data
+        .get_mut("hooks")
+        .and_then(Value::as_object_mut)
+        .and_then(|hooks| hooks.get_mut(event))
+        .and_then(Value::as_array_mut)
+    else {
+        return false;
+    };
+    let mut changed = false;
+    for entry in entries.iter_mut() {
+        let Some(hook_entries) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let before = hook_entries.len();
+        hook_entries.retain(|hook| !settings_hook_is_script(hook, script));
+        changed |= before != hook_entries.len();
+    }
+    let before = entries.len();
+    entries.retain(|entry| {
+        entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .is_none_or(|hooks| !hooks.is_empty())
+    });
+    changed | (before != entries.len())
+}
+
+fn settings_remove_legacy_mcp(data: &mut Value) -> bool {
+    let Some(object) = data.as_object_mut() else {
+        return false;
+    };
+    let Some(mcp) = object.get_mut("mcpServers").and_then(Value::as_object_mut) else {
+        return false;
+    };
+    let changed = mcp.remove("vibeguard").is_some();
+    if mcp.is_empty() {
+        object.remove("mcpServers");
+    }
+    changed
+}
+
+fn settings_remove_legacy_hooks(data: &mut Value, _repo_dir: &Path) -> SetupResult<bool> {
+    let mut changed = false;
+    for script in CLAUDE_LEGACY_SCRIPTS {
+        for event in ["PreToolUse", "PostToolUse", "Stop", "SessionStart"] {
+            changed |= settings_remove_hook(data, event, script);
+        }
+    }
+    Ok(changed)
+}
+
+fn settings_remove_stale_installed(data: &mut Value) -> bool {
+    let Some(hooks) = data.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return false;
+    };
+    let mut changed = false;
+    for entries in hooks.values_mut() {
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        for entry in entries.iter_mut() {
+            let Some(hook_entries) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            let before = hook_entries.len();
+            hook_entries.retain(|hook| {
+                let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+                settings_direct_installed_hook_target(command).is_none()
+                    && settings_hook_target(command, "run-hook.sh")
+                        .is_none_or(|target| target.exists())
+            });
+            changed |= before != hook_entries.len();
+        }
+    }
+    changed
+}
+
+fn claude_managed_scripts(repo_dir: &Path) -> SetupResult<BTreeSet<String>> {
+    Ok(claude_specs(repo_dir, None)?
+        .into_iter()
+        .map(|spec| spec.script)
+        .collect())
+}
+
+fn settings_entry_has_script(entry: &Value, script: &str) -> bool {
+    entry
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hooks| {
+            hooks
+                .iter()
+                .any(|hook| settings_hook_is_script(hook, script))
+        })
+}
+
+fn settings_hook_is_script(hook: &Value, script: &str) -> bool {
+    hook.get("command")
+        .and_then(Value::as_str)
+        .is_some_and(|command| {
+            shell_split(command)
+                .iter()
+                .any(|part| basename(part) == script)
+        })
+}
+
+fn settings_is_canonical(command: &str, script: &str) -> bool {
+    let parts = shell_split(command);
+    parts.len() == 3
+        && parts.first().is_some_and(|part| basename(part) == "bash")
+        && parts
+            .get(1)
+            .is_some_and(|part| part.ends_with("/.vibeguard/run-hook.sh"))
+        && parts.get(2).is_some_and(|part| part == script)
+}
+
+fn settings_stale_findings(data: &Value, config: &Path) -> Vec<String> {
+    let mut findings = Vec::new();
+    let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
+        return findings;
+    };
+    for (event, entries) in hooks {
+        let Some(entries) = entries.as_array() else {
+            continue;
+        };
+        for entry in entries {
+            let matcher = entry
+                .get("matcher")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("<none>");
+            let Some(hook_entries) = entry.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for hook in hook_entries {
+                let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+                let target = if let Some(target) = settings_direct_installed_hook_target(command) {
+                    target
+                } else {
+                    let Some(target) = settings_hook_target(command, "run-hook.sh") else {
+                        continue;
+                    };
+                    if target.exists() {
+                        continue;
+                    }
+                    target
+                };
+                findings.push(format!(
+                    "stale Claude hook command: config={} event={event} matcher={matcher} command_path={} repair=bash setup.sh --yes",
+                    display_home_path(config),
+                    target.display()
+                ));
+            }
+        }
+    }
+    findings
+}
+
+fn settings_direct_installed_hook_target(command: &str) -> Option<PathBuf> {
+    let home = home_dir()?;
+    shell_split(command).into_iter().find_map(|token| {
+        let path = settings_expand_path(&token, &home)?;
+        path.to_string_lossy()
+            .contains("/.vibeguard/installed/hooks/")
+            .then_some(path)
+    })
+}
+
+fn settings_hook_target(command: &str, wrapper_name: &str) -> Option<PathBuf> {
+    let home = home_dir()?;
+    let parts = shell_split(command);
+    for (idx, token) in parts.iter().enumerate() {
+        let path = settings_expand_path(token, &home)?;
+        if path
+            .to_string_lossy()
+            .ends_with(&format!("/.vibeguard/{wrapper_name}"))
+        {
+            let script = parts.get(idx + 1)?;
+            if !script.contains('/') {
+                let installed = path.parent()?.join("installed/hooks").join(script);
+                if installed.parent().is_some_and(Path::exists) {
+                    return Some(installed);
+                };
+            }
+        }
+    }
+    None
+}
+
+fn settings_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
+    token
+        .strip_prefix("~/")
+        .map(|tail| home.join(tail))
+        .or_else(|| token.strip_prefix("$HOME/").map(|tail| home.join(tail)))
+        .or_else(|| token.strip_prefix("${HOME}/").map(|tail| home.join(tail)))
+        .or_else(|| token.starts_with('/').then(|| PathBuf::from(token)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_marker_block() {
+        let original = "a\n\n<!-- vibeguard-start -->\nold\n<!-- vibeguard-end -->\n\nb\n";
+        let next = replace_managed_block(
+            original,
+            "<!-- vibeguard-start -->\nnew\n<!-- vibeguard-end -->",
+        );
+        assert!(next.contains("new"));
+        assert!(!next.contains("old"));
+        assert!(next.starts_with("a\n\n"));
+        assert!(next.ends_with("b\n"));
+    }
+}

--- a/vibeguard-runtime/src/setup_support.rs
+++ b/vibeguard-runtime/src/setup_support.rs
@@ -300,3 +300,61 @@ mod sha256 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> SetupResult<PathBuf> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        path.push(format!(
+            "vibeguard-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path)?;
+        Ok(path)
+    }
+
+    #[test]
+    fn shell_split_preserves_quoted_arguments() {
+        assert_eq!(
+            shell_split("bash '/tmp/run hook.sh' \"arg two\" plain\\ value"),
+            vec!["bash", "/tmp/run hook.sh", "arg two", "plain value"]
+        );
+    }
+
+    #[test]
+    fn shell_quote_wraps_unsafe_values() {
+        assert_eq!(shell_quote("/tmp/safe-path"), "/tmp/safe-path");
+        assert_eq!(shell_quote("/tmp/path with space"), "'/tmp/path with space'");
+        assert_eq!(shell_quote("it's"), "'it'\"'\"'s'");
+    }
+
+    #[test]
+    fn sha256_file_matches_known_digest() -> SetupResult<()> {
+        let dir = unique_temp_dir("setup-support-sha")?;
+        let path = dir.join("input.txt");
+        fs::write(&path, "abc")?;
+        assert_eq!(
+            sha256_file(&path)?,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        let _ = fs::remove_dir_all(dir);
+        Ok(())
+    }
+
+    #[test]
+    fn read_json_object_enforces_object_root() -> SetupResult<()> {
+        let dir = unique_temp_dir("setup-support-json")?;
+        let missing = dir.join("missing.json");
+        assert!(read_json_object(&missing, true)?.is_empty());
+
+        let array_path = dir.join("array.json");
+        fs::write(&array_path, "[]")?;
+        assert!(read_json_object(&array_path, false).is_err());
+
+        let _ = fs::remove_dir_all(dir);
+        Ok(())
+    }
+}

--- a/vibeguard-runtime/src/setup_support.rs
+++ b/vibeguard-runtime/src/setup_support.rs
@@ -1,0 +1,302 @@
+use serde_json::Value;
+use std::collections::hash_map::DefaultHasher;
+use std::fs::{self, File};
+use std::hash::{Hash, Hasher};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub type SetupResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+pub fn read_json_object(
+    path: &Path,
+    missing_as_empty: bool,
+) -> SetupResult<serde_json::Map<String, Value>> {
+    if missing_as_empty && !path.exists() {
+        return Ok(serde_json::Map::new());
+    }
+    let text = fs::read_to_string(path)?;
+    let value: Value = serde_json::from_str(&text)?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| format!("{} root must be an object", path.display()).into())
+}
+
+pub fn write_text_atomic(path: &Path, content: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = temp_path_for(path);
+    {
+        let mut file = File::create(&tmp)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+    }
+    fs::rename(&tmp, path)?;
+    if let Some(parent) = path.parent() {
+        let _ = File::open(parent).and_then(|file| file.sync_all());
+    }
+    Ok(())
+}
+
+pub fn write_json_atomic(path: &Path, value: &Value) -> SetupResult<()> {
+    let text = serde_json::to_string_pretty(value)? + "\n";
+    write_text_atomic(path, &text)?;
+    Ok(())
+}
+
+pub fn sha256_file(path: &Path) -> SetupResult<String> {
+    let mut file = File::open(path)?;
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)?;
+    let mut hasher = sha256::Sha256::new();
+    hasher.update(&data);
+    Ok(hasher.digest().to_string())
+}
+
+pub fn display_home_path(path: &Path) -> String {
+    if let Some(home) = home_dir() {
+        if let Ok(rel) = path.strip_prefix(&home) {
+            return format!("~/{}", rel.display());
+        }
+    }
+    path.display().to_string()
+}
+
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+pub fn shell_split(command: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.chars().peekable();
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && quote != Some('\'') {
+            escaped = true;
+            continue;
+        }
+        if let Some(active) = quote {
+            if ch == active {
+                quote = None;
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            c if c.is_whitespace() => {
+                if !current.is_empty() {
+                    out.push(std::mem::take(&mut current));
+                }
+                while matches!(chars.peek(), Some(next) if next.is_whitespace()) {
+                    chars.next();
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+pub fn shell_quote(value: &str) -> String {
+    if value.chars().all(|ch| {
+        ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':' | '@' | '%')
+    }) {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+pub fn basename(text: &str) -> &str {
+    text.rsplit('/').next().unwrap_or(text)
+}
+
+pub fn simple_unified_diff(path: &Path, before: &str, after: &str) -> String {
+    let mut diff = String::new();
+    let label = path.display();
+    diff.push_str(&format!("--- {label}\n+++ {label}\n"));
+    diff.push_str("@@\n");
+    for line in before.split_inclusive('\n') {
+        diff.push('-');
+        diff.push_str(line);
+        if !line.ends_with('\n') {
+            diff.push('\n');
+        }
+    }
+    for line in after.split_inclusive('\n') {
+        diff.push('+');
+        diff.push_str(line);
+        if !line.ends_with('\n') {
+            diff.push('\n');
+        }
+    }
+    diff
+}
+
+fn temp_path_for(path: &Path) -> PathBuf {
+    let mut hasher = DefaultHasher::new();
+    std::process::id().hash(&mut hasher);
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .hash(&mut hasher);
+    let suffix = hasher.finish();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("vibeguard");
+    path.with_file_name(format!(".{file_name}.{suffix}.tmp"))
+}
+
+mod sha256 {
+    pub struct Sha256 {
+        state: [u32; 8],
+        data: [u8; 64],
+        datalen: usize,
+        bitlen: u64,
+    }
+
+    impl Sha256 {
+        pub fn new() -> Self {
+            Self {
+                state: [
+                    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+                    0x1f83d9ab, 0x5be0cd19,
+                ],
+                data: [0; 64],
+                datalen: 0,
+                bitlen: 0,
+            }
+        }
+
+        pub fn update(&mut self, input: &[u8]) {
+            for &byte in input {
+                self.data[self.datalen] = byte;
+                self.datalen += 1;
+                if self.datalen == 64 {
+                    self.transform();
+                    self.bitlen += 512;
+                    self.datalen = 0;
+                }
+            }
+        }
+
+        pub fn digest(mut self) -> Digest {
+            let i = self.datalen;
+            if self.datalen < 56 {
+                self.data[i] = 0x80;
+                for item in &mut self.data[i + 1..56] {
+                    *item = 0;
+                }
+            } else {
+                self.data[i] = 0x80;
+                for item in &mut self.data[i + 1..64] {
+                    *item = 0;
+                }
+                self.transform();
+                self.data = [0; 64];
+            }
+            self.bitlen += (self.datalen as u64) * 8;
+            self.data[56..64].copy_from_slice(&self.bitlen.to_be_bytes());
+            self.transform();
+            let mut out = [0u8; 32];
+            for (idx, value) in self.state.iter().enumerate() {
+                out[idx * 4..idx * 4 + 4].copy_from_slice(&value.to_be_bytes());
+            }
+            Digest(out)
+        }
+
+        fn transform(&mut self) {
+            const K: [u32; 64] = [
+                0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+                0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+                0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+                0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+                0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+                0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+                0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+                0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+                0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+                0xc67178f2,
+            ];
+            let mut m = [0u32; 64];
+            for (idx, chunk) in self.data.chunks_exact(4).take(16).enumerate() {
+                m[idx] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            }
+            for idx in 16..64 {
+                let s0 =
+                    m[idx - 15].rotate_right(7) ^ m[idx - 15].rotate_right(18) ^ (m[idx - 15] >> 3);
+                let s1 =
+                    m[idx - 2].rotate_right(17) ^ m[idx - 2].rotate_right(19) ^ (m[idx - 2] >> 10);
+                m[idx] = m[idx - 16]
+                    .wrapping_add(s0)
+                    .wrapping_add(m[idx - 7])
+                    .wrapping_add(s1);
+            }
+            let mut a = self.state[0];
+            let mut b = self.state[1];
+            let mut c = self.state[2];
+            let mut d = self.state[3];
+            let mut e = self.state[4];
+            let mut f = self.state[5];
+            let mut g = self.state[6];
+            let mut h = self.state[7];
+            for idx in 0..64 {
+                let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+                let ch = (e & f) ^ ((!e) & g);
+                let temp1 = h
+                    .wrapping_add(s1)
+                    .wrapping_add(ch)
+                    .wrapping_add(K[idx])
+                    .wrapping_add(m[idx]);
+                let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+                let maj = (a & b) ^ (a & c) ^ (b & c);
+                let temp2 = s0.wrapping_add(maj);
+                h = g;
+                g = f;
+                f = e;
+                e = d.wrapping_add(temp1);
+                d = c;
+                c = b;
+                b = a;
+                a = temp1.wrapping_add(temp2);
+            }
+            self.state[0] = self.state[0].wrapping_add(a);
+            self.state[1] = self.state[1].wrapping_add(b);
+            self.state[2] = self.state[2].wrapping_add(c);
+            self.state[3] = self.state[3].wrapping_add(d);
+            self.state[4] = self.state[4].wrapping_add(e);
+            self.state[5] = self.state[5].wrapping_add(f);
+            self.state[6] = self.state[6].wrapping_add(g);
+            self.state[7] = self.state[7].wrapping_add(h);
+        }
+    }
+
+    pub struct Digest([u8; 32]);
+
+    impl std::fmt::Display for Digest {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            for byte in self.0 {
+                write!(f, "{byte:02x}")?;
+            }
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move setup/check/clean JSON/TOML/Markdown/install-state operations into `vibeguard-runtime` and bootstrap a verified runtime for fresh `--check`/`--clean`
- add Codex wrapped-hook timeout enforcement, align manifest/helper timeout values, and install the timeout helper for Codex
- add scheduled-GC catch-up behavior, oversized-log visibility, and bounded learn-evaluator log input
- document the Python-free production boundary without claiming the whole repo is Python-free

Closes #384
Closes #413
Closes #414
Refs #371
Refs #385
Refs #412

## Verification
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml setup`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_setup.sh` (325/325)
- `bash tests/test_setup_check.sh` (98/98)
- `bash tests/test_codex_runtime.sh` (119/119)
- `bash tests/test_gc_scheduled.sh` (15/15)
- `bash tests/test_manifest_contract.sh` (92/92)
- `bash tests/test_hooks.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/self-application/check-hook-production-python-free.sh`
- `git diff --check`
