### PR TITLE
fix: validate Claude hooks by install profile

### DIFF
--- a/scripts/lib/hook_config_model.py
+++ b/scripts/lib/hook_config_model.py
@@ -48,7 +48,39 @@ def _wrapper_is_invoked(parts: list[str], index: int) -> bool:
         return True
     if index >= 2 and parts[index - 1].startswith("-"):
         return _basename(parts[index - 2]) in {"bash", "sh", "zsh"}
+    if _env_invokes_token(parts, index):
+        return True
     return False
+
+
+def _env_invokes_token(parts: list[str], index: int) -> bool:
+    if not parts or _basename(parts[0]) != "env":
+        return False
+    cursor = 1
+    while cursor < index:
+        token = parts[cursor]
+        if token == "--":
+            cursor += 1
+            break
+        if token.startswith("-"):
+            if _env_option_takes_value(token) and cursor + 1 < index:
+                cursor += 2
+            else:
+                cursor += 1
+            continue
+        if _is_env_assignment(token):
+            cursor += 1
+            continue
+        return False
+    return cursor == index
+
+
+def _env_option_takes_value(token: str) -> bool:
+    return token in {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+
+
+def _is_env_assignment(token: str) -> bool:
+    return "=" in token and not token.startswith("=")
 
 
 def _looks_like_direct_script(parts: list[str], index: int) -> bool:

--- a/scripts/lib/hook_config_model.py
+++ b/scripts/lib/hook_config_model.py
@@ -41,6 +41,16 @@ def _shell_invokes_wrapper(parts: list[str], index: int) -> bool:
     return shell in {"bash", "sh", "zsh"} and not wrapper.startswith("-")
 
 
+def _wrapper_is_invoked(parts: list[str], index: int) -> bool:
+    if index == 0:
+        return True
+    if _basename(parts[index - 1]) in {"bash", "sh", "zsh"}:
+        return True
+    if index >= 2 and parts[index - 1].startswith("-"):
+        return _basename(parts[index - 2]) in {"bash", "sh", "zsh"}
+    return False
+
+
 def _looks_like_direct_script(parts: list[str], index: int) -> bool:
     token = parts[index]
     if "/" in token or token.startswith(("./", "../", "~/", "$HOME/", "${HOME}/")):
@@ -78,6 +88,8 @@ def hook_command_identity(
     for index, token in enumerate(parts):
         token_base = _basename(token)
         if token_base not in wrapper_set:
+            continue
+        if not _wrapper_is_invoked(parts, index):
             continue
         wrapper = token_base
         if index + 1 >= len(parts):

--- a/scripts/lib/hook_config_model.py
+++ b/scripts/lib/hook_config_model.py
@@ -46,11 +46,25 @@ def _wrapper_is_invoked(parts: list[str], index: int) -> bool:
         return True
     if _basename(parts[index - 1]) in {"bash", "sh", "zsh"}:
         return True
-    if index >= 2 and parts[index - 1].startswith("-"):
+    if (
+        index >= 2
+        and parts[index - 1].startswith("-")
+        and not _shell_option_uses_command_string(parts[index - 1])
+    ):
         return _basename(parts[index - 2]) in {"bash", "sh", "zsh"}
     if _env_invokes_token(parts, index):
         return True
     return False
+
+
+def _shell_option_uses_command_string(token: str) -> bool:
+    if token == "--":
+        return False
+    if token == "--command":
+        return True
+    if token.startswith("--"):
+        return False
+    return "c" in token.lstrip("-")
 
 
 def _env_invokes_token(parts: list[str], index: int) -> bool:

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -18,6 +18,7 @@ from hooks_manifest import all_managed_script_names, claude_specs, load_manifest
 
 MANIFEST = load_manifest()
 MANAGED_SCRIPT_NAMES = all_managed_script_names(MANIFEST)
+CLAUDE_PROFILE_SCRIPT_NAMES = frozenset(spec["script"] for spec in claude_specs(MANIFEST, None))
 LEGACY_SCRIPT_NAMES: frozenset[str] = frozenset(
     {"post-guard-check.sh", "session-tagger.sh", "cognitive-reminder.sh"}
 )
@@ -270,7 +271,7 @@ def _managed_hook_identities(data: dict[str, Any]) -> set[tuple[str, str, str]]:
             continue
         for entry in entries:
             for identity in _entry_identities(str(event), entry):
-                if identity.is_managed and identity.script:
+                if identity.is_managed and identity.script in CLAUDE_PROFILE_SCRIPT_NAMES:
                     identities.add((identity.event, identity.matcher or "", identity.script))
     return identities
 
@@ -426,7 +427,7 @@ def remove_unprofiled_managed_hooks(
                     kept_hooks.append(hook)
                     continue
                 identity = _hook_identity(str(event), matcher, hook)
-                if identity.is_managed and identity.script:
+                if identity.is_managed and identity.script in CLAUDE_PROFILE_SCRIPT_NAMES:
                     hook_identity = (identity.event, identity.matcher or "", identity.script)
                     if hook_identity not in desired_identities:
                         removed_any = True

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -260,20 +260,21 @@ def _spec_identity(spec: dict[str, Any]) -> tuple[str, str, str]:
     return (str(spec["event"]), str(spec.get("matcher") or ""), str(spec["script"]))
 
 
-def _managed_hook_identities(data: dict[str, Any]) -> set[tuple[str, str, str]]:
+def _managed_hook_identity_counts(data: dict[str, Any]) -> dict[tuple[str, str, str], int]:
     hooks = data.get("hooks", {})
     if not isinstance(hooks, dict):
-        return set()
+        return {}
 
-    identities: set[tuple[str, str, str]] = set()
+    counts: dict[tuple[str, str, str], int] = {}
     for event, entries in hooks.items():
         if not isinstance(entries, list):
             continue
         for entry in entries:
             for identity in _entry_identities(str(event), entry):
                 if identity.is_managed and identity.script in CLAUDE_PROFILE_SCRIPT_NAMES:
-                    identities.add((identity.event, identity.matcher or "", identity.script))
-    return identities
+                    hook_identity = (identity.event, identity.matcher or "", identity.script)
+                    counts[hook_identity] = counts.get(hook_identity, 0) + 1
+    return counts
 
 
 def has_pre_hooks(data: dict[str, Any]) -> bool:
@@ -301,7 +302,10 @@ def has_profile_hooks(data: dict[str, Any], profile: str) -> bool:
     if not _has_all_specs(data, desired_specs):
         return False
     desired_identities = {_spec_identity(spec) for spec in desired_specs}
-    return _managed_hook_identities(data).issubset(desired_identities)
+    managed_counts = _managed_hook_identity_counts(data)
+    return set(managed_counts).issubset(desired_identities) and all(
+        count == 1 for count in managed_counts.values()
+    )
 
 
 def _hook_command(repo_dir: str, script_name: str) -> str:
@@ -403,6 +407,7 @@ def remove_unprofiled_managed_hooks(
     desired_identities: set[tuple[str, str, str]],
     state: dict[str, Any],
 ) -> None:
+    seen_profile_identities: set[tuple[str, str, str]] = set()
     for event, entries in list(hooks.items()):
         if not isinstance(entries, list):
             continue
@@ -429,9 +434,13 @@ def remove_unprofiled_managed_hooks(
                 identity = _hook_identity(str(event), matcher, hook)
                 if identity.is_managed and identity.script in CLAUDE_PROFILE_SCRIPT_NAMES:
                     hook_identity = (identity.event, identity.matcher or "", identity.script)
-                    if hook_identity not in desired_identities:
+                    if (
+                        hook_identity not in desired_identities
+                        or hook_identity in seen_profile_identities
+                    ):
                         removed_any = True
                         continue
+                    seen_profile_identities.add(hook_identity)
                 kept_hooks.append(hook)
 
             if removed_any:

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -275,6 +275,10 @@ def has_full_hooks(data: dict[str, Any]) -> bool:
     return has_post_hooks(data) and _has_all_specs(data, specs)
 
 
+def has_profile_hooks(data: dict[str, Any], profile: str) -> bool:
+    return _has_all_specs(data, claude_specs(MANIFEST, profile))
+
+
 def _hook_command(repo_dir: str, script_name: str) -> str:
     """Generate the hook command using the run-hook.sh wrapper."""
     home = Path.home()
@@ -434,6 +438,13 @@ def cmd_check(args: argparse.Namespace) -> int:
         return 0 if has_post_hooks(data) else 1
     if args.target == "full-hooks":
         return 0 if has_full_hooks(data) else 1
+    if args.target.startswith("profile-hooks:"):
+        profile = args.target.removeprefix("profile-hooks:")
+        if profile not in {"minimal", "core", "full", "strict"}:
+            print(f"unsupported profile target: {profile}", file=sys.stderr)
+            return 2
+        return 0 if has_profile_hooks(data, profile) else 1
+    print(f"unsupported target: {args.target}", file=sys.stderr)
     return 1
 
 
@@ -562,7 +573,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     check = sub.add_parser("check", help="Check installed state")
     check.add_argument("--settings-file", required=True)
-    check.add_argument("--target", choices=["pre-hooks", "post-hooks", "full-hooks"], required=True)
+    check.add_argument(
+        "--target",
+        required=True,
+        help="pre-hooks, post-hooks, full-hooks, or profile-hooks:<minimal|core|full|strict>",
+    )
     check.set_defaults(func=cmd_check)
 
     stale = sub.add_parser("check-stale-hooks", help="Detect stale hook commands")

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -255,6 +255,10 @@ def _has_all_specs(data: dict[str, Any], specs: list[dict[str, Any]]) -> bool:
     return all(_has_hook_spec(data, spec) for spec in specs)
 
 
+def _spec_pair(spec: dict[str, Any]) -> tuple[str, str]:
+    return (str(spec["event"]), str(spec["script"]))
+
+
 def has_pre_hooks(data: dict[str, Any]) -> bool:
     specs = [spec for spec in claude_specs(MANIFEST, "minimal") if spec["event"] == "PreToolUse"]
     return _has_all_specs(data, specs)
@@ -276,7 +280,14 @@ def has_full_hooks(data: dict[str, Any]) -> bool:
 
 
 def has_profile_hooks(data: dict[str, Any], profile: str) -> bool:
-    return _has_all_specs(data, claude_specs(MANIFEST, profile))
+    desired_specs = claude_specs(MANIFEST, profile)
+    if not _has_all_specs(data, desired_specs):
+        return False
+    desired_pairs = {_spec_pair(spec) for spec in desired_specs}
+    return not any(
+        _spec_pair(spec) not in desired_pairs and _has_hook_spec(data, spec)
+        for spec in claude_specs(MANIFEST)
+    )
 
 
 def _hook_command(repo_dir: str, script_name: str) -> str:

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -255,8 +255,24 @@ def _has_all_specs(data: dict[str, Any], specs: list[dict[str, Any]]) -> bool:
     return all(_has_hook_spec(data, spec) for spec in specs)
 
 
-def _spec_pair(spec: dict[str, Any]) -> tuple[str, str]:
-    return (str(spec["event"]), str(spec["script"]))
+def _spec_identity(spec: dict[str, Any]) -> tuple[str, str, str]:
+    return (str(spec["event"]), str(spec.get("matcher") or ""), str(spec["script"]))
+
+
+def _managed_hook_identities(data: dict[str, Any]) -> set[tuple[str, str, str]]:
+    hooks = data.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return set()
+
+    identities: set[tuple[str, str, str]] = set()
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            for identity in _entry_identities(str(event), entry):
+                if identity.is_managed and identity.script:
+                    identities.add((identity.event, identity.matcher or "", identity.script))
+    return identities
 
 
 def has_pre_hooks(data: dict[str, Any]) -> bool:
@@ -283,11 +299,8 @@ def has_profile_hooks(data: dict[str, Any], profile: str) -> bool:
     desired_specs = claude_specs(MANIFEST, profile)
     if not _has_all_specs(data, desired_specs):
         return False
-    desired_pairs = {_spec_pair(spec) for spec in desired_specs}
-    return not any(
-        _spec_pair(spec) not in desired_pairs and _has_hook_spec(data, spec)
-        for spec in claude_specs(MANIFEST)
-    )
+    desired_identities = {_spec_identity(spec) for spec in desired_specs}
+    return _managed_hook_identities(data).issubset(desired_identities)
 
 
 def _hook_command(repo_dir: str, script_name: str) -> str:
@@ -382,6 +395,58 @@ def remove_hook(hooks: dict[str, Any], event: str, script_name: str, state: dict
         else:
             hooks.pop(event, None)
         state["changed"] = True
+
+
+def remove_unprofiled_managed_hooks(
+    hooks: dict[str, Any],
+    desired_identities: set[tuple[str, str, str]],
+    state: dict[str, Any],
+) -> None:
+    for event, entries in list(hooks.items()):
+        if not isinstance(entries, list):
+            continue
+
+        next_entries: list[Any] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                next_entries.append(entry)
+                continue
+
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                next_entries.append(entry)
+                continue
+
+            matcher_value = entry.get("matcher")
+            matcher = matcher_value if isinstance(matcher_value, str) and matcher_value else None
+            kept_hooks: list[Any] = []
+            removed_any = False
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    kept_hooks.append(hook)
+                    continue
+                identity = _hook_identity(str(event), matcher, hook)
+                if identity.is_managed and identity.script:
+                    hook_identity = (identity.event, identity.matcher or "", identity.script)
+                    if hook_identity not in desired_identities:
+                        removed_any = True
+                        continue
+                kept_hooks.append(hook)
+
+            if removed_any:
+                state["changed"] = True
+                if kept_hooks:
+                    next_entry = dict(entry)
+                    next_entry["hooks"] = kept_hooks
+                    next_entries.append(next_entry)
+            else:
+                next_entries.append(entry)
+
+        if len(next_entries) != len(entries) or next_entries != entries:
+            if next_entries:
+                hooks[event] = next_entries
+            else:
+                hooks.pop(event, None)
 
 
 def upsert_hook(
@@ -513,11 +578,7 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
         )
 
     # Remove hooks that do not belong to the current profile (handles profile downgrade).
-    desired_pairs = {(spec["event"], spec["script"]) for spec in desired_specs}
-    for spec in claude_specs(MANIFEST):
-        pair = (spec["event"], spec["script"])
-        if pair not in desired_pairs:
-            remove_hook(hooks, spec["event"], spec["script"], state)
+    remove_unprofiled_managed_hooks(hooks, {_spec_identity(spec) for spec in desired_specs}, state)
 
     if args.dry_run:
         if state["changed"]:

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -8,6 +8,7 @@
 #   bash setup.sh --check --json         # machine-readable JSON, no TTY output
 #   bash setup.sh --check --no-summary   # legacy behavior (no rollup, exit 0)
 #   bash setup.sh --check --install      # install final verification, fail on broken required state
+#   bash setup.sh --check --profile full # verify profile-specific hook coverage
 #
 # Exit code
 #   Default mode  : 0 always (backward compatible with pre-summary callers).
@@ -38,6 +39,7 @@ JSON=0
 STRICT=0
 WITH_SUMMARY=1
 INSTALL=0
+PROFILE="${VIBEGUARD_SETUP_PROFILE:-}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --quiet|-q)     QUIET=1; shift ;;
@@ -45,9 +47,14 @@ while [[ $# -gt 0 ]]; do
     --strict)       STRICT=1; shift ;;
     --install)      INSTALL=1; shift ;;
     --no-summary)   WITH_SUMMARY=0; shift ;;
+    --profile)
+      [[ $# -lt 2 ]] && { red "ERROR: --profile requires a value (minimal|core|full|strict)"; exit 64; }
+      PROFILE="$2"; shift 2 ;;
+    --profile=*)
+      PROFILE="${1#*=}"; shift ;;
     --help|-h)
       cat <<'USAGE'
-Usage: setup.sh --check [--quiet | --json | --strict | --install | --no-summary]
+Usage: setup.sh --check [--quiet | --json | --strict | --install | --no-summary] [--profile minimal|core|full|strict]
 
   --quiet        Suppress healthy [OK] rows; only print problems + summary.
   --strict       Reflect health in the exit code: 0 healthy, 1 degraded,
@@ -59,6 +66,8 @@ Usage: setup.sh --check [--quiet | --json | --strict | --install | --no-summary]
                  to stdout. Disables human-readable output. Implies --strict.
   --no-summary   Legacy mode: no rollup table, always exit 0.
                  Equivalent to the pre-summary behavior.
+  --profile      Override the install-state profile used for Claude hook
+                 coverage checks. Defaults to the installed profile, then core.
 
 Exit codes (--strict / --json / --install only):
   0  healthy
@@ -73,6 +82,25 @@ USAGE
       ;;
   esac
 done
+
+check_installed_profile() {
+  local state_out detected
+  state_out="$(state_list 2>/dev/null)" || return 1
+  detected="$(awk -F': ' '/^Profile:/ {print $2; exit}' <<< "${state_out}")"
+  case "${detected}" in
+    minimal|core|full|strict) printf '%s\n' "${detected}" ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ -z "${PROFILE}" ]]; then
+  PROFILE="$(check_installed_profile 2>/dev/null || true)"
+fi
+PROFILE="${PROFILE:-core}"
+case "${PROFILE}" in
+  minimal|core|full|strict) ;;
+  *) red "ERROR: unsupported profile: ${PROFILE} (expected minimal|core|full|strict)"; exit 64 ;;
+esac
 
 # --json implies --strict so machine consumers always get a real exit code.
 if [[ "${JSON}" -eq 1 ]]; then

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -93,14 +93,16 @@ check_installed_profile() {
   esac
 }
 
