### PR TITLE
perf: include Codex wrapper latency fixtures

### DIFF
--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -34,7 +34,7 @@ Use `--sla=<ms>` only when deliberately testing a temporary global threshold. Th
 
 Most fixtures invoke hook scripts directly so regressions in hook logic, JSON parsing, logging, and bounded event-log reads are isolated to the hook under test.
 
-Codex wrapper hooks invoke `hooks/run-hook-codex.sh` with a temporary `HOME/.vibeguard/repo-path` pointing at the repository. These fixtures include Codex event parsing, runtime policy lookup, status diagnostics, output adaptation, and wrapper finalization before the underlying hook returns. They are intentionally budgeted separately from direct hooks because they measure the installed Codex path, not just the hook body.
+Codex wrapper hooks invoke a temporary installed-wrapper copy with the same helper files installed by `scripts/setup/targets/codex-home.sh` and a repo-path file pointing at the repository. These fixtures include Codex event parsing, installed wrapper/helper lookup, runtime policy lookup, status diagnostics, output adaptation, and wrapper finalization before the underlying hook returns. They are intentionally budgeted separately from direct hooks because they measure the installed Codex path, not just the hook body.
 
 ## Hotspot Attribution
 

--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -25,6 +25,7 @@ These are cross-OS CI budgets, not ideal-machine optimization targets. Static pe
 Run the gate locally:
 
 ```bash
+cargo build --manifest-path vibeguard-runtime/Cargo.toml --quiet
 bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
 ```
 

--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -19,6 +19,8 @@ These are cross-OS CI budgets, not ideal-machine optimization targets. Static pe
 | `post-write-guard (5000)` | 500ms |
 | `stop-guard (5000)` | 400ms |
 | `learn-evaluator (5000)` | 400ms |
+| `codex-wrapper pre-bash-guard` | 900ms |
+| `codex-wrapper post-edit-guard (100)` | 900ms |
 
 Run the gate locally:
 
