### PR TITLE
Fix runtime resolution ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   validate-and-test:
     name: CI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/hooks/_lib/codex_diag.sh
+++ b/hooks/_lib/codex_diag.sh
@@ -9,19 +9,40 @@ codex_runtime_path() {
   fi
   helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
-  for candidate in \
-    "${VIBEGUARD_RUNTIME:-}" \
-    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
-    "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
-    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
-    "${wrapper_dir}/vibeguard-runtime"; do
+  while IFS= read -r candidate; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
       CODEX_RUNTIME_PATH_CACHE="${candidate}"
       printf '%s\n' "${candidate}"
       return 0
     fi
-  done
+  done < <(codex_runtime_candidates "${wrapper_dir}" "${helper_dir}")
   return 1
+}
+
+codex_installed_context() {
+  local wrapper_dir="$1" helper_dir="$2" home_prefix="${HOME:-}/.vibeguard"
+  [[ -n "${HOME:-}" && ( \
+    "${wrapper_dir}" == "${home_prefix}" || \
+    "${wrapper_dir}" == "${home_prefix}/installed/hooks" || \
+    "${helper_dir}" == "${home_prefix}/_lib" || \
+    "${helper_dir}" == "${home_prefix}/installed/hooks/_lib" \
+  ) ]]
+}
+
+codex_runtime_candidates() {
+  local wrapper_dir="$1" helper_dir="$2"
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if codex_installed_context "${wrapper_dir}" "${helper_dir}"; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+  fi
 }
 
 codex_runtime_stdin() {

--- a/hooks/_lib/config.sh
+++ b/hooks/_lib/config.sh
@@ -24,21 +24,37 @@ _vg_config_file() {
 _vg_config_runtime_path() {
   local wrapper_dir candidate
   wrapper_dir="$(cd "${_VG_CONFIG_LIB_DIR}/.." && pwd)"
-  for candidate in \
-    "${_VIBEGUARD_RUNTIME:-}" \
-    "${VIBEGUARD_RUNTIME:-}" \
-    "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
-    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
-    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
-    "${wrapper_dir}/vibeguard-runtime"; do
+  while IFS= read -r candidate; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
       if _vg_config_runtime_supports "${candidate}"; then
         printf '%s\n' "${candidate}"
         return 0
       fi
     fi
-  done
+  done < <(_vg_config_runtime_candidates "${wrapper_dir}")
   return 1
+}
+
+_vg_config_installed_context() {
+  local wrapper_dir="$1" installed_hooks="${HOME:-}/.vibeguard/installed/hooks"
+  [[ -n "${HOME:-}" && ( "${wrapper_dir}" == "${installed_hooks}" || "${wrapper_dir}" == "${installed_hooks}/"* ) ]]
+}
+
+_vg_config_runtime_candidates() {
+  local wrapper_dir="$1"
+  printf '%s\n' "${_VIBEGUARD_RUNTIME:-}"
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if _vg_config_installed_context "${wrapper_dir}"; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+  fi
 }
 
 _vg_config_runtime_supports() {

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -20,13 +20,7 @@ vg_policy_runtime_path() {
   fi
   helper_dir="${_VG_POLICY_LIB_DIR}"
   wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
-  for candidate in \
-    "${VIBEGUARD_POLICY_RUNTIME:-}" \
-    "${VIBEGUARD_RUNTIME:-}" \
-    "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime" \
-    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
-    "${wrapper_dir}/vibeguard-runtime" \
-    "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"; do
+  while IFS= read -r candidate; do
     if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
       if vg_policy_runtime_supports "${candidate}"; then
         VG_POLICY_RUNTIME_PATH_CACHE="${candidate}"
@@ -34,8 +28,34 @@ vg_policy_runtime_path() {
         return 0
       fi
     fi
-  done
+  done < <(vg_policy_runtime_candidates "${wrapper_dir}" "${helper_dir}")
   return 1
+}
+
+vg_policy_installed_context() {
+  local wrapper_dir="$1" helper_dir="$2" home_prefix="${HOME:-}/.vibeguard"
+  [[ -n "${HOME:-}" && ( \
+    "${wrapper_dir}" == "${home_prefix}" || \
+    "${wrapper_dir}" == "${home_prefix}/installed/hooks" || \
+    "${helper_dir}" == "${home_prefix}/installed/hooks/_lib" \
+  ) ]]
+}
+
+vg_policy_runtime_candidates() {
+  local wrapper_dir="$1" helper_dir="$2"
+  printf '%s\n' "${VIBEGUARD_POLICY_RUNTIME:-}"
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if vg_policy_installed_context "${wrapper_dir}" "${helper_dir}"; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+  fi
 }
 
 vg_policy_runtime_supports() {

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -63,17 +63,33 @@ vg_is_source_file() {
 # Resolve the canonical vibeguard-runtime binary path (Rust, ~4ms).
 _VG_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _VIBEGUARD_RUNTIME=""
-for _candidate in \
-  "${VIBEGUARD_RUNTIME:-}" \
-  "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime" \
-  "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime" \
-  "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
-  "${_VG_HOOK_DIR}/vibeguard-runtime"; do
+
+_vg_log_installed_hook_context() {
+  local installed_hooks="${HOME:-}/.vibeguard/installed/hooks"
+  [[ -n "${HOME:-}" && ( "${_VG_HOOK_DIR}" == "${installed_hooks}" || "${_VG_HOOK_DIR}" == "${installed_hooks}/"* ) ]]
+}
+
+_vg_log_runtime_candidates() {
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if _vg_log_installed_hook_context; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
+  fi
+}
+
+while IFS= read -r _candidate; do
   if [[ -f "$_candidate" ]] && [[ -x "$_candidate" ]]; then
     _VIBEGUARD_RUNTIME="$_candidate"
     break
   fi
-done
+done < <(_vg_log_runtime_candidates)
 if [[ -z "$_VIBEGUARD_RUNTIME" ]]; then
   printf '%s\n' "VIBEGUARD ERROR: vibeguard-runtime not found. Run setup.sh or cargo build --release --manifest-path vibeguard-runtime/Cargo.toml." >&2
   exit 2

--- a/scripts/hook-health.sh
+++ b/scripts/hook-health.sh
@@ -67,7 +67,7 @@ if ! [[ "${HOURS}" =~ ^[0-9]+$ ]] || [[ "${HOURS}" -le 0 ]]; then
   exit 1
 fi
 
-RUNTIME="$(vg_resolve_runtime "${REPO_DIR}")"
+RUNTIME="$(vg_resolve_runtime "${REPO_DIR}" observe_health_legacy)"
 CMD=("${RUNTIME}" observe health --legacy --limit all --hours "${HOURS}")
 
 if [[ "${SCOPE_EXPLICIT}" -eq 1 ]]; then

--- a/scripts/lib/project_config.sh
+++ b/scripts/lib/project_config.sh
@@ -9,10 +9,10 @@ _vg_project_config_runtime_path() {
   for candidate in \
     "${VIBEGUARD_PROJECT_CONFIG_RUNTIME:-}" \
     "${VIBEGUARD_RUNTIME:-}" \
+    "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime" \
     "${_VG_PROJECT_CONFIG_ROOT}/vibeguard-runtime/target/release/vibeguard-runtime" \
     "${_VG_PROJECT_CONFIG_ROOT}/vibeguard-runtime/target/debug/vibeguard-runtime" \
-    "${_VG_PROJECT_CONFIG_ROOT}/bin/vibeguard-runtime" \
-    "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"; do
+    "${_VG_PROJECT_CONFIG_ROOT}/bin/vibeguard-runtime"; do
     if resolved="$(_vg_project_config_resolve_runtime_candidate "${candidate}")"; then
       if _vg_project_config_runtime_supports "${resolved}"; then
         printf '%s\n' "${resolved}"

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -69,6 +69,9 @@ vg_runtime_supports() {
     observe_legacy)
       vg_runtime_supports_observe "${candidate}"
       ;;
+    observe_health_legacy)
+      vg_runtime_supports_observe_health "${candidate}"
+      ;;
     observe_export_prometheus)
       vg_runtime_supports_observe_export_prometheus "${candidate}"
       ;;
@@ -81,6 +84,11 @@ vg_runtime_supports() {
 vg_runtime_supports_observe() {
   local candidate="$1"
   "${candidate}" observe summary --legacy --days all --limit all --log-file /dev/null >/dev/null 2>&1
+}
+
+vg_runtime_supports_observe_health() {
+  local candidate="$1"
+  "${candidate}" observe health --legacy --limit all --hours 24 --log-file /dev/null >/dev/null 2>&1
 }
 
 vg_runtime_supports_observe_export_prometheus() {

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -4,9 +4,21 @@ vg_resolve_runtime() {
   local repo_dir="${1:?vg_resolve_runtime requires repo dir}"
   local capability="${2:-observe_legacy}"
 
-  local candidates=(
-    "${VIBEGUARD_RUNTIME:-}"
-  )
+  local explicit_runtime="${VIBEGUARD_RUNTIME:-}"
+  local candidates=()
+  if [[ -n "${explicit_runtime}" ]]; then
+    if ! resolved="$(vg_resolve_runtime_candidate "${explicit_runtime}")"; then
+      printf 'VIBEGUARD_RUNTIME is not executable or not found: %s\n' "${explicit_runtime}" >&2
+      return 2
+    fi
+    if ! vg_runtime_supports "${resolved}" "${capability}"; then
+      printf 'VIBEGUARD_RUNTIME does not support required capability: %s\n' "${capability}" >&2
+      return 2
+    fi
+    printf '%s\n' "${resolved}"
+    return 0
+  fi
+
   if [[ -n "${HOME:-}" ]]; then
     candidates+=("${HOME}/.vibeguard/installed/bin/vibeguard-runtime")
   fi
@@ -16,7 +28,7 @@ vg_resolve_runtime() {
     "vibeguard-runtime"
   )
 
-  local candidate resolved
+  local candidate
   for candidate in "${candidates[@]}"; do
     if resolved="$(vg_resolve_runtime_candidate "${candidate}")"; then
       if vg_runtime_supports "${resolved}" "${capability}"; then

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -4,37 +4,50 @@ vg_resolve_runtime() {
   local repo_dir="${1:?vg_resolve_runtime requires repo dir}"
   local capability="${2:-observe_legacy}"
 
-  if [[ -n "${VIBEGUARD_RUNTIME:-}" ]]; then
-    printf '%s\n' "${VIBEGUARD_RUNTIME}"
-    return 0
-  fi
-
   local candidates=(
-    "${repo_dir}/vibeguard-runtime/target/release/vibeguard-runtime"
-    "${repo_dir}/vibeguard-runtime/target/debug/vibeguard-runtime"
+    "${VIBEGUARD_RUNTIME:-}"
   )
   if [[ -n "${HOME:-}" ]]; then
     candidates+=("${HOME}/.vibeguard/installed/bin/vibeguard-runtime")
   fi
+  candidates+=(
+    "${repo_dir}/vibeguard-runtime/target/release/vibeguard-runtime"
+    "${repo_dir}/vibeguard-runtime/target/debug/vibeguard-runtime"
+    "vibeguard-runtime"
+  )
 
-  local candidate
+  local candidate resolved
   for candidate in "${candidates[@]}"; do
-    if [[ -x "${candidate}" ]] && vg_runtime_supports "${candidate}" "${capability}"; then
-      printf '%s\n' "${candidate}"
-      return 0
+    if resolved="$(vg_resolve_runtime_candidate "${candidate}")"; then
+      if vg_runtime_supports "${resolved}" "${capability}"; then
+        printf '%s\n' "${resolved}"
+        return 0
+      fi
     fi
   done
 
-  if command -v vibeguard-runtime >/dev/null 2>&1; then
-    candidate="$(command -v vibeguard-runtime)"
-    if vg_runtime_supports "${candidate}" "${capability}"; then
+  printf '%s\n' "vibeguard-runtime not found. Run cargo build --manifest-path vibeguard-runtime/Cargo.toml or setup.sh." >&2
+  return 2
+}
+
+vg_resolve_runtime_candidate() {
+  local candidate="${1:-}" resolved
+  [[ -n "${candidate}" ]] || return 1
+
+  if [[ "${candidate}" == */* ]]; then
+    if [[ -f "${candidate}" && -x "${candidate}" ]]; then
       printf '%s\n' "${candidate}"
       return 0
     fi
+    return 1
   fi
 
-  printf '%s\n' "vibeguard-runtime not found. Run cargo build --manifest-path vibeguard-runtime/Cargo.toml or setup.sh." >&2
-  return 2
+  if resolved="$(command -v "${candidate}" 2>/dev/null)" && [[ -n "${resolved}" && -x "${resolved}" ]]; then
+    printf '%s\n' "${resolved}"
+    return 0
+  fi
+
+  return 1
 }
 
 vg_runtime_supports() {

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -56,9 +56,13 @@ setup_runtime_supports() {
   for command in \
     setup-manifest-skill-links \
     setup-md-remove \
+    setup-settings-check \
     setup-settings-check-stale \
     setup-codex-config-check-hooks \
-    setup-codex-hooks-check-stale; do
+    setup-codex-hooks-upsert \
+    setup-codex-hooks-check \
+    setup-codex-hooks-check-stale \
+    setup-codex-hooks-check-timeouts; do
     probe_out="$("${runtime}" "${command}" 2>&1 || true)"
     if printf '%s\n' "${probe_out}" | grep -q "Unknown command"; then
       return 1

--- a/tests/hooks/test_runtime_config.sh
+++ b/tests/hooks/test_runtime_config.sh
@@ -8,6 +8,9 @@ hook_test_init
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
+RUNTIME_BIN="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
+export VIBEGUARD_RUNTIME="${RUNTIME_BIN}"
 
 make_log_dir() {
   mktemp -d "$WORK_DIR/logs.XXXXXX"
@@ -33,6 +36,30 @@ run_pre_write() {
   env -u VIBEGUARD_WRITE_MODE VIBEGUARD_LOG_DIR="$(make_log_dir)" VIBEGUARD_CONFIG_FILE="$cfg" "$@" \
     bash hooks/pre-write-guard.sh < "$prewrite_input"
 }
+
+header "runtime config — installed hook runtime resolver"
+resolver_home="$WORK_DIR/home-resolver"
+resolver_hooks="${resolver_home}/.vibeguard/installed/hooks"
+mkdir -p "${resolver_hooks}" "${resolver_home}/.vibeguard/installed/bin"
+cp hooks/log.sh "${resolver_hooks}/log.sh"
+cp -R hooks/_lib "${resolver_hooks}/_lib"
+cat > "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime"
+cat > "${resolver_hooks}/vibeguard-runtime" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "${resolver_hooks}/vibeguard-runtime"
+selected_hook_runtime="$(
+  env -u VIBEGUARD_RUNTIME HOME="${resolver_home}" VIBEGUARD_LOG_DIR="${resolver_home}/.vibeguard" bash -c '
+    source "$1"
+    printf "%s" "$_VIBEGUARD_RUNTIME"
+  ' bash "${resolver_hooks}/log.sh"
+)"
+assert_contains "$selected_hook_runtime" "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime" "installed hook log resolver prefers installed runtime"
 
 header "runtime config — pre-write write_mode"
 cfg="$WORK_DIR/config.json"

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -187,6 +187,19 @@ resolver_out="$(
 )"
 assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver honors VIBEGUARD_RUNTIME before installed binaries"
 
+installed_wrapper_home="${WORK_DIR}/home-installed-wrapper"
+mkdir -p "${installed_wrapper_home}/.vibeguard/installed/bin"
+cp "${explicit_runtime}" "${installed_wrapper_home}/.vibeguard/installed/bin/vibeguard-runtime"
+resolver_out="$(
+  WRAPPER_DIR="${installed_wrapper_home}/.vibeguard" \
+  HOME="${installed_wrapper_home}" \
+  env -u VIBEGUARD_POLICY_RUNTIME -u VIBEGUARD_RUNTIME bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_runtime_path
+  '
+)"
+assert_contains "${resolver_out}" "${installed_wrapper_home}/.vibeguard/installed/bin/vibeguard-runtime" "runtime policy resolver prefers installed runtime for installed wrapper"
+
 partial_runtime="${WORK_DIR}/partial-runtime"
 cat > "${partial_runtime}" <<'SH'
 #!/usr/bin/env bash

--- a/tests/test_gc_config.sh
+++ b/tests/test_gc_config.sh
@@ -98,6 +98,40 @@ ln -s "$REPO_DIR/vibeguard-runtime/target/debug/vibeguard-runtime" "${runtime_pa
 runtime_command_out="$(PATH="${runtime_path_bin}:$PATH" VIBEGUARD_RUNTIME="vibeguard-runtime" VIBEGUARD_PROJECT_CONFIG="$cfg" bash -c 'source scripts/lib/project_config.sh; vg_config_positive_int VIBEGUARD_GC_LOG_THRESHOLD_MB gc.log_threshold_mb 10')"
 assert_contains "$runtime_command_out" "7" "helper resolves VIBEGUARD_RUNTIME command name from PATH"
 
+project_resolver_root="${TMP_ROOT}/project-resolver-root"
+project_resolver_home="${TMP_ROOT}/project-resolver-home"
+mkdir -p \
+  "${project_resolver_root}/scripts/lib" \
+  "${project_resolver_root}/vibeguard-runtime/target/release" \
+  "${project_resolver_home}/.vibeguard/installed/bin"
+cp "$REPO_DIR/scripts/lib/project_config.sh" "${project_resolver_root}/scripts/lib/project_config.sh"
+cat > "${project_resolver_root}/vibeguard-runtime/target/release/vibeguard-runtime" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  project-config-validate) exit 0 ;;
+  project-config-value) printf '19\n' ;;
+  *) exit 2 ;;
+esac
+SH
+chmod +x "${project_resolver_root}/vibeguard-runtime/target/release/vibeguard-runtime"
+cat > "${project_resolver_home}/.vibeguard/installed/bin/vibeguard-runtime" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  project-config-validate) exit 0 ;;
+  project-config-value) printf '19\n' ;;
+  *) exit 2 ;;
+esac
+SH
+chmod +x "${project_resolver_home}/.vibeguard/installed/bin/vibeguard-runtime"
+project_resolver_out="$(
+  cd "${project_resolver_root}" && \
+    env -u VIBEGUARD_PROJECT_CONFIG_RUNTIME -u VIBEGUARD_RUNTIME HOME="${project_resolver_home}" bash -c '
+      source scripts/lib/project_config.sh
+      _vg_project_config_runtime_path
+    '
+)"
+assert_contains "$project_resolver_out" "${project_resolver_home}/.vibeguard/installed/bin/vibeguard-runtime" "project config resolver prefers installed runtime when capability matches"
+
 path_only_root="${TMP_ROOT}/path-only-root"
 path_only_home="${TMP_ROOT}/path-only-home"
 mkdir -p "${path_only_root}/scripts/lib" "$path_only_home"

--- a/tests/test_hook_health.sh
+++ b/tests/test_hook_health.sh
@@ -90,6 +90,33 @@ header "build"
 assert_cmd "vibeguard-runtime builds for health wrapper" \
   cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet
 
+header "Runtime support probe"
+health_only_runtime="${TMP_DIR}/health-only-runtime"
+cat > "${health_only_runtime}" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "observe" && "${2:-}" == "health" ]]; then
+  printf 'fake health\n'
+  exit 0
+fi
+exit 2
+SH
+chmod +x "${health_only_runtime}"
+assert_cmd "Health wrapper accepts runtime with observe health support" \
+  env VIBEGUARD_RUNTIME="${health_only_runtime}" bash "${SCRIPT}" --log-file /dev/null 24
+
+summary_only_runtime="${TMP_DIR}/summary-only-runtime"
+cat > "${summary_only_runtime}" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "observe" && "${2:-}" == "summary" ]]; then
+  printf 'fake stats\n'
+  exit 0
+fi
+exit 2
+SH
+chmod +x "${summary_only_runtime}"
+health_probe_out="$(VIBEGUARD_RUNTIME="${summary_only_runtime}" bash "${SCRIPT}" --log-file /dev/null 24 2>&1 || true)"
+assert_contains "${health_probe_out}" "VIBEGUARD_RUNTIME does not support required capability: observe_health_legacy" "Health wrapper rejects runtime without observe health support"
+
 header "No log file"
 no_log_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/missing" bash "${SCRIPT}" 2>&1 || true)"
 assert_contains "${no_log_out}" "No log data" "Prompt when logs are missing"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -127,6 +127,19 @@ exit 2
 SH
 chmod +x "${export_observe_runtime}"
 
+full_observe_runtime="${TMP_DIR}/full-observe-runtime"
+cat > "${full_observe_runtime}" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == "observe summary --legacy --days all --limit all --log-file /dev/null" ]]; then
+  exit 0
+fi
+if [[ "$*" == "observe export prometheus --since all --input-file /dev/null" ]]; then
+  exit 0
+fi
+exit 2
+SH
+chmod +x "${full_observe_runtime}"
+
 assert_cmd_fails "Probe rejects runtimes without legacy observe options" \
   vg_runtime_supports_observe "${old_observe_runtime}"
 assert_cmd "Probe accepts runtimes with legacy observe options" \
@@ -157,6 +170,17 @@ selected_export_runtime="$(
   ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}"
 )"
 assert_contains "${selected_export_runtime}" "${resolver_repo}/vibeguard-runtime/target/debug/vibeguard-runtime" "Resolver accepts repo runtime for exporter without legacy stats support"
+
+resolver_full_home="${TMP_DIR}/resolver-full-home"
+mkdir -p "${resolver_full_home}/.vibeguard/installed/bin"
+cp "${full_observe_runtime}" "${resolver_full_home}/.vibeguard/installed/bin/vibeguard-runtime"
+selected_installed_export_runtime="$(
+  env -u VIBEGUARD_RUNTIME HOME="${resolver_full_home}" bash -c '
+    source "$1"
+    vg_resolve_runtime "$2" observe_export_prometheus
+  ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}"
+)"
+assert_contains "${selected_installed_export_runtime}" "${resolver_full_home}/.vibeguard/installed/bin/vibeguard-runtime" "Resolver prefers installed runtime when capability matches"
 
 header "Project and explicit log scope"
 SCOPE_ROOT="${TMP_DIR}/scope"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -181,6 +181,19 @@ selected_installed_export_runtime="$(
   ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}"
 )"
 assert_contains "${selected_installed_export_runtime}" "${resolver_full_home}/.vibeguard/installed/bin/vibeguard-runtime" "Resolver prefers installed runtime when capability matches"
+assert_cmd_fails "Resolver rejects explicit runtime without requested exporter capability" \
+  env VIBEGUARD_RUNTIME="${legacy_observe_runtime}" HOME="${resolver_full_home}" bash -c '
+    source "$1"
+    vg_resolve_runtime "$2" observe_export_prometheus >/dev/null
+  ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}"
+explicit_bad_runtime_out="$(
+  env VIBEGUARD_RUNTIME="${legacy_observe_runtime}" HOME="${resolver_full_home}" bash -c '
+    source "$1"
+    vg_resolve_runtime "$2" observe_export_prometheus
+  ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}" 2>&1 || true
+)"
+assert_contains "${explicit_bad_runtime_out}" "VIBEGUARD_RUNTIME does not support required capability: observe_export_prometheus" "Explicit runtime capability failure is visible"
+assert_not_contains "${explicit_bad_runtime_out}" "${resolver_full_home}/.vibeguard/installed/bin/vibeguard-runtime" "Explicit runtime capability failure does not fall back to installed runtime"
 
 header "Project and explicit log scope"
 SCOPE_ROOT="${TMP_DIR}/scope"


### PR DESCRIPTION
## Summary

- align runtime candidate ordering across observe, project config, hook log, runtime policy, runtime config, and Codex diagnostics paths
- prefer the installed runtime for installed hook/wrapper execution unless an explicit env override is set
- expand setup runtime capability probes to cover the setup/codex helper commands used by setup flows
- add resolver regression coverage for installed runtime selection and capability matching

Closes #437

## Verification

- bash -n scripts/lib/runtime.sh scripts/lib/project_config.sh scripts/lib/install-state.sh scripts/setup/lib.sh hooks/log.sh hooks/_lib/policy.sh hooks/_lib/config.sh hooks/_lib/codex_diag.sh tests/test_stats.sh tests/test_gc_config.sh tests/hooks/test_runtime_config.sh tests/hooks/test_runtime_policy.sh
- bash tests/test_stats.sh
- bash tests/test_gc_config.sh
- bash tests/hooks/test_runtime_config.sh
- bash tests/hooks/test_runtime_policy.sh
- bash tests/test_setup.sh
- bash tests/test_codex_status.sh
- bash tests/test_codex_runtime.sh
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- git diff --check