### PR TITLE
perf: cache post-build checks and add latency fixture

### DIFF
--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -21,6 +21,7 @@ These are cross-OS CI budgets, not ideal-machine optimization targets. Static pe
 | `learn-evaluator (5000)` | 400ms |
 | `codex-wrapper pre-bash-guard` | 900ms |
 | `codex-wrapper post-edit-guard (100)` | 900ms |
+| `post-build-check (fake cargo)` | 900ms |
 
 Run the gate locally:
 
@@ -36,6 +37,8 @@ Use `--sla=<ms>` only when deliberately testing a temporary global threshold. Th
 Most fixtures invoke hook scripts directly so regressions in hook logic, JSON parsing, logging, and bounded event-log reads are isolated to the hook under test.
 
 Codex wrapper hooks invoke a temporary installed-wrapper copy with the same helper files installed by `scripts/setup/targets/codex-home.sh` and a repo-path file pointing at the repository. These fixtures include Codex event parsing, installed wrapper/helper lookup, runtime policy lookup, status diagnostics, output adaptation, and wrapper finalization before the underlying hook returns. They are intentionally budgeted separately from direct hooks because they measure the installed Codex path, not just the hook body.
+
+Post-build fixtures use fake build commands and disable the post-build cache so CI measures hook overhead, timeout wrapping, project detection, and command dispatch without running a real full build.
 
 ## Hotspot Attribution
 

--- a/hooks/post-build-check.sh
+++ b/hooks/post-build-check.sh
@@ -17,6 +17,9 @@ source "${HOOK_DIR}/_lib/timeout.sh"
 vg_start_timer
 VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-${HOOK_DIR}/_lib}"
 POST_BUILD_TIMEOUT="${VIBEGUARD_POST_BUILD_TIMEOUT:-30}"
+POST_BUILD_CACHE_TTL="${VIBEGUARD_POST_BUILD_CACHE_TTL:-10}"
+POST_BUILD_CACHE_VERSION="v1"
+POST_BUILD_CACHE_HIT=0
 
 INPUT=$(cat)
 
@@ -35,6 +38,74 @@ post_build_filter_or_head() {
   fi
 }
 
