### PR TITLE
fix: scan post-write files once

### DIFF
--- a/hooks/post-write-guard.sh
+++ b/hooks/post-write-guard.sh
@@ -18,22 +18,6 @@ _VG_SCAN_MAX_FILES="${VG_SCAN_MAX_FILES:-5000}"
 _VG_SCAN_MAX_DEFS="${VG_SCAN_MAX_DEFS:-20}"
 _VG_SCAN_MATCH_LIMIT="${VG_SCAN_MATCH_LIMIT:-5}"
 
-_VG_FAST_RESULT=$(printf '%s' "$INPUT" \
-  | "$_VIBEGUARD_RUNTIME" post-write-fast-check "$_VG_U16_BASE_LIMIT" "$_VG_SCAN_MAX_FILES" "$VIBEGUARD_LOG_FILE" \
-  2>/dev/null || true)
-_VG_FAST_STATUS="${_VG_FAST_RESULT%%$'\n'*}"
-case "$_VG_FAST_STATUS" in
-  SKIP|FAST_LOGGED)
-    exit 0
-    ;;
-  FAST_PASS)
-    FILE_PATH="${_VG_FAST_RESULT#*$'\n'}"
-    [[ "$FILE_PATH" == "$_VG_FAST_RESULT" ]] && FILE_PATH=""
-    vg_log "post-write-guard" "Write" "pass" "" "$FILE_PATH"
-    exit 0
-    ;;
-esac
-
 _VG_RUNTIME_ERR="$(mktemp)"
 _vg_cleanup_runtime_err() {
   local status=$?

--- a/tests/hooks/test_post_write_guard.sh
+++ b/tests/hooks/test_post_write_guard.sh
@@ -41,6 +41,50 @@ assert_not_contains "$result" "VIBEGUARD" "Empty content is released"
 result=$(echo '{"tool_input":{"file_path":"","content":"fn main() {}"}}' | bash hooks/post-write-guard.sh)
 assert_not_contains "$result" "VIBEGUARD" "Empty file_path is allowed"
 
+# The shell wrapper should not run a fast command and then a full command for
+# the same Write event; scan reuse lives inside the single runtime command.
+tmp_repo_runtime_once="$(mktemp -d)"
+tmp_runtime_log="${tmp_repo_runtime_once}/commands.log"
+tmp_runtime_bin="${tmp_repo_runtime_once}/vibeguard-runtime"
+cat >"$tmp_runtime_bin" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-}"
+shift || true
+printf '%s\n' "$command" >> "${VIBEGUARD_RUNTIME_COMMAND_LOG:?}"
+
+case "$command" in
+  runtime-config-get-int|runtime-config-get-str)
+    printf '%s\n' "${3:-}"
+    ;;
+  post-write-check)
+    cat >/dev/null
+    ;;
+  post-write-fast-check)
+    printf 'unexpected fast check\n' >&2
+    exit 9
+    ;;
+  *)
+    printf 'Unknown command: %s\n' "$command" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$tmp_runtime_bin"
+json_payload='{"tool_input":{"file_path":"/tmp/vg_runtime_once/src/new.py","content":"def newThing():\n    return 1"}}'
+result=$(printf '%s\n' "$json_payload" \
+  | VIBEGUARD_RUNTIME="$tmp_runtime_bin" \
+    VIBEGUARD_RUNTIME_COMMAND_LOG="$tmp_runtime_log" \
+    HOME="${tmp_repo_runtime_once}/home" \
+    VIBEGUARD_LOG_DIR="${tmp_repo_runtime_once}/logs" \
+    bash hooks/post-write-guard.sh)
+runtime_commands="$(cat "$tmp_runtime_log")"
+assert_not_contains "$result" "VIBEGUARD" "Single-command runtime fixture remains silent"
+assert_occurrences "$runtime_commands" "post-write-fast-check" "0" "Post-write guard no longer calls fast check before full check"
+assert_occurrences "$runtime_commands" "post-write-check" "1" "Post-write guard calls the full runtime command once per Write event"
+rm -rf "$tmp_repo_runtime_once"
+
 # Git worktrees expose .git as a file, and hook inputs can be relative paths.
 tmp_repo_worktree="$(mktemp -d)"
 mkdir -p "$tmp_repo_worktree/src"

