### PR TITLE
fix: mirror hook logs in one runtime call

### DIFF
--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -102,14 +102,24 @@ _vg_append_log_line_mirror_shell() {
   local primary_file="$1"
   local mirror_file="$2"
   local line="$3"
+  local primary_status=0
+  local mirror_status=0
 
-  if ! _vg_append_log_line_shell "$primary_file" "$line"; then
+  if _vg_append_log_line_shell "$primary_file" "$line"; then
+    primary_status=0
+  else
+    primary_status=$?
     printf 'VIBEGUARD ERROR: primary event log write failed: %s\n' "$primary_file" >&2
-    return 1
   fi
 
-  if ! _vg_append_log_line_shell "$mirror_file" "$line"; then
+  if _vg_append_log_line_shell "$mirror_file" "$line"; then
+    mirror_status=0
+  else
+    mirror_status=$?
     printf 'VIBEGUARD ERROR: global event log write failed: %s\n' "$mirror_file" >&2
+  fi
+
+  if [[ "$primary_status" -ne 0 || "$mirror_status" -ne 0 ]]; then
     return 1
   fi
 }

--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -27,6 +27,38 @@ vg_append_log_line() {
   _vg_append_log_line_shell "$file" "$line"
 }
 
+vg_append_log_line_mirror() {
+  local primary_file="$1"
+  local mirror_file="$2"
+  local line="$3"
+  local status=0
+  local runtime_stderr=""
+
+  if [[ "$primary_file" == "$mirror_file" ]]; then
+    vg_append_log_line "$primary_file" "$line"
+    return $?
+  fi
+
+  if [[ -n "${_VIBEGUARD_RUNTIME:-}" && -x "$_VIBEGUARD_RUNTIME" ]]; then
+    if runtime_stderr=$("$_VIBEGUARD_RUNTIME" append-jsonl-mirror "$primary_file" "$mirror_file" <<<"$line" 2>&1); then
+      return 0
+    else
+      status=$?
+    fi
+
+    if [[ "$runtime_stderr" == *"Unknown command: append-jsonl-mirror"* ]]; then
+      _vg_append_log_line_mirror_shell "$primary_file" "$mirror_file" "$line"
+      return $?
+    fi
+
+    [[ -z "$runtime_stderr" ]] || printf '%s\n' "$runtime_stderr" >&2
+    printf 'VIBEGUARD ERROR: runtime mirrored JSONL append failed for %s -> %s\n' "$primary_file" "$mirror_file" >&2
+    return "$status"
+  fi
+
+  _vg_append_log_line_mirror_shell "$primary_file" "$mirror_file" "$line"
+}
+
 _vg_append_log_line_shell() {
   local file="$1"
   local line="$2"
@@ -64,6 +96,22 @@ _vg_append_log_line_shell() {
   rmdir "$lock_dir" 2>/dev/null || true
 
   return "$status"
+}
+
+_vg_append_log_line_mirror_shell() {
+  local primary_file="$1"
+  local mirror_file="$2"
+  local line="$3"
+
+  if ! _vg_append_log_line_shell "$primary_file" "$line"; then
+    printf 'VIBEGUARD ERROR: primary event log write failed: %s\n' "$primary_file" >&2
+    return 1
+  fi
+
+  if ! _vg_append_log_line_shell "$mirror_file" "$line"; then
+    printf 'VIBEGUARD ERROR: global event log write failed: %s\n' "$mirror_file" >&2
+    return 1
+  fi
 }
 
 vg_private_log_file() {
@@ -169,19 +217,19 @@ vg_log() {
   json="$(vg_log_append_string_field "$json" "caller_evidence" "${VIBEGUARD_CALLER_EVIDENCE:-}")"
   json="${json}}"
 
-  vg_private_log_file "$VIBEGUARD_LOG_FILE"
-  if ! vg_append_log_line "$VIBEGUARD_LOG_FILE" "$json"; then
-    printf 'VIBEGUARD ERROR: primary event log write failed: %s\n' "$VIBEGUARD_LOG_FILE" >&2
-  fi
-  vg_private_log_file "$VIBEGUARD_LOG_FILE"
-
-  # Synchronously write to the global log (for stats.sh aggregation analysis)
+  # Synchronously mirror project logs into the global log for stats aggregation.
   local global_log="${VIBEGUARD_LOG_DIR}/events.jsonl"
+  vg_private_log_file "$VIBEGUARD_LOG_FILE"
+  vg_private_log_file "$global_log"
   if [[ "$VIBEGUARD_LOG_FILE" != "$global_log" ]]; then
-    vg_private_log_file "$global_log"
-    if ! vg_append_log_line "$global_log" "$json"; then
-      printf 'VIBEGUARD ERROR: global event log write failed: %s\n' "$global_log" >&2
+    if ! vg_append_log_line_mirror "$VIBEGUARD_LOG_FILE" "$global_log" "$json"; then
+      printf 'VIBEGUARD ERROR: mirrored event log write failed: %s -> %s\n' "$VIBEGUARD_LOG_FILE" "$global_log" >&2
     fi
-    vg_private_log_file "$global_log"
+  else
+    if ! vg_append_log_line "$VIBEGUARD_LOG_FILE" "$json"; then
+      printf 'VIBEGUARD ERROR: primary event log write failed: %s\n' "$VIBEGUARD_LOG_FILE" >&2
+    fi
   fi
+  vg_private_log_file "$VIBEGUARD_LOG_FILE"
+  vg_private_log_file "$global_log"
 }

--- a/tests/hooks/test_log_injection.sh
+++ b/tests/hooks/test_log_injection.sh
@@ -275,6 +275,31 @@ assert_contains "$mirror_result" "primary=1" "Runtime mirror append writes the p
 assert_contains "$mirror_result" "global=1" "Runtime mirror append writes the global log"
 rm -rf "$mirror_runtime_test_dir"
 
+header "log.sh — shell mirror preserves global on primary failure"
+
+shell_mirror_lock_dir="$(mktemp -d)"
+shell_mirror_primary="${shell_mirror_lock_dir}/project/events.jsonl"
+shell_mirror_global="${shell_mirror_lock_dir}/events.jsonl"
+shell_mirror_stderr="${shell_mirror_lock_dir}/stderr"
+mkdir -p "$(dirname "$shell_mirror_primary")"
+mkdir "${shell_mirror_primary}.lock.d"
+
+set +e
+shell_mirror_result=$(
+  export VIBEGUARD_LOG_LOCK_ATTEMPTS=1
+  export VIBEGUARD_LOG_LOCK_SLEEP_SECONDS=0
+  source hooks/_lib/log_write.sh
+  vg_append_log_line_mirror "$shell_mirror_primary" "$shell_mirror_global" '{"shell_mirror":true}' 2>"$shell_mirror_stderr"
+  printf 'rc=%s' "$?"
+)
+set -e
+
+assert_contains "$shell_mirror_result" "rc=1" "Shell mirror primary lock failure returns nonzero"
+assert_contains "$(cat "$shell_mirror_stderr")" "primary event log write failed" "Shell mirror primary failure is visible"
+assert_contains "$(cat "$shell_mirror_global")" '{"shell_mirror":true}' "Shell mirror still writes global log after primary failure"
+assert_not_contains "$(cat "$shell_mirror_primary" 2>/dev/null || true)" '{"shell_mirror":true}' "Shell mirror primary lock failure does not write unlocked"
+rm -rf "$shell_mirror_lock_dir"
+
 header "log.sh — stale runtime fallback"
 
 stale_runtime_test_dir="$(mktemp -d)"

--- a/tests/hooks/test_log_injection.sh
+++ b/tests/hooks/test_log_injection.sh
@@ -213,6 +213,68 @@ assert_contains "$(cat "$runtime_errexit_stderr")" "runtime JSONL append failed"
 assert_not_contains "$(cat "$runtime_lock_test_file")" '{"errexit_locked":true}' "Runtime append set -e failure does not write unlocked"
 rm -rf "$runtime_lock_test_dir"
 
+header "log.sh — runtime mirror append"
+
+mirror_runtime_test_dir="$(mktemp -d)"
+mirror_runtime_bin="${mirror_runtime_test_dir}/vibeguard-runtime"
+mirror_runtime_count="${mirror_runtime_test_dir}/runtime-calls"
+cat > "$mirror_runtime_bin" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-}"
+shift || true
+
+case "$command" in
+  append-jsonl-mirror)
+    printf 'mirror\n' >> "${VIBEGUARD_MIRROR_COUNT:?}"
+    primary_file="${1:?append-jsonl-mirror requires a primary path}"
+    mirror_file="${2:?append-jsonl-mirror requires a mirror path}"
+    line="$(cat)"
+    mkdir -p "$(dirname "$primary_file")" "$(dirname "$mirror_file")"
+    printf '%s\n' "$line" >> "$primary_file"
+    printf '%s\n' "$line" >> "$mirror_file"
+    ;;
+  append-jsonl)
+    printf 'single\n' >> "${VIBEGUARD_MIRROR_COUNT:?}"
+    file="${1:?append-jsonl requires a path}"
+    line="$(cat)"
+    mkdir -p "$(dirname "$file")"
+    printf '%s\n' "$line" >> "$file"
+    ;;
+  *)
+    printf 'Unknown command: %s\n' "$command" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$mirror_runtime_bin"
+
+mirror_result=$(
+  export HOME="${mirror_runtime_test_dir}/home"
+  export VIBEGUARD_LOG_DIR="${mirror_runtime_test_dir}/logs"
+  export VIBEGUARD_PROJECT_LOG_DIR="${mirror_runtime_test_dir}/project"
+  export VIBEGUARD_LOG_FILE="${VIBEGUARD_PROJECT_LOG_DIR}/events.jsonl"
+  export VIBEGUARD_SESSION_ID="runtime-mirror-test"
+  export VIBEGUARD_RUNTIME="$mirror_runtime_bin"
+  export VIBEGUARD_MIRROR_COUNT="$mirror_runtime_count"
+  source hooks/log.sh
+  vg_log "test" "Tool" "pass" "mirror" "runtime"
+  printf 'calls=%s mirror=%s single=%s primary=%s global=%s' \
+    "$(wc -l < "$VIBEGUARD_MIRROR_COUNT" | tr -d ' ')" \
+    "$(grep -c '^mirror$' "$VIBEGUARD_MIRROR_COUNT" || true)" \
+    "$(grep -c '^single$' "$VIBEGUARD_MIRROR_COUNT" || true)" \
+    "$(wc -l < "$VIBEGUARD_LOG_FILE" | tr -d ' ')" \
+    "$(wc -l < "$VIBEGUARD_LOG_DIR/events.jsonl" | tr -d ' ')"
+)
+
+assert_contains "$mirror_result" "calls=1" "Project/global vg_log uses one runtime process for mirror append"
+assert_contains "$mirror_result" "mirror=1" "Runtime mirror append command is used"
+assert_contains "$mirror_result" "single=0" "Runtime single append is not used for mirrored vg_log"
+assert_contains "$mirror_result" "primary=1" "Runtime mirror append writes the primary log"
+assert_contains "$mirror_result" "global=1" "Runtime mirror append writes the global log"
+rm -rf "$mirror_runtime_test_dir"
+
 header "log.sh — stale runtime fallback"
 
 stale_runtime_test_dir="$(mktemp -d)"
