### PR TITLE
Reduce Codex wrapper runtime spawns

### DIFF
--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -153,6 +153,14 @@ codex_hook_status_matcher() {
   printf '\n'
 }
 
+codex_hook_start_info() {
+  local input="$1" hook_name="$2" timeout_ms="${3:-}"
+  local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
+  local runtime_path
+  runtime_path="$(codex_runtime_path 2>/dev/null)" || return 127
+  printf '%s' "${input}" | "${runtime_path}" codex-hook-start "${diag_file}" "${hook_name}" "${timeout_ms}"
+}
+
 codex_hook_status() {
   local hook_name="$1" event_name="$2" matcher="$3" status="$4" reason="${5:-}" detail="${6:-}"
   local timeout_ms="${7:-}"
@@ -182,4 +190,13 @@ codex_hook_status_from_output() {
     return 0
   fi
   codex_hook_status "${hook_name}" "${event_name}" "${matcher}" "hook_error" "runtime-unavailable" "${detail}" "${timeout_ms}"
+}
+
+codex_finalize_output() {
+  local hook_name="$1" event_name="$2" matcher="$3" hook_output="$4" detail="${5:-}" timeout_ms="${6:-}"
+  local diag_file="${VIBEGUARD_CODEX_DIAG_FILE:-${HOME}/.vibeguard/codex-wrapper.jsonl}"
+  local runtime_path
+  runtime_path="$(codex_runtime_path 2>/dev/null)" || return 127
+  printf '%s' "${hook_output}" | "${runtime_path}" codex-finalize-output \
+    "${diag_file}" "${hook_name}" "${event_name}" "${matcher}" "${detail}" "${timeout_ms}"
 }

--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -67,16 +67,26 @@ codex_run_hook() {
 
   local first_adapted_output=""
   local normalized_input hook_output hook_exit hook_err_file hook_err event_name
-  local pretool_status pretool_output permission_status permission_output
-  local posttool_status posttool_output
+  local adapted_status adapted_output finalized_output
   while IFS= read -r normalized_input || [[ -n "${normalized_input:-}" ]]; do
     [[ -n "${normalized_input}" ]] || continue
 
     hook_err_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-hook.XXXXXX")"
-    event_name=$(codex_event_name "${normalized_input}")
-    local hook_matcher hook_detail hook_timeout_ms hook_status_info
+    local hook_matcher hook_detail hook_timeout_ms hook_status_info hook_status_started
     local hook_timeout_seconds
-    if declare -F codex_hook_status_info >/dev/null 2>&1; then
+    hook_timeout_ms="$(codex_hook_timeout_ms "${hook_name}" 2>/dev/null || true)"
+    hook_status_started=0
+    if declare -F codex_hook_start_info >/dev/null 2>&1 \
+      && hook_status_info="$(codex_hook_start_info "${normalized_input}" "${hook_name}" "${hook_timeout_ms}" 2>/dev/null)"; then
+      event_name="${hook_status_info%%$'\t'*}"
+      hook_status_info="${hook_status_info#*$'\t'}"
+      hook_matcher="${hook_status_info%%$'\t'*}"
+      hook_detail="${hook_status_info#*$'\t'}"
+      if [[ "${hook_matcher}" == "${hook_status_info}" ]]; then
+        hook_detail=""
+      fi
+      hook_status_started=1
+    elif declare -F codex_hook_status_info >/dev/null 2>&1; then
       hook_status_info="$(codex_hook_status_info "${normalized_input}" 2>/dev/null || true)"
       event_name="${hook_status_info%%$'\t'*}"
       hook_status_info="${hook_status_info#*$'\t'}"
@@ -91,8 +101,9 @@ codex_run_hook() {
       hook_detail="$(codex_hook_status_detail "${normalized_input}" 2>/dev/null || true)"
     fi
     [[ -n "${event_name}" ]] || event_name=$(codex_event_name "${normalized_input}")
-    hook_timeout_ms="$(codex_hook_timeout_ms "${hook_name}" 2>/dev/null || true)"
-    codex_hook_status "${hook_name}" "${event_name}" "${hook_matcher}" "running" "" "${hook_detail}" "${hook_timeout_ms}"
+    if [[ "${hook_status_started}" -eq 0 ]]; then
+      codex_hook_status "${hook_name}" "${event_name}" "${hook_matcher}" "running" "" "${hook_detail}" "${hook_timeout_ms}"
+    fi
 
     hook_output=""
     hook_exit=0
@@ -131,67 +142,85 @@ codex_run_hook() {
     if [[ "${VIBEGUARD_POLICY_ENFORCEMENT:-}" == "warn" ]] && declare -F vg_policy_downgrade_output >/dev/null 2>&1; then
       hook_output="$(vg_policy_downgrade_output "${hook_output}")"
     fi
-    codex_hook_status_from_output "${hook_name}" "${event_name}" "${hook_matcher}" "${hook_output}" "${hook_detail}" "${hook_timeout_ms}"
+    adapted_status=0
+    adapted_output=""
+    finalized_output=0
+    if declare -F codex_finalize_output >/dev/null 2>&1; then
+      adapted_output=$(codex_finalize_output "${hook_name}" "${event_name}" "${hook_matcher}" "${hook_output}" "${hook_detail}" "${hook_timeout_ms}" 2>/dev/null) || adapted_status=$?
+      if [[ ${adapted_status} -eq 0 || ${adapted_status} -eq 3 ]]; then
+        finalized_output=1
+      else
+        adapted_status=0
+        adapted_output=""
+      fi
+    fi
+
+    if [[ "${finalized_output}" -eq 0 ]]; then
+      codex_hook_status_from_output "${hook_name}" "${event_name}" "${hook_matcher}" "${hook_output}" "${hook_detail}" "${hook_timeout_ms}"
+      if [[ "${event_name}" == "PreToolUse" ]]; then
+        adapted_output=$(codex_adapt_pretool "${hook_output}") || adapted_status=$?
+      elif [[ "${event_name}" == "PermissionRequest" ]]; then
+        adapted_output=$(codex_adapt_permission_request "${hook_output}") || adapted_status=$?
+      elif [[ "${event_name}" == "PostToolUse" ]]; then
+        adapted_output=$(codex_adapt_posttool "${hook_output}" 2>/dev/null) || adapted_status=$?
+      else
+        adapted_output="${hook_output}"
+      fi
+    fi
 
     if [[ "${event_name}" == "PreToolUse" ]]; then
-      pretool_status=0
-      pretool_output=$(codex_adapt_pretool "${hook_output}") || pretool_status=$?
-      if [[ ${pretool_status} -ne 0 ]]; then
+      if [[ ${adapted_status} -ne 0 ]]; then
         rm -f "${normalized_file}" 2>/dev/null || true
-        if [[ -n "${pretool_output}" ]]; then
-          printf '%s\n' "${pretool_output}"
+        if [[ -n "${adapted_output}" ]]; then
+          printf '%s\n' "${adapted_output}"
         else
           codex_pretool_deny "VIBEGUARD hook failed: wrapped hook output could not be adapted."
         fi
         return 0
       fi
-      if [[ -n "${pretool_output}" ]]; then
-        if [[ "${pretool_output}" == *'"permissionDecision": "deny"'* || "${pretool_output}" == *'"permissionDecision":"deny"'* ]]; then
+      if [[ -n "${adapted_output}" ]]; then
+        if [[ "${adapted_output}" == *'"permissionDecision": "deny"'* || "${adapted_output}" == *'"permissionDecision":"deny"'* ]]; then
           rm -f "${normalized_file}" 2>/dev/null || true
-          printf '%s\n' "${pretool_output}"
+          printf '%s\n' "${adapted_output}"
           return 0
         fi
-        [[ -n "${first_adapted_output}" ]] || first_adapted_output="${pretool_output}"
+        [[ -n "${first_adapted_output}" ]] || first_adapted_output="${adapted_output}"
       fi
     elif [[ "${event_name}" == "PermissionRequest" ]]; then
-      permission_status=0
-      permission_output=$(codex_adapt_permission_request "${hook_output}") || permission_status=$?
-      if [[ ${permission_status} -ne 0 ]]; then
+      if [[ ${adapted_status} -ne 0 ]]; then
         rm -f "${normalized_file}" 2>/dev/null || true
-        if [[ -n "${permission_output}" ]]; then
-          printf '%s\n' "${permission_output}"
+        if [[ -n "${adapted_output}" ]]; then
+          printf '%s\n' "${adapted_output}"
         else
           codex_permission_deny "VIBEGUARD hook failed: wrapped hook output could not be adapted."
         fi
         return 0
       fi
-      if [[ -n "${permission_output}" ]]; then
-        if [[ "${permission_output}" == *'"behavior": "deny"'* || "${permission_output}" == *'"behavior":"deny"'* ]]; then
+      if [[ -n "${adapted_output}" ]]; then
+        if [[ "${adapted_output}" == *'"behavior": "deny"'* || "${adapted_output}" == *'"behavior":"deny"'* ]]; then
           rm -f "${normalized_file}" 2>/dev/null || true
-          printf '%s\n' "${permission_output}"
+          printf '%s\n' "${adapted_output}"
           return 0
         fi
-        [[ -n "${first_adapted_output}" ]] || first_adapted_output="${permission_output}"
+        [[ -n "${first_adapted_output}" ]] || first_adapted_output="${adapted_output}"
       fi
     elif [[ "${event_name}" == "PostToolUse" ]]; then
-      posttool_status=0
-      posttool_output=$(codex_adapt_posttool "${hook_output}" 2>/dev/null) || posttool_status=$?
-      if [[ ${posttool_status} -ne 0 ]]; then
+      if [[ ${adapted_status} -ne 0 ]]; then
         codex_diag "${hook_name}" "${event_name}" "posttool-adapter-failed" "${hook_output}"
         rm -f "${normalized_file}" 2>/dev/null || true
         codex_visible_failure_raw "${event_name}" "VIBEGUARD hook failed: wrapped PostToolUse output could not be adapted."
         return 0
       fi
-      if [[ -n "${posttool_output}" ]]; then
-        if [[ "${posttool_output}" == *'"decision": "block"'* || "${posttool_output}" == *'"decision":"block"'* ]]; then
+      if [[ -n "${adapted_output}" ]]; then
+        if [[ "${adapted_output}" == *'"decision": "block"'* || "${adapted_output}" == *'"decision":"block"'* ]]; then
           rm -f "${normalized_file}" 2>/dev/null || true
-          printf '%s\n' "${posttool_output}"
+          printf '%s\n' "${adapted_output}"
           return 0
         fi
-        [[ -n "${first_adapted_output}" ]] || first_adapted_output="${posttool_output}"
+        [[ -n "${first_adapted_output}" ]] || first_adapted_output="${adapted_output}"
       fi
     else
-      [[ -n "${first_adapted_output}" ]] || first_adapted_output="${hook_output}"
+      [[ -n "${first_adapted_output}" ]] || first_adapted_output="${adapted_output}"
     fi
   done <"${normalized_file}"
 

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -40,6 +40,9 @@ vg_policy_runtime_path() {
 
 vg_policy_runtime_supports() {
   local candidate="$1" probe_diag downgrade_probe codex_probe
+  if "${candidate}" runtime-policy-supports >/dev/null 2>&1; then
+    return 0
+  fi
   probe_diag="${TMPDIR:-/tmp}/vibeguard-policy-probe.$$.jsonl"
   VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
     VIBEGUARD_USER_CONFIG_FILE="" \

--- a/tests/codex_runtime/protocol_helper_tests.sh
+++ b/tests/codex_runtime/protocol_helper_tests.sh
@@ -35,8 +35,10 @@ protocol_helper_out="$(
     printf "status_info=%s\n" "$(codex_hook_status_info "${payload}")"
     printf "matcher=%s\n" "$(codex_hook_status_matcher "${payload}")"
     printf "detail=%s\n" "$(codex_hook_status_detail "${payload}")"
+    printf "start_info=%s\n" "$(codex_hook_start_info "${payload}" "vibeguard-pre-bash-guard.sh" "15000")"
     codex_hook_status() { printf "status=%s reason=%s\n" "$4" "$5"; }
     codex_hook_status_from_output "vibeguard-pre-bash-guard.sh" "PreToolUse" "Bash" "{\"hookSpecificOutput\":{\"decision\":{\"behavior\":\"deny\",\"message\":\"stop\"}}}"
+    printf "finalize_start\n"; codex_finalize_output "vibeguard-pre-bash-guard.sh" "PreToolUse" "Bash" "{\"decision\":\"block\",\"reason\":\"finalized without python\"}" "cargo test" "15000"; printf "finalize_end\n"
     printf "status_json=%s\n" "$(cat "${VIBEGUARD_CODEX_DIAG_FILE}")"
     printf "pretool_deny_start\n"; codex_pretool_deny "blocked without python"; printf "pretool_deny_end\n"
     printf "permission_deny_start\n"; codex_permission_deny "permission blocked without python"; printf "permission_deny_end\n"
@@ -50,7 +52,9 @@ assert_contains "${protocol_helper_out}" "adapter_event=PreToolUse" "codex_event
 assert_contains "${protocol_helper_out}" $'status_info=PreToolUse\tBash\tcargo test' "codex_hook_status_info works without python3"
 assert_contains "${protocol_helper_out}" "matcher=Bash" "codex_hook_status_matcher works without python3"
 assert_contains "${protocol_helper_out}" "detail=cargo test" "codex_hook_status_detail works without python3"
+assert_contains "${protocol_helper_out}" $'start_info=PreToolUse\tBash\tcargo test' "codex_hook_start_info works without python3"
 assert_contains "${protocol_helper_out}" '"status":"block"' "codex_hook_status_from_output works without python3"
+assert_contains "${protocol_helper_out}" "finalized without python" "codex_finalize_output adapts output without python3"
 assert_contains "${protocol_helper_out}" "blocked without python" "codex_pretool_deny works without python3"
 assert_contains "${protocol_helper_out}" "permission blocked without python" "codex_permission_deny works without python3"
 assert_contains "${protocol_helper_out}" "adapted without python" "codex_adapt_pretool works without python3"
@@ -77,7 +81,7 @@ cat > "${OLD_STATUS_RUNTIME}" <<'SH'
 cmd="$1"
 shift
 case "$cmd" in
-  codex-status-info|codex-hook-status-from-output)
+  codex-status-info|codex-hook-start|codex-hook-status-from-output|codex-finalize-output)
     printf 'Unknown command: %s\n' "$cmd" >&2
     exit 2
     ;;
@@ -96,6 +100,10 @@ case "$cmd" in
   codex-status-from-output)
     cat >/dev/null
     printf 'block\told-runtime-block\n'
+    ;;
+  codex-adapt-pretool)
+    cat >/dev/null
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"old-runtime-adapted"}}\n'
     ;;
   codex-hook-status)
     diag_file="$1"