@@ -27,6 +29,12 @@ bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
 ```
 
 Use `--sla=<ms>` only when deliberately testing a temporary global threshold. The default contract is per-hook.
+
+## Direct vs Wrapper Coverage
+
+Most fixtures invoke hook scripts directly so regressions in hook logic, JSON parsing, logging, and bounded event-log reads are isolated to the hook under test.
+
+Codex wrapper hooks invoke `hooks/run-hook-codex.sh` with a temporary `HOME/.vibeguard/repo-path` pointing at the repository. These fixtures include Codex event parsing, runtime policy lookup, status diagnostics, output adaptation, and wrapper finalization before the underlying hook returns. They are intentionally budgeted separately from direct hooks because they measure the installed Codex path, not just the hook body.
 
 ## Hotspot Attribution
 

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -120,10 +120,24 @@ cat > "$TMPDIR_BENCH/bash-input.json" <<'EOF'
 {"tool_input":{"command":"cargo check"}}
 EOF
 
+# Mock Codex wrapper inputs. These fixtures keep the hook payload shape close to
+# real Codex hook events while preserving the direct-hook fields under tool_input.
+cat > "$TMPDIR_BENCH/codex-pre-bash-input.json" <<'EOF'
+{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cargo check"}}
+EOF
+
+cat > "$TMPDIR_BENCH/codex-post-edit-input.json" <<'EOF'
+{"hook_event_name":"PostToolUse","tool_name":"Edit","tool_input":{"file_path":"src/main.rs","old_string":"fn main()","new_string":"fn main() {\n    println!(\"hello\");\n}"},"tool_response":{"output":"ok"}}
+EOF
+
 # Mock Stop input JSON
 cat > "$TMPDIR_BENCH/stop-input.json" <<'EOF'
 {"stop_hook_active":false}
 EOF
+
+CODEX_BENCH_HOME="$TMPDIR_BENCH/codex-home"
+mkdir -p "$CODEX_BENCH_HOME/.vibeguard"
+printf '%s' "$REPO_DIR" > "$CODEX_BENCH_HOME/.vibeguard/repo-path"
 
 # --- Benchmark runner ---
 RESULTS=()
@@ -143,6 +157,7 @@ budget_for() {
     post-write-guard\ \(100\)) printf '%s\n' 400 ;;
     post-edit-guard\ \(5000\)|post-write-guard\ \(5000\)) printf '%s\n' 500 ;;
     stop-guard\ \(5000\)|learn-evaluator\ \(5000\)) printf '%s\n' 400 ;;
+    codex-wrapper\ pre-bash-guard|codex-wrapper\ post-edit-guard\ \(100\)) printf '%s\n' 900 ;;
     synthetic-slow-hook) printf '%s\n' 1 ;;
     *) printf '%s\n' "$DEFAULT_BUDGET_MS" ;;
   esac
@@ -208,6 +223,65 @@ bench_hook() {
   RESULTS+=("{\"name\":\"$name\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
 }
 
+bench_codex_wrapper() {
+  local name="$1"
+  local hook_name="$2"
+  local input_file="$3"
+  local events_file="${4:-}"
+  local budget_ms="${5:-$(budget_for "$name")}"
+  local hotspot="${6:-run-hook-codex.sh ${hook_name}}"
+  local latencies=()
+
+  for _run in $(seq 1 "$RUNS"); do
+    local bench_log_file="${events_file:-$TMPDIR_BENCH/events-bench.jsonl}"
+    local -a hook_env=(
+      "HOME=$CODEX_BENCH_HOME"
+      "VIBEGUARD_LOG_DIR=$TMPDIR_BENCH"
+      "VIBEGUARD_LOG_FILE=$bench_log_file"
+      "VIBEGUARD_SESSION_ID=bench"
+      "VIBEGUARD_PROJECT_HASH=bench000"
+      "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
+      "VIBEGUARD_CODEX_DIAG_FILE=$TMPDIR_BENCH/codex-wrapper.jsonl"
+      "VIBEGUARD_POLICY_DIAG_FILE=$TMPDIR_BENCH/policy.jsonl"
+    )
+
+    local start=$(_now_ms)
+    env "${hook_env[@]}" bash "$HOOKS_DIR/run-hook-codex.sh" "$hook_name" < "$input_file" > /dev/null 2>&1 || true
+    local end=$(_now_ms)
+    local elapsed=$((end - start))
+    latencies+=("$elapsed")
+  done
+
+  local sorted
+  sorted=$(printf '%s\n' "${latencies[@]}" | sort -n)
+  local count=${#latencies[@]}
+  local p50_idx=$(( (count * 50 / 100) ))
+  local p95_idx=$(( (count * 95 / 100) ))
+  local p99_idx=$(( (count * 99 / 100) ))
+  [[ $p50_idx -ge $count ]] && p50_idx=$((count - 1))
+  [[ $p95_idx -ge $count ]] && p95_idx=$((count - 1))
+  [[ $p99_idx -ge $count ]] && p99_idx=$((count - 1))
+
+  local p50=$(echo "$sorted" | sed -n "$((p50_idx + 1))p")
+  local p95=$(echo "$sorted" | sed -n "$((p95_idx + 1))p")
+  local p99=$(echo "$sorted" | sed -n "$((p99_idx + 1))p")
+  local max_lat=$(echo "$sorted" | tail -1)
+
+  local status="PASS"
+  if [[ "$p95" -gt "$budget_ms" ]]; then
+    if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
+      status="ENV-DISTORTED"
+    else
+      status="FAIL"
+      FAILURES=$((FAILURES + 1))
+    fi
+  fi
+
+  printf "  %-35s P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
+
+  RESULTS+=("{\"name\":\"$name\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
+}
+
 echo "======================================"
 echo "VibeGuard Hook Latency Benchmark"
 if [[ -n "$GLOBAL_SLA_MS" ]]; then
@@ -233,6 +307,11 @@ echo ""
 echo "[PostToolUse hooks — 100-line log]"
 bench_hook "post-edit-guard (100)" "$HOOKS_DIR/post-edit-guard.sh" "$TMPDIR_BENCH/edit-input.json" "$TMPDIR_BENCH/events-100.jsonl"
 bench_hook "post-write-guard (100)" "$HOOKS_DIR/post-write-guard.sh" "$TMPDIR_BENCH/write-input.json" "$TMPDIR_BENCH/events-100.jsonl"
+echo ""
+
+echo "[Codex wrapper hooks]"
+bench_codex_wrapper "codex-wrapper pre-bash-guard" "vibeguard-pre-bash-guard.sh" "$TMPDIR_BENCH/codex-pre-bash-input.json"
+bench_codex_wrapper "codex-wrapper post-edit-guard (100)" "vibeguard-post-edit-guard.sh" "$TMPDIR_BENCH/codex-post-edit-input.json" "$TMPDIR_BENCH/events-100.jsonl"
 echo ""
 
 # --- Post-hooks with large log (stress test, should still be <200ms) ---

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -9,7 +9,8 @@
 #   bash tests/bench_hook_latency.sh --json       # JSON output for CI
 #   bash tests/bench_hook_latency.sh --fail-on-regression  # exit 1 if a fixture exceeds its budget
 #
-# Requires: perl (for hi-res timing) or python3
+# Requires: perl (for hi-res timing) or python3. Codex wrapper fixtures also
+# require a built vibeguard-runtime binary.
 
 set -euo pipefail
 
@@ -155,6 +156,10 @@ for runtime_candidate in \
     break
   fi
 done
+if [[ ! -x "$CODEX_BENCH_RUNTIME" ]]; then
+  printf '%s\n' "ERROR: Codex wrapper benchmark requires vibeguard-runtime. Run: cargo build --manifest-path vibeguard-runtime/Cargo.toml" >&2
+  exit 1
+fi
 
 # --- Benchmark runner ---
 RESULTS=()

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -136,8 +136,25 @@ cat > "$TMPDIR_BENCH/stop-input.json" <<'EOF'
 EOF
 
 CODEX_BENCH_HOME="$TMPDIR_BENCH/codex-home"
-mkdir -p "$CODEX_BENCH_HOME/.vibeguard"
+CODEX_BENCH_WRAPPER="$CODEX_BENCH_HOME/.vibeguard/run-hook-codex.sh"
+CODEX_BENCH_RUNTIME="$CODEX_BENCH_HOME/.vibeguard/installed/bin/vibeguard-runtime"
+mkdir -p "$CODEX_BENCH_HOME/.vibeguard/_lib" "$CODEX_BENCH_HOME/.vibeguard/installed/bin"
 printf '%s' "$REPO_DIR" > "$CODEX_BENCH_HOME/.vibeguard/repo-path"
+cp "$HOOKS_DIR/run-hook-codex.sh" "$CODEX_BENCH_WRAPPER"
+cp "$HOOKS_DIR/_lib/codex_diag.sh" "$CODEX_BENCH_HOME/.vibeguard/_lib/codex_diag.sh"
+cp "$HOOKS_DIR/_lib/codex_runner.sh" "$CODEX_BENCH_HOME/.vibeguard/_lib/codex_runner.sh"
+cp "$HOOKS_DIR/_lib/timeout.sh" "$CODEX_BENCH_HOME/.vibeguard/_lib/timeout.sh"
+chmod +x "$CODEX_BENCH_WRAPPER"
+for runtime_candidate in \
+  "${VIBEGUARD_RUNTIME:-}" \
+  "$REPO_DIR/vibeguard-runtime/target/debug/vibeguard-runtime" \
+  "$REPO_DIR/vibeguard-runtime/target/release/vibeguard-runtime"; do
+  if [[ -n "$runtime_candidate" && -x "$runtime_candidate" ]]; then
+    cp "$runtime_candidate" "$CODEX_BENCH_RUNTIME"
+    chmod +x "$CODEX_BENCH_RUNTIME"
+    break
+  fi
+done
 
 # --- Benchmark runner ---
 RESULTS=()
@@ -229,7 +246,7 @@ bench_codex_wrapper() {
   local input_file="$3"
   local events_file="${4:-}"
   local budget_ms="${5:-$(budget_for "$name")}"
-  local hotspot="${6:-run-hook-codex.sh ${hook_name}}"
+  local hotspot="${6:-~/.vibeguard/run-hook-codex.sh ${hook_name}}"
   local latencies=()
 
   for _run in $(seq 1 "$RUNS"); do
@@ -243,10 +260,12 @@ bench_codex_wrapper() {
       "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
       "VIBEGUARD_CODEX_DIAG_FILE=$TMPDIR_BENCH/codex-wrapper.jsonl"
       "VIBEGUARD_POLICY_DIAG_FILE=$TMPDIR_BENCH/policy.jsonl"
+      "VIBEGUARD_RUNTIME="
+      "VIBEGUARD_POLICY_RUNTIME="
     )
 
     local start=$(_now_ms)
-    env "${hook_env[@]}" bash "$HOOKS_DIR/run-hook-codex.sh" "$hook_name" < "$input_file" > /dev/null 2>&1 || true
+    env "${hook_env[@]}" bash "$CODEX_BENCH_WRAPPER" "$hook_name" < "$input_file" > /dev/null 2>&1 || true
     local end=$(_now_ms)
     local elapsed=$((end - start))
     latencies+=("$elapsed")

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -127,9 +127,13 @@ header "dynamic latency gate"
 assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
 assert_file_contains "${TMP_DIR}/slow.out" "exceeded latency budget" "slow hook output explains budget failure"
 assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "slow hook output includes hotspot attribution"
+assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper pre-bash-guard" "latency gate includes Codex PreToolUse wrapper fixture"
+assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper post-edit-guard (100)" "latency gate includes Codex PostToolUse wrapper fixture"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P50)" "benchmark action output includes P50 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P95)" "benchmark action output includes P95 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P99)" "benchmark action output includes P99 samples"
+assert_file_contains "${REPO_DIR}/bench-output.json" "codex-wrapper pre-bash-guard (P95)" "benchmark action output includes Codex wrapper samples"
+assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "Codex wrapper hooks" "latency contract documents wrapper coverage"
 assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
 
 echo ""

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -96,6 +96,7 @@ write_hook() {
 header "syntax"
 assert_cmd "performance validator syntax" bash -n "${VALIDATOR}"
 assert_cmd "latency benchmark syntax" bash -n "${BENCH}"
+assert_file_contains "${BENCH}" "Codex wrapper benchmark requires vibeguard-runtime" "latency benchmark fails fast without runtime for Codex wrapper fixtures"
 
 header "static performance gates"
 GOOD_HOOKS="${TMP_DIR}/good-hooks"


### PR DESCRIPTION
## Summary
- add Codex wrapper latency fixtures for representative PreToolUse and PostToolUse hooks
- wire the wrapper fixtures into the fail-on-regression benchmark output and benchmark-action JSON
- document direct hook vs installed Codex wrapper latency coverage

Fixes #440

## Verification
- bash -n tests/bench_hook_latency.sh tests/test_hook_perf_contract.sh
- cargo build --manifest-path vibeguard-runtime/Cargo.toml --quiet
- bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
- bash tests/test_hook_perf_contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- git diff --check
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml