### PR TITLE
Harden hook performance gates

### DIFF
--- a/hooks/analysis-paralysis-guard.sh
+++ b/hooks/analysis-paralysis-guard.sh
@@ -20,6 +20,10 @@ if [[ ! -t 0 ]]; then
   fi
 fi
 
+if [[ "${VIBEGUARD_SUPPRESS_PARALYSIS:-0}" == "1" ]]; then
+  exit 0
+fi
+
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -513,15 +513,21 @@ vg_is_ci() {
 # Passes JSON via stdin (pipe) instead of an environment variable to avoid
 # hitting execve env-size limits when the input contains a long last_assistant_message.
 vg_stop_hook_active() {
-  local input="$1"
-  printf '%s' "$input" | python3 -c "
-import json, sys
-try:
-    data = json.loads(sys.stdin.read())
-    val = data.get('stop_hook_active', False)
-    # Require the boolean literal true, not a truthy string like 'false'
-    sys.exit(0 if val is True else 1)
-except Exception:
-    sys.exit(1)
-"
+  local input="$1" active="" runtime_path=""
+
+  if [[ -n "${_VIBEGUARD_RUNTIME:-}" && -x "${_VIBEGUARD_RUNTIME}" ]]; then
+    runtime_path="${_VIBEGUARD_RUNTIME}"
+  elif declare -F _vg_config_runtime_path >/dev/null 2>&1; then
+    runtime_path="$(_vg_config_runtime_path 2>/dev/null || true)"
+  fi
+
+  if [[ -n "$runtime_path" ]]; then
+    active=$(printf '%s' "$input" | "$runtime_path" json-field stop_hook_active 2>/dev/null || true)
+    [[ "$active" == "true" ]]
+    return
+  fi
+
+  # Standalone fallback for unit tests that source this file without log.sh.
+  # Require the boolean literal true; truthy strings must not count as active.
+  [[ "$input" =~ \"stop_hook_active\"[[:space:]]*:[[:space:]]*true([^A-Za-z0-9_]|$) ]]
 }

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -505,6 +505,69 @@ vg_is_ci() {
 
 # ── stop_hook_active guard ────────────────────────────────────────────────────
 
+_vg_stop_hook_active_literal_top_level() {
+  local input="$1" len i c rest
+  local depth=0 in_string=false escape=false current="" key="" after_key=false
+
+  len=${#input}
+  i=0
+  while [[ "$i" -lt "$len" ]]; do
+    c="${input:i:1}"
+
+    if [[ "$in_string" == "true" ]]; then
+      if [[ "$escape" == "true" ]]; then
+        escape=false
+      elif [[ "$c" == "\\" ]]; then
+        escape=true
+      elif [[ "$c" == '"' ]]; then
+        in_string=false
+        if [[ "$depth" -eq 1 ]]; then
+          key="$current"
+          after_key=true
+        fi
+      elif [[ "$depth" -eq 1 ]]; then
+        current="${current}${c}"
+      fi
+      i=$((i + 1))
+      continue
+    fi
+
+    case "$c" in
+      '"')
+        in_string=true
+        escape=false
+        current=""
+        ;;
+      "{"|"[")
+        depth=$((depth + 1))
+        after_key=false
+        ;;
+      "}"|"]")
+        depth=$((depth - 1))
+        after_key=false
+        ;;
+      ":")
+        if [[ "$depth" -eq 1 && "$after_key" == "true" && "$key" == "stop_hook_active" ]]; then
+          rest="${input:i+1}"
+          [[ "$rest" =~ ^[[:space:]]*true([[:space:],}]|$) ]]
+          return
+        fi
+        after_key=false
+        ;;
+      ",")
+        if [[ "$depth" -eq 1 ]]; then
+          key=""
+          after_key=false
+        fi
+        ;;
+    esac
+
+    i=$((i + 1))
+  done
+
+  return 1
+}
+
 # vg_stop_hook_active <json_string>
 # Returns 0 (true) if the Stop hook input JSON has stop_hook_active == true,
 # indicating this invocation was triggered by another Stop hook and should not block.