@@ -128,6 +136,72 @@ old_status_out="$(
 assert_contains "${old_status_out}" $'old_status_info=PreToolUse\tBash\tcargo test' "codex_hook_status_info falls back to old runtime helpers"
 assert_contains "${old_status_out}" '"status":"block"' "codex_hook_status_from_output falls back to old runtime helpers"
 assert_not_contains "${old_status_out}" "runtime-unavailable" "old runtime status fallback does not create false hook_error"
+
+TMP_FAKE_REPO_OLD_RUNTIME="${TMP_DIR}/fake-repo-old-runtime"
+mkdir -p "${TMP_FAKE_REPO_OLD_RUNTIME}/hooks"
+cat > "${TMP_FAKE_REPO_OLD_RUNTIME}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"block","reason":"old runner fallback"}\n'
+HOOK
+chmod +x "${TMP_FAKE_REPO_OLD_RUNTIME}/hooks/vibeguard-pre-bash-guard.sh"
+old_runner_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_RUNTIME="${OLD_STATUS_RUNTIME}" VIBEGUARD_CODEX_DIAG_FILE="${TMP_DIR}/old-runner-diag.jsonl" bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    source "$3"
+    EVENT_NAME=PreToolUse
+    codex_run_hook "vibeguard-pre-bash-guard.sh" "$4" "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cargo test\"}}"
+  ' -- \
+    "${REPO_DIR}/hooks/_lib/codex_diag.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_adapter.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_runner.sh" \
+    "${TMP_FAKE_REPO_OLD_RUNTIME}/hooks/vibeguard-pre-bash-guard.sh"
+)"
+assert_contains "${old_runner_out}" '"permissionDecision":"deny"' "codex_run_hook falls back when old runtime lacks batched helpers"
+assert_contains "${old_runner_out}" "old-runtime-adapted" "old runtime fallback still adapts PreToolUse output"
+
+COUNTING_RUNTIME="${TMP_DIR}/counting-vibeguard-runtime"
+COUNTING_RUNTIME_LOG="${TMP_DIR}/counting-runtime.log"
+: > "${COUNTING_RUNTIME_LOG}"
+cat > "${COUNTING_RUNTIME}" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >> "${VIBEGUARD_RUNTIME_COUNT_LOG:?}"
+exec "${VIBEGUARD_REAL_RUNTIME:?}" "$@"
+SH
+chmod +x "${COUNTING_RUNTIME}"
+TMP_FAKE_REPO_COUNTING="${TMP_DIR}/fake-repo-counting-runtime"
+mkdir -p "${TMP_FAKE_REPO_COUNTING}/hooks"
+cat > "${TMP_FAKE_REPO_COUNTING}/hooks/vibeguard-pre-bash-guard.sh" <<'HOOK'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"decision":"block","reason":"counted block"}\n'
+HOOK
+chmod +x "${TMP_FAKE_REPO_COUNTING}/hooks/vibeguard-pre-bash-guard.sh"
+COUNTING_REAL_RUNTIME="${VIBEGUARD_RUNTIME}"
+counting_runner_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_RUNTIME="${COUNTING_RUNTIME}" \
+  VIBEGUARD_REAL_RUNTIME="${COUNTING_REAL_RUNTIME}" \
+  VIBEGUARD_RUNTIME_COUNT_LOG="${COUNTING_RUNTIME_LOG}" \
+  VIBEGUARD_CODEX_DIAG_FILE="${TMP_DIR}/counting-runner-diag.jsonl" \
+  bash -c '
+    set -euo pipefail
+    source "$1"
+    source "$2"
+    source "$3"
+    EVENT_NAME=PreToolUse
+    codex_run_hook "vibeguard-pre-bash-guard.sh" "$4" "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cargo test\"}}"
+    printf "runtime_count=%s\n" "$(wc -l < "${VIBEGUARD_RUNTIME_COUNT_LOG}" | tr -d " ")"
+  ' -- \
+    "${REPO_DIR}/hooks/_lib/codex_diag.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_adapter.sh" \
+    "${REPO_DIR}/hooks/_lib/codex_runner.sh" \
+    "${TMP_FAKE_REPO_COUNTING}/hooks/vibeguard-pre-bash-guard.sh"
+)"
+assert_contains "${counting_runner_out}" "counted block" "counting runtime path still blocks PreToolUse"
+assert_contains "${counting_runner_out}" "runtime_count=2" "codex_run_hook uses two runtime spawns for normal non-empty PreToolUse output"
 
 BROKEN_RUNTIME="${TMP_DIR}/broken-vibeguard-runtime"
 cat > "${BROKEN_RUNTIME}" <<'SH'

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -139,6 +139,38 @@ resolver_out="$(
 )"
 assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver honors explicit VIBEGUARD_POLICY_RUNTIME before checkout binaries"
 
