### PR TITLE
skill: validate repo-local Claude skills

### DIFF
--- a/scripts/ci/validate-skill-format.py
+++ b/scripts/ci/validate-skill-format.py
@@ -20,7 +20,7 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="*",
         help=(
             "Specific SKILL.md files to validate. Defaults to skills/*/SKILL.md, "
-            "workflows/*/SKILL.md, and templates/skill-template.md."
+            "workflows/*/SKILL.md, .claude/skills/*/SKILL.md, and templates/skill-template.md."
         ),
     )
     parser.add_argument(

--- a/scripts/lib/skill_format.py
+++ b/scripts/lib/skill_format.py
@@ -7,7 +7,12 @@ import re
 from pathlib import Path
 
 
-FORMAT_PATH_PATTERNS = ("skills/*/SKILL.md", "workflows/*/SKILL.md", "templates/skill-template.md")
+FORMAT_PATH_PATTERNS = (
+    "skills/*/SKILL.md",
+    "workflows/*/SKILL.md",
+    ".claude/skills/*/SKILL.md",
+    "templates/skill-template.md",
+)
 FORMAT_REQUIRED_SECTIONS = ("## When to Activate", "## Red Flags", "## Checklist")
 FORMAT_LIST_SECTIONS = ("## Red Flags", "## Checklist")
 MIN_RED_FLAGS = 3

--- a/tests/test_skill_format.sh
+++ b/tests/test_skill_format.sh
@@ -85,6 +85,7 @@ assert_cmd "repository skills, workflows, and template pass format validation" \
   bash "${REPO_DIR}/scripts/ci/validate-skill-format.sh"
 repo_format_out="$(python3 "${VALIDATOR}" --repo-dir "${REPO_DIR}")"
 assert_contains "${repo_format_out}" "templates/skill-template.md" "repository format coverage includes skill template"
+assert_contains "${repo_format_out}" ".claude/skills/benchmark-regression-triage/SKILL.md" "repository format coverage includes repo-local Claude skill"
 assert_cmd "skill template passes direct format validation" \
   python3 "${VALIDATOR}" "${REPO_DIR}/templates/skill-template.md"
 


### PR DESCRIPTION
## Summary

Closes #445.

This PR includes tracked repo-local Claude skills under `.claude/skills/*/SKILL.md` in the shared skill format validator. It also updates the validator help text and adds a regression assertion that `.claude/skills/benchmark-regression-triage/SKILL.md` is covered by default repository validation.

## Verification

- `bash scripts/ci/validate-skill-format.sh`
- `bash tests/test_skill_format.sh`
- `python3 -m py_compile scripts/lib/skill_format.py scripts/ci/validate-skill-format.py`
- `git diff --check`