--- a/vibeguard-runtime/src/hook_checks_write.rs
+++ b/vibeguard-runtime/src/hook_checks_write.rs
@@ -8,7 +8,7 @@ use crate::hook_checks_common::{
 };
 use crate::hook_checks_scan::find_project_dir;
 use crate::hook_checks_write_scan::{
-    duplicate_definition_scan, scan_project_files, scan_same_name_matches,
+    duplicate_definition_scan, scan_project_files, scan_project_files_with_same_name,
 };
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -112,10 +112,16 @@ fn evaluate_post_write(
     let ext = extension(file_path);
     let mut warnings = Vec::new();
     let mut scan_incomplete = false;
-    let scan_files = scan_project_files(&project_dir, config.max_scan_files);
-
-    if ext != "go" {
-        let same_name = scan_same_name_matches(&project_dir, file_path, config.max_matches);
+    let scan_files = if ext == "go" {
+        scan_project_files(&project_dir, config.max_scan_files)
+    } else {
+        let scan = scan_project_files_with_same_name(
+            &project_dir,
+            file_path,
+            config.max_scan_files,
+            config.max_matches,
+        );
+        let same_name = scan.same_name;
         scan_incomplete |= same_name.incomplete;
         if !same_name.matches.is_empty() {
             warnings.push(format!(
@@ -123,7 +129,8 @@ fn evaluate_post_write(
                 same_name.matches.join(", ")
             ));
         }
-    }
+        scan.project
+    };
 
     scan_incomplete |= scan_files.incomplete;
     if scan_files.degraded {

--- a/vibeguard-runtime/src/hook_checks_write_scan.rs
+++ b/vibeguard-runtime/src/hook_checks_write_scan.rs
@@ -43,6 +43,12 @@ pub(crate) struct DefinitionScan {
     pub(crate) incomplete: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ProjectScanWithSameName {
+    pub(crate) project: ProjectScan,
+    pub(crate) same_name: SameNameScan,
+}
+
 pub(crate) fn scan_project_files(project_dir: &Path, max_files: usize) -> ProjectScan {
     let mut files = Vec::new();
     let mut count = 0usize;
@@ -53,6 +59,7 @@ pub(crate) fn scan_project_files(project_dir: &Path, max_files: usize) -> Projec
         Some(&mut files),
         &mut count,
         &mut incomplete,
+        None,
     );
     ProjectScan {
         files,
@@ -62,6 +69,7 @@ pub(crate) fn scan_project_files(project_dir: &Path, max_files: usize) -> Projec
     }
 }
 
+#[cfg(test)]
 pub(crate) fn scan_same_name_matches(
     project_dir: &Path,
     file_path: &str,
@@ -89,6 +97,38 @@ pub(crate) fn scan_same_name_matches(
     SameNameScan {
         matches,
         incomplete,
+    }
+}
+
+pub(crate) fn scan_project_files_with_same_name(
+    project_dir: &Path,
+    file_path: &str,
+    max_files: usize,
+    max_matches: usize,
+) -> ProjectScanWithSameName {
+    let mut files = Vec::new();
+    let mut count = 0usize;
+    let mut incomplete = false;
+    let mut same_name = SameNameCollector::new(file_path, max_matches);
+    let degraded = scan_dir(
+        project_dir,
+        max_files,
+        Some(&mut files),
+        &mut count,
+        &mut incomplete,
+        Some(&mut same_name),
+    );
+    ProjectScanWithSameName {
+        project: ProjectScan {
+            files,
+            count,
+            degraded,
+            incomplete,
+        },
+        same_name: SameNameScan {
+            matches: same_name.matches,
+            incomplete,
+        },
     }
 }
 
@@ -133,11 +173,13 @@ fn scan_dir(
     mut files: Option<&mut Vec<PathBuf>>,
     count: &mut usize,
     incomplete: &mut bool,
+    mut same_name: Option<&mut SameNameCollector>,
 ) -> bool {
     let Ok(entries) = fs::read_dir(dir) else {
         *incomplete = true;
         return false;
     };
+    let mut degraded = false;
     for entry_result in entries {
         let Ok(entry) = entry_result else {
             *incomplete = true;
@@ -153,22 +195,45 @@ fn scan_dir(
                 continue;
             }
             let child_files = files.as_deref_mut();
-            if scan_dir(&path, max_files, child_files, count, incomplete) {
-                return true;
+            if scan_dir(
+                &path,
+                max_files,
+                child_files,
+                count,
+                incomplete,
+                same_name.as_deref_mut(),
+            ) {
+                degraded = true;
+                if same_name
+                    .as_ref()
+                    .is_none_or(|collector| collector.is_saturated())
+                {
+                    return true;
+                }
             }
         } else if file_type.is_file() {
             *count += 1;
-            if *count > max_files {
-                return true;
+            if let Some(collector) = same_name.as_deref_mut() {
+                collector.visit(&path);
             }
-            if let Some(files) = files.as_deref_mut() {
+            if *count > max_files {
+                degraded = true;
+            } else if let Some(files) = files.as_deref_mut() {
                 files.push(path);
+            }
+            if degraded
+                && same_name
+                    .as_ref()
+                    .is_none_or(|collector| collector.is_saturated())
+            {
+                return true;
             }
         }
     }
-    false
+    degraded
 }
 
+#[cfg(test)]
 fn scan_same_name_dir(
     dir: &Path,
     basename: &str,
@@ -218,6 +283,45 @@ fn scan_same_name_dir(
             {
                 matches.push(path.to_string_lossy().into_owned());
             }
+        }
+    }
+}
+
+struct SameNameCollector {
+    basename: Option<String>,
+    target: PathBuf,
+    max_matches: usize,
+    matches: Vec<String>,
+}
+
+impl SameNameCollector {
+    fn new(file_path: &str, max_matches: usize) -> Self {
+        Self {
+            basename: Path::new(file_path)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(ToOwned::to_owned),
+            target: absolute_path(file_path),
+            max_matches,
+            matches: Vec::new(),
+        }
+    }
+
+    fn is_saturated(&self) -> bool {
+        self.matches.len() >= self.max_matches
+    }
+
+    fn visit(&mut self, path: &Path) {
+        if self.is_saturated() {
+            return;
+        }
+        let Some(basename) = self.basename.as_deref() else {
+            return;
+        };
+        if path.file_name().and_then(|s| s.to_str()) == Some(basename)
+            && absolute_path(path.to_string_lossy().as_ref()) != self.target
+        {
+            self.matches.push(path.to_string_lossy().into_owned());
         }
     }
 }

--- a/vibeguard-runtime/src/hook_checks_write_scan.rs
+++ b/vibeguard-runtime/src/hook_checks_write_scan.rs
@@ -2,6 +2,7 @@ use regex::Regex;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::hook_checks_common::is_test_path;
 use crate::hook_checks_scan::absolute_path;
 
 const SKIP_DIRS: &[&str] = &[
@@ -280,6 +281,7 @@ fn scan_same_name_dir(
             *count += 1;
             if path.file_name().and_then(|s| s.to_str()) == Some(basename)
                 && absolute_path(path.to_string_lossy().as_ref()) != target
+                && !is_test_path(path.to_string_lossy().as_ref())
             {
                 matches.push(path.to_string_lossy().into_owned());
             }
@@ -320,6 +322,7 @@ impl SameNameCollector {
         };
         if path.file_name().and_then(|s| s.to_str()) == Some(basename)
             && absolute_path(path.to_string_lossy().as_ref()) != self.target
+            && !is_test_path(path.to_string_lossy().as_ref())
         {
             self.matches.push(path.to_string_lossy().into_owned());
         }

--- a/vibeguard-runtime/src/hook_checks_write_scan_tests.rs
+++ b/vibeguard-runtime/src/hook_checks_write_scan_tests.rs
@@ -1,114 +1,154 @@
-use super::*;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(test)]
+mod write_scan_tests {
+    use super::super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
-fn temp_write_scan_project(name: &str) -> std::io::Result<PathBuf> {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let root = std::env::temp_dir().join(format!(
-        "vibeguard_write_scan_{name}_{}_{}",
-        std::process::id(),
-        unique
-    ));
-    fs::create_dir_all(root.join(".git"))?;
-    Ok(root)
-}
+    fn temp_write_scan_project(name: &str) -> std::io::Result<PathBuf> {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "vibeguard_write_scan_{name}_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(root.join(".git"))?;
+        Ok(root)
+    }
 
-#[test]
-fn scan_skips_test_dirs_and_respects_budget() -> TestResult {
-    let root = temp_write_scan_project("skip_tests")?;
-    fs::create_dir_all(root.join("src"))?;
-    fs::create_dir_all(root.join("tests"))?;
-    let target = root.join("src").join("lib.py");
-    fs::write(&target, "def realThing():\n    pass\n")?;
-    fs::write(
-        root.join("tests").join("lib.py"),
-        "def testThing():\n    pass\n",
-    )?;
+    #[test]
+    fn scan_skips_test_dirs_and_respects_budget() -> TestResult {
+        let root = temp_write_scan_project("skip_tests")?;
+        fs::create_dir_all(root.join("src"))?;
+        fs::create_dir_all(root.join("tests"))?;
+        let target = root.join("src").join("lib.py");
+        fs::write(&target, "def realThing():\n    pass\n")?;
+        fs::write(
+            root.join("tests").join("lib.py"),
+            "def testThing():\n    pass\n",
+        )?;
 
-    let scan = scan_project_files(&root, 10);
-    assert_eq!(scan.count, 1);
-    assert!(!scan.degraded);
-    assert!(
-        scan_same_name_matches(&root, target.to_string_lossy().as_ref(), 5)
-            .matches
-            .is_empty()
-    );
-    let combined =
-        scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 10, 5);
-    assert_eq!(combined.project.count, 1);
-    assert!(combined.same_name.matches.is_empty());
+        let scan = scan_project_files(&root, 10);
+        assert_eq!(scan.count, 1);
+        assert!(!scan.degraded);
+        assert!(
+            scan_same_name_matches(&root, target.to_string_lossy().as_ref(), 5)
+                .matches
+                .is_empty()
+        );
+        let combined =
+            scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 10, 5);
+        assert_eq!(combined.project.count, 1);
+        assert!(combined.same_name.matches.is_empty());
 
-    let degraded = scan_project_files(&root, 0);
-    assert!(degraded.degraded);
-    fs::remove_dir_all(root)?;
-    Ok(())
-}
+        let degraded = scan_project_files(&root, 0);
+        assert!(degraded.degraded);
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
 
-#[test]
-fn combined_scan_preserves_same_name_matches_after_budget_degrades() -> TestResult {
-    let root = temp_write_scan_project("same_name_budget")?;
-    fs::create_dir_all(root.join("src").join("existing"))?;
-    fs::create_dir_all(root.join("src").join("new"))?;
-    fs::write(root.join("src").join("existing").join("service.py"), "")?;
-    let target = root.join("src").join("new").join("service.py");
+    #[test]
+    fn same_name_scan_ignores_test_and_fixture_paths() -> TestResult {
+        let root = temp_write_scan_project("same_name_test_paths")?;
+        fs::create_dir_all(root.join("src").join("new"))?;
+        for dir in ["fixtures", "mocks", "testdata"] {
+            fs::create_dir_all(root.join(dir))?;
+            fs::write(root.join(dir).join("config.rs"), "pub fn fake() {}\n")?;
+        }
+        fs::write(
+            root.join("src").join("config.test.py"),
+            "def fake():\n    pass\n",
+        )?;
+        fs::write(
+            root.join("src").join("config_test.py"),
+            "def fake():\n    pass\n",
+        )?;
+        fs::write(root.join("src").join("config.rs"), "pub fn real() {}\n")?;
+        let target = root.join("src").join("new").join("config.rs");
 
-    let combined =
-        scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 0, 5);
+        let legacy = scan_same_name_matches(&root, target.to_string_lossy().as_ref(), 10);
+        let combined =
+            scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 0, 10);
 
-    assert!(combined.project.degraded);
-    assert!(
-        combined
-            .same_name
-            .matches
-            .iter()
-            .any(|path| path.ends_with("existing/service.py")),
-        "{combined:?}"
-    );
-    fs::remove_dir_all(root)?;
-    Ok(())
-}
+        assert_eq!(
+            legacy.matches,
+            vec![root.join("src").join("config.rs").to_string_lossy()]
+        );
+        assert_eq!(
+            combined.same_name.matches,
+            vec![root.join("src").join("config.rs").to_string_lossy()]
+        );
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
 
-#[test]
-fn duplicate_definition_matches_same_extension_only() -> TestResult {
-    let root = temp_write_scan_project("duplicate_defs")?;
-    fs::create_dir_all(root.join("src"))?;
-    fs::write(
-        root.join("src").join("existing.py"),
-        "def sharedName():\n    pass\n",
-    )?;
-    fs::write(
-        root.join("src").join("existing.ts"),
-        "function sharedName() {}\n",
-    )?;
-    let scan = scan_project_files(&root, 10);
+    #[test]
+    fn combined_scan_preserves_same_name_matches_after_budget_degrades() -> TestResult {
+        let root = temp_write_scan_project("same_name_budget")?;
+        fs::create_dir_all(root.join("src").join("existing"))?;
+        fs::create_dir_all(root.join("src").join("new"))?;
+        fs::write(root.join("src").join("existing").join("service.py"), "")?;
+        let target = root.join("src").join("new").join("service.py");
 
-    let found = duplicate_definition_scan(
-        &scan.files,
-        root.join("src").join("new.py").to_string_lossy().as_ref(),
-        "def sharedName():\n    return 1\n",
-        "py",
-        20,
-        5,
-    );
-    assert_eq!(found.duplicates.len(), 1);
-    assert!(found.duplicates[0].contains("existing.py"), "{found:?}");
-    assert!(!found.duplicates[0].contains("existing.ts"), "{found:?}");
-    fs::remove_dir_all(root)?;
-    Ok(())
-}
+        let combined =
+            scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 0, 5);
 
-#[test]
-fn missing_scan_root_marks_incomplete() -> TestResult {
-    let root = temp_write_scan_project("missing_root")?;
-    let missing = root.join("missing");
+        assert!(combined.project.degraded);
+        assert!(
+            combined
+                .same_name
+                .matches
+                .iter()
+                .any(|path| path.ends_with("existing/service.py")),
+            "{combined:?}"
+        );
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
 
-    assert!(scan_project_files(&missing, 10).incomplete);
-    assert!(scan_same_name_matches(&missing, "new.py", 5).incomplete);
+    #[test]
+    fn duplicate_definition_matches_same_extension_only() -> TestResult {
+        let root = temp_write_scan_project("duplicate_defs")?;
+        fs::create_dir_all(root.join("src"))?;
+        fs::write(
+            root.join("src").join("existing.py"),
+            "def sharedName():\n    pass\n",
+        )?;
+        fs::write(
+            root.join("src").join("existing.ts"),
+            "function sharedName() {}\n",
+        )?;
+        let scan = scan_project_files(&root, 10);
 
-    fs::remove_dir_all(root)?;
-    Ok(())
+        let found = duplicate_definition_scan(
+            &scan.files,
+            root.join("src").join("new.py").to_string_lossy().as_ref(),
+            "def sharedName():\n    return 1\n",
+            "py",
+            20,
+            5,
+        );
+        assert_eq!(found.duplicates.len(), 1);
+        assert!(found.duplicates[0].contains("existing.py"), "{found:?}");
+        assert!(!found.duplicates[0].contains("existing.ts"), "{found:?}");
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn missing_scan_root_marks_incomplete() -> TestResult {
+        let root = temp_write_scan_project("missing_root")?;
+        let missing = root.join("missing");
+
+        assert!(scan_project_files(&missing, 10).incomplete);
+        assert!(scan_same_name_matches(&missing, "new.py", 5).incomplete);
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
 }

--- a/vibeguard-runtime/src/hook_checks_write_scan_tests.rs
+++ b/vibeguard-runtime/src/hook_checks_write_scan_tests.rs
@@ -37,9 +37,37 @@ fn scan_skips_test_dirs_and_respects_budget() -> TestResult {
             .matches
             .is_empty()
     );
+    let combined =
+        scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 10, 5);
+    assert_eq!(combined.project.count, 1);
+    assert!(combined.same_name.matches.is_empty());
 
     let degraded = scan_project_files(&root, 0);
     assert!(degraded.degraded);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn combined_scan_preserves_same_name_matches_after_budget_degrades() -> TestResult {
+    let root = temp_write_scan_project("same_name_budget")?;
+    fs::create_dir_all(root.join("src").join("existing"))?;
+    fs::create_dir_all(root.join("src").join("new"))?;
+    fs::write(root.join("src").join("existing").join("service.py"), "")?;
+    let target = root.join("src").join("new").join("service.py");
+
+    let combined =
+        scan_project_files_with_same_name(&root, target.to_string_lossy().as_ref(), 0, 5);
+
+    assert!(combined.project.degraded);
+    assert!(
+        combined
+            .same_name
+            .matches
+            .iter()
+            .any(|path| path.ends_with("existing/service.py")),
+        "{combined:?}"
+    );
     fs::remove_dir_all(root)?;
     Ok(())
 }


### PR DESCRIPTION
Closes #442.

## Summary
- remove the shell fast-check/full-check double runtime path for post-write handling
- add a combined project scan that returns file list, degraded/incomplete state, and same-name matches from one traversal
- preserve Go same-name carve-out, scan-budget/degraded warnings, duplicate definition checks, and visible runtime failures

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml hook_checks_write`
- `bash tests/hooks/test_post_write_guard.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_hooks.sh`
- `git diff --check`