+optimized_runtime="${WORK_DIR}/optimized-runtime"
+optimized_probe_log="${WORK_DIR}/optimized-runtime.log"
+cat > "${optimized_runtime}" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  runtime-policy-supports)
+    printf 'supports\n' >>"${OPTIMIZED_PROBE_LOG:?}"
+    exit 0
+    ;;
+  runtime-policy-check|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
+    printf 'unexpected:%s\n' "${1:-}" >>"${OPTIMIZED_PROBE_LOG:?}"
+    exit 70
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${optimized_runtime}"
+resolver_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${optimized_runtime}" \
+  OPTIMIZED_PROBE_LOG="${optimized_probe_log}" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_runtime_path
+  '
+)"
+assert_contains "${resolver_out}" "${optimized_runtime}" "runtime policy resolver accepts batched support probe"
+assert_contains "$(cat "${optimized_probe_log}")" "supports" "runtime policy resolver calls batched support probe"
+assert_not_contains "$(cat "${optimized_probe_log}")" "unexpected:" "runtime policy resolver skips legacy semantic probes when batched probe passes"
+
 resolver_home="${WORK_DIR}/home-resolver"
 mkdir -p "${resolver_home}/.vibeguard/installed/bin"
 stale_installed_runtime="${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime"

--- a/vibeguard-runtime/src/codex_hooks.rs
+++ b/vibeguard-runtime/src/codex_hooks.rs
@@ -2,11 +2,10 @@
 
 use crate::hook_checks_common::{read_stdin, truncate_chars};
 use serde_json::{Map, Value, json};