-if [[ -z "${PROFILE}" ]]; then
-  PROFILE="$(check_installed_profile 2>/dev/null || true)"
+validate_setup_profile() {
+  case "$1" in
+    minimal|core|full|strict) ;;
+    *) red "ERROR: unsupported profile: $1 (expected minimal|core|full|strict)"; exit 64 ;;
+  esac
+}
+
+if [[ -n "${PROFILE}" ]]; then
+  validate_setup_profile "${PROFILE}"
 fi
-PROFILE="${PROFILE:-core}"
-case "${PROFILE}" in
-  minimal|core|full|strict) ;;
-  *) red "ERROR: unsupported profile: ${PROFILE} (expected minimal|core|full|strict)"; exit 64 ;;
-esac
 
 # --json implies --strict so machine consumers always get a real exit code.
 if [[ "${JSON}" -eq 1 ]]; then
@@ -126,6 +128,12 @@ if ! ensure_setup_runtime_available >/dev/null 2>&1; then
     yellow "[WARN] vibeguard-runtime unavailable for setup helper checks; run: bash setup.sh --yes"
   fi
 fi
+
+if [[ -z "${PROFILE}" ]]; then
+  PROFILE="$(check_installed_profile 2>/dev/null || true)"
+fi
+PROFILE="${PROFILE:-core}"
+validate_setup_profile "${PROFILE}"
 
 _check_repo_git_hook() {
   local hook_name="$1"

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -196,7 +196,30 @@ ensure_setup_runtime_available() {
 settings_check() {
   local settings_file="$1" target="$2"
   [[ -f "${settings_file}" ]] || return 1
+  if [[ "${target}" == profile-hooks:* ]] && command -v python3 >/dev/null 2>&1; then
+    python3 "${SETTINGS_HELPER}" check --settings-file "${settings_file}" --target "${target}" >/dev/null 2>&1
+    local python_status=$?
+    case "${python_status}" in
+      126|127) ;;
+      *) return "${python_status}" ;;
+    esac
+  fi
+  if [[ "${target}" == profile-hooks:* ]]; then
+    local runtime probe_out
+    runtime="$(setup_runtime_path)" || return 2
+    probe_out="$("${runtime}" setup-settings-check-supports-profile-hooks 2>&1 || true)"
+    if printf '%s\n' "${probe_out}" | grep -q "Unknown command"; then
+      return 2
+    fi
+    "${runtime}" setup-settings-check "${REPO_DIR}" "${settings_file}" "${target}" >/dev/null 2>&1
+    return $?
+  fi
   setup_runtime setup-settings-check "${REPO_DIR}" "${settings_file}" "${target}" >/dev/null 2>&1
+  local status=$?
+  if [[ "${status}" -eq 127 ]]; then
+    return 2
+  fi
+  return "${status}"
 }
 
 settings_stale_hooks_report() {

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -474,6 +474,12 @@ check_claude_home_installation() {
     yellow "[INFO] Full profile hooks not configured (current install may be core profile)"
   fi
 
+  if settings_check "${SETTINGS_FILE}" "profile-hooks:${PROFILE}"; then
+    green "[OK] Claude hooks match ${PROFILE} profile"
+  else
+    yellow "[MISSING] Claude hooks missing for ${PROFILE} profile"
+  fi
+
   local stale_hooks_report
   if stale_hooks_report="$(settings_stale_hooks_report "${SETTINGS_FILE}" 2>&1)"; then
     :

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -474,8 +474,13 @@ check_claude_home_installation() {
     yellow "[INFO] Full profile hooks not configured (current install may be core profile)"
   fi
 
-  if settings_check "${SETTINGS_FILE}" "profile-hooks:${PROFILE}"; then
+  local profile_hook_status
+  profile_hook_status=0
+  settings_check "${SETTINGS_FILE}" "profile-hooks:${PROFILE}" || profile_hook_status=$?
+  if [[ "${profile_hook_status}" -eq 0 ]]; then
     green "[OK] Claude hooks match ${PROFILE} profile"
+  elif [[ "${profile_hook_status}" -eq 2 ]]; then
+    yellow "[WARN] Claude ${PROFILE} profile hook coverage could not be verified; rebuild or reinstall vibeguard-runtime"
   else
     yellow "[MISSING] Claude hooks missing for ${PROFILE} profile"
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -34,9 +34,13 @@ Install options:
   --profile minimal|core|full|strict
   --languages lang1,lang2
 
+Check options:
+  --profile minimal|core|full|strict
+
 Examples:
   bash setup.sh --yes
   bash setup.sh --check --strict
+  bash setup.sh --check --profile strict
   bash setup.sh --profile strict --languages rust,python
 USAGE
 }

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -83,6 +83,15 @@ assert_cmd "core profile check catches missing analysis-paralysis hook" assert_p
 core_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
 assert_contains "${core_missing_out}" "[MISSING] Claude hooks missing for core profile" "setup --check reports missing core profile hook"
 assert_cmd "core profile repair restores analysis-paralysis hook" assert_profile_hook_restored_after_repair core profile-hooks:core
+assert_cmd "setup --check reads default profile after runtime bootstrap" python3 - "${REPO_DIR}/scripts/setup/check.sh" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+bootstrap = text.index("ensure_setup_runtime_available")
+profile_lookup = text.index('PROFILE="$(check_installed_profile')
+raise SystemExit(0 if bootstrap < profile_lookup else 1)
+PY
 old_profile_runtime="${TMP_HOME}/old-profile-runtime"
 cat > "${old_profile_runtime}" <<'SH'
 #!/usr/bin/env bash

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -80,6 +80,29 @@ assert_cmd "default install includes Python native rules" test -L "${HOME}/.clau
 assert_cmd "default install includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
 assert_cmd "core profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
 python3 - "${HOME}/.claude/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+data = json.loads(settings_path.read_text(encoding="utf-8"))
+hooks = data.setdefault("hooks", {})
+hooks.setdefault("PostToolUse", []).append(
+    {
+        "matcher": "Edit",
+        "hooks": [
+            {
+                "type": "command",
+                "command": f"node /custom/audit.js {Path.home() / '.vibeguard' / 'run-hook.sh'} post-build-check.sh",
+            }
+        ],
+    }
+)
+settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+assert_cmd "core profile check allows unmanaged wrapper argument" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
+assert_cmd "core profile repair preserves unmanaged wrapper argument" bash -c "bash '${REPO_DIR}/setup.sh' --yes --profile core >/dev/null && grep -q 'node /custom/audit.js' '${HOME}/.claude/settings.json' && python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core"
+python3 - "${HOME}/.claude/settings.json" <<'PY'
 import copy
 import json
 import shlex

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -103,6 +103,27 @@ PY
 assert_cmd "core profile check allows unmanaged wrapper argument" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
 assert_cmd "core profile repair preserves unmanaged wrapper argument" bash -c "bash '${REPO_DIR}/setup.sh' --yes --profile core >/dev/null && grep -q 'node /custom/audit.js' '${HOME}/.claude/settings.json' && python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core"
 python3 - "${HOME}/.claude/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+data = json.loads(settings_path.read_text(encoding="utf-8"))
+for entry in data["hooks"]["PreToolUse"]:
+    if entry.get("matcher") != "Bash":
+        continue
+    for hook in entry.get("hooks", []):
+        command = hook.get("command") if isinstance(hook, dict) else ""
+        if "pre-bash-guard.sh" in command:
+            hook["command"] = f"env VIBEGUARD_FOO=1 {Path.home() / '.vibeguard' / 'run-hook.sh'} pre-bash-guard.sh"
+            settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            raise SystemExit(0)
+raise SystemExit(1)
+PY
+assert_cmd "core profile check allows env wrapper command" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
+assert_cmd "core profile repair preserves env wrapper command" bash -c "bash '${REPO_DIR}/setup.sh' --yes --profile core >/dev/null && grep -q 'env VIBEGUARD_FOO=1' '${HOME}/.claude/settings.json' && python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core"
+assert_cmd "core profile repair does not duplicate env wrapper command" python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); commands=[hook.get("command", "") for entry in data["hooks"]["PreToolUse"] for hook in entry.get("hooks", [])]; raise SystemExit(0 if sum("pre-bash-guard.sh" in command for command in commands) == 1 else 1)' "${HOME}/.claude/settings.json"
+python3 - "${HOME}/.claude/settings.json" <<'PY'
 import copy
 import json
 import shlex

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -87,6 +87,28 @@ from pathlib import Path
 settings_path = Path(sys.argv[1])
 data = json.loads(settings_path.read_text(encoding="utf-8"))
 hooks = data.setdefault("hooks", {})
+hooks.setdefault("SessionStart", []).append(
+    {
+        "hooks": [
+            {
+                "type": "command",
+                "command": f"bash {Path.home() / '.vibeguard' / 'run-hook.sh'} skills-loader.sh",
+            }
+        ]
+    }
+)
+settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+assert_cmd "core profile check allows manual skills-loader hook" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
+assert_cmd "core profile repair preserves manual skills-loader hook" bash -c "bash '${REPO_DIR}/setup.sh' --yes --profile core >/dev/null && grep -q 'skills-loader.sh' '${HOME}/.claude/settings.json' && python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core"
+python3 - "${HOME}/.claude/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+data = json.loads(settings_path.read_text(encoding="utf-8"))
+hooks = data.setdefault("hooks", {})
 entries = hooks.setdefault("PostToolUse", [])
 entries.append(
     {

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -83,6 +83,31 @@ assert_cmd "core profile check catches missing analysis-paralysis hook" assert_p
 core_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
 assert_contains "${core_missing_out}" "[MISSING] Claude hooks missing for core profile" "setup --check reports missing core profile hook"
 assert_cmd "core profile repair restores analysis-paralysis hook" assert_profile_hook_restored_after_repair core profile-hooks:core
+old_profile_runtime="${TMP_HOME}/old-profile-runtime"
+cat > "${old_profile_runtime}" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  setup-settings-check-supports-profile-hooks)
+    printf '%s\n' 'Unknown command: setup-settings-check-supports-profile-hooks' >&2
+    exit 2
+    ;;
+  setup-state-list-symlinks-under|setup-manifest-skill-links|setup-md-remove|setup-settings-check-stale|setup-codex-config-check-hooks|setup-codex-hooks-check-stale)
+    exit 0
+    ;;
+  setup-settings-check)
+    case "${4:-}" in
+      profile-hooks:*) exit 1 ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "${old_profile_runtime}"
+old_runtime_check_out="$(VIBEGUARD_SETUP_RUNTIME="${old_profile_runtime}" bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
+assert_not_contains "${old_runtime_check_out}" "[MISSING] Claude hooks missing for core profile" "setup --check skips stale runtime profile-hook false missing"
 
 header "setup install --languages rust"
 install_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core --languages rust)"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -79,6 +79,30 @@ assert_contains "${install_default_lang_out}" "manifest rules -> ~/.claude/rules
 assert_cmd "default install includes Python native rules" test -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
 assert_cmd "default install includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
 assert_cmd "core profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