+post_build_hash_stream() {
+  shasum -a 256 | awk '{print $1}'
+}
+
+post_build_hash_file() {
+  shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+}
+
+post_build_cache_enabled() {
+  [[ "$POST_BUILD_CACHE_TTL" =~ ^[0-9]+$ && "$POST_BUILD_CACHE_TTL" -gt 0 ]]
+}
+
+post_build_cache_root() {
+  local cache_root="${VIBEGUARD_PROJECT_LOG_DIR:-${VIBEGUARD_LOG_DIR}/projects/post-build-check}/cache/post-build-check"
+  mkdir -p "$cache_root" 2>/dev/null || return 1
+  printf '%s\n' "$cache_root"
+}
+
+post_build_worktree_state() {
+  local project_root="$1" file_path="$2"
+  local state_root="${project_root:-$(dirname "$file_path")}"
+
+  if [[ -n "$state_root" && -d "$state_root" ]] && git -C "$state_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    {
+      printf 'git\n'
+      git -C "$state_root" rev-parse HEAD 2>/dev/null || true
+      git -C "$state_root" status --porcelain=v1 --untracked-files=all -- . 2>/dev/null || true
+      git -C "$state_root" diff --no-ext-diff --binary -- . 2>/dev/null || true
+      git -C "$state_root" diff --cached --no-ext-diff --binary -- . 2>/dev/null || true
+      (cd "$state_root" && git ls-files --others --exclude-standard -z -- . 2>/dev/null | xargs -0 shasum -a 256 2>/dev/null || true)
+    } | post_build_hash_stream
+    return 0
+  fi
+
+  {
+    printf 'file\n'
+    printf '%s\n' "$file_path"
+    [[ -f "$file_path" ]] && post_build_hash_file "$file_path"
+  } | post_build_hash_stream
+}
+
+post_build_cache_key() {
+  local project_root="$1" ext="$2" label="$3" state="$4"
+  printf '%s\0%s\0%s\0%s\0%s' "$POST_BUILD_CACHE_VERSION" "$project_root" "$ext" "$label" "$state" | post_build_hash_stream
+}
+
+post_build_cache_read() {
+  local cache_file="$1" now ts
+  [[ -f "$cache_file" ]] || return 1
+  IFS= read -r ts < "$cache_file" || return 1
+  [[ "$ts" =~ ^[0-9]+$ ]] || return 1
+  now=$(date +%s)
+  [[ $((now - ts)) -le "$POST_BUILD_CACHE_TTL" ]] || return 1
+  POST_BUILD_CACHE_HIT=1
+  tail -n +3 "$cache_file" 2>/dev/null || true
+  return 0
+}
+
+post_build_cache_write() {
+  local cache_file="$1" errors="$2" tmp_file
+  tmp_file="${cache_file}.$$"
+  {
+    date +%s
+    printf '%s\n' "$POST_BUILD_CACHE_VERSION"
+    printf '%s\n' "$errors"
+  } > "$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" 2>/dev/null || rm -f "$tmp_file" 2>/dev/null || true
+}
+
 post_build_run() {
   local project_root="$1" label="$2" pattern="$3"
   shift 3
@@ -49,8 +120,34 @@ post_build_run() {
   if [[ ${status} -eq 124 ]]; then
     printf '%s\n' "post-build-check timeout after ${POST_BUILD_TIMEOUT}s while running: ${label}"
   elif [[ ${status} -ne 0 ]]; then
-    post_build_filter_or_head "${pattern}" "${output}"
+    if [[ -n "${output}" ]]; then
+      post_build_filter_or_head "${pattern}" "${output}"
+    else
+      printf '%s\n' "post-build-check failed with exit status ${status} while running: ${label}"
+    fi
   fi
+}
+
+post_build_run_cached() {
+  local project_root="$1" ext="$2" label="$3" pattern="$4"
+  shift 4
+  local cache_dir cache_file cache_key errors state
+
+  if post_build_cache_enabled \
+    && cache_dir=$(post_build_cache_root) \
+    && state=$(post_build_worktree_state "$project_root" "$FILE_PATH"); then
+    cache_key=$(post_build_cache_key "${project_root:-$(dirname "$FILE_PATH")}" "$ext" "$label" "$state")
+    cache_file="${cache_dir}/${cache_key}.txt"
+    if post_build_cache_read "$cache_file"; then
+      return 0
+    fi
+  fi
+
+  errors=$(post_build_run "$project_root" "$label" "$pattern" "$@")
+  if [[ -n "${cache_file:-}" ]]; then
+    post_build_cache_write "$cache_file" "$errors"
+  fi
+  printf '%s\n' "$errors"
 }
 
 # Extract file_path from Edit or Write JSON
@@ -104,14 +201,14 @@ case "$EXT" in
       post_build_log_skip "missing Cargo.toml" "${FILE_PATH}"
       exit 0
     fi
-    ERRORS=$(post_build_run "$PROJECT_ROOT" "cargo check --message-format=short" "^error" cargo check --message-format=short)
+    ERRORS=$(post_build_run_cached "$PROJECT_ROOT" "$EXT" "cargo check --message-format=short" "^error" cargo check --message-format=short)
     ;;
   ts|tsx)
     if ! PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "tsconfig.json"); then
       post_build_log_skip "missing tsconfig.json" "${FILE_PATH}"
       exit 0
     fi
-    ERRORS=$(post_build_run "$PROJECT_ROOT" "npx tsc --noEmit" "error TS" npx tsc --noEmit)
+    ERRORS=$(post_build_run_cached "$PROJECT_ROOT" "$EXT" "npx tsc --noEmit" "error TS" npx tsc --noEmit)
     ;;
   js|mjs|cjs)
     # JavaScript syntax check (does not depend on tsconfig)
@@ -120,19 +217,23 @@ case "$EXT" in
       exit 0
     fi
     PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "package.json") || true
-    ERRORS=$(post_build_run "" "node --check" "." node --check "$FILE_PATH")
+    ERRORS=$(post_build_run_cached "$PROJECT_ROOT" "$EXT" "node --check" "." node --check "$FILE_PATH")
     ;;
   go)
     if ! PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")" "go.mod"); then
       post_build_log_skip "missing go.mod" "${FILE_PATH}"
       exit 0
     fi
-    ERRORS=$(post_build_run "$PROJECT_ROOT" "go build ./..." "." go build ./...)
+    ERRORS=$(post_build_run_cached "$PROJECT_ROOT" "$EXT" "go build ./..." "." go build ./...)
     ;;
 esac
 
 if [[ -z "$ERRORS" ]]; then
-  vg_log "post-build-check" "PostToolUse" "pass" "" "$FILE_PATH"
+  if [[ "$POST_BUILD_CACHE_HIT" -eq 1 ]]; then
+    vg_log "post-build-check" "PostToolUse" "pass" "cache hit" "$FILE_PATH"
+  else
+    vg_log "post-build-check" "PostToolUse" "pass" "" "$FILE_PATH"
+  fi
   exit 0
 fi
 

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -121,6 +121,29 @@ cat > "$TMPDIR_BENCH/bash-input.json" <<'EOF'
 {"tool_input":{"command":"cargo check"}}
 EOF
 