-use std::process;
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
-fn ensure_no_args(args: &[String], usage: &str) -> Result {
+pub(crate) fn ensure_no_args(args: &[String], usage: &str) -> Result {
     if args.is_empty() {
         Ok(())
     } else {
@@ -45,6 +44,41 @@ fn codex_status_detail(data: &Value) -> String {
 
 fn shell_status_field(value: &str) -> String {
     value.replace(['\t', '\n', '\r'], " ")
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CodexStatusInfo {
+    pub(crate) event_name: String,
+    pub(crate) matcher: String,
+    pub(crate) detail: String,
+}
+
+impl CodexStatusInfo {
+    pub(crate) fn shell_line(&self) -> String {
+        format!(
+            "{}\t{}\t{}",
+            shell_status_field(&self.event_name),
+            shell_status_field(&self.matcher),
+            shell_status_field(&self.detail)
+        )
+    }
+}
+
+pub(crate) fn status_info_from_raw(input: &str) -> CodexStatusInfo {
+    let data = serde_json::from_str::<Value>(input).ok();
+    CodexStatusInfo {
+        event_name: data
+            .as_ref()
+            .map(codex_event_name)
+            .unwrap_or("")
+            .to_string(),
+        matcher: data
+            .as_ref()
+            .map(codex_status_matcher)
+            .unwrap_or("")
+            .to_string(),
+        detail: data.as_ref().map(codex_status_detail).unwrap_or_default(),
+    }
 }
 
 fn codex_status_from_output(data: &Value) -> (String, String) {
@@ -96,96 +130,6 @@ fn codex_status_from_output(data: &Value) -> (String, String) {
 
 pub(crate) fn print_json(value: &Value) -> Result {
     println!("{}", serde_json::to_string_pretty(value)?);
-    Ok(())
-}
-
-fn read_json_object_or_invalid_pretool() -> std::io::Result<Map<String, Value>> {
-    let input = read_stdin()?;
-    match serde_json::from_str::<Value>(&input) {
-        Ok(Value::Object(object)) => Ok(object),
-        _ => {
-            print_json(&json!({
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": "VIBEGUARD hook failed: wrapped hook produced invalid JSON.",
-                }
-            }))
-            .ok();
-            process::exit(3);
-        }
-    }
-}
-
-fn read_json_object_or_invalid_permission() -> std::io::Result<Map<String, Value>> {
-    let input = read_stdin()?;
-    match serde_json::from_str::<Value>(&input) {
-        Ok(Value::Object(object)) => Ok(object),
-        _ => {
-            print_json(&json!({
-                "hookSpecificOutput": {
-                    "hookEventName": "PermissionRequest",
-                    "decision": {
-                        "behavior": "deny",
-                        "message": "VIBEGUARD hook failed: wrapped hook produced invalid JSON.",
-                    },
-                }
-            }))
-            .ok();
-            process::exit(3);
-        }
-    }
-}
-
-fn read_json_object_or_exit_3() -> std::io::Result<Map<String, Value>> {
-    let input = read_stdin()?;
-    match serde_json::from_str::<Value>(&input) {
-        Ok(Value::Object(object)) => Ok(object),
-        _ => process::exit(3),
-    }
-}
-
-fn decision_field(object: &Map<String, Value>) -> &str {
-    match object.get("decision") {
-        None => "pass",
-        Some(Value::String(decision)) => decision,
-        Some(_) => "",
-    }
-}
-
-fn string_field<'a>(object: &'a Map<String, Value>, key: &str) -> &'a str {
-    object.get(key).and_then(Value::as_str).unwrap_or("")
-}
-
-fn has_native_output(object: &Map<String, Value>) -> bool {
-    object
-        .get("hookSpecificOutput")
-        .is_some_and(Value::is_object)
-        || object.contains_key("systemMessage")
-}
-
-fn updated_input_is_absent_or_null(object: &Map<String, Value>) -> bool {
-    !object.contains_key("updatedInput") || object.get("updatedInput") == Some(&Value::Null)
-}
-
-fn native_output(object: &Map<String, Value>) -> Map<String, Value> {
-    let mut output = Map::new();
-    if let Some(system_message) = object.get("systemMessage") {
-        output.insert("systemMessage".to_string(), system_message.clone());
-    }
-    if let Some(hook_specific) = object.get("hookSpecificOutput").and_then(Value::as_object) {
-        output.insert(
-            "hookSpecificOutput".to_string(),
-            Value::Object(hook_specific.clone()),
-        );
-    }
-    output
-}
-
-fn print_object_if_not_empty(object: Map<String, Value>) -> Result {
-    if !object.is_empty() {
-        print_json(&Value::Object(object))?;
-    }
     Ok(())
 }
 
@@ -412,19 +356,8 @@ pub fn status_matcher(args: &[String]) -> Result {
 
 pub fn status_info(args: &[String]) -> Result {
     ensure_no_args(args, "Usage: vibeguard-runtime codex-status-info")?;
-    let data = read_json_tolerant()?;
-    let event_name = data.as_ref().map(codex_event_name).unwrap_or("");
-    let matcher = data.as_ref().map(codex_status_matcher).unwrap_or("");
-    let detail = data
-        .as_ref()
-        .map(codex_status_detail)
-        .unwrap_or_else(String::new);
-    println!(
-        "{}\t{}\t{}",
-        shell_status_field(event_name),
-        shell_status_field(matcher),
-        shell_status_field(&detail)
-    );
+    let input = read_stdin()?;
+    println!("{}", status_info_from_raw(&input).shell_line());
     Ok(())
 }
 
@@ -450,140 +383,6 @@ pub fn deny_permission(args: &[String]) -> Result {
     ensure_no_args(args, "Usage: vibeguard-runtime codex-permission-deny")?;
     let reason = read_stdin()?;
     print_json(&deny_permission_payload(&reason))
-}
-
-pub fn adapt_pretool(args: &[String]) -> Result {
-    ensure_no_args(args, "Usage: vibeguard-runtime codex-adapt-pretool")?;
-    let object = read_json_object_or_invalid_pretool()?;
-    let decision = decision_field(&object);
-    let reason = string_field(&object, "reason");
-    let updated = object.get("updatedInput").and_then(Value::as_object);
-    let native = has_native_output(&object);
-
-    if native && decision == "pass" && updated_input_is_absent_or_null(&object) {
-        return print_object_if_not_empty(native_output(&object));
-    }
-
-    if decision == "block" {
-        let mut hook_specific = object
-            .get("hookSpecificOutput")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        hook_specific.insert("hookEventName".to_string(), json!("PreToolUse"));
-        hook_specific.insert("permissionDecision".to_string(), json!("deny"));
-        hook_specific.insert("permissionDecisionReason".to_string(), json!(reason));
-        return print_json(&json!({ "hookSpecificOutput": hook_specific }));
-    }
-
-    if decision == "warn" {
-        let mut output = if native {
-            native_output(&object)
-        } else {
-            Map::new()
-        };
-        if !reason.is_empty() {
-            output.insert("systemMessage".to_string(), json!(reason));
-        }
-        return print_object_if_not_empty(output);
-    }
-
-    if decision == "allow"
-        && let Some(command) = updated
-            .and_then(|updated| updated.get("command"))
-            .and_then(Value::as_str)
-        && !command.is_empty()
-    {
-        return print_json(&json!({
-            "systemMessage": format!(
-                "VIBEGUARD note: Codex CLI hooks cannot auto-apply command rewrites. Suggested command: {command}"
-            )
-        }));
-    }
-
-    Ok(())
-}
-
-pub fn adapt_posttool(args: &[String]) -> Result {
-    ensure_no_args(args, "Usage: vibeguard-runtime codex-adapt-posttool")?;
-    let object = read_json_object_or_exit_3()?;
-    let decision = decision_field(&object);
-    let reason = string_field(&object, "reason");
-    let native = has_native_output(&object);
-
-    if native && decision == "pass" {
-        return print_object_if_not_empty(native_output(&object));
-    }
-
-    if decision == "block" || decision == "escalate" {
-        let mut hook_specific = object
-            .get("hookSpecificOutput")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        hook_specific.insert("hookEventName".to_string(), json!("PostToolUse"));
-        hook_specific
-            .entry("additionalContext".to_string())
-            .or_insert_with(|| json!(reason));
-        return print_json(&json!({
-            "decision": "block",
-            "reason": reason,
-            "hookSpecificOutput": hook_specific,
-        }));
-    }
-
-    if decision == "warn" {
-        let mut output = if native {
-            native_output(&object)
-        } else {
-            Map::new()
-        };
-        if !reason.is_empty() {
-            output.insert("systemMessage".to_string(), json!(reason));
-        }
-        return print_object_if_not_empty(output);
-    }
-
-    Ok(())
-}
-
-pub fn adapt_permission_request(args: &[String]) -> Result {
-    ensure_no_args(
-        args,
-        "Usage: vibeguard-runtime codex-adapt-permission-request",
-    )?;
-    let object = read_json_object_or_invalid_permission()?;
-    let decision = decision_field(&object);
-    let reason = string_field(&object, "reason");
-    let updated = object.get("updatedInput").and_then(Value::as_object);
-
-    if has_native_output(&object) && decision == "pass" && updated_input_is_absent_or_null(&object)
-    {
-        return print_object_if_not_empty(native_output(&object));
-    }
-
-    if decision == "block" {
-        return print_json(&deny_permission_payload(reason));
-    }
-
-    if decision == "warn" {
-        return print_json(&json!({ "systemMessage": reason }));
-    }
-
-    if decision == "allow"
-        && let Some(command) = updated
-            .and_then(|updated| updated.get("command"))
-            .and_then(Value::as_str)
-        && !command.is_empty()
-    {
-        return print_json(&json!({
-            "systemMessage": format!(
-                "VIBEGUARD note: Codex CLI PermissionRequest hooks cannot auto-apply command rewrites. Suggested command: {command}"
-            )
-        }));
-    }
-
-    Ok(())
 }
 
 pub fn normalize_apply_patch(args: &[String]) -> Result {
@@ -674,36 +473,6 @@ mod tests {
             })),
             ("block".to_string(), String::new())
         );
-    }
-
-    #[test]
-    fn native_output_preserves_system_message_and_hook_specific_output() {
-        let object = json!({
-            "systemMessage": "note",
-            "hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "context"},
-            "ignored": "field",
-        })
-        .as_object()
-        .unwrap()
-        .clone();
-
-        let output = Value::Object(native_output(&object));
-        assert_eq!(output["systemMessage"], "note");
-        assert_eq!(output["hookSpecificOutput"]["additionalContext"], "context");
-        assert!(output.get("ignored").is_none());
-    }
-
-    #[test]
-    fn decision_field_defaults_only_when_missing() {
-        let missing = Map::new();
-        let mut null_decision = Map::new();
-        null_decision.insert("decision".to_string(), Value::Null);
-        let mut string_decision = Map::new();
-        string_decision.insert("decision".to_string(), json!("warn"));
-
-        assert_eq!(decision_field(&missing), "pass");
-        assert_eq!(decision_field(&null_decision), "");
-        assert_eq!(decision_field(&string_decision), "warn");
     }
 
     #[test]

--- a/vibeguard-runtime/src/codex_hooks_adapter.rs
+++ b/vibeguard-runtime/src/codex_hooks_adapter.rs
@@ -1,0 +1,332 @@
+//! Codex hook output adapters used by run-hook-codex.sh.
+
+use crate::codex_hooks::{
+    deny_permission_payload, deny_pretool_payload, ensure_no_args, print_json,
+};
+use crate::hook_checks_common::read_stdin;
+use serde_json::{Map, Value, json};
+use std::io::Write;
+use std::process;
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+const ADAPTER_FAILURE_STATUS: i32 = 3;
+const INVALID_JSON_REASON: &str = "VIBEGUARD hook failed: wrapped hook produced invalid JSON.";
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum CodexAdaptedOutput {
+    Empty,
+    Json(Value),
+    Raw(String),
+}
+
+impl CodexAdaptedOutput {
+    pub(crate) fn print(self) -> Result {
+        match self {
+            CodexAdaptedOutput::Empty => Ok(()),
+            CodexAdaptedOutput::Json(value) => print_json(&value),
+            CodexAdaptedOutput::Raw(raw) => {
+                let mut stdout = std::io::stdout();
+                stdout.write_all(raw.as_bytes())?;
+                if !raw.is_empty() && !raw.ends_with('\n') {
+                    stdout.write_all(b"\n")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn decision_field(object: &Map<String, Value>) -> &str {
+    match object.get("decision") {
+        None => "pass",
+        Some(Value::String(decision)) => decision,
+        Some(_) => "",
+    }
+}
+
+fn string_field<'a>(object: &'a Map<String, Value>, key: &str) -> &'a str {
+    object.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn has_native_output(object: &Map<String, Value>) -> bool {
+    object
+        .get("hookSpecificOutput")
+        .is_some_and(Value::is_object)
+        || object.contains_key("systemMessage")
+}
+
+fn updated_input_is_absent_or_null(object: &Map<String, Value>) -> bool {
+    !object.contains_key("updatedInput") || object.get("updatedInput") == Some(&Value::Null)
+}
+
+fn codex_native_output(object: &Map<String, Value>) -> Map<String, Value> {
+    let mut output = Map::new();
+    if let Some(system_message) = object.get("systemMessage") {
+        output.insert("systemMessage".to_string(), system_message.clone());
+    }
+    if let Some(hook_specific) = object.get("hookSpecificOutput").and_then(Value::as_object) {
+        output.insert(
+            "hookSpecificOutput".to_string(),
+            Value::Object(hook_specific.clone()),
+        );
+    }
+    output
+}
+
+fn adapted_object_if_not_empty(object: Map<String, Value>) -> CodexAdaptedOutput {
+    if object.is_empty() {
+        CodexAdaptedOutput::Empty
+    } else {
+        CodexAdaptedOutput::Json(Value::Object(object))
+    }
+}
+
+pub(crate) fn adapt_output_for_event(event_name: &str, input: &str) -> (i32, CodexAdaptedOutput) {
+    match event_name {
+        "PreToolUse" => adapt_pretool_result(input),
+        "PostToolUse" => adapt_posttool_result(input),
+        "PermissionRequest" => adapt_permission_request_result(input),
+        _ => (0, CodexAdaptedOutput::Raw(input.to_string())),
+    }
+}
+
+pub fn adapt_pretool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-adapt-pretool")?;
+    let input = read_stdin()?;
+    let (status, output) = adapt_pretool_result(&input);
+    output.print()?;
+    if status != 0 {
+        process::exit(status);
+    }
+    Ok(())
+}
+
+fn adapt_pretool_result(input: &str) -> (i32, CodexAdaptedOutput) {
+    let Ok(Value::Object(object)) = serde_json::from_str::<Value>(input) else {
+        return (
+            ADAPTER_FAILURE_STATUS,
+            CodexAdaptedOutput::Json(deny_pretool_payload(INVALID_JSON_REASON)),
+        );
+    };
+    (0, adapt_pretool_object(object))
+}
+
+fn adapt_pretool_object(object: Map<String, Value>) -> CodexAdaptedOutput {
+    let decision = decision_field(&object);
+    let reason = string_field(&object, "reason");
+    let updated = object.get("updatedInput").and_then(Value::as_object);
+    let native = has_native_output(&object);
+
+    if native && decision == "pass" && updated_input_is_absent_or_null(&object) {
+        return adapted_object_if_not_empty(codex_native_output(&object));
+    }
+
+    if decision == "block" {
+        let mut hook_specific = object
+            .get("hookSpecificOutput")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        hook_specific.insert("hookEventName".to_string(), json!("PreToolUse"));
+        hook_specific.insert("permissionDecision".to_string(), json!("deny"));
+        hook_specific.insert("permissionDecisionReason".to_string(), json!(reason));
+        return CodexAdaptedOutput::Json(json!({ "hookSpecificOutput": hook_specific }));
+    }
+
+    if decision == "warn" {
+        let mut output = if native {
+            codex_native_output(&object)
+        } else {
+            Map::new()
+        };
+        if !reason.is_empty() {
+            output.insert("systemMessage".to_string(), json!(reason));
+        }
+        return adapted_object_if_not_empty(output);
+    }
+
+    if decision == "allow"
+        && let Some(command) = updated
+            .and_then(|updated| updated.get("command"))
+            .and_then(Value::as_str)
+        && !command.is_empty()
+    {
+        return CodexAdaptedOutput::Json(json!({
+            "systemMessage": format!(
+                "VIBEGUARD note: Codex CLI hooks cannot auto-apply command rewrites. Suggested command: {command}"
+            )
+        }));
+    }
+
+    CodexAdaptedOutput::Empty
+}
+
+pub fn adapt_posttool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-adapt-posttool")?;
+    let input = read_stdin()?;
+    let (status, output) = adapt_posttool_result(&input);
+    output.print()?;
+    if status != 0 {
+        process::exit(status);
+    }
+    Ok(())
+}
+
+fn adapt_posttool_result(input: &str) -> (i32, CodexAdaptedOutput) {
+    let Ok(Value::Object(object)) = serde_json::from_str::<Value>(input) else {
+        return (ADAPTER_FAILURE_STATUS, CodexAdaptedOutput::Empty);
+    };
+    (0, adapt_posttool_object(object))
+}
+
+fn adapt_posttool_object(object: Map<String, Value>) -> CodexAdaptedOutput {
+    let decision = decision_field(&object);
+    let reason = string_field(&object, "reason");
+    let native = has_native_output(&object);
+
+    if native && decision == "pass" {
+        return adapted_object_if_not_empty(codex_native_output(&object));
+    }
+
+    if decision == "block" || decision == "escalate" {
+        let mut hook_specific = object
+            .get("hookSpecificOutput")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        hook_specific.insert("hookEventName".to_string(), json!("PostToolUse"));
+        hook_specific
+            .entry("additionalContext".to_string())
+            .or_insert_with(|| json!(reason));
+        return CodexAdaptedOutput::Json(json!({
+            "decision": "block",
+            "reason": reason,
+            "hookSpecificOutput": hook_specific,
+        }));
+    }
+
+    if decision == "warn" {
+        let mut output = if native {
+            codex_native_output(&object)
+        } else {
+            Map::new()
+        };
+        if !reason.is_empty() {
+            output.insert("systemMessage".to_string(), json!(reason));
+        }
+        return adapted_object_if_not_empty(output);
+    }
+
+    CodexAdaptedOutput::Empty
+}
+
+pub fn adapt_permission_request(args: &[String]) -> Result {
+    ensure_no_args(
+        args,
+        "Usage: vibeguard-runtime codex-adapt-permission-request",
+    )?;
+    let input = read_stdin()?;
+    let (status, output) = adapt_permission_request_result(&input);
+    output.print()?;
+    if status != 0 {
+        process::exit(status);
+    }
+    Ok(())
+}
+
+fn adapt_permission_request_result(input: &str) -> (i32, CodexAdaptedOutput) {
+    let Ok(Value::Object(object)) = serde_json::from_str::<Value>(input) else {
+        return (
+            ADAPTER_FAILURE_STATUS,
+            CodexAdaptedOutput::Json(deny_permission_payload(INVALID_JSON_REASON)),
+        );
+    };
+    (0, adapt_permission_request_object(object))
+}
+
+fn adapt_permission_request_object(object: Map<String, Value>) -> CodexAdaptedOutput {
+    let decision = decision_field(&object);
+    let reason = string_field(&object, "reason");
+    let updated = object.get("updatedInput").and_then(Value::as_object);
+
+    if has_native_output(&object) && decision == "pass" && updated_input_is_absent_or_null(&object)
+    {
+        return adapted_object_if_not_empty(codex_native_output(&object));
+    }
+
+    if decision == "block" {
+        return CodexAdaptedOutput::Json(deny_permission_payload(reason));
+    }
+
+    if decision == "warn" {
+        return CodexAdaptedOutput::Json(json!({ "systemMessage": reason }));
+    }
+
+    if decision == "allow"
+        && let Some(command) = updated
+            .and_then(|updated| updated.get("command"))
+            .and_then(Value::as_str)
+        && !command.is_empty()
+    {
+        return CodexAdaptedOutput::Json(json!({
+            "systemMessage": format!(
+                "VIBEGUARD note: Codex CLI PermissionRequest hooks cannot auto-apply command rewrites. Suggested command: {command}"
+            )
+        }));
+    }
+
+    CodexAdaptedOutput::Empty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_output_preserves_system_message_and_hook_specific_output() {
+        let object = json!({
+            "systemMessage": "note",
+            "hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "context"},
+            "ignored": "field",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let output = Value::Object(codex_native_output(&object));
+        assert_eq!(output["systemMessage"], "note");
+        assert_eq!(output["hookSpecificOutput"]["additionalContext"], "context");
+        assert!(output.get("ignored").is_none());
+    }
+
+    #[test]
+    fn decision_field_defaults_only_when_missing() {
+        let missing = Map::new();
+        let mut null_decision = Map::new();
+        null_decision.insert("decision".to_string(), Value::Null);
+        let mut string_decision = Map::new();
+        string_decision.insert("decision".to_string(), json!("warn"));
+
+        assert_eq!(decision_field(&missing), "pass");
+        assert_eq!(decision_field(&null_decision), "");
+        assert_eq!(decision_field(&string_decision), "warn");
+    }
+
+    #[test]
+    fn invalid_pretool_json_returns_deny_and_status_3() {
+        let (status, output) = adapt_output_for_event("PreToolUse", "{");
+        assert_eq!(status, ADAPTER_FAILURE_STATUS);
+        assert_eq!(
+            output,
+            CodexAdaptedOutput::Json(deny_pretool_payload(INVALID_JSON_REASON))
+        );
+    }
+
+    #[test]
+    fn posttool_invalid_json_returns_status_3_without_output() {
+        let (status, output) = adapt_output_for_event("PostToolUse", "{");
+        assert_eq!(status, ADAPTER_FAILURE_STATUS);
+        assert_eq!(output, CodexAdaptedOutput::Empty);
+    }
+}

--- a/vibeguard-runtime/src/codex_hooks_diag.rs
+++ b/vibeguard-runtime/src/codex_hooks_diag.rs
@@ -1,6 +1,8 @@
 //! Codex wrapper diagnostics and visible-failure payload helpers.
 
+use crate::codex_hooks::status_info_from_raw;
 use crate::codex_hooks::{deny_permission_payload, deny_pretool_payload, print_json};
+use crate::codex_hooks_adapter::adapt_output_for_event;
 use crate::hook_checks_common::{append_jsonl, read_stdin, truncate_chars};
 use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
 use serde_json::{Value, json};
@@ -42,6 +44,49 @@ fn append_codex_jsonl(path: &str, value: Value) -> Result {
     Ok(())
 }
 
+fn hook_status_entry(
+    hook_name: &str,
+    event_name: &str,
+    matcher: &str,
+    status: &str,
+    reason: &str,
+    detail: &str,
+    timeout_ms: &str,
+) -> Value {
+    let mut entry = json!({
+        "ts": codex_ts(),
+        "cli": "codex",
+        "hook": clean_hook_name(hook_name),
+        "event": event_name,
+        "matcher": matcher,
+        "status": status,
+        "reason": reason,
+        "detail": truncate_chars(detail, 300),
+    });
+    if let Ok(timeout_ms) = timeout_ms.parse::<u64>() {
+        entry["timeout_ms"] = json!(timeout_ms);
+    }
+    entry
+}
+
+fn append_hook_status(
+    diag_file: &str,
+    hook_name: &str,
+    event_name: &str,
+    matcher: &str,
+    status: &str,
+    reason: &str,
+    detail: &str,
+    timeout_ms: &str,
+) -> Result {
+    append_codex_jsonl(
+        diag_file,
+        hook_status_entry(
+            hook_name, event_name, matcher, status, reason, detail, timeout_ms,
+        ),
+    )
+}
+
 pub fn visible_failure(args: &[String]) -> Result {
     if args.len() != 1 {
         return Err("Usage: vibeguard-runtime codex-visible-failure <event-name>".into());
@@ -78,20 +123,9 @@ pub fn hook_status(args: &[String]) -> Result {
                 .into(),
         );
     }
-    let mut entry = json!({
-        "ts": codex_ts(),
-        "cli": "codex",
-        "hook": clean_hook_name(&args[1]),
-        "event": args[2],
-        "matcher": args[3],
-        "status": args[4],
-        "reason": args[5],
-        "detail": truncate_chars(&args[6], 300),
-    });
-    if let Ok(timeout_ms) = args[7].parse::<u64>() {
-        entry["timeout_ms"] = json!(timeout_ms);
-    }
-    append_codex_jsonl(&args[0], entry)
+    append_hook_status(
+        &args[0], &args[1], &args[2], &args[3], &args[4], &args[5], &args[6], &args[7],
+    )
 }
 
 fn status_from_hook_output(data: &Value) -> (String, String) {
@@ -152,20 +186,54 @@ pub fn hook_status_from_output(args: &[String]) -> Result {
         Ok(data) => status_from_hook_output(&data),
         Err(_) => ("hook_error".to_string(), "invalid-json".to_string()),
     };
-    let mut entry = json!({
-        "ts": codex_ts(),
-        "cli": "codex",
-        "hook": clean_hook_name(&args[1]),
-        "event": args[2],
-        "matcher": args[3],
-        "status": status,
-        "reason": reason,
-        "detail": truncate_chars(&args[4], 300),
-    });
-    if let Ok(timeout_ms) = args[5].parse::<u64>() {
-        entry["timeout_ms"] = json!(timeout_ms);
+    append_hook_status(
+        &args[0], &args[1], &args[2], &args[3], &status, &reason, &args[4], &args[5],
+    )
+}
+
+pub fn hook_start(args: &[String]) -> Result {
+    if args.len() != 3 {
+        return Err(
+            "Usage: vibeguard-runtime codex-hook-start <diag-file> <hook-name> <timeout-ms>".into(),
+        );
     }
-    append_codex_jsonl(&args[0], entry)
+    let input = read_stdin()?;
+    let status_info = status_info_from_raw(&input);
+    append_hook_status(
+        &args[0],
+        &args[1],
+        &status_info.event_name,
+        &status_info.matcher,
+        "running",
+        "",
+        &status_info.detail,
+        &args[2],
+    )?;
+    println!("{}", status_info.shell_line());
+    Ok(())
+}
+
+pub fn finalize_output(args: &[String]) -> Result {
+    if args.len() != 6 {
+        return Err(
+            "Usage: vibeguard-runtime codex-finalize-output <diag-file> <hook-name> <event-name> <matcher> <detail> <timeout-ms>"
+                .into(),
+        );
+    }
+    let input = read_stdin()?;
+    let (status, reason) = match serde_json::from_str::<Value>(&input) {
+        Ok(data) => status_from_hook_output(&data),
+        Err(_) => ("hook_error".to_string(), "invalid-json".to_string()),
+    };
+    append_hook_status(
+        &args[0], &args[1], &args[2], &args[3], &status, &reason, &args[4], &args[5],
+    )?;
+    let (adapter_status, adapted_output) = adapt_output_for_event(&args[2], &input);
+    adapted_output.print()?;
+    if adapter_status != 0 {
+        std::process::exit(adapter_status);
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -6,6 +6,7 @@ mod codex_app_server_file_changes;
 mod codex_app_server_policy;
 mod codex_app_server_strategies;
 mod codex_hooks;
+mod codex_hooks_adapter;
 mod codex_hooks_diag;
 mod event_schema;
 mod git_root;
@@ -194,24 +195,34 @@ static COMMANDS: &[Command] = &[
         handler: codex_hooks_diag::hook_status,
     },
     Command {
+        name: "codex-hook-start",
+        usage: "<diag-file> <hook-name> <timeout-ms>  — parse Codex hook input, append running status, and emit event/matcher/detail",
+        handler: codex_hooks_diag::hook_start,
+    },
+    Command {
         name: "codex-hook-status-from-output",
         usage: "<diag-file> <hook-name> <event-name> <matcher> <detail> <timeout-ms>  — classify wrapped hook output and append Codex status JSONL",
         handler: codex_hooks_diag::hook_status_from_output,
     },
     Command {
+        name: "codex-finalize-output",
+        usage: "<diag-file> <hook-name> <event-name> <matcher> <detail> <timeout-ms>  — append final status and adapt wrapped hook output",
+        handler: codex_hooks_diag::finalize_output,
+    },
+    Command {
         name: "codex-adapt-pretool",
         usage: "  — adapt wrapped hook output to Codex PreToolUse JSON",
-        handler: codex_hooks::adapt_pretool,
+        handler: codex_hooks_adapter::adapt_pretool,
     },
     Command {
         name: "codex-adapt-posttool",
         usage: "  — adapt wrapped hook output to Codex PostToolUse JSON",
-        handler: codex_hooks::adapt_posttool,
+        handler: codex_hooks_adapter::adapt_posttool,
     },
     Command {
         name: "codex-adapt-permission-request",
         usage: "  — adapt wrapped hook output to Codex PermissionRequest JSON",
-        handler: codex_hooks::adapt_permission_request,
+        handler: codex_hooks_adapter::adapt_permission_request,
     },
     Command {
         name: "codex-normalize-apply-patch",
@@ -222,6 +233,11 @@ static COMMANDS: &[Command] = &[
         name: "runtime-policy-check",
         usage: "<hook-name>  — evaluate runtime hook policy and config",
         handler: runtime_policy::runtime_policy_check,
+    },
+    Command {
+        name: "runtime-policy-supports",
+        usage: "  — verify this runtime supports policy helper commands",
+        handler: runtime_policy::runtime_policy_supports,
     },
     Command {
         name: "runtime-policy-downgrade-output",

--- a/vibeguard-runtime/src/runtime_policy.rs
+++ b/vibeguard-runtime/src/runtime_policy.rs
@@ -14,6 +14,13 @@ const SKIP: i32 = 10;
 const POLICY_ERROR: i32 = 20;
 const CONFIG_PARSE_ERROR: i32 = 30;
 
+pub fn runtime_policy_supports(args: &[String]) -> HandlerResult {
+    if !args.is_empty() {
+        return Err("Usage: vibeguard-runtime runtime-policy-supports".into());
+    }
+    Ok(())
+}
+
 pub fn runtime_policy_check(args: &[String]) -> HandlerResult {
     if args.len() != 1 {
         return Err("Usage: vibeguard-runtime runtime-policy-check <hook-name>".into());


### PR DESCRIPTION
## Summary

Closes #412. References #371.

- Add batched Codex runtime commands for hook start/finalize so the wrapper can append diagnostics and adapt output in fewer subprocesses.
- Add a `runtime-policy-supports` capability probe so policy runtime resolution avoids the legacy 4-command semantic probe on current runtimes while preserving fallback for older runtimes.
- Split Codex output adapter logic into `codex_hooks_adapter.rs` to keep `codex_hooks.rs` below the hard file-size ceiling and preserve existing fail-closed adapter status 3 behavior.

## Runtime spawn evidence

Full `run-hook-codex` PreToolUse block path now uses 5 runtime commands:

`codex-event-name,runtime-policy-supports,runtime-policy-check,codex-hook-start,codex-finalize-output`

Runner-only normal non-empty PreToolUse output path is covered by regression test at `runtime_count=2`.

## Tests

- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_codex_runtime.sh`
- `bash tests/hooks/test_runtime_policy.sh`
- `bash tests/test_hooks.sh`
- `bash tests/test_setup.sh`
- `bash tests/test_behavior_eval.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `git diff --cached --check`