+python3 - "${HOME}/.claude/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+data = json.loads(settings_path.read_text(encoding="utf-8"))
+hooks = data.setdefault("hooks", {})
+entries = hooks.setdefault("PostToolUse", [])
+entries.append(
+    {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": f"bash {Path.home() / '.vibeguard' / 'run-hook.sh'} analysis-paralysis-guard.sh",
+            }
+        ],
+    }
+)
+settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+assert_cmd "core profile check rejects stale same-script matcher" bash -c "! python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core >/dev/null 2>&1"
+assert_cmd "core profile repair removes stale same-script matcher" assert_profile_hook_restored_after_repair core profile-hooks:core
 assert_cmd "core profile check catches missing analysis-paralysis hook" assert_profile_hook_missing_after_remove analysis-paralysis-guard.sh profile-hooks:core
 core_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
 assert_contains "${core_missing_out}" "[MISSING] Claude hooks missing for core profile" "setup --check reports missing core profile hook"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -1,3 +1,59 @@
+remove_claude_hook_for_test() {
+  python3 - "${HOME}/.claude/settings.json" "$1" <<'PY'
+import json
+import shlex
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+script = sys.argv[2]
+data = json.loads(settings_path.read_text(encoding="utf-8"))
+hooks = data.get("hooks", {})
+changed = False
+for event, entries in list(hooks.items()):
+    if not isinstance(entries, list):
+        continue
+    next_entries = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            next_entries.append(entry)
+            continue
+        hook_entries = entry.get("hooks")
+        if not isinstance(hook_entries, list):
+            next_entries.append(entry)
+            continue
+        kept = []
+        for hook in hook_entries:
+            command = hook.get("command") if isinstance(hook, dict) else ""
+            parts = shlex.split(command) if isinstance(command, str) else []
+            if any(Path(part).name == script for part in parts):
+                changed = True
+                continue
+            kept.append(hook)
+        if kept:
+            entry["hooks"] = kept
+            next_entries.append(entry)
+    if next_entries:
+        hooks[event] = next_entries
+    else:
+        hooks.pop(event, None)
+settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+raise SystemExit(0 if changed else 1)
+PY
+}
+
+assert_profile_hook_missing_after_remove() {
+  local script="$1" target="$2"
+  remove_claude_hook_for_test "${script}" &&
+    ! python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target "${target}"
+}
+
+assert_profile_hook_restored_after_repair() {
+  local profile="$1" target="$2"
+  bash "${REPO_DIR}/setup.sh" --yes --profile "${profile}" >/dev/null &&
+    python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target "${target}"
+}
+
 header "setup --clean"
 printf 'user codex note\n' >> "${HOME}/.codex/AGENTS.md"
 clean_out="$(bash "${REPO_DIR}/setup.sh" --clean)"
@@ -22,6 +78,11 @@ install_default_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core)"
 assert_contains "${install_default_lang_out}" "manifest rules -> ~/.claude/rules/vibeguard/" "default install writes manifest native rules"
 assert_cmd "default install includes Python native rules" test -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
 assert_cmd "default install includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
+assert_cmd "core profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
+assert_cmd "core profile check catches missing analysis-paralysis hook" assert_profile_hook_missing_after_remove analysis-paralysis-guard.sh profile-hooks:core
+core_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
+assert_contains "${core_missing_out}" "[MISSING] Claude hooks missing for core profile" "setup --check reports missing core profile hook"
+assert_cmd "core profile repair restores analysis-paralysis hook" assert_profile_hook_restored_after_repair core profile-hooks:core
 
 header "setup install --languages rust"
 install_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core --languages rust)"