+POST_BUILD_BENCH_PROJECT="$TMPDIR_BENCH/post-build-rust"
+POST_BUILD_FAKE_BIN="$TMPDIR_BENCH/fake-bin"
+mkdir -p "$POST_BUILD_BENCH_PROJECT/src" "$POST_BUILD_FAKE_BIN"
+cat > "$POST_BUILD_BENCH_PROJECT/Cargo.toml" <<'EOF'
+[package]
+name = "post-build-bench"
+version = "0.0.0"
+edition = "2021"
+EOF
+cat > "$POST_BUILD_BENCH_PROJECT/src/lib.rs" <<'EOF'
+pub fn value() -> i32 { 1 }
+EOF
+cat > "$POST_BUILD_FAKE_BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${VIBEGUARD_POST_BUILD_FAKE_COMMAND_LOG:?}"
+exit 0
+EOF
+chmod +x "$POST_BUILD_FAKE_BIN/cargo"
+cat > "$TMPDIR_BENCH/post-build-input.json" <<EOF
+{"tool_input":{"file_path":"$POST_BUILD_BENCH_PROJECT/src/lib.rs"}}
+EOF
+
 # Mock Codex wrapper inputs. These fixtures keep the hook payload shape close to
 # real Codex hook events while preserving the direct-hook fields under tool_input.
 cat > "$TMPDIR_BENCH/codex-pre-bash-input.json" <<'EOF'
@@ -180,6 +203,7 @@ budget_for() {
     post-edit-guard\ \(5000\)|post-write-guard\ \(5000\)) printf '%s\n' 500 ;;
     stop-guard\ \(5000\)|learn-evaluator\ \(5000\)) printf '%s\n' 400 ;;
     codex-wrapper\ pre-bash-guard|codex-wrapper\ post-edit-guard\ \(100\)) printf '%s\n' 900 ;;
+    post-build-check\ \(fake\ cargo\)) printf '%s\n' 900 ;;
     synthetic-slow-hook) printf '%s\n' 1 ;;
     *) printf '%s\n' "$DEFAULT_BUDGET_MS" ;;
   esac
