### PR TITLE
Fix GC learning robustness and benchmark regressions

### DIFF
--- a/.claude/skills/benchmark-regression-triage/SKILL.md
+++ b/.claude/skills/benchmark-regression-triage/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: benchmark-regression-triage
+description: Use this skill whenever VibeGuard hook latency, benchmark-action output, GitHub Actions bench-output artifacts, or a suspected performance regression needs investigation. It preserves the PR-to-CI-artifact workflow for comparing recent PRs, older anchors such as PR #350, and current main without mixing local machine noise into CI trend evidence.
+---
+
+# Benchmark Regression Triage
+
+## Overview
+
+This skill diagnoses VibeGuard hook latency regressions by comparing GitHub Actions `bench-output` artifacts across PR runs, merge runs, and mainline runs. It is meant for non-obvious cases where the current benchmark is under budget but slower than a previous design, such as a `post-write-guard` path losing its `post-write-fast-check` fast path after a runtime migration.
+
+Treat CI artifacts as the trend source. Local benchmarks are useful for reproduction after a hypothesis exists, but they are not comparable to GitHub runner history because machine load, shell startup, cache state, and `--runs` count can dominate P95.
+
+## When to Activate
+
+- A user asks why VibeGuard benchmark numbers are slower than before.
+- A PR appears to change hook latency, benchmark output, or benchmark-action reporting.
+- You need to compare recent PRs with older anchors such as PR #350 or a known fast-path implementation.
+- A hook is still below the absolute latency budget but may have lost a faster design.
+- You need a reusable workflow for downloading and comparing GitHub Actions `bench-output` artifacts.
+
+## Inputs
+
+Collect these before drawing conclusions:
+
+- Repository full name from `gh repo view`.
+- Candidate PR numbers or commits, including one recent run and one older anchor.
+- GitHub Actions run IDs tied to the exact PR head, merge commit, or main commit.
+- `bench-output.json` from each run, downloaded into separate directories.
+- The relevant budget contract from `docs/reference/hook-latency-contract.md`.
+
+## Workflow
+
+### 1. Search Existing Context
+
+Search before adding a new hypothesis or artifact path:
+
+```bash
+rg -n "benchmark|bench-output|hook latency|post-write-fast|post-write-fast-check|post-write-guard|github-action-benchmark" \
+  .github docs tests hooks scripts skills workflows README.md CHANGELOG.md
+```
+
+Open the latency contract and CI workflow:
+
+```bash
+sed -n '1,120p' docs/reference/hook-latency-contract.md
+sed -n '270,420p' .github/workflows/ci.yml
+```
+
+Confirm whether the benchmark artifact is uploaded from Linux only. In this repo, the `Upload benchmark results` step is guarded by `runner.os == 'Linux'`, so artifact comparisons should use the Linux `bench-output` artifact unless the workflow changes.
+
+### 2. Identify PR and Mainline Runs
+
+Start with metadata, not assumptions:
+
+```bash
+REPO="$(gh repo view --json owner,name --jq '.owner.login + "/" + .name')"
+
+gh pr view 417 --repo "$REPO" \
+  --json number,title,state,mergedAt,headRefName,baseRefName,mergeCommit,url
+
+gh pr view 350 --repo "$REPO" \
+  --json number,title,state,mergedAt,headRefName,baseRefName,mergeCommit,url
+
+gh run list --repo "$REPO" --branch main --limit 30 \
+  --json databaseId,workflowName,event,displayTitle,headSha,createdAt,status,conclusion,url
+```
+
+For a PR head branch, resolve the branch and list its runs:
+
+```bash
+PR=417
+HEAD_BRANCH="$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq '.headRefName')"
+
+gh run list --repo "$REPO" --branch "$HEAD_BRANCH" --limit 20 \
+  --json databaseId,workflowName,event,displayTitle,headSha,createdAt,status,conclusion,url
+```
+
+Record whether each run is a `pull_request` run, a merge-to-main run, or a later mainline run. Do not compare an unrelated later main commit against a PR head without stating the extra changes in between.
+
+### 3. Download Benchmark Artifacts
+
+For each chosen run, confirm the artifact exists:
+
+```bash
+RUN_ID=27085248846
+
+gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
+  --jq '.artifacts[] | select(.name == "bench-output") | [.id, .name, .expired, .size_in_bytes] | @tsv'
+```
+
+Download into a per-run directory so files do not overwrite each other:
+
+```bash
+LABEL="pr-417-head"
+OUT="/tmp/vg-bench/$LABEL"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+gh run download "$RUN_ID" --repo "$REPO" -n bench-output -D "$OUT"
+test -f "$OUT/bench-output.json"
+```
+
+If an old PR artifact has expired, do not present reconstructed local numbers as historical CI truth. Use the old run logs or benchmark-action report if available, otherwise label the old comparison as a code-path reconstruction and state the evidence gap.
+
+### 4. Extract Comparable P95 Values
+
+Extract only P95 rows when checking the latency contract:
+
+```bash
+jq -r '
+  .[]
+  | select(.name | endswith("(P95)"))
+  | [.name, .value]
+  | @tsv
+' "$OUT/bench-output.json"
+```
+
+For side-by-side comparisons, keep run IDs and labels visible:
+
+```bash
+for file in /tmp/vg-bench/*/bench-output.json; do
+  label="$(basename "$(dirname "$file")")"
+  jq -r --arg label "$label" '
+    .[]
+    | select(.name | endswith("(P95)"))
+    | [$label, .name, .value]
+    | @tsv
+  ' "$file"
+done
+```
+
+Normalize fixture names exactly. Compare `post-write-guard (100) (P95)` to the same fixture in another run, not to `post-write-guard (5000)` or a P50/P99 row.
+
+### 5. Compare Against Budgets and Prior Design
+
+Use the contract to decide whether CI is failing:
+
+```bash
+bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
+```
+
+Use artifact deltas to decide whether a design got slower:
+
+- Under budget means acceptable by the current CI gate.
+- Slower than a known fast path can still be a real regression worth fixing.
+- A one-run delta needs code evidence before claiming root cause.
+
+For the `post-write-guard` fast-path incident, the useful comparison was:
+
+- Recent PR and mainline artifacts showed `post-write-guard` P95 stayed under budget.
+- Older code around PR #350 had a `post-write-fast-check` front path that allowed clean writes to exit before full duplicate and quality scans.
+- Later runtime consolidation preserved correctness but the wrapper path no longer called the fast check first, so clean writes paid the full `post-write-check` cost.
+
+### 6. Locate the Root Cause
+
+Do not stop at a chart. Tie the numbers to a code path:
+
+```bash
+rg -n "post-write-fast-check|post-write-check|post-write-guard|FALLBACK|NEEDS_FULL_CHECK" hooks tests vibeguard-runtime scripts
+
+git log --oneline --decorate -- hooks/post-write-guard.sh hooks/post-write-fast-check.sh tests/bench_hook_latency.sh
+
+git show <old-commit>:hooks/post-write-guard.sh | sed -n '1,220p'
+git show <new-commit>:hooks/post-write-guard.sh | sed -n '1,220p'
+```
+
+Classify the finding carefully:
+
+- `budget failure`: the benchmark gate exceeds the contract.
+- `design regression`: the benchmark is still green, but a previously cheap safe path became more expensive.
+- `measurement gap`: old artifacts expired or the compared runs are not equivalent.
+
+### 7. Verify a Fix or Recommendation
+
+If code is changed, run the focused checks for the touched surface:
+
+```bash
+bash tests/test_hook_perf_contract.sh
+bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
+bash scripts/ci/validate-hook-perf.sh
+git diff --check
+```
+
+When the change touches Rust runtime code, add:
+
+```bash
+cargo check --manifest-path vibeguard-runtime/Cargo.toml
+cargo test --manifest-path vibeguard-runtime/Cargo.toml
+```
+
+When the work is only a skill or document, run skill format validation instead:
+
+```bash
+python3 scripts/skill_validate.py --format-only --proposed-skill path/to/SKILL.md
+```
+
+## Report Format
+
+Use this compact report shape:
+
+```text
+facts:
+- repo:
+- runs compared:
+- artifact paths:
+
+comparison:
+| fixture | old anchor | recent PR | merge/main | budget |
+|---|---:|---:|---:|---:|
+
+root_cause:
+- classification:
+- evidence:
+- affected path:
+
+pitfalls_checked:
+- same fixture and metric:
+- CI artifact vs local benchmark separated:
+- run IDs tied to commits:
+
+verification:
+- commands:
+- result:
+
+gaps:
+- expired artifacts or non-equivalent runs:
+```
+
+## Red Flags
+
+- Comparing local benchmark output to CI artifact history as if they came from the same environment.
+- Reporting a benchmark regression without the run ID, commit SHA, event type, and downloaded artifact path.
+- Treating a green budget result as proof that no design regression happened.
+- Comparing different fixtures, such as `post-write-guard (100)` against `post-write-guard (5000)`.
+- Guessing root cause from timing alone without checking the hook wrapper, runtime path, or relevant git history.
+
+## Checklist
+
+- [ ] Search existing benchmark docs, CI workflow, tests, and hook paths before adding a new hypothesis.
+- [ ] Download `bench-output` artifacts into separate per-run directories.
+- [ ] Compare the same P95 fixture names across PR, merge, and mainline runs.
+- [ ] Tie every run to a PR number, commit SHA, event type, and Actions URL.
+- [ ] Separate CI trend evidence from local reproduction measurements.
+- [ ] Check the code path and git history before naming root cause.
+- [ ] Run focused verification or clearly state why validation is unavailable.
+
+## Boundaries
+
+This skill does not change benchmark budgets by itself. Budget changes need separate justification in `docs/reference/hook-latency-contract.md`, CI updates, and focused tests.
+
+This skill does not authorize editing hooks, runtime code, or GC scripts. Use it to investigate and report. Implementation requires a separate explicit task with file ownership and verification.