@@ -40,9 +101,14 @@ header "setup install --profile full"
 install_full_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile full)"
 assert_contains "${install_full_out}" "Profile: full" "full profile parameter takes effect"
 assert_cmd "full profile configuration full hooks" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target full-hooks
+assert_cmd "full profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:full
 assert_cmd "full profile enable stop-guard" grep -q "stop-guard.sh" "${HOME}/.claude/settings.json"
 assert_cmd "full profile enable learn-evaluator" grep -q "learn-evaluator.sh" "${HOME}/.claude/settings.json"
 assert_cmd "full profile enable post-build-check" grep -q "post-build-check.sh" "${HOME}/.claude/settings.json"
+assert_cmd "full profile check catches missing analysis-paralysis hook" assert_profile_hook_missing_after_remove analysis-paralysis-guard.sh profile-hooks:full
+full_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
+assert_contains "${full_missing_out}" "[MISSING] Claude hooks missing for full profile" "setup --check reports missing full profile hook"
+assert_cmd "full profile repair restores manifest hooks" assert_profile_hook_restored_after_repair full profile-hooks:full
 
 header "setup --clean (after full)"
 clean_full_out="$(bash "${REPO_DIR}/setup.sh" --clean)"
@@ -53,9 +119,14 @@ header "setup install --profile strict"
 install_strict_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile strict)"
 assert_contains "${install_strict_out}" "Profile: strict" "strict profile parameter takes effect"
 assert_cmd "strict profile still configures full hooks" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target full-hooks
+assert_cmd "strict profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:strict
 assert_cmd "strict profile enables U-32 constraint budget hook" grep -q "count_active_constraints.sh" "${HOME}/.claude/settings.json"
 assert_cmd "strict profile does not enable session-tagger" bash -c "! grep -q 'session-tagger.sh' '${HOME}/.claude/settings.json' && ! grep -q 'session-tagger.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "strict profile does not enable cognitive-reminder" bash -c "! grep -q 'cognitive-reminder.sh' '${HOME}/.claude/settings.json' && ! grep -q 'cognitive-reminder.sh' '${HOME}/.codex/hooks.json'"
+assert_cmd "strict profile check catches missing U-32 constraint hook" assert_profile_hook_missing_after_remove count_active_constraints.sh profile-hooks:strict
+strict_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
+assert_contains "${strict_missing_out}" "[MISSING] Claude hooks missing for strict profile" "setup --check reports missing strict profile hook"
+assert_cmd "strict profile repair restores U-32 hook" assert_profile_hook_restored_after_repair strict profile-hooks:strict
 
 header "setup --clean (after strict)"
 clean_strict_out="$(bash "${REPO_DIR}/setup.sh" --clean)"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -130,6 +130,9 @@ assert_cmd "full profile hooks match manifest" python3 "${SETTINGS_HELPER}" chec
 assert_cmd "full profile enable stop-guard" grep -q "stop-guard.sh" "${HOME}/.claude/settings.json"
 assert_cmd "full profile enable learn-evaluator" grep -q "learn-evaluator.sh" "${HOME}/.claude/settings.json"
 assert_cmd "full profile enable post-build-check" grep -q "post-build-check.sh" "${HOME}/.claude/settings.json"
+assert_cmd "core profile check rejects leftover full hooks" bash -c "! python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core >/dev/null 2>&1"
+full_as_core_out="$(bash "${REPO_DIR}/setup.sh" --check --strict --profile core 2>&1 || true)"
+assert_contains "${full_as_core_out}" "[MISSING] Claude hooks missing for core profile" "setup --check reports core profile mismatch when full hooks remain"
 assert_cmd "full profile check catches missing analysis-paralysis hook" assert_profile_hook_missing_after_remove analysis-paralysis-guard.sh profile-hooks:full
 full_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
 assert_contains "${full_missing_out}" "[MISSING] Claude hooks missing for full profile" "setup --check reports missing full profile hook"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -80,6 +80,30 @@ assert_cmd "default install includes Python native rules" test -L "${HOME}/.clau
 assert_cmd "default install includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
 assert_cmd "core profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
 python3 - "${HOME}/.claude/settings.json" <<'PY'
+import copy
+import json
+import shlex
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+data = json.loads(settings_path.read_text(encoding="utf-8"))
+entries = data["hooks"]["PreToolUse"]
+for entry in entries:
+    if entry.get("matcher") != "Bash":
+        continue
+    for hook in entry.get("hooks", []):
+        command = hook.get("command") if isinstance(hook, dict) else ""
+        parts = shlex.split(command) if isinstance(command, str) else []
+        if any(Path(part).name == "pre-bash-guard.sh" for part in parts):
+            entries.append(copy.deepcopy(entry))
+            settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            raise SystemExit(0)
+raise SystemExit(1)
+PY
+assert_cmd "core profile check rejects duplicate managed hook" bash -c "! python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target profile-hooks:core >/dev/null 2>&1"
+assert_cmd "core profile repair removes duplicate managed hook" assert_profile_hook_restored_after_repair core profile-hooks:core
+python3 - "${HOME}/.claude/settings.json" <<'PY'
 import json
 import sys
 from pathlib import Path

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -79,6 +79,27 @@ assert_contains "${install_default_lang_out}" "manifest rules -> ~/.claude/rules
 assert_cmd "default install includes Python native rules" test -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
 assert_cmd "default install includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
 assert_cmd "core profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
+BASH_C_PROFILE_SETTINGS="${TMP_HOME}/bash-c-profile-settings.json"
+python3 - "${HOME}/.claude/settings.json" "${BASH_C_PROFILE_SETTINGS}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source_path = Path(sys.argv[1])
+target_path = Path(sys.argv[2])
+data = json.loads(source_path.read_text(encoding="utf-8"))
+for entry in data["hooks"]["PreToolUse"]:
+    if entry.get("matcher") != "Bash":
+        continue
+    for hook in entry.get("hooks", []):
+        command = hook.get("command") if isinstance(hook, dict) else ""
+        if "pre-bash-guard.sh" in command:
+            hook["command"] = f"bash -c {Path.home() / '.vibeguard' / 'run-hook.sh'} pre-bash-guard.sh"
+            target_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            raise SystemExit(0)
+raise SystemExit(1)
+PY
+assert_cmd "core profile check rejects bash -c wrapper without hook args" bash -c "! python3 '${SETTINGS_HELPER}' check --settings-file '${BASH_C_PROFILE_SETTINGS}' --target profile-hooks:core >/dev/null 2>&1"
 python3 - "${HOME}/.claude/settings.json" <<'PY'
 import json
 import sys

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -350,6 +350,11 @@ static COMMANDS: &[Command] = &[
         handler: setup_markdown::settings_check,
     },
     Command {
+        name: "setup-settings-check-supports-profile-hooks",
+        usage: "— capability probe for profile-hooks setup-settings-check target",
+        handler: setup_markdown::settings_check_supports_profile_hooks,
+    },
+    Command {
         name: "setup-settings-upsert",
         usage: "<repo-dir> <settings-file> <profile> [--dry-run] [--force-overwrite]  — upsert Claude settings",
         handler: setup_markdown::settings_upsert,

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -346,7 +346,7 @@ static COMMANDS: &[Command] = &[
     },
     Command {
         name: "setup-settings-check",
-        usage: "<repo-dir> <settings-file> <pre-hooks|post-hooks|full-hooks>  — check Claude settings",
+        usage: "<repo-dir> <settings-file> <pre-hooks|post-hooks|full-hooks|profile-hooks:<profile>>  — check Claude settings",
         handler: setup_markdown::settings_check,
     },
     Command {

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -174,6 +174,10 @@ pub fn settings_check(args: &[String]) -> SetupResult<()> {
     }
 }
 
+pub fn settings_check_supports_profile_hooks(_args: &[String]) -> SetupResult<()> {
+    Ok(())
+}
+
 pub fn settings_upsert(args: &[String]) -> SetupResult<()> {
     if args.len() < 3 {
         return Err("Usage: vibeguard-runtime setup-settings-upsert <repo-dir> <settings-file> <profile> [--dry-run] [--force-overwrite]".into());

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -203,15 +203,9 @@ pub fn settings_upsert(args: &[String]) -> SetupResult<()> {
     for spec in &desired {
         changed |= settings_upsert_hook(&mut data, spec, force);
     }
-    let desired_pairs: BTreeSet<(String, String)> = desired
-        .iter()
-        .map(|spec| (spec.event.clone(), spec.script.clone()))
-        .collect();
-    for spec in claude_specs(repo_dir, None)? {
-        if !desired_pairs.contains(&(spec.event.clone(), spec.script.clone())) {
-            changed |= settings_remove_hook(&mut data, &spec.event, &spec.script);
-        }
-    }
+    let desired_identities: BTreeSet<(String, String, String)> =
+        desired.iter().map(settings_spec_identity).collect();
+    changed |= settings_remove_unprofiled_hooks(repo_dir, &mut data, &desired_identities)?;
     if dry_run {
         if changed {
             let after = serde_json::to_string_pretty(&data)? + "\n";
@@ -372,14 +366,9 @@ fn settings_has_profile_hooks(repo_dir: &Path, data: &Value, profile: &str) -> S
     if !desired.iter().all(|spec| settings_has_spec(data, spec)) {
         return Ok(false);
     }
-    let desired_pairs: BTreeSet<(String, String)> = desired
-        .iter()
-        .map(|spec| (spec.event.clone(), spec.script.clone()))
-        .collect();
-    Ok(!claude_specs(repo_dir, None)?.iter().any(|spec| {
-        !desired_pairs.contains(&(spec.event.clone(), spec.script.clone()))
-            && settings_has_spec(data, spec)
-    }))
+    let desired_identities: BTreeSet<(String, String, String)> =
+        desired.iter().map(settings_spec_identity).collect();
+    Ok(settings_managed_hook_identities(repo_dir, data)?.is_subset(&desired_identities))
 }
 
 fn settings_has_spec(data: &Value, spec: &ClaudeSpec) -> bool {
@@ -501,6 +490,49 @@ fn settings_remove_hook(data: &mut Value, event: &str, script: &str) -> bool {
     changed | (before != entries.len())
 }
 
+fn settings_remove_unprofiled_hooks(
+    repo_dir: &Path,
+    data: &mut Value,
+    desired: &BTreeSet<(String, String, String)>,
+) -> SetupResult<bool> {
+    let managed_scripts = claude_managed_scripts(repo_dir)?;
+    let Some(hooks) = data.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return Ok(false);
+    };
+    let mut changed = false;
+    for (event, entries) in hooks.iter_mut() {
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        for entry in entries.iter_mut() {
+            let matcher = entry
+                .get("matcher")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let Some(hook_entries) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            let before = hook_entries.len();
+            hook_entries.retain(|hook| {
+                settings_hook_managed_script(hook, &managed_scripts).is_none_or(|script| {
+                    desired.contains(&(event.clone(), matcher.clone(), script.to_string()))
+                })
+            });
+            changed |= before != hook_entries.len();
+        }
+        let before = entries.len();
+        entries.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(Value::as_array)
+                .is_none_or(|hooks| !hooks.is_empty())
+        });
+        changed |= before != entries.len();
+    }
+    Ok(changed)
+}
+
 fn settings_remove_legacy_mcp(data: &mut Value) -> bool {
     let Some(object) = data.as_object_mut() else {
         return false;
@@ -558,6 +590,42 @@ fn claude_managed_scripts(repo_dir: &Path) -> SetupResult<BTreeSet<String>> {
         .collect())
 }
 
+fn settings_spec_identity(spec: &ClaudeSpec) -> (String, String, String) {
+    (
+        spec.event.clone(),
+        spec.matcher.clone(),
+        spec.script.clone(),
+    )
+}
+
+fn settings_managed_hook_identities(
+    repo_dir: &Path,
+    data: &Value,
+) -> SetupResult<BTreeSet<(String, String, String)>> {
+    let managed_scripts = claude_managed_scripts(repo_dir)?;
+    let mut identities = BTreeSet::new();
+    let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
+        return Ok(identities);
+    };
+    for (event, entries) in hooks {
+        let Some(entries) = entries.as_array() else {
+            continue;
+        };
+        for entry in entries {
+            let matcher = entry.get("matcher").and_then(Value::as_str).unwrap_or("");
+            let Some(hook_entries) = entry.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for hook in hook_entries {
+                if let Some(script) = settings_hook_managed_script(hook, &managed_scripts) {
+                    identities.insert((event.clone(), matcher.to_string(), script.to_string()));
+                }
+            }
+        }
+    }
+    Ok(identities)
+}
+
 fn settings_entry_has_script(entry: &Value, script: &str) -> bool {
     entry
         .get("hooks")
@@ -576,6 +644,19 @@ fn settings_hook_is_script(hook: &Value, script: &str) -> bool {
             shell_split(command)
                 .iter()
                 .any(|part| basename(part) == script)
+        })
+}
+
+fn settings_hook_managed_script<'a>(
+    hook: &Value,
+    managed_scripts: &'a BTreeSet<String>,
+) -> Option<&'a str> {
+    hook.get("command")
+        .and_then(Value::as_str)
+        .and_then(|command| {
+            shell_split(command)
+                .into_iter()
+                .find_map(|part| managed_scripts.get(basename(&part)).map(String::as_str))
         })
 }
 