@@ -239,6 +301,41 @@ assert_contains "$stale_runtime_result" "rc=0" "Stale runtime without append-jso
 assert_contains "$(cat "$stale_runtime_file")" '{"stale_runtime":true}' "Stale runtime fallback still writes the log line"
 assert_not_contains "$(cat "$stale_runtime_stderr")" "runtime JSONL append failed" "Stale runtime fallback does not report runtime append failure"
 rm -rf "$stale_runtime_test_dir"
+
+header "log.sh — stale runtime mirror fallback"
+
+stale_mirror_runtime_test_dir="$(mktemp -d)"
+stale_mirror_runtime_stderr="${stale_mirror_runtime_test_dir}/stderr"
+stale_mirror_runtime_bin="${stale_mirror_runtime_test_dir}/vibeguard-runtime"
+cat > "$stale_mirror_runtime_bin" <<'SH'
+#!/usr/bin/env bash
+printf 'Unknown command: %s\n' "$1" >&2
+exit 2
+SH
+chmod +x "$stale_mirror_runtime_bin"
+
+set +e
+stale_mirror_result=$(
+  export HOME="${stale_mirror_runtime_test_dir}/home"
+  export VIBEGUARD_LOG_DIR="${stale_mirror_runtime_test_dir}/logs"
+  export VIBEGUARD_PROJECT_LOG_DIR="${stale_mirror_runtime_test_dir}/project"
+  export VIBEGUARD_LOG_FILE="${VIBEGUARD_PROJECT_LOG_DIR}/events.jsonl"
+  export VIBEGUARD_SESSION_ID="stale-runtime-mirror-test"
+  export VIBEGUARD_RUNTIME="$stale_mirror_runtime_bin"
+  source hooks/log.sh
+  vg_log "test" "Tool" "pass" "stale mirror" "fallback" 2>"$stale_mirror_runtime_stderr"
+  printf 'rc=%s primary=%s global=%s' \
+    "$?" \
+    "$(wc -l < "$VIBEGUARD_LOG_FILE" | tr -d ' ')" \
+    "$(wc -l < "$VIBEGUARD_LOG_DIR/events.jsonl" | tr -d ' ')"
+)
+set -e
+
+assert_contains "$stale_mirror_result" "rc=0" "Stale runtime without append-jsonl-mirror falls back for mirrored vg_log"
+assert_contains "$stale_mirror_result" "primary=1" "Stale runtime mirror fallback writes the primary log"
+assert_contains "$stale_mirror_result" "global=1" "Stale runtime mirror fallback writes the global log"
+assert_not_contains "$(cat "$stale_mirror_runtime_stderr")" "runtime mirrored JSONL append failed" "Stale runtime mirror fallback does not report runtime mirror failure"
+rm -rf "$stale_mirror_runtime_test_dir"
 
 # =========================================================
 