@@ -526,9 +589,13 @@ vg_stop_hook_active() {
       [[ "$active" == "true" ]]
       return
     fi
+    if active=$(printf '%s' "$input" | "$runtime_path" json-field stop_hook_active 2>/dev/null); then
+      [[ "$active" == "true" ]] && _vg_stop_hook_active_literal_top_level "$input"
+      return
+    fi
   fi
 
   # Standalone and stale-runtime fallback for unit tests that source this file without log.sh.
   # Require the boolean literal true; truthy strings must not count as active.
-  [[ "$input" =~ \"stop_hook_active\"[[:space:]]*:[[:space:]]*true([^A-Za-z0-9_]|$) ]]
+  _vg_stop_hook_active_literal_top_level "$input"
 }

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -522,12 +522,13 @@ vg_stop_hook_active() {
   fi
 
   if [[ -n "$runtime_path" ]]; then
-    active=$(printf '%s' "$input" | "$runtime_path" json-field stop_hook_active 2>/dev/null || true)
-    [[ "$active" == "true" ]]
-    return
+    if active=$(printf '%s' "$input" | "$runtime_path" json-bool-field stop_hook_active 2>/dev/null); then
+      [[ "$active" == "true" ]]
+      return
+    fi
   fi
 
-  # Standalone fallback for unit tests that source this file without log.sh.
+  # Standalone and stale-runtime fallback for unit tests that source this file without log.sh.
   # Require the boolean literal true; truthy strings must not count as active.
   [[ "$input" =~ \"stop_hook_active\"[[:space:]]*:[[:space:]]*true([^A-Za-z0-9_]|$) ]]
 }

--- a/rules/claude-rules/common/workflow.md
+++ b/rules/claude-rules/common/workflow.md
@@ -68,6 +68,9 @@ If there are 7+ consecutive read-only actions (Read / Glob / Grep) with no write
 - Tell the user what blocker is preventing progress
 - If more reading is genuinely required, explain why the earlier reading was insufficient
 
+**Downgrade path** (U-32 compliance):
+- `VIBEGUARD_SUPPRESS_PARALYSIS=1` skips the detector entirely. Use it for explicitly read-only agent roles such as architecture review, code review, research, or audit agents where the expected output is a written conclusion rather than a file edit.
+
 **Anti-patterns**:
 - Reading 10 files in a row without producing either a change or a conclusion
 - Jumping between files in search of "perfect understanding" without ever starting the work

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -53,16 +53,32 @@ measure_spawn_baseline_ms() {
     return 0
   fi
 
-  local samples=()
-  local start end elapsed
-  for _run in 1 2 3 4 5; do
-    start=$(_now_ms)
-    /usr/bin/true
-    end=$(_now_ms)
-    elapsed=$((end - start))
-    samples+=("$elapsed")
-  done
-  printf '%s\n' "${samples[@]}" | sort -n | sed -n '5p'
+  if command -v perl &>/dev/null; then
+    perl -MTime::HiRes=time -e '
+      my @samples;
+      for (1..5) {
+        my $start = time;
+        system("/usr/bin/true");
+        push @samples, (time - $start) * 1000;
+      }
+      @samples = sort { $a <=> $b } @samples;
+      printf "%.0f\n", $samples[-1];
+    '
+  elif command -v python3 &>/dev/null; then
+    python3 - <<'PY'
+import subprocess
+import time
+
+samples = []
+for _ in range(5):
+    start = time.perf_counter()
+    subprocess.run(["/usr/bin/true"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    samples.append((time.perf_counter() - start) * 1000)
+print(f"{sorted(samples)[-1]:.0f}")
+PY
+  else
+    printf '0\n'
+  fi
 }
 
 SPAWN_BASELINE_MS="$(measure_spawn_baseline_ms)"

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -21,6 +21,9 @@ GLOBAL_SLA_MS=""
 DEFAULT_BUDGET_MS=300
 RUNS=5
 INCLUDE_SLOW_FIXTURE=false
+SPAWN_BASELINE_MAX_MS="${VIBEGUARD_BENCH_SPAWN_MAX_MS:-10}"
+SPAWN_BASELINE_MS=""
+ENVIRONMENT_DISTORTED=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,6 +46,30 @@ _now_ms() {
     echo "$(date +%s)000"
   fi
 }
+
+measure_spawn_baseline_ms() {
+  if [[ -n "${VIBEGUARD_BENCH_SPAWN_BASELINE_MS:-}" ]]; then
+    printf '%s\n' "${VIBEGUARD_BENCH_SPAWN_BASELINE_MS}"
+    return 0
+  fi
+
+  local samples=()
+  local start end elapsed
+  for _run in 1 2 3 4 5; do
+    start=$(_now_ms)
+    /usr/bin/true
+    end=$(_now_ms)
+    elapsed=$((end - start))
+    samples+=("$elapsed")
+  done
+  printf '%s\n' "${samples[@]}" | sort -n | sed -n '5p'
+}
+
+SPAWN_BASELINE_MS="$(measure_spawn_baseline_ms)"
+if [[ "$SPAWN_BASELINE_MS" =~ ^[0-9]+$ && "$SPAWN_BASELINE_MAX_MS" =~ ^[0-9]+$ \
+    && "$SPAWN_BASELINE_MS" -gt "$SPAWN_BASELINE_MAX_MS" ]]; then
+  ENVIRONMENT_DISTORTED=true
+fi
 
 # --- Generate mock data ---
 TMPDIR_BENCH=$(mktemp -d)
@@ -118,10 +145,17 @@ bench_hook() {
     # Keep benchmark runs isolated from the caller's ambient project log and
     # avoid measuring parent-process session discovery instead of hook work.
     local bench_log_file="${events_file:-$TMPDIR_BENCH/events-bench.jsonl}"
-    local env_prefix="VIBEGUARD_LOG_DIR=$TMPDIR_BENCH VIBEGUARD_LOG_FILE=$bench_log_file VIBEGUARD_SESSION_ID=bench VIBEGUARD_CLI=bench VIBEGUARD_PROJECT_HASH=bench000 VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
+    local -a hook_env=(
+      "VIBEGUARD_LOG_DIR=$TMPDIR_BENCH"
+      "VIBEGUARD_LOG_FILE=$bench_log_file"
+      "VIBEGUARD_SESSION_ID=bench"
+      "VIBEGUARD_CLI=bench"
+      "VIBEGUARD_PROJECT_HASH=bench000"
+      "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
+    )
 
     local start=$(_now_ms)
-    env $env_prefix bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
+    env "${hook_env[@]}" bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
     local end=$(_now_ms)
     local elapsed=$((end - start))
     latencies+=("$elapsed")
@@ -145,8 +179,12 @@ bench_hook() {
 
   local status="PASS"
   if [[ "$p95" -gt "$budget_ms" ]]; then
-    status="FAIL"
-    FAILURES=$((FAILURES + 1))
+    if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
+      status="ENV-DISTORTED"
+    else
+      status="FAIL"
+      FAILURES=$((FAILURES + 1))
+    fi
   fi
 
   printf "  %-35s P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
@@ -160,6 +198,10 @@ if [[ -n "$GLOBAL_SLA_MS" ]]; then
   echo "Budget mode: global <${GLOBAL_SLA_MS}ms (P95)  Runs: ${RUNS}  Tail: P99/max reported"
 else
   echo "Budget mode: per-hook P95 budgets  Runs: ${RUNS}  Tail: P99/max reported"
+fi
+echo "Spawn baseline: /usr/bin/true P95=${SPAWN_BASELINE_MS}ms  threshold=${SPAWN_BASELINE_MAX_MS}ms"
+if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
+  echo "Environment distorted: spawn baseline exceeds threshold; latency SLA failures will be reported but not counted."
 fi
 echo "======================================"
 echo ""
@@ -205,6 +247,8 @@ fi
 echo "======================================"
 if [[ $FAILURES -gt 0 ]]; then
   printf "\033[31mFAILED: %d hook fixture(s) exceeded latency budget\033[0m\n" "$FAILURES"
+elif [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
+  printf "\033[33mENVIRONMENT DISTORTED: spawn baseline too high; SLA verdict suppressed\033[0m\n"
 else
   printf "\033[32mPASSED: All hooks within latency budget\033[0m\n"
 fi
@@ -212,11 +256,13 @@ fi
 # --- JSON output (internal format) ---
 if [[ -n "$RESULTS_FILE" ]]; then
   mkdir -p "$(dirname "$RESULTS_FILE")"
-  printf '{"date":"%s","budget_mode":"%s","global_sla_ms":"%s","runs":%d,"results":[%s]}\n' \
+  printf '{"date":"%s","budget_mode":"%s","global_sla_ms":"%s","runs":%d,"spawn_baseline_ms":%d,"environment_distorted":%s,"results":[%s]}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "$([[ -n "$GLOBAL_SLA_MS" ]] && printf global || printf per-hook)" \
     "${GLOBAL_SLA_MS}" \
     "$RUNS" \
+    "$SPAWN_BASELINE_MS" \
+    "$ENVIRONMENT_DISTORTED" \
     "$(IFS=,; echo "${RESULTS[*]}")" \
     > "$RESULTS_FILE"
   echo "Results: $RESULTS_FILE"

--- a/tests/hooks/test_runtime_config.sh
+++ b/tests/hooks/test_runtime_config.sh
@@ -115,6 +115,13 @@ result=$(env CI=false GITHUB_ACTIONS=false TRAVIS=false CIRCLECI=false JENKINS_U
   bash hooks/analysis-paralysis-guard.sh)
 assert_contains "$result" "ANALYSIS PARALYSIS" "JSON paralysis.threshold=2 triggers warning"
 
+paralysis_suppressed_log="$(make_log_dir)"
+seed_research_events "$paralysis_suppressed_log" "cfg-paralysis-suppressed" 2
+result=$(env CI=false GITHUB_ACTIONS=false TRAVIS=false CIRCLECI=false JENKINS_URL= GITLAB_CI=false TF_BUILD=false \
+  VIBEGUARD_LOG_DIR="$paralysis_suppressed_log" VIBEGUARD_SESSION_ID="cfg-paralysis-suppressed" VIBEGUARD_CONFIG_FILE="$cfg" \
+  VIBEGUARD_SUPPRESS_PARALYSIS=1 bash hooks/analysis-paralysis-guard.sh)
+assert_not_contains "$result" "ANALYSIS PARALYSIS" "VIBEGUARD_SUPPRESS_PARALYSIS disables read-only agent warning"
+
 paralysis_env_log="$(make_log_dir)"
 seed_research_events "$paralysis_env_log" "cfg-paralysis-env" 2
 result=$(env CI=false GITHUB_ACTIONS=false TRAVIS=false CIRCLECI=false JENKINS_URL= GITLAB_CI=false TF_BUILD=false \

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -67,6 +67,23 @@ assert_fail_contains() {
   fi
 }
 
+assert_success_contains() {
+  local desc="$1"
+  local expected="$2"
+  local output_file="$3"
+  shift 3
+  TOTAL=$((TOTAL + 1))
+  "$@" >"${output_file}" 2>&1
+  local exit_code=$?
+  if [[ "$exit_code" -eq 0 ]] && grep -qF -- "$expected" "${output_file}"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit=${exit_code}, expected output: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 write_hook() {
   local dir="$1"
   local name="$2"
@@ -107,12 +124,13 @@ assert_fail_contains "subprocess in loop fails static validator" "PERF-04" "${TM
 assert_file_contains "${TMP_DIR}/bad-loop.out" "bad-loop-hook.sh" "loop subprocess output names the hook"
 
 header "dynamic latency gate"
-assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
+assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
 assert_file_contains "${TMP_DIR}/slow.out" "exceeded latency budget" "slow hook output explains budget failure"
 assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "slow hook output includes hotspot attribution"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P50)" "benchmark action output includes P50 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P95)" "benchmark action output includes P95 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P99)" "benchmark action output includes P99 samples"
+assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
 
 echo ""
 echo "======================================"

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -317,6 +317,16 @@ assert_fail "stop_hook_active: returns 1 when value is string \"true\"" \
     source '${CB_SCRIPT}'
     vg_stop_hook_active '{\"stop_hook_active\": \"true\"}'
   "
+assert_fail "stop_hook_active: ignores nested true when top-level is false" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"other\":{\"stop_hook_active\":true},\"stop_hook_active\":false}'
+  "
+assert_ok "stop_hook_active: sees top-level true after nested object" \
+  bash -c "
+    source '${CB_SCRIPT}'
+    vg_stop_hook_active '{\"other\":{\"stop_hook_active\":false},\"stop_hook_active\":true}'
+  "
 teardown
 
 # ── 10. State directory is created automatically ─────────────────────────────

--- a/vibeguard-runtime/src/json_field.rs
+++ b/vibeguard-runtime/src/json_field.rs
@@ -66,6 +66,21 @@ pub fn run_field(args: &[String]) -> Result {
     Ok(())
 }
 
+/// vibeguard-runtime json-bool-field <field_path>
+/// Reads JSON from stdin, prints only literal JSON booleans as true/false.
+pub fn run_bool_field(args: &[String]) -> Result {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime json-bool-field <field_path>".into());
+    }
+    let input = read_stdin()?;
+    let data: Value = serde_json::from_str(&input)?;
+    match get_nested(&data, &args[0]) {
+        Some(Value::Bool(value)) => println!("{value}"),
+        _ => println!("false"),
+    }
+    Ok(())
+}
+
 /// vibeguard-runtime json-two-fields <field1> <field2>
 /// Reads JSON from stdin, prints field1 on first line, field2 on remaining lines.
 pub fn run_two_fields(args: &[String]) -> Result {
@@ -120,6 +135,20 @@ mod tests {
         assert_eq!(value_to_string(&json!(true)), "true");
         assert_eq!(value_to_string(&json!(["a", "b"])), "[\"a\",\"b\"]");
         assert_eq!(value_to_string(&json!({"n": 1})), "{\"n\":1}");
+    }
+
+    #[test]
+    fn bool_field_preserves_json_boolean_type() {
+        let args = vec!["stop_hook_active".to_string()];
+
+        let data = json!({"stop_hook_active": true});
+        assert_eq!(
+            get_nested(&data, &args[0]).and_then(Value::as_bool),
+            Some(true)
+        );
+
+        let data = json!({"stop_hook_active": "true"});
+        assert_eq!(get_nested(&data, &args[0]).and_then(Value::as_bool), None);
     }
 
     #[test]

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -55,6 +55,11 @@ static COMMANDS: &[Command] = &[
         handler: json_field::run_field,
     },
     Command {
+        name: "json-bool-field",
+        usage: "<field_path>  — extract one boolean field from stdin JSON",
+        handler: json_field::run_bool_field,
+    },
+    Command {
         name: "json-two-fields",
         usage: "<field1> <field2>  — extract two fields from stdin JSON",
         handler: json_field::run_two_fields,

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -53,6 +53,7 @@ fn help_lists_all_commands() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     for name in &[
         "json-field",
+        "json-bool-field",
         "json-two-fields",
         "churn-count",
         "warn-count",

--- a/vibeguard-runtime/tests/cli_json.rs
+++ b/vibeguard-runtime/tests/cli_json.rs
@@ -128,6 +128,53 @@ fn strict_null_field_exits_1_with_error() {
 }
 
 #[test]
+fn bool_field_preserves_literal_boolean_type() {
+    let mut child = bin()
+        .args(["json-bool-field", "stop_hook_active"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"stop_hook_active\": \"true\"}")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "false\n");
+
+    let mut child = bin()
+        .args(["json-bool-field", "stop_hook_active"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"stop_hook_active\": true}")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "true\n");
+}
+
+#[test]
 fn invalid_json_exits_1() {
     let mut child = bin()
         .args(["json-field", "tool"])


### PR DESCRIPTION
## Summary

- add `VIBEGUARD_SUPPRESS_PARALYSIS=1` as the U-32 downgrade path for explicitly read-only agents
- remove the remaining `python3` fork from `vg_stop_hook_active` by adding typed `vibeguard-runtime json-bool-field`
- preserve the old Stop-hook safety contract: only literal JSON boolean `true` counts, strings like `"true"` stay false
- add a spawn-baseline sanity check to `tests/bench_hook_latency.sh` so saturated machines report `ENV-DISTORTED` instead of false SLA failures
- pass benchmark hook env vars as an array to avoid accidental splitting and stray log files

Closes #432.
Partially addresses #429 by removing the remaining `stop_hook_active` Python scalar extraction.

## Verification

- `bash tests/unit/test_circuit_breaker.sh`
- `bash tests/unit/run_all.sh`
- `bash tests/hooks/test_runtime_config.sh`
- `bash tests/test_hook_perf_contract.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_hooks.sh`
- `git diff --check`
- `bash scripts/ci/self-application/check-hook-production-python-free.sh`
- `bash tests/bench_hook_latency.sh --runs=1 --fail-on-regression`

Bench note: this machine was still CPU-saturated during verification. The bench script reported spawn baseline above the 10ms threshold and marked the run `ENV-DISTORTED`, suppressing SLA failure as intended.