@@ -695,85 +776,4 @@ fn settings_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn replaces_marker_block() {
-        let original = "a\n\n<!-- vibeguard-start -->\nold\n<!-- vibeguard-end -->\n\nb\n";
-        let next = replace_managed_block(
-            original,
-            "<!-- vibeguard-start -->\nnew\n<!-- vibeguard-end -->",
-        );
-        assert!(next.contains("new"));
-        assert!(!next.contains("old"));
-        assert!(next.starts_with("a\n\n"));
-        assert!(next.ends_with("b\n"));
-    }
-
-    #[test]
-    fn profile_settings_reject_out_of_profile_managed_hooks() -> SetupResult<()> {
-        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .ok_or("vibeguard-runtime must be inside the repository")?;
-        let core_specs = claude_specs(repo_dir, Some("core"))?;
-        let extra_spec = claude_specs(repo_dir, None)?
-            .into_iter()
-            .find(|spec| {
-                !core_specs
-                    .iter()
-                    .any(|desired| desired.event == spec.event && desired.script == spec.script)
-            })
-            .ok_or("expected an out-of-profile managed hook spec")?;
-
-        let core_data = settings_data_with_specs(&core_specs);
-        assert!(settings_has_profile_hooks(repo_dir, &core_data, "core")?);
-
-        let mut stale_specs = core_specs;
-        stale_specs.push(extra_spec);
-        let stale_data = settings_data_with_specs(&stale_specs);
-        assert!(!settings_has_profile_hooks(repo_dir, &stale_data, "core")?);
-        Ok(())
-    }
-
-    fn settings_data_with_specs(specs: &[ClaudeSpec]) -> Value {
-        let mut data = serde_json::json!({"hooks": {}});
-        let hooks = data
-            .get_mut("hooks")
-            .and_then(Value::as_object_mut)
-            .expect("hooks object");
-        for spec in specs {
-            let entries = hooks
-                .entry(spec.event.clone())
-                .or_insert_with(|| serde_json::json!([]))
-                .as_array_mut()
-                .expect("event entries");
-            let mut entry = serde_json::json!({
-                "hooks": [{
-                    "type": "command",
-                    "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", spec.script),
-                }]
-            });
-            if !spec.matcher.is_empty() {
-                entry
-                    .as_object_mut()
-                    .expect("entry object")
-                    .insert("matcher".to_string(), Value::String(spec.matcher.clone()));
-            }
-            entries.push(entry);
-        }
-        data
-    }
-
-    #[test]
-    fn canonical_settings_command_accepts_legacy_unquoted_home_spaces() {
-        let command = "bash /tmp/home with spaces/.vibeguard/run-hook.sh pre-bash-guard.sh";
-        assert!(settings_is_canonical(command, "pre-bash-guard.sh"));
-    }
-
-    #[test]
-    fn canonical_settings_command_rejects_custom_bash_options() {
-        let command = "bash -x /tmp/workspace/.vibeguard/run-hook.sh pre-bash-guard.sh";
-        assert!(!settings_is_canonical(command, "pre-bash-guard.sh"));
-    }
-}
+mod tests;

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -7,6 +7,8 @@ use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
+mod hook_identity;
+
 const START: &str = "<!-- vibeguard-start -->";
 const END: &str = "<!-- vibeguard-end -->";
 const RULE_COUNT_PLACEHOLDER: &str = "__VIBEGUARD_RULE_COUNT__";
@@ -648,11 +650,7 @@ fn settings_entry_has_script(entry: &Value, script: &str) -> bool {
 fn settings_hook_is_script(hook: &Value, script: &str) -> bool {
     hook.get("command")
         .and_then(Value::as_str)
-        .is_some_and(|command| {
-            shell_split(command)
-                .iter()
-                .any(|part| basename(part) == script)
-        })
+        .is_some_and(|command| hook_identity::command_invokes_script(command, script))
 }
 
 fn settings_hook_managed_script<'a>(
@@ -661,11 +659,7 @@ fn settings_hook_managed_script<'a>(
 ) -> Option<&'a str> {
     hook.get("command")
         .and_then(Value::as_str)
