### PR TITLE
Document no-Python production boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard
 bash ~/vibeguard/setup.sh
 ```
 
-Requires Python 3. On supported macOS/Linux targets, setup downloads a
-prebuilt `vibeguard-runtime` release binary and verifies it with `SHA256SUMS`,
-so Rust/Cargo is not required by default.
+On supported macOS/Linux targets, the production install/check/clean path is
+Python-free: setup downloads a prebuilt `vibeguard-runtime` release binary and
+verifies it with `SHA256SUMS`, so Rust/Cargo is not required by default.
+Python still supports evals, docs generation, developer tools, and optional
+language-specific guard packs.
 
 Open a new Claude Code or Codex session. Run `bash ~/vibeguard/setup.sh --check` to verify.
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -31,8 +31,9 @@ git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard
 bash ~/vibeguard/setup.sh
 ```
 
-安装需要 Python 3。在支持的 macOS/Linux 目标上，`setup.sh` 默认下载并校验
-预编译的 `vibeguard-runtime` release binary，因此默认不需要 Rust/Cargo。
+在支持的 macOS/Linux 目标上，生产安装/check/clean 路径不需要 Python：
+`setup.sh` 默认下载并校验预编译的 `vibeguard-runtime` release binary，
+因此默认不需要 Rust/Cargo。Python 仍用于 eval、文档生成、开发者工具和可选的语言专项 guard packs。
 
 安装后重新打开 Claude Code 或 Codex 会话。用下面的命令检查安装状态：
 

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -4,8 +4,10 @@ VibeGuard supports Linux via **systemd user units** as the scheduled task mechan
 
 ## Requirements
 
-- Python 3.
 - `gh` or `curl` for the default prebuilt `vibeguard-runtime` download.
+- Python 3 is not required for default production install/check/clean on
+  supported release targets. It remains used by evals, docs generation,
+  developer tools, and optional Python-backed guard tools.
 - Rust/Cargo only for unsupported targets, offline installs, or `--build-from-source`.
 - Linux with systemd, `systemctl` in `$PATH`, and a `systemd --user` session only if
   you opt in to the scheduled GC timer.

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -67,6 +67,12 @@ require_present "README.md" '`pre-bash-guard` does not regex-match `git push --f
   "README.md must make the pre-bash/pre-push boundary explicit"
 require_present "README.md" '| `PreToolUse(Bash)` | `pre-bash-guard.sh` | Destructive local cleanup interception + package manager correction |' \
   "README.md Codex hook table must not imply force-push lives in pre-bash"
+require_absent "README.md" 'Requires Python 3. On supported macOS/Linux targets' \
+  "README.md must not claim Python 3 is required for the default production install path"
+require_present "README.md" 'the production install/check/clean path is' \
+  "README.md must state the Python-free production install/check/clean boundary"
+require_present "README.md" 'Python still supports evals, docs generation, developer tools, and optional' \
+  "README.md must keep eval/docs/dev/optional Python tooling documented separately"
 
 require_absent "docs/README_CN.md" '| AI 想结束但还没有验证改动 | `stop-guard` | **闸门**' \
   "docs/README_CN.md must not describe stop-guard as a blocking gate"
@@ -90,6 +96,16 @@ require_present "docs/README_CN.md" 'git `pre-push` hook 负责非快进推送/�
   "docs/README_CN.md setup prose must make the pre-bash/pre-push boundary explicit"
 require_present "docs/README_CN.md" '| `PreToolUse(Bash)` | `pre-bash-guard.sh` | 危险本地清理拦截 + 包管理器纠偏 |' \
   "docs/README_CN.md Codex hook table must not imply force-push lives in pre-bash"
+require_absent "docs/README_CN.md" '安装需要 Python 3。在支持的 macOS/Linux 目标上' \
+  "docs/README_CN.md must not claim Python 3 is required for the default production install path"
+require_present "docs/README_CN.md" '生产安装/check/clean 路径不需要 Python' \
+  "docs/README_CN.md must state the Python-free production install/check/clean boundary"
+require_present "docs/README_CN.md" 'Python 仍用于 eval、文档生成、开发者工具和可选的语言专项 guard packs' \
+  "docs/README_CN.md must keep eval/docs/dev/optional Python tooling documented separately"
+require_absent "docs/linux-setup.md" '- Python 3.' \
+  "Linux setup docs must not list Python 3 as a default production install requirement"
+require_present "docs/linux-setup.md" 'Python 3 is not required for default production install/check/clean on' \
+  "Linux setup docs must state the Python-free production install/check/clean boundary"
 require_absent "SECURITY.md" 'pre-bash-guard.sh`, which blocks force-pushes (`git push --force`), destructive resets (`git reset --hard`), and dangerous `rm -rf` operations.' \
   "SECURITY.md must not assign force-push/reset-hard protection to pre-bash"
 require_present "SECURITY.md" 'pre-bash-guard.sh`, which blocks dangerous local cleanup such as risky `rm -rf` targets, `git clean -f`, and batch `git checkout/restore .` operations.' \


### PR DESCRIPTION
## Summary

Closes #385.

Updates the public dependency boundary now that the production setup/check/clean and configured first-party hook paths are Python-free on supported release targets.

## Changes

- Replace old public "Requires Python 3" install wording with a scoped Python-free production boundary.
- Keep evals, docs generation, developer tools, and optional language-specific guard packs documented as Python-supported.
- Add doc validator sentinels so README, Chinese README, and Linux setup docs cannot regress to the old default Python requirement wording.

## Verification

- `bash scripts/ci/validate-hook-behavior-docs.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_setup.sh`
- `git diff --check`

## Notes

This does not claim the whole repository is Python-free. Python remains allowed for eval/dev/docs/optional tooling.