--- a/vibeguard-runtime/src/log_append.rs
+++ b/vibeguard-runtime/src/log_append.rs
@@ -26,25 +26,32 @@ pub fn run_mirror(args: &[String]) -> Result {
     let primary = Path::new(&args[0]);
     let mirror = Path::new(&args[1]);
 
-    append_jsonl(primary, &line).map_err(|err| {
+    let primary_result = append_jsonl(primary, &line).map_err(|err| {
         format!(
             "primary JSONL append failed for {}: {}",
             primary.display(),
             err
         )
-    })?;
+    });
 
-    if mirror != primary {
+    let mirror_result = if mirror != primary {
         append_jsonl(mirror, &line).map_err(|err| {
             format!(
                 "mirror JSONL append failed for {}: {}",
                 mirror.display(),
                 err
             )
-        })?;
-    }
+        })
+    } else {
+        Ok(())
+    };
 
-    Ok(())
+    match (primary_result, mirror_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(primary_err), Ok(())) => Err(primary_err.into()),
+        (Ok(()), Err(mirror_err)) => Err(mirror_err.into()),
+        (Err(primary_err), Err(mirror_err)) => Err(format!("{primary_err}; {mirror_err}").into()),
+    }
 }
 
 fn read_valid_jsonl_line(command_name: &str) -> Result<String> {

--- a/vibeguard-runtime/src/log_append.rs
+++ b/vibeguard-runtime/src/log_append.rs
@@ -2,13 +2,52 @@ use std::path::Path;
 
 use crate::hook_checks_common::{append_jsonl, read_stdin};
 
-type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub fn run(args: &[String]) -> Result {
     if args.len() != 1 {
         return Err("Usage: vibeguard-runtime append-jsonl <log-file>".into());
     }
 
+    let line = read_valid_jsonl_line("append-jsonl")?;
+    append_jsonl(Path::new(&args[0]), &line)?;
+    Ok(())
+}
+
+pub fn run_mirror(args: &[String]) -> Result {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime append-jsonl-mirror <primary-log-file> <mirror-log-file>"
+                .into(),
+        );
+    }
+
+    let line = read_valid_jsonl_line("append-jsonl-mirror")?;
+    let primary = Path::new(&args[0]);
+    let mirror = Path::new(&args[1]);
+
+    append_jsonl(primary, &line).map_err(|err| {
+        format!(
+            "primary JSONL append failed for {}: {}",
+            primary.display(),
+            err
+        )
+    })?;
+
+    if mirror != primary {
+        append_jsonl(mirror, &line).map_err(|err| {
+            format!(
+                "mirror JSONL append failed for {}: {}",
+                mirror.display(),
+                err
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn read_valid_jsonl_line(command_name: &str) -> Result<String> {
     let mut line = read_stdin()?;
     if line.ends_with('\n') {
         line.pop();
@@ -18,16 +57,15 @@ pub fn run(args: &[String]) -> Result {
     }
 
     if line.is_empty() {
-        return Err("append-jsonl input must not be empty".into());
+        return Err(format!("{command_name} input must not be empty").into());
     }
     if line.contains('\n') || line.contains('\r') {
-        return Err("append-jsonl input must be exactly one JSONL line".into());
+        return Err(format!("{command_name} input must be exactly one JSONL line").into());
     }
 
     let value = serde_json::from_str::<serde_json::Value>(&line)?;
     if !value.is_object() {
-        return Err("append-jsonl input must be a JSON object".into());
+        return Err(format!("{command_name} input must be a JSON object").into());
     }
-    append_jsonl(Path::new(&args[0]), &line)?;
-    Ok(())
+    Ok(line)
 }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -105,6 +105,11 @@ static COMMANDS: &[Command] = &[
         handler: log_append::run,
     },
     Command {
+        name: "append-jsonl-mirror",
+        usage: "<primary-log-file> <mirror-log-file>  — append one stdin JSONL line to two JSONL files with runtime locking",
+        handler: log_append::run_mirror,
+    },
+    Command {
         name: "circuit-breaker",
         usage: "<check|record-block|record-pass> <hook> <state-file> <lock-file> <threshold> <cooldown> <lock-timeout>  — update hook circuit breaker state with runtime locking",
         handler: circuit_breaker::run,

--- a/vibeguard-runtime/tests/cli_log_commands.rs
+++ b/vibeguard-runtime/tests/cli_log_commands.rs
@@ -322,6 +322,89 @@ fn append_jsonl_command_appends_one_line() {
 }
 
 #[test]
+fn append_jsonl_mirror_command_appends_to_primary_and_mirror() {
+    let dir = unique_temp_dir("append-jsonl-mirror");
+    fs::create_dir_all(&dir).unwrap();
+    let primary_file = dir.join("project-events.jsonl");
+    let mirror_file = dir.join("events.jsonl");
+    let mut child = bin()
+        .args([
+            "append-jsonl-mirror",
+            primary_file.to_str().unwrap(),
+            mirror_file.to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"mirrored\":true}\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&primary_file).unwrap(),
+        "{\"mirrored\":true}\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&mirror_file).unwrap(),
+        "{\"mirrored\":true}\n"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn append_jsonl_mirror_command_reports_mirror_failure_after_primary_write() {
+    let dir = unique_temp_dir("append-jsonl-mirror-failure");
+    fs::create_dir_all(&dir).unwrap();
+    let primary_file = dir.join("project-events.jsonl");
+    let mirror_file = dir.join("events.jsonl");
+    fs::create_dir(format!("{}.lock.d", mirror_file.display())).unwrap();
+
+    let mut child = bin()
+        .args([
+            "append-jsonl-mirror",
+            primary_file.to_str().unwrap(),
+            mirror_file.to_str().unwrap(),
+        ])
+        .env("VIBEGUARD_LOG_LOCK_ATTEMPTS", "1")
+        .env("VIBEGUARD_LOG_LOCK_SLEEP_SECONDS", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"mirrored\":true}\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("mirror JSONL append failed"),
+        "expected mirror failure in stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&primary_file).unwrap(),
+        "{\"mirrored\":true}\n"
+    );
+    assert!(!mirror_file.exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn append_jsonl_command_rejects_multiline_input() {
     let dir = unique_temp_dir("append-jsonl-multiline");
     fs::create_dir_all(&dir).unwrap();

--- a/vibeguard-runtime/tests/cli_log_commands.rs
+++ b/vibeguard-runtime/tests/cli_log_commands.rs
@@ -405,6 +405,48 @@ fn append_jsonl_mirror_command_reports_mirror_failure_after_primary_write() {
 }
 
 #[test]
+fn append_jsonl_mirror_command_writes_mirror_after_primary_failure() {
+    let dir = unique_temp_dir("append-jsonl-primary-failure");
+    fs::create_dir_all(&dir).unwrap();
+    let primary_file = dir.join("project-events.jsonl");
+    let mirror_file = dir.join("events.jsonl");
+    fs::create_dir(format!("{}.lock.d", primary_file.display())).unwrap();
+
+    let mut child = bin()
+        .args([
+            "append-jsonl-mirror",
+            primary_file.to_str().unwrap(),
+            mirror_file.to_str().unwrap(),
+        ])
+        .env("VIBEGUARD_LOG_LOCK_ATTEMPTS", "1")
+        .env("VIBEGUARD_LOG_LOCK_SLEEP_SECONDS", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"mirrored\":true}\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("primary JSONL append failed"),
+        "expected primary failure in stderr: {stderr}"
+    );
+    assert!(!primary_file.exists());
+    assert_eq!(
+        fs::read_to_string(&mirror_file).unwrap(),
+        "{\"mirrored\":true}\n"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn append_jsonl_command_rejects_multiline_input() {
     let dir = unique_temp_dir("append-jsonl-multiline");
     fs::create_dir_all(&dir).unwrap();


### PR DESCRIPTION
Closes #441.

## Summary
- add a runtime `append-jsonl-mirror` command that validates one JSONL input and appends it to primary + mirror logs
- update `vg_log` to use one runtime process for project/global mirrored writes, with shell fallback for stale runtimes
- cover one-process mirror behavior, stale-runtime fallback, and mirror failure visibility

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml append_jsonl_mirror`
- `bash tests/hooks/test_log_injection.sh`
- `bash tests/hooks/test_log_session.sh`
- `bash tests/test_hooks.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `git diff --check`