-        .and_then(|command| {
-            shell_split(command)
-                .into_iter()
-                .find_map(|part| managed_scripts.get(basename(&part)).map(String::as_str))
-        })
+        .and_then(|command| hook_identity::managed_script_from_command(command, managed_scripts))
 }
 
 fn settings_is_canonical(command: &str, script: &str) -> bool {

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -150,7 +150,7 @@ const CLAUDE_LEGACY_SCRIPTS: &[&str] = &[
 
 pub fn settings_check(args: &[String]) -> SetupResult<()> {
     if args.len() != 3 {
-        return Err("Usage: vibeguard-runtime setup-settings-check <repo-dir> <settings-file> <pre-hooks|post-hooks|full-hooks>".into());
+        return Err("Usage: vibeguard-runtime setup-settings-check <repo-dir> <settings-file> <pre-hooks|post-hooks|full-hooks|profile-hooks:<profile>>".into());
     }
     let repo_dir = Path::new(&args[0]);
     let data = Value::Object(read_json_object(Path::new(&args[1]), false)?);
@@ -158,6 +158,13 @@ pub fn settings_check(args: &[String]) -> SetupResult<()> {
         "pre-hooks" => settings_has_pre_hooks(repo_dir, &data)?,
         "post-hooks" => settings_has_post_hooks(repo_dir, &data)?,
         "full-hooks" => settings_has_full_hooks(repo_dir, &data)?,
+        target if target.starts_with("profile-hooks:") => {
+            let profile = &target["profile-hooks:".len()..];
+            if !matches!(profile, "minimal" | "core" | "full" | "strict") {
+                return Err(format!("unsupported profile target: {profile}").into());
+            }
+            settings_has_profile_hooks(repo_dir, &data, profile)?
+        }
         _ => false,
     };
     if ok {
@@ -354,6 +361,12 @@ fn settings_has_full_hooks(repo_dir: &Path, data: &Value) -> SetupResult<bool> {
             .iter()
             .filter(|spec| !core_scripts.contains(&spec.script))
             .all(|spec| settings_has_spec(data, spec)))
+}
+
+fn settings_has_profile_hooks(repo_dir: &Path, data: &Value, profile: &str) -> SetupResult<bool> {
+    Ok(claude_specs(repo_dir, Some(profile))?
+        .iter()
+        .all(|spec| settings_has_spec(data, spec)))
 }
 
 fn settings_has_spec(data: &Value, spec: &ClaudeSpec) -> bool {

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -4,7 +4,7 @@ use crate::setup_support::{
 };
 use regex::Regex;
 use serde_json::{Value, json};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 const START: &str = "<!-- vibeguard-start -->";
@@ -368,7 +368,11 @@ fn settings_has_profile_hooks(repo_dir: &Path, data: &Value, profile: &str) -> S
     }
     let desired_identities: BTreeSet<(String, String, String)> =
         desired.iter().map(settings_spec_identity).collect();
-    Ok(settings_managed_hook_identities(repo_dir, data)?.is_subset(&desired_identities))
+    let managed_counts = settings_managed_hook_identity_counts(repo_dir, data)?;
+    Ok(managed_counts
+        .keys()
+        .all(|identity| desired_identities.contains(identity))
+        && managed_counts.values().all(|count| *count == 1))
 }
 
 fn settings_has_spec(data: &Value, spec: &ClaudeSpec) -> bool {
@@ -500,6 +504,7 @@ fn settings_remove_unprofiled_hooks(
         return Ok(false);
     };
     let mut changed = false;
+    let mut seen_profile_identities = BTreeSet::new();
     for (event, entries) in hooks.iter_mut() {
         let Some(entries) = entries.as_array_mut() else {
             continue;
@@ -516,7 +521,8 @@ fn settings_remove_unprofiled_hooks(
             let before = hook_entries.len();
             hook_entries.retain(|hook| {
                 settings_hook_managed_script(hook, &managed_scripts).is_none_or(|script| {
-                    desired.contains(&(event.clone(), matcher.clone(), script.to_string()))
+                    let identity = (event.clone(), matcher.clone(), script.to_string());
+                    desired.contains(&identity) && seen_profile_identities.insert(identity)
                 })
             });
             changed |= before != hook_entries.len();
@@ -598,14 +604,14 @@ fn settings_spec_identity(spec: &ClaudeSpec) -> (String, String, String) {
     )
 }
 
-fn settings_managed_hook_identities(
+fn settings_managed_hook_identity_counts(
     repo_dir: &Path,
     data: &Value,
-) -> SetupResult<BTreeSet<(String, String, String)>> {
+) -> SetupResult<BTreeMap<(String, String, String), usize>> {
     let managed_scripts = claude_managed_scripts(repo_dir)?;
-    let mut identities = BTreeSet::new();
+    let mut counts = BTreeMap::new();
     let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
-        return Ok(identities);
+        return Ok(counts);
     };
     for (event, entries) in hooks {
         let Some(entries) = entries.as_array() else {
@@ -618,12 +624,14 @@ fn settings_managed_hook_identities(
             };
             for hook in hook_entries {
                 if let Some(script) = settings_hook_managed_script(hook, &managed_scripts) {
-                    identities.insert((event.clone(), matcher.to_string(), script.to_string()));
+                    *counts
+                        .entry((event.clone(), matcher.to_string(), script.to_string()))
+                        .or_insert(0) += 1;
                 }
             }
         }
     }
-    Ok(identities)
+    Ok(counts)
 }
 
 fn settings_entry_has_script(entry: &Value, script: &str) -> bool {

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -368,9 +368,18 @@ fn settings_has_full_hooks(repo_dir: &Path, data: &Value) -> SetupResult<bool> {
 }
 
 fn settings_has_profile_hooks(repo_dir: &Path, data: &Value, profile: &str) -> SetupResult<bool> {
-    Ok(claude_specs(repo_dir, Some(profile))?
+    let desired = claude_specs(repo_dir, Some(profile))?;
+    if !desired.iter().all(|spec| settings_has_spec(data, spec)) {
+        return Ok(false);
+    }
+    let desired_pairs: BTreeSet<(String, String)> = desired
         .iter()
-        .all(|spec| settings_has_spec(data, spec)))
+        .map(|spec| (spec.event.clone(), spec.script.clone()))
+        .collect();
+    Ok(!claude_specs(repo_dir, None)?.iter().any(|spec| {
+        !desired_pairs.contains(&(spec.event.clone(), spec.script.clone()))
+            && settings_has_spec(data, spec)
+    }))
 }
 
 fn settings_has_spec(data: &Value, spec: &ClaudeSpec) -> bool {
@@ -673,5 +682,59 @@ mod tests {
         assert!(!next.contains("old"));
         assert!(next.starts_with("a\n\n"));
         assert!(next.ends_with("b\n"));
+    }
+
+    #[test]
+    fn profile_settings_reject_out_of_profile_managed_hooks() -> SetupResult<()> {
+        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or("vibeguard-runtime must be inside the repository")?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let extra_spec = claude_specs(repo_dir, None)?
+            .into_iter()
+            .find(|spec| {
+                !core_specs
+                    .iter()
+                    .any(|desired| desired.event == spec.event && desired.script == spec.script)
+            })
+            .ok_or("expected an out-of-profile managed hook spec")?;
+
+        let core_data = settings_data_with_specs(&core_specs);
+        assert!(settings_has_profile_hooks(repo_dir, &core_data, "core")?);
+
+        let mut stale_specs = core_specs;
+        stale_specs.push(extra_spec);
+        let stale_data = settings_data_with_specs(&stale_specs);
+        assert!(!settings_has_profile_hooks(repo_dir, &stale_data, "core")?);
+        Ok(())
+    }
+
+    fn settings_data_with_specs(specs: &[ClaudeSpec]) -> Value {
+        let mut data = serde_json::json!({"hooks": {}});
+        let hooks = data
+            .get_mut("hooks")
+            .and_then(Value::as_object_mut)
+            .expect("hooks object");
+        for spec in specs {
+            let entries = hooks
+                .entry(spec.event.clone())
+                .or_insert_with(|| serde_json::json!([]))
+                .as_array_mut()
+                .expect("event entries");
+            let mut entry = serde_json::json!({
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", spec.script),
+                }]
+            });
+            if !spec.matcher.is_empty() {
+                entry
+                    .as_object_mut()
+                    .expect("entry object")
+                    .insert("matcher".to_string(), Value::String(spec.matcher.clone()));
+            }
+            entries.push(entry);
+        }
+        data
     }
 }

--- a/vibeguard-runtime/src/setup_markdown/hook_identity.rs
+++ b/vibeguard-runtime/src/setup_markdown/hook_identity.rs
@@ -12,7 +12,7 @@ pub(super) fn managed_script_from_command<'a>(
 ) -> Option<&'a str> {
     let parts = shell_split(command);
     for (index, token) in parts.iter().enumerate() {
-        if basename(token) != "run-hook.sh" {
+        if basename(token) != "run-hook.sh" || !wrapper_is_invoked(&parts, index) {
             continue;
         }
         let Some(next) = parts.get(index + 1) else {
@@ -37,6 +37,7 @@ pub(super) fn managed_script_from_command<'a>(
 fn parts_invokes_script(parts: &[String], script: &str) -> bool {
     for (index, token) in parts.iter().enumerate() {
         if basename(token) == "run-hook.sh"
+            && wrapper_is_invoked(parts, index)
             && parts
                 .get(index + 1)
                 .is_some_and(|next| basename(next) == script)
@@ -61,6 +62,16 @@ fn looks_like_direct_script(parts: &[String], index: usize) -> bool {
 
 fn shell_invokes_wrapper(parts: &[String], index: usize) -> bool {
     index >= 2 && is_shell(&parts[index - 2]) && !parts[index - 1].starts_with('-')
+}
+
+fn wrapper_is_invoked(parts: &[String], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+    if is_shell(&parts[index - 1]) {
+        return true;
+    }
+    index >= 2 && parts[index - 1].starts_with('-') && is_shell(&parts[index - 2])
 }
 
 fn is_shell(token: &str) -> bool {

--- a/vibeguard-runtime/src/setup_markdown/hook_identity.rs
+++ b/vibeguard-runtime/src/setup_markdown/hook_identity.rs
@@ -1,0 +1,68 @@
+use crate::setup_support::{basename, shell_split};
+use std::collections::BTreeSet;
+
+pub(super) fn command_invokes_script(command: &str, script: &str) -> bool {
+    let parts = shell_split(command);
+    parts_invokes_script(&parts, script)
+}
+
+pub(super) fn managed_script_from_command<'a>(
+    command: &str,
+    managed_scripts: &'a BTreeSet<String>,
+) -> Option<&'a str> {
+    let parts = shell_split(command);
+    for (index, token) in parts.iter().enumerate() {
+        if basename(token) != "run-hook.sh" {
+            continue;
+        }
+        let Some(next) = parts.get(index + 1) else {
+            continue;
+        };
+        if let Some(script) = managed_scripts.get(basename(next)) {
+            return Some(script);
+        }
+    }
+    for (index, token) in parts.iter().enumerate() {
+        let token_base = basename(token);
+        let Some(script) = managed_scripts.get(token_base) else {
+            continue;
+        };
+        if looks_like_direct_script(&parts, index) || shell_invokes_wrapper(&parts, index) {
+            return Some(script);
+        }
+    }
+    None
+}
+
+fn parts_invokes_script(parts: &[String], script: &str) -> bool {
+    for (index, token) in parts.iter().enumerate() {
+        if basename(token) == "run-hook.sh"
+            && parts
+                .get(index + 1)
+                .is_some_and(|next| basename(next) == script)
+        {
+            return true;
+        }
+    }
+    parts.iter().enumerate().any(|(index, token)| {
+        basename(token) == script
+            && (looks_like_direct_script(parts, index) || shell_invokes_wrapper(parts, index))
+    })
+}
+
+fn looks_like_direct_script(parts: &[String], index: usize) -> bool {
+    let token = &parts[index];
+    token.contains('/')
+        || index
+            .checked_sub(1)
+            .is_some_and(|previous| is_shell(&parts[previous]))
+        || (index == 0 && token.ends_with(".sh"))
+}
+
+fn shell_invokes_wrapper(parts: &[String], index: usize) -> bool {
+    index >= 2 && is_shell(&parts[index - 2]) && !parts[index - 1].starts_with('-')
+}
+
+fn is_shell(token: &str) -> bool {
+    matches!(basename(token), "bash" | "sh" | "zsh")
+}

--- a/vibeguard-runtime/src/setup_markdown/hook_identity.rs
+++ b/vibeguard-runtime/src/setup_markdown/hook_identity.rs
@@ -71,7 +71,11 @@ fn wrapper_is_invoked(parts: &[String], index: usize) -> bool {
     if is_shell(&parts[index - 1]) {
         return true;
     }
-    if index >= 2 && parts[index - 1].starts_with('-') && is_shell(&parts[index - 2]) {
+    if index >= 2
+        && parts[index - 1].starts_with('-')
+        && !shell_option_uses_command_string(&parts[index - 1])
+        && is_shell(&parts[index - 2])
+    {
         return true;
     }
     if env_invokes_token(parts, index) {
@@ -106,6 +110,19 @@ fn env_invokes_token(parts: &[String], index: usize) -> bool {
         return false;
     }
     cursor == index
+}
+
+fn shell_option_uses_command_string(token: &str) -> bool {
+    if token == "--" {
+        return false;
+    }
+    if token == "--command" {
+        return true;
+    }
+    if token.starts_with("--") {
+        return false;
+    }
+    token.trim_start_matches('-').contains('c')
 }
 
 fn env_option_takes_value(token: &str) -> bool {
@@ -150,6 +167,28 @@ mod tests {
         assert_eq!(
             managed_script_from_command(command, &managed_scripts()),
             None
+        );
+    }
+
+    #[test]
+    fn shell_c_command_string_does_not_count_as_wrapper_invocation() {
+        let command = "bash -c /tmp/.vibeguard/run-hook.sh pre-bash-guard.sh";
+
+        assert!(!command_invokes_script(command, "pre-bash-guard.sh"));
+        assert_eq!(
+            managed_script_from_command(command, &managed_scripts()),
+            None
+        );
+    }
+
+    #[test]
+    fn shell_non_command_option_counts_as_wrapper_invocation() {
+        let command = "bash -e /tmp/.vibeguard/run-hook.sh pre-bash-guard.sh";
+
+        assert!(command_invokes_script(command, "pre-bash-guard.sh"));
+        assert_eq!(
+            managed_script_from_command(command, &managed_scripts()),
+            Some("pre-bash-guard.sh")
         );
     }
 }

--- a/vibeguard-runtime/src/setup_markdown/hook_identity.rs
+++ b/vibeguard-runtime/src/setup_markdown/hook_identity.rs
@@ -71,7 +71,52 @@ fn wrapper_is_invoked(parts: &[String], index: usize) -> bool {
     if is_shell(&parts[index - 1]) {
         return true;
     }
-    index >= 2 && parts[index - 1].starts_with('-') && is_shell(&parts[index - 2])
+    if index >= 2 && parts[index - 1].starts_with('-') && is_shell(&parts[index - 2]) {
+        return true;
+    }
+    if env_invokes_token(parts, index) {
+        return true;
+    }
+    false
+}
+
+fn env_invokes_token(parts: &[String], index: usize) -> bool {
+    if parts.first().map(|token| basename(token)) != Some("env") {
+        return false;
+    }
+    let mut cursor = 1;
+    while cursor < index {
+        let token = &parts[cursor];
+        if token == "--" {
+            cursor += 1;
+            break;
+        }
+        if token.starts_with('-') {
+            if env_option_takes_value(token) && cursor + 1 < index {
+                cursor += 2;
+            } else {
+                cursor += 1;
+            }
+            continue;
+        }
+        if is_env_assignment(token) {
+            cursor += 1;
+            continue;
+        }
+        return false;
+    }
+    cursor == index
+}
+
+fn env_option_takes_value(token: &str) -> bool {
+    matches!(
+        token,
+        "-u" | "--unset" | "-C" | "--chdir" | "-S" | "--split-string"
+    )
+}
+
+fn is_env_assignment(token: &str) -> bool {
+    token.contains('=') && !token.starts_with('=')
 }
 
 fn is_shell(token: &str) -> bool {

--- a/vibeguard-runtime/src/setup_markdown/hook_identity.rs
+++ b/vibeguard-runtime/src/setup_markdown/hook_identity.rs
@@ -122,3 +122,34 @@ fn is_env_assignment(token: &str) -> bool {
 fn is_shell(token: &str) -> bool {
     matches!(basename(token), "bash" | "sh" | "zsh")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn managed_scripts() -> BTreeSet<String> {
+        BTreeSet::from(["pre-bash-guard.sh".to_string()])
+    }
+
+    #[test]
+    fn env_prefix_counts_as_wrapper_invocation() {
+        let command = "env VIBEGUARD_FOO=1 /tmp/.vibeguard/run-hook.sh pre-bash-guard.sh";
+
+        assert!(command_invokes_script(command, "pre-bash-guard.sh"));
+        assert_eq!(
+            managed_script_from_command(command, &managed_scripts()),
+            Some("pre-bash-guard.sh")
+        );
+    }
+
+    #[test]
+    fn env_wrapped_tool_argument_does_not_count_as_wrapper_invocation() {
+        let command = "env node /custom/audit.js /tmp/.vibeguard/run-hook.sh pre-bash-guard.sh";
+
+        assert!(!command_invokes_script(command, "pre-bash-guard.sh"));
+        assert_eq!(
+            managed_script_from_command(command, &managed_scripts()),
+            None
+        );
+    }
+}

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -107,6 +107,32 @@ mod setup_markdown_tests {
     }
 
     #[test]
+    fn profile_repair_preserves_unmanaged_wrapper_argument() -> SetupResult<()> {
+        let repo_dir = repo_dir()?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let mut data = settings_data_with_specs(&core_specs);
+        let command = "node /custom/audit.js /tmp/.vibeguard/run-hook.sh post-build-check.sh";
+        data["hooks"]["PostToolUse"]
+            .as_array_mut()
+            .expect("PostToolUse entries")
+            .push(serde_json::json!({
+                "matcher": "Edit",
+                "hooks": [{
+                    "type": "command",
+                    "command": command,
+                }]
+            }));
+
+        assert!(settings_has_profile_hooks(repo_dir, &data, "core")?);
+        let desired = core_specs.iter().map(settings_spec_identity).collect();
+        assert!(!settings_remove_unprofiled_hooks(
+            repo_dir, &mut data, &desired
+        )?);
+        assert!(serde_json::to_string(&data)?.contains(command));
+        Ok(())
+    }
+
+    #[test]
     fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
         let repo_dir = repo_dir()?;
         let core_specs = claude_specs(repo_dir, Some("core"))?;

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -133,6 +133,34 @@ mod setup_markdown_tests {
     }
 
     #[test]
+    fn profile_repair_preserves_env_invoked_wrapper_customization() -> SetupResult<()> {
+        let repo_dir = repo_dir()?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let pre_bash_spec = core_specs
+            .iter()
+            .find(|spec| spec.script == "pre-bash-guard.sh")
+            .ok_or("expected pre-bash hook in core profile")?;
+        let mut data = settings_data_with_specs(&core_specs);
+        let command = "env VIBEGUARD_FOO=1 /tmp/.vibeguard/run-hook.sh pre-bash-guard.sh";
+        let pre_tool_entries = data["hooks"]["PreToolUse"]
+            .as_array_mut()
+            .expect("PreToolUse entries");
+        for entry in pre_tool_entries {
+            if entry.get("matcher").and_then(Value::as_str) != Some("Bash") {
+                continue;
+            }
+            entry["hooks"][0]["command"] = Value::String(command.to_string());
+        }
+
+        assert!(settings_has_profile_hooks(repo_dir, &data, "core")?);
+        assert!(!settings_upsert_hook(&mut data, pre_bash_spec, false));
+        let rendered = serde_json::to_string(&data)?;
+        assert!(rendered.contains(command));
+        assert_eq!(rendered.matches("pre-bash-guard.sh").count(), 1);
+        Ok(())
+    }
+
+    #[test]
     fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
         let repo_dir = repo_dir()?;
         let core_specs = claude_specs(repo_dir, Some("core"))?;

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+fn repo_dir() -> SetupResult<&'static Path> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .ok_or_else(|| "vibeguard-runtime must be inside the repository".into())
+}
+
+#[test]
+fn replaces_marker_block() {
+    let original = "a\n\n<!-- vibeguard-start -->\nold\n<!-- vibeguard-end -->\n\nb\n";
+    let next = replace_managed_block(
+        original,
+        "<!-- vibeguard-start -->\nnew\n<!-- vibeguard-end -->",
+    );
+    assert!(next.contains("new"));
+    assert!(!next.contains("old"));
+    assert!(next.starts_with("a\n\n"));
+    assert!(next.ends_with("b\n"));
+}
+
+#[test]
+fn profile_settings_reject_out_of_profile_managed_hooks() -> SetupResult<()> {
+    let repo_dir = repo_dir()?;
+    let core_specs = claude_specs(repo_dir, Some("core"))?;
+    let extra_spec = claude_specs(repo_dir, None)?
+        .into_iter()
+        .find(|spec| {
+            !core_specs
+                .iter()
+                .any(|desired| desired.event == spec.event && desired.script == spec.script)
+        })
+        .ok_or("expected an out-of-profile managed hook spec")?;
+
+    let core_data = settings_data_with_specs(&core_specs);
+    assert!(settings_has_profile_hooks(repo_dir, &core_data, "core")?);
+
+    let mut stale_specs = core_specs;
+    stale_specs.push(extra_spec);
+    let stale_data = settings_data_with_specs(&stale_specs);
+    assert!(!settings_has_profile_hooks(repo_dir, &stale_data, "core")?);
+    Ok(())
+}
+
+#[test]
+fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
+    let repo_dir = repo_dir()?;
+    let core_specs = claude_specs(repo_dir, Some("core"))?;
+    let analysis_spec = core_specs
+        .iter()
+        .find(|spec| spec.script == "analysis-paralysis-guard.sh")
+        .ok_or("expected analysis-paralysis hook in core profile")?;
+    let mut data = settings_data_with_specs(&core_specs);
+    data["hooks"]["PostToolUse"]
+        .as_array_mut()
+        .expect("PostToolUse entries")
+        .push(serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [{
+                "type": "command",
+                "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", analysis_spec.script),
+            }]
+        }));
+
+    assert!(!settings_has_profile_hooks(repo_dir, &data, "core")?);
+    let desired = core_specs.iter().map(settings_spec_identity).collect();
+    assert!(settings_remove_unprofiled_hooks(
+        repo_dir, &mut data, &desired
+    )?);
+    assert!(settings_has_profile_hooks(repo_dir, &data, "core")?);
+    Ok(())
+}
+
+fn settings_data_with_specs(specs: &[ClaudeSpec]) -> Value {
+    let mut data = serde_json::json!({"hooks": {}});
+    let hooks = data
+        .get_mut("hooks")
+        .and_then(Value::as_object_mut)
+        .expect("hooks object");
+    for spec in specs {
+        let entries = hooks
+            .entry(spec.event.clone())
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .expect("event entries");
+        let mut entry = serde_json::json!({
+            "hooks": [{
+                "type": "command",
+                "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", spec.script),
+            }]
+        });
+        if !spec.matcher.is_empty() {
+            entry
+                .as_object_mut()
+                .expect("entry object")
+                .insert("matcher".to_string(), Value::String(spec.matcher.clone()));
+        }
+        entries.push(entry);
+    }
+    data
+}
+
+#[test]
+fn canonical_settings_command_accepts_legacy_unquoted_home_spaces() {
+    let command = "bash /tmp/home with spaces/.vibeguard/run-hook.sh pre-bash-guard.sh";
+    assert!(settings_is_canonical(command, "pre-bash-guard.sh"));
+}
+
+#[test]
+fn canonical_settings_command_rejects_custom_bash_options() {
+    let command = "bash -x /tmp/workspace/.vibeguard/run-hook.sh pre-bash-guard.sh";
+    assert!(!settings_is_canonical(command, "pre-bash-guard.sh"));
+}

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -1,113 +1,116 @@
-use super::*;
+#[cfg(test)]
+mod setup_markdown_tests {
+    use super::super::*;
 
-fn repo_dir() -> SetupResult<&'static Path> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .ok_or_else(|| "vibeguard-runtime must be inside the repository".into())
-}
-
-#[test]
-fn replaces_marker_block() {
-    let original = "a\n\n<!-- vibeguard-start -->\nold\n<!-- vibeguard-end -->\n\nb\n";
-    let next = replace_managed_block(
-        original,
-        "<!-- vibeguard-start -->\nnew\n<!-- vibeguard-end -->",
-    );
-    assert!(next.contains("new"));
-    assert!(!next.contains("old"));
-    assert!(next.starts_with("a\n\n"));
-    assert!(next.ends_with("b\n"));
-}
-
-#[test]
-fn profile_settings_reject_out_of_profile_managed_hooks() -> SetupResult<()> {
-    let repo_dir = repo_dir()?;
-    let core_specs = claude_specs(repo_dir, Some("core"))?;
-    let extra_spec = claude_specs(repo_dir, None)?
-        .into_iter()
-        .find(|spec| {
-            !core_specs
-                .iter()
-                .any(|desired| desired.event == spec.event && desired.script == spec.script)
-        })
-        .ok_or("expected an out-of-profile managed hook spec")?;
-
-    let core_data = settings_data_with_specs(&core_specs);
-    assert!(settings_has_profile_hooks(repo_dir, &core_data, "core")?);
-
-    let mut stale_specs = core_specs;
-    stale_specs.push(extra_spec);
-    let stale_data = settings_data_with_specs(&stale_specs);
-    assert!(!settings_has_profile_hooks(repo_dir, &stale_data, "core")?);
-    Ok(())
-}
-
-#[test]
-fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
-    let repo_dir = repo_dir()?;
-    let core_specs = claude_specs(repo_dir, Some("core"))?;
-    let analysis_spec = core_specs
-        .iter()
-        .find(|spec| spec.script == "analysis-paralysis-guard.sh")
-        .ok_or("expected analysis-paralysis hook in core profile")?;
-    let mut data = settings_data_with_specs(&core_specs);
-    data["hooks"]["PostToolUse"]
-        .as_array_mut()
-        .expect("PostToolUse entries")
-        .push(serde_json::json!({
-            "matcher": "Bash",
-            "hooks": [{
-                "type": "command",
-                "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", analysis_spec.script),
-            }]
-        }));
-
-    assert!(!settings_has_profile_hooks(repo_dir, &data, "core")?);
-    let desired = core_specs.iter().map(settings_spec_identity).collect();
-    assert!(settings_remove_unprofiled_hooks(
-        repo_dir, &mut data, &desired
-    )?);
-    assert!(settings_has_profile_hooks(repo_dir, &data, "core")?);
-    Ok(())
-}
-
-fn settings_data_with_specs(specs: &[ClaudeSpec]) -> Value {
-    let mut data = serde_json::json!({"hooks": {}});
-    let hooks = data
-        .get_mut("hooks")
-        .and_then(Value::as_object_mut)
-        .expect("hooks object");
-    for spec in specs {
-        let entries = hooks
-            .entry(spec.event.clone())
-            .or_insert_with(|| serde_json::json!([]))
-            .as_array_mut()
-            .expect("event entries");
-        let mut entry = serde_json::json!({
-            "hooks": [{
-                "type": "command",
-                "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", spec.script),
-            }]
-        });
-        if !spec.matcher.is_empty() {
-            entry
-                .as_object_mut()
-                .expect("entry object")
-                .insert("matcher".to_string(), Value::String(spec.matcher.clone()));
-        }
-        entries.push(entry);
+    fn repo_dir() -> SetupResult<&'static Path> {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| "vibeguard-runtime must be inside the repository".into())
     }
-    data
-}
 
-#[test]
-fn canonical_settings_command_accepts_legacy_unquoted_home_spaces() {
-    let command = "bash /tmp/home with spaces/.vibeguard/run-hook.sh pre-bash-guard.sh";
-    assert!(settings_is_canonical(command, "pre-bash-guard.sh"));
-}
+    #[test]
+    fn replaces_marker_block() {
+        let original = "a\n\n<!-- vibeguard-start -->\nold\n<!-- vibeguard-end -->\n\nb\n";
+        let next = replace_managed_block(
+            original,
+            "<!-- vibeguard-start -->\nnew\n<!-- vibeguard-end -->",
+        );
+        assert!(next.contains("new"));
+        assert!(!next.contains("old"));
+        assert!(next.starts_with("a\n\n"));
+        assert!(next.ends_with("b\n"));
+    }
 
-#[test]
-fn canonical_settings_command_rejects_custom_bash_options() {
-    let command = "bash -x /tmp/workspace/.vibeguard/run-hook.sh pre-bash-guard.sh";
-    assert!(!settings_is_canonical(command, "pre-bash-guard.sh"));
+    #[test]
+    fn profile_settings_reject_out_of_profile_managed_hooks() -> SetupResult<()> {
+        let repo_dir = repo_dir()?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let extra_spec = claude_specs(repo_dir, None)?
+            .into_iter()
+            .find(|spec| {
+                !core_specs
+                    .iter()
+                    .any(|desired| desired.event == spec.event && desired.script == spec.script)
+            })
+            .ok_or("expected an out-of-profile managed hook spec")?;
+
+        let core_data = settings_data_with_specs(&core_specs);
+        assert!(settings_has_profile_hooks(repo_dir, &core_data, "core")?);
+
+        let mut stale_specs = core_specs;
+        stale_specs.push(extra_spec);
+        let stale_data = settings_data_with_specs(&stale_specs);
+        assert!(!settings_has_profile_hooks(repo_dir, &stale_data, "core")?);
+        Ok(())
+    }
+
+    #[test]
+    fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
+        let repo_dir = repo_dir()?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let analysis_spec = core_specs
+            .iter()
+            .find(|spec| spec.script == "analysis-paralysis-guard.sh")
+            .ok_or("expected analysis-paralysis hook in core profile")?;
+        let mut data = settings_data_with_specs(&core_specs);
+        data["hooks"]["PostToolUse"]
+            .as_array_mut()
+            .expect("PostToolUse entries")
+            .push(serde_json::json!({
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", analysis_spec.script),
+                }]
+            }));
+
+        assert!(!settings_has_profile_hooks(repo_dir, &data, "core")?);
+        let desired = core_specs.iter().map(settings_spec_identity).collect();
+        assert!(settings_remove_unprofiled_hooks(
+            repo_dir, &mut data, &desired
+        )?);
+        assert!(settings_has_profile_hooks(repo_dir, &data, "core")?);
+        Ok(())
+    }
+
+    fn settings_data_with_specs(specs: &[ClaudeSpec]) -> Value {
+        let mut data = serde_json::json!({"hooks": {}});
+        let hooks = data
+            .get_mut("hooks")
+            .and_then(Value::as_object_mut)
+            .expect("hooks object");
+        for spec in specs {
+            let entries = hooks
+                .entry(spec.event.clone())
+                .or_insert_with(|| serde_json::json!([]))
+                .as_array_mut()
+                .expect("event entries");
+            let mut entry = serde_json::json!({
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("bash /tmp/.vibeguard/run-hook.sh {}", spec.script),
+                }]
+            });
+            if !spec.matcher.is_empty() {
+                entry
+                    .as_object_mut()
+                    .expect("entry object")
+                    .insert("matcher".to_string(), Value::String(spec.matcher.clone()));
+            }
+            entries.push(entry);
+        }
+        data
+    }
+
+    #[test]
+    fn canonical_settings_command_accepts_legacy_unquoted_home_spaces() {
+        let command = "bash /tmp/home with spaces/.vibeguard/run-hook.sh pre-bash-guard.sh";
+        assert!(settings_is_canonical(command, "pre-bash-guard.sh"));
+    }
+
+    #[test]
+    fn canonical_settings_command_rejects_custom_bash_options() {
+        let command = "bash -x /tmp/workspace/.vibeguard/run-hook.sh pre-bash-guard.sh";
+        assert!(!settings_is_canonical(command, "pre-bash-guard.sh"));
+    }
 }

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -45,6 +45,41 @@ mod setup_markdown_tests {
     }
 
     #[test]