@@ -193,6 +217,12 @@ bench_hook() {
   local budget_ms="${5:-$(budget_for "$name")}"
   local hotspot="${6:-${name}}"
   local latencies=()
+  local -a extra_env=()
+
+  if [[ $# -gt 6 ]]; then
+    shift 6
+    extra_env=("$@")
+  fi
 
   for _run in $(seq 1 "$RUNS"); do
     # Keep benchmark runs isolated from the caller's ambient project log and
@@ -208,7 +238,7 @@ bench_hook() {
     )
 
     local start=$(_now_ms)
-    env "${hook_env[@]}" bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
+    env "${hook_env[@]}" "${extra_env[@]}" bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
     local end=$(_now_ms)
     local elapsed=$((end - start))
     latencies+=("$elapsed")
@@ -331,6 +361,10 @@ echo ""
 echo "[PostToolUse hooks — 100-line log]"
 bench_hook "post-edit-guard (100)" "$HOOKS_DIR/post-edit-guard.sh" "$TMPDIR_BENCH/edit-input.json" "$TMPDIR_BENCH/events-100.jsonl"
 bench_hook "post-write-guard (100)" "$HOOKS_DIR/post-write-guard.sh" "$TMPDIR_BENCH/write-input.json" "$TMPDIR_BENCH/events-100.jsonl"
+echo ""
+
+echo "[Post-build hooks — fake command]"
+bench_hook "post-build-check (fake cargo)" "$HOOKS_DIR/post-build-check.sh" "$TMPDIR_BENCH/post-build-input.json" "$TMPDIR_BENCH/events-100.jsonl" "$(budget_for "post-build-check (fake cargo)")" "fake cargo check" "PATH=$POST_BUILD_FAKE_BIN:$PATH" "VIBEGUARD_POST_BUILD_CACHE_TTL=0" "VIBEGUARD_POST_BUILD_FAKE_COMMAND_LOG=$TMPDIR_BENCH/post-build-fake-command.log"
 echo ""
 
 echo "[Codex wrapper hooks]"

--- a/tests/hooks/test_post_build_check.sh
+++ b/tests/hooks/test_post_build_check.sh
@@ -69,6 +69,60 @@ assert_contains "$result" "timeout after 1s" "Post-build check reports timeout v
 assert_contains "$(grep -R "post-build-check timeout after 1s" "$VIBEGUARD_LOG_DIR" 2>/dev/null || true)" "post-build-check timeout after 1s" "Post-build timeout records telemetry"
 rm -rf "$tmp_js_timeout"
 
+# Build commands that fail without stderr/stdout should still be visible.
+tmp_js_empty_fail="$(mktemp -d)"
+mkdir -p "$tmp_js_empty_fail/bin"
+cat >"$tmp_js_empty_fail/bin/node" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+chmod +x "$tmp_js_empty_fail/bin/node"
+cat >"$tmp_js_empty_fail/fail.js" <<'EOF'
+const value = 1;
+EOF
+result=$(PATH="$tmp_js_empty_fail/bin:$PATH" bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp_js_empty_fail/fail.js\"}}' | bash hooks/post-build-check.sh")
+assert_contains "$result" "failed with exit status 7" "Post-build command failure without output is visible"
+rm -rf "$tmp_js_empty_fail"
+
+# Repeated checks for the same unchanged project should reuse a short-lived cache,
+# but changing the checked file must invalidate the cache and surface failures.
+tmp_js_cache="$(mktemp -d)"
+mkdir -p "$tmp_js_cache/bin"
+cat >"$tmp_js_cache/bin/node" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${POST_BUILD_NODE_LOG:?}"
+target=""
+for arg in "$@"; do
+  target="$arg"
+done
+if grep -q "BROKEN" "$target"; then
+  printf '%s\n' "SyntaxError: broken fixture" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$tmp_js_cache/bin/node"
+cat >"$tmp_js_cache/cached.js" <<'EOF'
+const value = 1;
+EOF
+cache_node_log="$tmp_js_cache/node.log"
+cache_env=(PATH="$tmp_js_cache/bin:$PATH" POST_BUILD_NODE_LOG="$cache_node_log" VIBEGUARD_POST_BUILD_CACHE_TTL=60)
+result=$(env "${cache_env[@]}" bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp_js_cache/cached.js\"}}' | bash hooks/post-build-check.sh")
+assert_not_contains "$result" "VIBEGUARD" "Initial post-build cache fixture passes"
+result=$(env "${cache_env[@]}" bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp_js_cache/cached.js\"}}' | bash hooks/post-build-check.sh")
+assert_not_contains "$result" "VIBEGUARD" "Unchanged post-build cache fixture reuses pass"
+assert_occurrences "$(cat "$cache_node_log")" "--check" 1 "Unchanged post-build check reuses cached pass result"
+cat >"$tmp_js_cache/cached.js" <<'EOF'
+const value = BROKEN;
+EOF
+result=$(env "${cache_env[@]}" bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp_js_cache/cached.js\"}}' | bash hooks/post-build-check.sh")
+assert_contains "$result" "VIBEGUARD" "Changed post-build cache fixture reruns and surfaces failure"
+result=$(env "${cache_env[@]}" bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp_js_cache/cached.js\"}}' | bash hooks/post-build-check.sh")
+assert_contains "$result" "VIBEGUARD" "Cached failing post-build result remains visible"
+assert_occurrences "$(cat "$cache_node_log")" "--check" 2 "Changed worktree invalidates post-build cache once"
+rm -rf "$tmp_js_cache"
+
 # =========================================================
 
 hook_test_finish

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -130,10 +130,12 @@ assert_file_contains "${TMP_DIR}/slow.out" "exceeded latency budget" "slow hook 
 assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "slow hook output includes hotspot attribution"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper pre-bash-guard" "latency gate includes Codex PreToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper post-edit-guard (100)" "latency gate includes Codex PostToolUse wrapper fixture"
+assert_file_contains "${TMP_DIR}/slow.out" "post-build-check (fake cargo)" "latency gate includes post-build fake command fixture"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P50)" "benchmark action output includes P50 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P95)" "benchmark action output includes P95 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P99)" "benchmark action output includes P99 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "codex-wrapper pre-bash-guard (P95)" "benchmark action output includes Codex wrapper samples"
+assert_file_contains "${REPO_DIR}/bench-output.json" "post-build-check (fake cargo) (P95)" "benchmark action output includes post-build samples"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "Codex wrapper hooks" "latency contract documents wrapper coverage"
 assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
 


### PR DESCRIPTION
## Summary
- add a short TTL post-build-check cache keyed by project root, language, command, and worktree/file fingerprint
- keep changed worktrees and build failures visible, including commands that fail without output
- add a fake cargo post-build latency fixture and benchmark/documentation coverage

Fixes #443

## Verification
- cargo build --manifest-path vibeguard-runtime/Cargo.toml --quiet
- bash -n hooks/post-build-check.sh tests/hooks/test_post_build_check.sh tests/bench_hook_latency.sh tests/test_hook_perf_contract.sh
- bash scripts/ci/validate-hook-perf.sh
- bash tests/hooks/test_post_build_check.sh
- bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
- bash tests/test_hook_perf_contract.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/self-application/check-hook-production-python-free.sh
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- git diff --check