--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -18,6 +18,22 @@ _VG_SCAN_MAX_FILES="${VG_SCAN_MAX_FILES:-5000}"
 _VG_SCAN_MAX_DEFS="${VG_SCAN_MAX_DEFS:-20}"
 _VG_SCAN_MATCH_LIMIT="${VG_SCAN_MATCH_LIMIT:-5}"
 
+_VG_FAST_RESULT=$(printf '%s' "$INPUT" \
+  | "$_VIBEGUARD_RUNTIME" post-write-fast-check "$_VG_U16_BASE_LIMIT" "$_VG_SCAN_MAX_FILES" "$VIBEGUARD_LOG_FILE" \
+  2>/dev/null || true)
+_VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
+case "$_VG_FAST_STATUS" in
+  SKIP|FAST_LOGGED)
+    exit 0
+    ;;
+  FAST_PASS)
+    FILE_PATH="${_VG_FAST_RESULT#*$'\n'}"
+    [[ "$FILE_PATH" == "$_VG_FAST_RESULT" ]] && FILE_PATH=""
+    vg_log "post-write-guard" "Write" "pass" "" "$FILE_PATH"
+    exit 0
+    ;;
+esac
+
 _VG_RUNTIME_ERR="$(mktemp)"
 _vg_cleanup_runtime_err() {
   local status=$?

--- a/scripts/gc/gc-logs.sh
+++ b/scripts/gc/gc-logs.sh
@@ -119,7 +119,7 @@ def atomic_replace_log(lines):
 
 lock_fd = acquire_lock()
 try:
-    with open(log_file, encoding='utf-8') as f:
+    with open(log_file, encoding='utf-8', errors='replace') as f:
         for line in f:
             total += 1
             line = line.strip()

--- a/scripts/gc/learn_digest.py
+++ b/scripts/gc/learn_digest.py
@@ -26,6 +26,17 @@ cutoff_7d = (now - timedelta(days=learning_window_days)).strftime("%Y-%m-%dT")
 signals_found = 0
 
 
+def iter_text_lines_lossy(path):
+    """Yield UTF-8 text lines without letting malformed bytes abort GC learning."""
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        yield from handle
+
+
+def read_text_lossy(path):
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
 def detect_guards(project_root):
     """Return [(guard_script, rule_id_prefix)] list."""
     guards = []
@@ -84,6 +95,7 @@ for proj in os.listdir(projects_dir):
 
     signals = []
     session_set = set()
+    has_recent_activity = False
 
     if os.path.exists(events_file):
         warn_reasons = Counter()
@@ -91,29 +103,29 @@ for proj in os.listdir(projects_dir):
         edit_files = Counter()
         slow_count = 0
 
-        with open(events_file, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    evt = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                ts = evt.get("ts", "")
-                if ts[:10] < cutoff_7d[:10]:
-                    continue
-                session_set.add(evt.get("session", ""))
-                decision = evt.get("decision", "")
-                reason = evt.get("reason", "")
-                if decision == "warn" and reason:
-                    warn_reasons[reason] += 1
-                elif decision == "block" and reason:
-                    block_reasons[reason] += 1
-                if evt.get("tool") == "Edit" and evt.get("detail"):
-                    edit_files[evt["detail"].split()[-1]] += 1
-                if evt.get("duration_ms", 0) > 5000:
-                    slow_count += 1
+        for line in iter_text_lines_lossy(events_file):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = evt.get("ts", "")
+            if ts[:10] < cutoff_7d[:10]:
+                continue
+            has_recent_activity = True
+            session_set.add(evt.get("session", ""))
+            decision = evt.get("decision", "")
+            reason = evt.get("reason", "")
+            if decision == "warn" and reason:
+                warn_reasons[reason] += 1
+            elif decision == "block" and reason:
+                block_reasons[reason] += 1
+            if evt.get("tool") == "Edit" and evt.get("detail"):
+                edit_files[evt["detail"].split()[-1]] += 1
+            if evt.get("duration_ms", 0) > 5000:
+                slow_count += 1
 
         for reason, count in warn_reasons.most_common(5):
             if count >= 10:
@@ -162,23 +174,23 @@ for proj in os.listdir(projects_dir):
         if os.path.exists(metrics_file):
             mid = (now - timedelta(days=3.5)).strftime("%Y-%m-%dT")
             early_warns, late_warns = 0, 0
-            with open(metrics_file, encoding="utf-8") as mf:
-                for ml in mf:
-                    ml = ml.strip()
-                    if not ml:
-                        continue
-                    try:
-                        m = json.loads(ml)
-                    except json.JSONDecodeError:
-                        continue
-                    mts = m.get("ts", "")
-                    if mts[:10] < cutoff_7d[:10]:
-                        continue
-                    w = m.get("decisions", {}).get("warn", 0)
-                    if mts < mid:
-                        early_warns += w
-                    else:
-                        late_warns += w
+            for ml in iter_text_lines_lossy(metrics_file):
+                ml = ml.strip()
+                if not ml:
+                    continue
+                try:
+                    m = json.loads(ml)
+                except json.JSONDecodeError:
+                    continue
+                mts = m.get("ts", "")
+                if mts[:10] < cutoff_7d[:10]:
+                    continue
+                has_recent_activity = True
+                w = m.get("decisions", {}).get("warn", 0)
+                if mts < mid:
+                    early_warns += w
+                else:
+                    late_warns += w
             if early_warns > 0 and late_warns > early_warns * 1.5:
                 signals.append(
                     {
@@ -190,8 +202,8 @@ for proj in os.listdir(projects_dir):
                     }
                 )
 
-    if os.path.exists(project_root_file):
-        project_root = open(project_root_file, encoding="utf-8").read().strip()
+    if has_recent_activity and os.path.exists(project_root_file):
+        project_root = read_text_lossy(project_root_file).strip()
         if os.path.isdir(project_root):
             guards = detect_guards(project_root)
             for guard_script, prefix in guards:
@@ -217,7 +229,7 @@ for proj in os.listdir(projects_dir):
             "recommendation": f"consider /vibeguard:learn for project {proj}",
         }
         if os.path.exists(project_root_file):
-            entry["project_root"] = open(project_root_file, encoding="utf-8").read().strip()
+            entry["project_root"] = read_text_lossy(project_root_file).strip()
         with open(digest_file, "a", encoding="utf-8") as df:
             df.write(json.dumps(entry, ensure_ascii=False) + "\n")
         print(f" project {proj}: {len(signals)} learning signals")

--- a/tests/test_gc_logs_concurrent.sh
+++ b/tests/test_gc_logs_concurrent.sh
@@ -149,6 +149,32 @@ assert_not_contains "$project_remaining" "old-line" "project old-month line is r
 assert_contains "$project_archived" "old-line" "project old-month line is archived"
 assert_cmd "project events.jsonl remains mode 600" test "$(file_mode "${project_log_dir}/events.jsonl")" = "600"
 
+header "gc-logs.sh tolerates malformed UTF-8"
+
+malformed_dir="${TMP_ROOT}/malformed"
+mkdir -p "$malformed_dir"
+python3 - "${malformed_dir}/events.jsonl" "$(current_ts)" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+current_ts = sys.argv[2]
+path.write_bytes(
+    b'{"ts":"2024-01-01T00:00:00Z","detail":"old-\xff-line"}\n'
+    + b'{"ts":"'
+    + current_ts.encode("utf-8")
+    + b'","detail":"current-line"}\n'
+)
+PY
+malformed_out="$(run_gc "$malformed_dir" --retain 60)"
+malformed_remaining="$(cat "${malformed_dir}/events.jsonl")"
+malformed_archived="$(gzip -dc "${malformed_dir}/archive/events-2024-01.jsonl.gz")"
+
+assert_not_contains "$malformed_out" "UnicodeDecodeError" "malformed UTF-8 does not abort log archive"
+assert_contains "$malformed_out" "archive 1 items, retain 1 items" "malformed UTF-8 archive reports moved and retained counts"
+assert_contains "$malformed_remaining" "current-line" "current line remains after malformed UTF-8 archive"
+assert_contains "$malformed_archived" "old-" "malformed UTF-8 old line is archived with replacement"
+
 printf '\n==============================\n'
 printf 'Total: %s  Pass: \033[32m%s\033[0m  Fail: \033[31m%s\033[0m\n' "$TOTAL" "$PASS" "$FAIL"
 printf '==============================\n'

--- a/tests/test_gc_scheduled.sh
+++ b/tests/test_gc_scheduled.sh
@@ -92,6 +92,64 @@ assert_contains "$metrics_after" "$today" "current session metric remains"
 assert_not_contains "$metrics_after" "2020-01-01" "expired session metric is removed"
 assert_contains "$reflection" "VibeGuard Weekly Reflection Report" "reflection report is generated"
 
+header "learn_digest.py tolerates malformed UTF-8"
+
+learn_log_dir="${TMP_ROOT}/learn-logs"
+learn_project_dir="${learn_log_dir}/projects/badutf8"
+learn_root="${TMP_ROOT}/learn-project"
+stale_project_dir="${learn_log_dir}/projects/stale-code-scan"
+stale_root="${TMP_ROOT}/stale-code-project"
+mkdir -p "$learn_project_dir" "$learn_root" "$stale_project_dir" "${stale_root}/src"
+printf '%s\n' "$learn_root" > "${learn_project_dir}/.project-root"
+printf '%s\n' "$stale_root" > "${stale_project_dir}/.project-root"
+printf '{"scripts":{}}\n' > "${stale_root}/package.json"
+cat > "${stale_root}/src/stale.ts" <<'EOF'
+export function stale(value: any): any {
+  const one: any = value;
+  const two: any = one;
+  const three: any = two;
+  const four: any = three;
+  const five: any = four;
+  return five;
+}
+EOF
+printf '%s\n' '{"ts":"2020-01-01T00:00:00Z","session":"stale","decision":"warn","reason":"old-only"}' > "${stale_project_dir}/events.jsonl"
+python3 - "${learn_project_dir}/events.jsonl" "$today" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+today = sys.argv[2]
+with path.open("wb") as f:
+    f.write(
+        b'{"ts":"'
+        + today.encode("utf-8")
+        + b'","session":"bad-utf8","decision":"warn","reason":"recoverable-utf8-\xff"}\n'
+    )
+    for index in range(10):
+        f.write(
+            (
+                json.dumps(
+                    {
+                        "ts": today,
+                        "session": f"learn-{index}",
+                        "decision": "warn",
+                        "reason": "repeat-gc-warning",
+                    }
+                )
+                + "\n"
+            ).encode("utf-8")
+        )
+PY
+learn_out="$(_GC_LOG_DIR="$learn_log_dir" _GC_VIBEGUARD_DIR="$REPO_DIR" _GC_LEARNING_WINDOW_DAYS=7 python3 scripts/gc/learn_digest.py 2>&1)"
+learn_digest="$(cat "${learn_log_dir}/learn-digest.jsonl" 2>/dev/null || true)"
+
+assert_not_contains "$learn_out" "UnicodeDecodeError" "learning digest tolerates malformed UTF-8 event bytes"
+assert_cmd "learning digest writes output after malformed UTF-8" test -f "${learn_log_dir}/learn-digest.jsonl"
+assert_contains "$learn_digest" "repeat-gc-warning" "learning digest keeps valid rows after malformed UTF-8"
+assert_not_contains "$learn_digest" "$stale_root" "learning digest skips code scan for stale project activity"
+
 header "gc-scheduled.sh catch-up mode"
 
 skip_log_before="$(wc -l < "${log_dir}/gc-cron.log" | tr -d ' ')"

--- a/vibeguard-runtime/src/codex_app_server_core.rs
+++ b/vibeguard-runtime/src/codex_app_server_core.rs
@@ -7,6 +7,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+const MAX_APP_SERVER_THREADS: usize = 100;
+
 pub type WriteServer<'a> = dyn FnMut(Value) + 'a;
 
 pub fn capabilities() -> Value {
@@ -30,21 +32,54 @@ pub struct ThreadState {
     pub turn_id: Option<String>,
     pub pending_file_changes: HashMap<String, Vec<FilePatch>>,
     pub research_streak: usize,
+    pub last_seen: u64,
 }
 
 #[derive(Debug, Default)]
 pub struct SessionState {
     pub threads: HashMap<String, ThreadState>,
+    next_seen: u64,
 }
 
 impl SessionState {
     pub fn ensure_thread(&mut self, thread_id: &str) -> &mut ThreadState {
-        self.threads
+        self.next_seen = self.next_seen.saturating_add(1);
+        let last_seen = self.next_seen;
+        if !self.threads.contains_key(thread_id) && self.threads.len() >= MAX_APP_SERVER_THREADS {
+            self.prune_thread_for_insert(thread_id);
+        }
+
+        let thread = self
+            .threads
             .entry(thread_id.to_string())
             .or_insert_with(|| ThreadState {
                 session_id: Some(session_id_for_thread(thread_id)),
                 ..ThreadState::default()
+            });
+        thread.last_seen = last_seen;
+        thread
+    }
+
+    fn prune_thread_for_insert(&mut self, incoming_thread_id: &str) {
+        let victim = self
+            .threads
+            .iter()
+            .filter(|(id, thread)| {
+                id.as_str() != incoming_thread_id && thread.pending_file_changes.is_empty()
             })
+            .min_by_key(|(_, thread)| thread.last_seen)
+            .map(|(id, _)| id.clone())
+            .or_else(|| {
+                self.threads
+                    .iter()
+                    .filter(|(id, _)| id.as_str() != incoming_thread_id)
+                    .min_by_key(|(_, thread)| thread.last_seen)
+                    .map(|(id, _)| id.clone())
+            });
+
+        if let Some(victim) = victim {
+            self.threads.remove(&victim);
+        }
     }
 }
 
@@ -669,6 +704,41 @@ mod tests {
         let payloads = extract_payloads(output);
 
         assert_eq!(payloads, vec![json!({"decision": "pass"})]);
+    }
+
+    #[test]
+    fn ensure_thread_bounds_long_lived_app_server_state() {
+        let mut state = SessionState::default();
+        for index in 0..(MAX_APP_SERVER_THREADS + 25) {
+            state.ensure_thread(&format!("thread-{index}"));
+        }
+
+        assert_eq!(state.threads.len(), MAX_APP_SERVER_THREADS);
+        assert!(!state.threads.contains_key("thread-0"));
+        assert!(
+            state
+                .threads
+                .contains_key(&format!("thread-{}", MAX_APP_SERVER_THREADS + 24))
+        );
+    }
+
+    #[test]
+    fn ensure_thread_prunes_idle_threads_before_pending_file_changes() {
+        let mut state = SessionState::default();
+        for index in 0..MAX_APP_SERVER_THREADS {
+            state.ensure_thread(&format!("thread-{index}"));
+        }
+        state
+            .ensure_thread("thread-0")
+            .pending_file_changes
+            .insert("turn:item".into(), Vec::new());
+
+        state.ensure_thread("thread-new");
+
+        assert!(state.threads.contains_key("thread-0"));
+        assert!(!state.threads.contains_key("thread-1"));
+        assert!(state.threads.contains_key("thread-new"));
+        assert_eq!(state.threads.len(), MAX_APP_SERVER_THREADS);
     }
 
     #[test]

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -520,7 +520,7 @@ pub fn post_write_fast_check(args: &[String]) -> Result {
     let log_file = &args[2];
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
-        println!("SKIP");
+        println!("FALLBACK");
         return Ok(());
     };
 
@@ -544,8 +544,7 @@ pub fn post_write_fast_check(args: &[String]) -> Result {
         {
             println!("FAST_LOGGED");
         } else {
-            println!("FAST_PASS");
-            println!("{file_path}");
+            println!("FALLBACK");
         }
         return Ok(());
     }
@@ -568,8 +567,7 @@ pub fn post_write_fast_check(args: &[String]) -> Result {
         {
             println!("FAST_LOGGED");
         } else {
-            println!("FAST_PASS");
-            println!("{file_path}");
+            println!("FALLBACK");
         }
         return Ok(());
     };
@@ -588,8 +586,7 @@ pub fn post_write_fast_check(args: &[String]) -> Result {
             {
                 println!("FAST_LOGGED");
             } else {
-                println!("FAST_PASS");
-                println!("{file_path}");
+                println!("FALLBACK");
             }
         }
         SameNameScan::Duplicate | SameNameScan::TooLarge => println!("FALLBACK"),

--- a/vibeguard-runtime/src/setup_codex_hooks.rs
+++ b/vibeguard-runtime/src/setup_codex_hooks.rs
@@ -589,7 +589,8 @@ mod tests {
             .and_then(Value::as_array);
         assert_eq!(hooks.map(Vec::len), Some(1));
         assert_eq!(
-            hooks.and_then(|items| items.first())
+            hooks
+                .and_then(|items| items.first())
                 .and_then(|hook| hook.get("command"))
                 .and_then(Value::as_str),
             Some("bash /tmp/third-party.sh")
@@ -637,7 +638,13 @@ mod tests {
             ]
         })];
 
-        assert!(!codex_has_entry(&entries, repo_dir, command, None, Some(15)));
+        assert!(!codex_has_entry(
+            &entries,
+            repo_dir,
+            command,
+            None,
+            Some(15)
+        ));
         assert!(codex_has_entry(&entries, repo_dir, command, None, Some(99)));
     }
 }

--- a/vibeguard-runtime/src/setup_install_state.rs
+++ b/vibeguard-runtime/src/setup_install_state.rs
@@ -294,10 +294,7 @@ mod tests {
     fn unique_temp_dir(name: &str) -> SetupResult<PathBuf> {
         let mut path = std::env::temp_dir();
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-        path.push(format!(
-            "vibeguard-{name}-{}-{nanos}",
-            std::process::id()
-        ));
+        path.push(format!("vibeguard-{name}-{}-{nanos}", std::process::id()));
         fs::create_dir_all(&path)?;
         Ok(path)
     }

--- a/vibeguard-runtime/src/setup_support.rs
+++ b/vibeguard-runtime/src/setup_support.rs
@@ -308,10 +308,7 @@ mod tests {
     fn unique_temp_dir(name: &str) -> SetupResult<PathBuf> {
         let mut path = std::env::temp_dir();
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-        path.push(format!(
-            "vibeguard-{name}-{}-{nanos}",
-            std::process::id()
-        ));
+        path.push(format!("vibeguard-{name}-{}-{nanos}", std::process::id()));
         fs::create_dir_all(&path)?;
         Ok(path)
     }
@@ -327,7 +324,10 @@ mod tests {
     #[test]
     fn shell_quote_wraps_unsafe_values() {
         assert_eq!(shell_quote("/tmp/safe-path"), "/tmp/safe-path");
-        assert_eq!(shell_quote("/tmp/path with space"), "'/tmp/path with space'");
+        assert_eq!(
+            shell_quote("/tmp/path with space"),
+            "'/tmp/path with space'"
+        );
         assert_eq!(shell_quote("it's"), "'it'\"'\"'s'");
     }
 


### PR DESCRIPTION
## Summary

Closes #418.

- restore the `post-write-guard` fast path by running `post-write-fast-check` before the full write check
- make fast-path fallback preserve visible malformed-input and runtime-failure diagnostics
- make GC learning/log archive tolerate malformed UTF-8 bytes in event logs
- limit learn-time code scans to projects with recent activity so stale projects do not slow every digest run
- bound long-lived Codex app server thread state to 100 entries, pruning idle threads before pending-change threads
- add a reusable benchmark regression triage skill for comparing GitHub Actions `bench-output` artifacts

## Verification

- `bash tests/test_gc_scheduled.sh`
- `bash tests/test_gc_logs_concurrent.sh`
- `bash tests/hooks/test_post_write_guard.sh`
- `python3 scripts/skill_validate.py --format-only --proposed-skill .claude/skills/benchmark-regression-triage/SKILL.md`
- `bash scripts/ci/validate-skill-format.sh`
- `rustup run stable cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `rustup run stable cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/bench_hook_latency.sh --runs=3`
- `git diff --check origin/main..HEAD`