+    fn profile_settings_reject_duplicate_managed_hooks() -> SetupResult<()> {
+        let repo_dir = repo_dir()?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let pre_bash_spec = core_specs
+            .iter()
+            .find(|spec| spec.script == "pre-bash-guard.sh")
+            .ok_or("expected pre-bash hook in core profile")?;
+
+        let core_data = settings_data_with_specs(&core_specs);
+        assert!(settings_has_profile_hooks(repo_dir, &core_data, "core")?);
+
+        let mut duplicate_specs = core_specs.clone();
+        duplicate_specs.push(pre_bash_spec.clone());
+        let mut duplicate_data = settings_data_with_specs(&duplicate_specs);
+        assert!(!settings_has_profile_hooks(
+            repo_dir,
+            &duplicate_data,
+            "core"
+        )?);
+
+        let desired = core_specs.iter().map(settings_spec_identity).collect();
+        assert!(settings_remove_unprofiled_hooks(
+            repo_dir,
+            &mut duplicate_data,
+            &desired
+        )?);
+        assert!(settings_has_profile_hooks(
+            repo_dir,
+            &duplicate_data,
+            "core"
+        )?);
+        Ok(())
+    }
+
+    #[test]
     fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
         let repo_dir = repo_dir()?;
         let core_specs = claude_specs(repo_dir, Some("core"))?;

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -80,6 +80,33 @@ mod setup_markdown_tests {
     }
 
     #[test]
+    fn profile_repair_preserves_unmanaged_hook_script_argument() -> SetupResult<()> {
+        let repo_dir = repo_dir()?;
+        let core_specs = claude_specs(repo_dir, Some("core"))?;
+        let mut data = settings_data_with_specs(&core_specs);
+        data["hooks"]["PostToolUse"]
+            .as_array_mut()
+            .expect("PostToolUse entries")
+            .push(serde_json::json!({
+                "matcher": "Edit",
+                "hooks": [{
+                    "type": "command",
+                    "command": "node /custom/audit.js post-build-check.sh",
+                }]
+            }));
+
+        assert!(settings_has_profile_hooks(repo_dir, &data, "core")?);
+        let desired = core_specs.iter().map(settings_spec_identity).collect();
+        assert!(!settings_remove_unprofiled_hooks(
+            repo_dir, &mut data, &desired
+        )?);
+        assert!(
+            serde_json::to_string(&data)?.contains("node /custom/audit.js post-build-check.sh")
+        );
+        Ok(())
+    }
+
+    #[test]
     fn profile_repair_removes_same_script_wrong_matcher() -> SetupResult<()> {
         let repo_dir = repo_dir()?;
         let core_specs = claude_specs(repo_dir, Some("core"))?;


### PR DESCRIPTION
## Summary
- make setup --check derive the installed profile and validate Claude hooks against the exact manifest profile
- add profile-hooks:<profile> checks to the Rust runtime and Python helper
- add regressions for missing core/full analysis-paralysis and strict U-32 SessionStart hooks

Closes #444

## Verification
- bash -n setup.sh scripts/setup/check.sh scripts/setup/targets/claude-home.sh tests/setup/profile_flow_tests.sh
- python3 -m py_compile scripts/lib/settings_json.py
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash scripts/ci/validate-hooks-manifest.sh
- bash tests/test_setup.sh (341/341)
- git diff --check