### PR TITLE
perf(hooks): precompute wrapper log environment

### DIFF
--- a/hooks/_lib/wrapper_env.sh
+++ b/hooks/_lib/wrapper_env.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Shared wrapper preflight for project log and session environment.
+
+if [[ -n "${_VG_WRAPPER_ENV_SH_LOADED:-}" ]]; then
+  return 0
+fi
+_VG_WRAPPER_ENV_SH_LOADED=1
+
+_VG_WRAPPER_ENV_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+vg_wrapper_env_installed_context() {
+  local wrapper_dir="$1" helper_dir="$2" home_prefix="${HOME:-}/.vibeguard"
+  [[ -n "${HOME:-}" && ( \
+    "${wrapper_dir}" == "${home_prefix}" || \
+    "${wrapper_dir}" == "${home_prefix}/installed/hooks" || \
+    "${helper_dir}" == "${home_prefix}/_lib" || \
+    "${helper_dir}" == "${home_prefix}/installed/hooks/_lib" \
+  ) ]]
+}
+
+vg_wrapper_env_runtime_candidates() {
+  local wrapper_dir="$1" helper_dir="$2"
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if vg_wrapper_env_installed_context "${wrapper_dir}" "${helper_dir}"; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${wrapper_dir}/vibeguard-runtime"
+  fi
+}
+
+vg_wrapper_env_runtime_path() {
+  local wrapper_dir helper_dir candidate
+  if [[ -n "${VG_WRAPPER_ENV_RUNTIME_PATH_CACHE:-}" && -x "${VG_WRAPPER_ENV_RUNTIME_PATH_CACHE}" ]]; then
+    printf '%s\n' "${VG_WRAPPER_ENV_RUNTIME_PATH_CACHE}"
+    return 0
+  fi
+  helper_dir="${_VG_WRAPPER_ENV_LIB_DIR}"
+  wrapper_dir="${WRAPPER_DIR:-$(cd "${helper_dir}/.." && pwd)}"
+  while IFS= read -r candidate; do
+    if [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]]; then
+      VG_WRAPPER_ENV_RUNTIME_PATH_CACHE="${candidate}"
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done < <(vg_wrapper_env_runtime_candidates "${wrapper_dir}" "${helper_dir}")
+  return 1
+}
+
+vg_wrapper_env_export_line() {
+  local line="$1" key value
+  key="${line%%=*}"
+  value="${line#*=}"
+  [[ "${key}" != "${line}" ]] || return 0
+  case "${key}" in
+    VIBEGUARD_CLI|VIBEGUARD_PROJECT_HASH|VIBEGUARD_PROJECT_LOG_DIR|VIBEGUARD_LOG_FILE|VIBEGUARD_SESSION_ID)
+      export "${key}=${value}"
+      ;;
+  esac
+}
+
+vg_wrapper_env_export() {
+  local cli="${1:-unknown}" runtime_path output line
+  export VIBEGUARD_CLI="${VIBEGUARD_CLI:-${cli}}"
+  if [[ -n "${VIBEGUARD_PROJECT_HASH:-}" \
+    && -n "${VIBEGUARD_PROJECT_LOG_DIR:-}" \
+    && -n "${VIBEGUARD_LOG_FILE:-}" \
+    && -n "${VIBEGUARD_SESSION_ID:-}" ]]; then
+    return 0
+  fi
+  runtime_path="$(vg_wrapper_env_runtime_path)" || return 0
+  output="$("${runtime_path}" wrapper-env "${cli}" 2>/dev/null)" || return 0
+  while IFS= read -r line; do
+    vg_wrapper_env_export_line "${line}"
+  done <<< "${output}"
+}

--- a/hooks/_lib/wrapper_env.sh
+++ b/hooks/_lib/wrapper_env.sh
@@ -74,7 +74,7 @@ vg_wrapper_env_export() {
     return 0
   fi
   runtime_path="$(vg_wrapper_env_runtime_path)" || return 0
-  output="$("${runtime_path}" wrapper-env "${cli}" 2>/dev/null)" || return 0
+  output="$(VIBEGUARD_WRAPPER_PARENT_PID="${PPID:-}" "${runtime_path}" wrapper-env "${cli}" 2>/dev/null)" || return 0
   while IFS= read -r line; do
     vg_wrapper_env_export_line "${line}"
   done <<< "${output}"

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -74,6 +74,8 @@ _vg_cb_state_file() {
   local slug
   if [[ -n "${_vg_project_hash:-}" ]]; then
     slug="$_vg_project_hash"
+  elif [[ -n "${VIBEGUARD_PROJECT_HASH:-}" ]]; then
+    slug="$VIBEGUARD_PROJECT_HASH"
   else
     local root
     root=$(git rev-parse --show-toplevel 2>/dev/null || echo "global")

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -27,6 +27,7 @@ export VIBEGUARD_LOG_DIR
 if [[ -z "${VIBEGUARD_PROJECT_LOG_DIR:-}" || -z "${VIBEGUARD_LOG_FILE:-}" ]]; then
   _vg_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "global")
   _vg_project_hash=$(printf '%s' "$_vg_repo_root" | shasum -a 256 2>/dev/null | cut -c1-8) || _vg_project_hash="fallback0"
+  VIBEGUARD_PROJECT_HASH="$_vg_project_hash"
   VIBEGUARD_PROJECT_LOG_DIR="${VIBEGUARD_LOG_DIR}/projects/${_vg_project_hash}"
   mkdir -p "$VIBEGUARD_PROJECT_LOG_DIR" 2>/dev/null
   VIBEGUARD_LOG_FILE="${VIBEGUARD_PROJECT_LOG_DIR}/events.jsonl"
@@ -36,9 +37,16 @@ if [[ -z "${VIBEGUARD_PROJECT_LOG_DIR:-}" || -z "${VIBEGUARD_LOG_FILE:-}" ]]; th
     printf '%s' "$_vg_repo_root" > "$VIBEGUARD_PROJECT_LOG_DIR/.project-root" 2>/dev/null || true
   fi
 else
-  _vg_project_hash="${VIBEGUARD_PROJECT_HASH:-override0}"
+  if [[ -n "${VIBEGUARD_PROJECT_HASH:-}" ]]; then
+    _vg_project_hash="$VIBEGUARD_PROJECT_HASH"
+  else
+    _vg_project_hash="${VIBEGUARD_PROJECT_LOG_DIR##*/}"
+    [[ "$_vg_project_hash" =~ ^[0-9A-Fa-f]{8,64}$ ]] || _vg_project_hash="override0"
+  fi
+  VIBEGUARD_PROJECT_HASH="$_vg_project_hash"
   mkdir -p "$VIBEGUARD_PROJECT_LOG_DIR" 2>/dev/null
 fi
+export VIBEGUARD_PROJECT_HASH
 export VIBEGUARD_PROJECT_LOG_DIR
 export VIBEGUARD_LOG_FILE
 

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -16,9 +16,7 @@ if [[ ! -f "${DIAG_PATH}" ]]; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ -f "${REPO_PATH_FILE}" ]]; then
     REPO_DIR=$(<"${REPO_PATH_FILE}")
-    if [[ -f "${REPO_DIR}/hooks/_lib/codex_diag.sh" ]]; then
-      DIAG_PATH="${REPO_DIR}/hooks/_lib/codex_diag.sh"
-    fi
+    [[ -f "${REPO_DIR}/hooks/_lib/codex_diag.sh" ]] && DIAG_PATH="${REPO_DIR}/hooks/_lib/codex_diag.sh"
   fi
 fi
 
@@ -84,16 +82,15 @@ if [[ ! -d "$INSTALLED_DIR" ]]; then
   fi
   REPO_DIR=$(<"$REPO_PATH_FILE")
   HOOK_PATH="${REPO_DIR}/hooks/${HOOK_NAME}"
-  if [[ -z "${VIBEGUARD_CODEX_ADAPTER_PATH:-}" && ! -f "${ADAPTER_PATH}" && -f "${REPO_DIR}/hooks/_lib/codex_adapter.sh" ]]; then
-    ADAPTER_PATH="${REPO_DIR}/hooks/_lib/codex_adapter.sh"
-  fi
-  if [[ ! -f "${RUNNER_PATH}" && -f "${REPO_DIR}/hooks/_lib/codex_runner.sh" ]]; then
-    RUNNER_PATH="${REPO_DIR}/hooks/_lib/codex_runner.sh"
-  fi
-  if [[ ! -f "${TIMEOUT_PATH}" && -f "${REPO_DIR}/hooks/_lib/timeout.sh" ]]; then
-    TIMEOUT_PATH="${REPO_DIR}/hooks/_lib/timeout.sh"
-  fi
+  [[ -n "${VIBEGUARD_CODEX_ADAPTER_PATH:-}" || -f "${ADAPTER_PATH}" || ! -f "${REPO_DIR}/hooks/_lib/codex_adapter.sh" ]] || ADAPTER_PATH="${REPO_DIR}/hooks/_lib/codex_adapter.sh"
+  [[ -f "${RUNNER_PATH}" || ! -f "${REPO_DIR}/hooks/_lib/codex_runner.sh" ]] || RUNNER_PATH="${REPO_DIR}/hooks/_lib/codex_runner.sh"
+  [[ -f "${TIMEOUT_PATH}" || ! -f "${REPO_DIR}/hooks/_lib/timeout.sh" ]] || TIMEOUT_PATH="${REPO_DIR}/hooks/_lib/timeout.sh"
 fi
+
+WRAPPER_ENV_PATH="${WRAPPER_DIR}/_lib/wrapper_env.sh"
+[[ -f "${WRAPPER_ENV_PATH}" ]] || WRAPPER_ENV_PATH="${INSTALLED_DIR}/_lib/wrapper_env.sh"
+[[ -f "${WRAPPER_ENV_PATH}" ]] || WRAPPER_ENV_PATH="$(dirname "${HOOK_PATH}")/_lib/wrapper_env.sh"
+[[ ! -f "${WRAPPER_ENV_PATH}" ]] || { source "${WRAPPER_ENV_PATH}"; vg_wrapper_env_export "codex"; }
 
 POLICY_PATH="${WRAPPER_DIR}/_lib/policy.sh"
 [[ -f "${POLICY_PATH}" ]] || POLICY_PATH="${INSTALLED_DIR}/_lib/policy.sh"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -53,6 +53,15 @@ if [[ ! -f "$HOOK_PATH" ]]; then
   exit 1
 fi
 
+WRAPPER_ENV_PATH="${WRAPPER_DIR}/_lib/wrapper_env.sh"
+[[ -f "${WRAPPER_ENV_PATH}" ]] || WRAPPER_ENV_PATH="${INSTALLED_DIR}/_lib/wrapper_env.sh"
+[[ -f "${WRAPPER_ENV_PATH}" ]] || WRAPPER_ENV_PATH="$(dirname "${HOOK_PATH}")/_lib/wrapper_env.sh"
+if [[ -f "${WRAPPER_ENV_PATH}" ]]; then
+  # shellcheck source=hooks/_lib/wrapper_env.sh
+  source "${WRAPPER_ENV_PATH}"
+  vg_wrapper_env_export "claude"
+fi
+
 POLICY_PATH="${WRAPPER_DIR}/_lib/policy.sh"
 [[ -f "${POLICY_PATH}" ]] || POLICY_PATH="${INSTALLED_DIR}/_lib/policy.sh"
 [[ -f "${POLICY_PATH}" ]] || POLICY_PATH="$(dirname "${HOOK_PATH}")/_lib/policy.sh"

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -421,6 +421,7 @@ cp "${REPO_DIR}/hooks/run-hook.sh" "${VIBEGUARD_HOME}/run-hook.sh"
 cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${VIBEGUARD_HOME}/run-hook-codex.sh"
 mkdir -p "${VIBEGUARD_HOME}/_lib"
 cp "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${VIBEGUARD_HOME}/_lib/codex_diag.sh"
+cp "${REPO_DIR}/hooks/_lib/wrapper_env.sh" "${VIBEGUARD_HOME}/_lib/wrapper_env.sh"
 chmod +x "${VIBEGUARD_HOME}/run-hook.sh" "${VIBEGUARD_HOME}/run-hook-codex.sh"
 green "  ~/.vibeguard/repo-path + run-hook.sh + run-hook-codex.sh ready"
 
@@ -480,6 +481,7 @@ state_record_tree "${INSTALLED_DIR}" "installed"
 state_record_file "${VIBEGUARD_HOME}/repo-path" "generated/repo-path" "copy"
 state_record_file "${VIBEGUARD_HOME}/run-hook.sh" "hooks/run-hook.sh" "copy"
 state_record_file "${VIBEGUARD_HOME}/_lib/codex_diag.sh" "hooks/_lib/codex_diag.sh" "copy"
+state_record_file "${VIBEGUARD_HOME}/_lib/wrapper_env.sh" "hooks/_lib/wrapper_env.sh" "copy"
 green "  Install state tracker initialized"
 echo
 

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -18,11 +18,13 @@ install_codex_home_assets() {
   cp "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${HOME}/.vibeguard/_lib/codex_diag.sh"
   cp "${REPO_DIR}/hooks/_lib/codex_runner.sh" "${HOME}/.vibeguard/_lib/codex_runner.sh"
   cp "${REPO_DIR}/hooks/_lib/timeout.sh" "${HOME}/.vibeguard/_lib/timeout.sh"
+  cp "${REPO_DIR}/hooks/_lib/wrapper_env.sh" "${HOME}/.vibeguard/_lib/wrapper_env.sh"
   chmod +x "${HOME}/.vibeguard/run-hook-codex.sh"
   state_record_file "${HOME}/.vibeguard/run-hook-codex.sh" "hooks/run-hook-codex.sh" "copy"
   state_record_file "${HOME}/.vibeguard/_lib/codex_diag.sh" "hooks/_lib/codex_diag.sh" "copy"
   state_record_file "${HOME}/.vibeguard/_lib/codex_runner.sh" "hooks/_lib/codex_runner.sh" "copy"
   state_record_file "${HOME}/.vibeguard/_lib/timeout.sh" "hooks/_lib/timeout.sh" "copy"
+  state_record_file "${HOME}/.vibeguard/_lib/wrapper_env.sh" "hooks/_lib/wrapper_env.sh" "copy"
   green "  ~/.vibeguard/run-hook-codex.sh ready"
 
   # Merge VibeGuard hooks into ~/.codex/hooks.json (do not overwrite existing hooks)
@@ -497,6 +499,7 @@ clean_codex_home_installation() {
   rm -f "${HOME}/.vibeguard/_lib/codex_diag.sh"
   rm -f "${HOME}/.vibeguard/_lib/codex_runner.sh"
   rm -f "${HOME}/.vibeguard/_lib/timeout.sh"
+  rm -f "${HOME}/.vibeguard/_lib/wrapper_env.sh"
   rmdir "${HOME}/.vibeguard/_lib" 2>/dev/null || true
   yellow "Removed Codex hook wrapper"
 

--- a/tests/hooks/test_log_timer.sh
+++ b/tests/hooks/test_log_timer.sh
@@ -61,8 +61,9 @@ _claude_log=$(mktemp -d)
 mkdir -p "$_claude_home/.vibeguard"
 printf '%s' "$PWD" > "$_claude_home/.vibeguard/repo-path"
 hook_test_install_runtime_stub "$_claude_home"
+_claude_runtime="$_claude_home/.vibeguard/installed/bin/vibeguard-runtime"
 printf '%s\n' '{"tool_input":{"command":"echo hello"}}' \
-  | HOME="$_claude_home" VIBEGUARD_LOG_DIR="$_claude_log" VIBEGUARD_CLI="claude" bash hooks/run-hook.sh pre-bash-guard.sh >/dev/null 2>&1 || true
+  | HOME="$_claude_home" VIBEGUARD_LOG_DIR="$_claude_log" VIBEGUARD_CLI="claude" VIBEGUARD_RUNTIME="$_claude_runtime" bash hooks/run-hook.sh pre-bash-guard.sh >/dev/null 2>&1 || true
 _claude_result=$(cat "$_claude_log/events.jsonl" 2>/dev/null || true)
 assert_contains "$_claude_result" '"client": "claude"' "Claude wrapper: client is inferred from caller CLI"
 assert_contains "$_claude_result" '"client_variant": "claude-code-hooks"' "Claude wrapper: client_variant is recorded"
@@ -76,8 +77,9 @@ _codex_log=$(mktemp -d)
 mkdir -p "$_codex_home/.vibeguard"
 printf '%s' "$PWD" > "$_codex_home/.vibeguard/repo-path"
 hook_test_install_runtime_stub "$_codex_home"
+_codex_runtime="$_codex_home/.vibeguard/installed/bin/vibeguard-runtime"
 printf '%s\n' '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo hello"}}' \
-  | HOME="$_codex_home" VIBEGUARD_LOG_DIR="$_codex_log" bash hooks/run-hook-codex.sh vibeguard-pre-bash-guard.sh >/dev/null 2>&1 || true
+  | HOME="$_codex_home" VIBEGUARD_LOG_DIR="$_codex_log" VIBEGUARD_RUNTIME="$_codex_runtime" bash hooks/run-hook-codex.sh vibeguard-pre-bash-guard.sh >/dev/null 2>&1 || true
 _codex_result=$(cat "$_codex_log/events.jsonl" 2>/dev/null || true)
 assert_contains "$_codex_result" '"cli": "codex"' "Codex wrapper: legacy cli remains compatible"
 assert_contains "$_codex_result" '"client": "codex"' "Codex wrapper: client is recorded from hook payload"
@@ -93,12 +95,48 @@ _stale_codex_log=$(mktemp -d)
 mkdir -p "$_stale_codex_home/.vibeguard"
 printf '%s' "$PWD" > "$_stale_codex_home/.vibeguard/repo-path"
 hook_test_install_runtime_stub "$_stale_codex_home"
+_stale_codex_runtime="$_stale_codex_home/.vibeguard/installed/bin/vibeguard-runtime"
 printf '%s\n' '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo hello"}}' \
-  | HOME="$_stale_codex_home" VIBEGUARD_LOG_DIR="$_stale_codex_log" VIBEGUARD_CLI="claude" VIBEGUARD_CLIENT="claude" bash hooks/run-hook-codex.sh vibeguard-pre-bash-guard.sh >/dev/null 2>&1 || true
+  | HOME="$_stale_codex_home" VIBEGUARD_LOG_DIR="$_stale_codex_log" VIBEGUARD_RUNTIME="$_stale_codex_runtime" VIBEGUARD_CLI="claude" VIBEGUARD_CLIENT="claude" bash hooks/run-hook-codex.sh vibeguard-pre-bash-guard.sh >/dev/null 2>&1 || true
 _stale_codex_result=$(cat "$_stale_codex_log/events.jsonl" 2>/dev/null || true)
 assert_contains "$_stale_codex_result" '"cli": "codex"' "Codex wrapper: hook payload overrides stale ambient cli"
 assert_contains "$_stale_codex_result" '"client": "codex"' "Codex wrapper: hook payload overrides stale ambient client"
 rm -rf "$_stale_codex_home" "$_stale_codex_log"
+
+header "hook wrappers — precomputed log/session environment"
+
+_precompute_home=$(mktemp -d)
+_precompute_log=$(mktemp -d)
+mkdir -p "$_precompute_home/.vibeguard"
+printf '%s' "$PWD" > "$_precompute_home/.vibeguard/repo-path"
+hook_test_install_runtime_stub "$_precompute_home"
+_precompute_runtime="$_precompute_home/.vibeguard/installed/bin/vibeguard-runtime"
+_claude_trace=$(
+  printf '%s\n' '{"tool_input":{"command":"echo hello"}}' \
+    | HOME="$_precompute_home" VIBEGUARD_LOG_DIR="$_precompute_log" VIBEGUARD_RUNTIME="$_precompute_runtime" bash -x hooks/run-hook.sh pre-bash-guard.sh 2>&1 >/dev/null || true
+)
+assert_not_contains "$_claude_trace" "git rev-parse" "Claude wrapper precompute: hook trace avoids git rev-parse"
+assert_not_contains "$_claude_trace" "shasum" "Claude wrapper precompute: hook trace avoids shasum"
+assert_not_contains "$_claude_trace" "ps -" "Claude wrapper precompute: hook trace avoids ps process walks"
+assert_contains "$(cat "$_precompute_log/events.jsonl" 2>/dev/null || true)" '"session": "stub-session"' "Claude wrapper precompute: exported session reaches log event"
+assert_contains "$(cat "$_precompute_log/projects/abcdef12/.project-root" 2>/dev/null || true)" "$PWD" "Claude wrapper precompute: project hash mapping is written"
+rm -rf "$_precompute_home" "$_precompute_log"
+
+_codex_precompute_home=$(mktemp -d)
+_codex_precompute_log=$(mktemp -d)
+mkdir -p "$_codex_precompute_home/.vibeguard"
+printf '%s' "$PWD" > "$_codex_precompute_home/.vibeguard/repo-path"
+hook_test_install_runtime_stub "$_codex_precompute_home"
+_codex_precompute_runtime="$_codex_precompute_home/.vibeguard/installed/bin/vibeguard-runtime"
+_codex_trace=$(
+  printf '%s\n' '{"hook_event_name":"PreToolUse","tool_input":{"command":"echo hello"}}' \
+    | HOME="$_codex_precompute_home" VIBEGUARD_LOG_DIR="$_codex_precompute_log" VIBEGUARD_RUNTIME="$_codex_precompute_runtime" bash -x hooks/run-hook-codex.sh vibeguard-pre-bash-guard.sh 2>&1 >/dev/null || true
+)
+assert_not_contains "$_codex_trace" "git rev-parse" "Codex wrapper precompute: hook trace avoids git rev-parse"
+assert_not_contains "$_codex_trace" "shasum" "Codex wrapper precompute: hook trace avoids shasum"
+assert_not_contains "$_codex_trace" "ps -" "Codex wrapper precompute: hook trace avoids ps process walks"
+assert_contains "$(cat "$_codex_precompute_log/events.jsonl" 2>/dev/null || true)" '"session": "stub-session"' "Codex wrapper precompute: exported session reaches log event"
+rm -rf "$_codex_precompute_home" "$_codex_precompute_log"
 
 # Extract duration_ms value and verify it's a positive integer >= 1
 _dur=$(echo "$_timer_result" | python3 -c "import sys,json; e=json.loads(sys.stdin.read()); print(e.get('duration_ms','missing'))" 2>/dev/null || echo "missing")

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -99,6 +99,37 @@ command="${1:-}"
 shift || true
 
 case "$command" in
+  codex-event-name)
+    input="$(cat)"
+    if [[ "$input" =~ \"hook_event_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
+    ;;
+  wrapper-env)
+    cli="${1:-${VIBEGUARD_CLI:-unknown}}"
+    log_dir="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}"
+    project_hash="${VIBEGUARD_PROJECT_HASH:-${VIBEGUARD_TEST_PROJECT_HASH:-abcdef12}}"
+    project_dir="${VIBEGUARD_PROJECT_LOG_DIR:-${log_dir}/projects/${project_hash}}"
+    log_file="${VIBEGUARD_LOG_FILE:-${project_dir}/events.jsonl}"
+    session_id="${VIBEGUARD_SESSION_ID:-stub-session}"
+    mkdir -p "$project_dir"
+    printf '%s' "$PWD" > "${project_dir}/.project-root"
+    printf 'VIBEGUARD_CLI=%s\n' "$cli"
+    printf 'VIBEGUARD_PROJECT_HASH=%s\n' "$project_hash"
+    printf 'VIBEGUARD_PROJECT_LOG_DIR=%s\n' "$project_dir"
+    printf 'VIBEGUARD_LOG_FILE=%s\n' "$log_file"
+    printf 'VIBEGUARD_SESSION_ID=%s\n' "$session_id"
+    ;;
+  append-jsonl-mirror)
+    primary_file="${1:?append-jsonl-mirror requires a primary file path}"
+    mirror_file="${2:?append-jsonl-mirror requires a mirror file path}"
+    line="$(cat)"
+    mkdir -p "$(dirname "$primary_file")" "$(dirname "$mirror_file")"
+    printf '%s\n' "$line" >> "$primary_file"
+    if [[ "$primary_file" != "$mirror_file" ]]; then
+      printf '%s\n' "$line" >> "$mirror_file"
+    fi
+    ;;
   append-jsonl)
     file="${1:?append-jsonl requires a file path}"
     line="$(cat)"

--- a/tests/unit/test_circuit_breaker.sh
+++ b/tests/unit/test_circuit_breaker.sh
@@ -349,6 +349,22 @@ else
 fi
 teardown
 
+setup
+ENV_HASH_TEST=$(bash -c "
+  export VIBEGUARD_LOG_DIR='${CB_TMPDIR}'
+  export VIBEGUARD_SESSION_ID='testsession01'
+  export VIBEGUARD_PROJECT_HASH='cccccccc'
+  source '${CB_SCRIPT}'
+  _vg_cb_state_file 'env-hash-hook'
+" 2>&1 || true)
+TOTAL=$((TOTAL+1))
+if echo "$ENV_HASH_TEST" | grep -q "/cccccccc/env-hash-hook.cb"; then
+  green "State file uses VIBEGUARD_PROJECT_HASH when log.sh was not sourced"; PASS=$((PASS+1))
+else
+  red "State file hash env: expected cccccccc slug, got: $ENV_HASH_TEST"; FAIL=$((FAIL+1))
+fi
+teardown
+
 # ── 11. Cross-project isolation: OPEN in one project does not affect another ──
 printf '\n--- Cross-project isolation ---\n'
 

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -36,6 +36,7 @@ mod setup_manifest;
 mod setup_markdown;
 mod setup_support;
 mod time_utils;
+mod wrapper_env;
 
 use std::env;
 use std::process;
@@ -273,6 +274,11 @@ static COMMANDS: &[Command] = &[
         name: "runtime-config-get-str",
         usage: "<env-name> <json-path> <default>  — read a string from runtime config",
         handler: runtime_config::runtime_config_get_str,
+    },
+    Command {
+        name: "wrapper-env",
+        usage: "[cli]  — precompute hook wrapper log and session environment",
+        handler: wrapper_env::run,
     },
     Command {
         name: "project-config-validate",

--- a/vibeguard-runtime/src/setup_support.rs
+++ b/vibeguard-runtime/src/setup_support.rs
@@ -55,6 +55,16 @@ pub fn sha256_file(path: &Path) -> SetupResult<String> {
     Ok(hasher.digest().to_string())
 }
 
+pub fn sha256_text(value: &str) -> String {
+    let mut hasher = sha256::Sha256::new();
+    hasher.update(value.as_bytes());
+    hasher.digest().to_string()
+}
+
+pub fn sha256_text_short(value: &str) -> String {
+    sha256_text(value)[..8].to_string()
+}
+
 pub fn display_home_path(path: &Path) -> String {
     if let Some(home) = home_dir() {
         if let Ok(rel) = path.strip_prefix(&home) {
@@ -342,6 +352,15 @@ mod tests {
         );
         let _ = fs::remove_dir_all(dir);
         Ok(())
+    }
+
+    #[test]
+    fn sha256_text_matches_known_digest() {
+        assert_eq!(
+            sha256_text("abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(sha256_text_short("abc"), "ba7816bf");
     }
 
     #[test]

--- a/vibeguard-runtime/src/wrapper_env.rs
+++ b/vibeguard-runtime/src/wrapper_env.rs
@@ -1,0 +1,220 @@
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::setup_support::{home_dir, sha256_text_short};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+const SESSION_TTL: Duration = Duration::from_secs(30 * 60);
+const SESSION_CLEANUP_AGE: Duration = Duration::from_secs(120 * 60);
+
+pub(crate) fn run(args: &[String]) -> Result<()> {
+    if args.len() > 1 {
+        return Err("Usage: vibeguard-runtime wrapper-env [cli]".into());
+    }
+
+    let cli = env_nonempty("VIBEGUARD_CLI").unwrap_or_else(|| {
+        args.first()
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string())
+    });
+    let log_root = log_root();
+    let project_root = current_project_root();
+    let project_root_text = project_root
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| "global".to_string());
+    let project_hash = env_nonempty("VIBEGUARD_PROJECT_HASH")
+        .unwrap_or_else(|| sha256_text_short(&project_root_text));
+    let project_log_dir = env_nonempty("VIBEGUARD_PROJECT_LOG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| log_root.join("projects").join(&project_hash));
+    let log_file = env_nonempty("VIBEGUARD_LOG_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| project_log_dir.join("events.jsonl"));
+
+    fs::create_dir_all(&project_log_dir)?;
+    if project_root.is_some() {
+        let _ = fs::write(
+            project_log_dir.join(".project-root"),
+            project_root_text.as_bytes(),
+        );
+    }
+
+    let session_id = env_nonempty("VIBEGUARD_SESSION_ID")
+        .unwrap_or_else(|| resolve_session_id(&project_log_dir, &cli, &project_root_text));
+
+    println!("VIBEGUARD_CLI={cli}");
+    println!("VIBEGUARD_PROJECT_HASH={project_hash}");
+    println!(
+        "VIBEGUARD_PROJECT_LOG_DIR={}",
+        project_log_dir.to_string_lossy()
+    );
+    println!("VIBEGUARD_LOG_FILE={}", log_file.to_string_lossy());
+    println!("VIBEGUARD_SESSION_ID={session_id}");
+    Ok(())
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.trim().is_empty())
+}
+
+fn log_root() -> PathBuf {
+    env_nonempty("VIBEGUARD_LOG_DIR")
+        .map(PathBuf::from)
+        .or_else(|| home_dir().map(|home| home.join(".vibeguard")))
+        .unwrap_or_else(|| PathBuf::from(".vibeguard"))
+}
+
+fn current_project_root() -> Option<PathBuf> {
+    project_root_for(&env::current_dir().ok()?)
+}
+
+fn project_root_for(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if current.join(".git").exists() {
+            return fs::canonicalize(&current).ok().or(Some(current));
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn resolve_session_id(project_log_dir: &Path, cli: &str, project_root: &str) -> String {
+    cleanup_old_sessions(project_log_dir);
+    let parent = unsafe { libc::getppid() };
+    let token = sanitize_token(cli);
+    let session_file = project_log_dir.join(format!(".wrapper_session_{token}_{parent}"));
+
+    if let Some(session_id) = read_recent_session(&session_file) {
+        let _ = fs::write(&session_file, &session_id);
+        return session_id;
+    }
+
+    let session_id = new_session_id(parent, project_root);
+    let _ = fs::write(&session_file, &session_id);
+    session_id
+}
+
+fn read_recent_session(path: &Path) -> Option<String> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    if modified.elapsed().ok()? > SESSION_TTL {
+        return None;
+    }
+    let session_id = fs::read_to_string(path).ok()?.trim().to_string();
+    if session_id.is_empty() {
+        None
+    } else {
+        Some(session_id)
+    }
+}
+
+fn cleanup_old_sessions(project_log_dir: &Path) {
+    let Ok(entries) = fs::read_dir(project_log_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if !name.to_string_lossy().starts_with(".wrapper_session_") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|meta| meta.modified())
+            .ok()
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age > SESSION_CLEANUP_AGE);
+        if stale {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
+fn new_session_id(parent: libc::pid_t, project_root: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    parent.hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    project_root.hash(&mut hasher);
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn sanitize_token(value: &str) -> String {
+    let token: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if token.is_empty() {
+        "unknown".to_string()
+    } else {
+        token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!(
+            "vibeguard-wrapper-env-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn project_root_walk_finds_git_marker_without_git_command() {
+        let temp = unique_temp_dir("git-root");
+        let repo = temp.join("repo");
+        let nested = repo.join("a/b");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(project_root_for(&nested), fs::canonicalize(&repo).ok());
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn recent_session_is_reused() {
+        let temp = unique_temp_dir("session");
+        let session_file = temp.join(".wrapper_session_codex_1");
+        fs::write(&session_file, "session-one").unwrap();
+
+        assert_eq!(
+            read_recent_session(&session_file).as_deref(),
+            Some("session-one")
+        );
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn token_sanitizer_keeps_session_file_names_safe() {
+        assert_eq!(sanitize_token("codex-cli"), "codex-cli");
+        assert_eq!(sanitize_token("bad/value"), "bad_value");
+        assert_eq!(sanitize_token(""), "unknown");
+    }
+}

--- a/vibeguard-runtime/src/wrapper_env.rs
+++ b/vibeguard-runtime/src/wrapper_env.rs
@@ -323,8 +323,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn linux_stat_start_time_reads_field_22_after_comm() {
-        let stat =
-            "10 (bash with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 12345 678";
+        let stat = "10 (bash with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 12345 678";
         assert_eq!(linux_stat_start_time(stat).as_deref(), Some("12345"));
     }
 

--- a/vibeguard-runtime/src/wrapper_env.rs
+++ b/vibeguard-runtime/src/wrapper_env.rs
@@ -89,31 +89,63 @@ fn project_root_for(start: &Path) -> Option<PathBuf> {
 
 fn resolve_session_id(project_log_dir: &Path, cli: &str, project_root: &str) -> String {
     cleanup_old_sessions(project_log_dir);
-    let parent = unsafe { libc::getppid() };
+    let anchor = session_anchor();
     let token = sanitize_token(cli);
-    let session_file = project_log_dir.join(format!(".wrapper_session_{token}_{parent}"));
+    let session_file = project_log_dir.join(format!(".wrapper_session_{token}_{}", anchor.pid));
 
-    if let Some(session_id) = read_recent_session(&session_file) {
-        let _ = fs::write(&session_file, &session_id);
+    if let Some(session_id) = read_recent_session(&session_file, &anchor.start) {
+        let _ = write_session_file(&session_file, &anchor.start, &session_id);
         return session_id;
     }
 
-    let session_id = new_session_id(parent, project_root);
-    let _ = fs::write(&session_file, &session_id);
+    let session_id = new_session_id(&anchor, project_root);
+    let _ = write_session_file(&session_file, &anchor.start, &session_id);
     session_id
 }
 
-fn read_recent_session(path: &Path) -> Option<String> {
+struct SessionAnchor {
+    pid: libc::pid_t,
+    start: String,
+}
+
+fn session_anchor() -> SessionAnchor {
+    let pid = env_nonempty("VIBEGUARD_WRAPPER_PARENT_PID")
+        .and_then(|value| parse_pid(&value))
+        .unwrap_or_else(|| unsafe { libc::getppid() });
+    let start = process_start_token(pid).unwrap_or_else(|| "unknown".to_string());
+    SessionAnchor { pid, start }
+}
+
+fn parse_pid(value: &str) -> Option<libc::pid_t> {
+    let parsed = value.trim().parse::<libc::pid_t>().ok()?;
+    (parsed > 1).then_some(parsed)
+}
+
+fn read_recent_session(path: &Path, expected_start: &str) -> Option<String> {
     let modified = fs::metadata(path).ok()?.modified().ok()?;
     if modified.elapsed().ok()? > SESSION_TTL {
         return None;
     }
-    let session_id = fs::read_to_string(path).ok()?.trim().to_string();
+    let contents = fs::read_to_string(path).ok()?;
+    let mut lines = contents.lines();
+    let first = lines.next()?.trim();
+    let session_id = if let Some(second) = lines.next() {
+        if first != expected_start {
+            return None;
+        }
+        second.trim().to_string()
+    } else {
+        first.to_string()
+    };
     if session_id.is_empty() {
         None
     } else {
         Some(session_id)
     }
+}
+
+fn write_session_file(path: &Path, start: &str, session_id: &str) -> std::io::Result<()> {
+    fs::write(path, format!("{start}\n{session_id}\n"))
 }
 
 fn cleanup_old_sessions(project_log_dir: &Path) {
@@ -137,9 +169,10 @@ fn cleanup_old_sessions(project_log_dir: &Path) {
     }
 }
 
-fn new_session_id(parent: libc::pid_t, project_root: &str) -> String {
+fn new_session_id(anchor: &SessionAnchor, project_root: &str) -> String {
     let mut hasher = DefaultHasher::new();
-    parent.hash(&mut hasher);
+    anchor.pid.hash(&mut hasher);
+    anchor.start.hash(&mut hasher);
     std::process::id().hash(&mut hasher);
     project_root.hash(&mut hasher);
     SystemTime::now()
@@ -148,6 +181,52 @@ fn new_session_id(parent: libc::pid_t, project_root: &str) -> String {
         .as_nanos()
         .hash(&mut hasher);
     format!("{:016x}", hasher.finish())
+}
+
+#[cfg(target_os = "linux")]
+fn process_start_token(pid: libc::pid_t) -> Option<String> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    linux_stat_start_time(&stat)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_stat_start_time(stat: &str) -> Option<String> {
+    let end = stat.rfind(") ")?;
+    stat[end + 2..]
+        .split_whitespace()
+        .nth(19)
+        .map(|value| value.to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn process_start_token(pid: libc::pid_t) -> Option<String> {
+    use std::mem;
+
+    let mut info = mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    let result = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size,
+        )
+    };
+    if result == size {
+        let info = unsafe { info.assume_init() };
+        Some(format!(
+            "{}:{}",
+            info.pbi_start_tvsec, info.pbi_start_tvusec
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn process_start_token(_pid: libc::pid_t) -> Option<String> {
+    None
 }
 
 fn sanitize_token(value: &str) -> String {
@@ -202,13 +281,51 @@ mod tests {
     fn recent_session_is_reused() {
         let temp = unique_temp_dir("session");
         let session_file = temp.join(".wrapper_session_codex_1");
-        fs::write(&session_file, "session-one").unwrap();
+        fs::write(&session_file, "start-one\nsession-one\n").unwrap();
 
         assert_eq!(
-            read_recent_session(&session_file).as_deref(),
+            read_recent_session(&session_file, "start-one").as_deref(),
             Some("session-one")
         );
         let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn recent_session_rejects_mismatched_start_anchor() {
+        let temp = unique_temp_dir("session-start");
+        let session_file = temp.join(".wrapper_session_codex_1");
+        fs::write(&session_file, "old-start\nsession-one\n").unwrap();
+
+        assert_eq!(read_recent_session(&session_file, "new-start"), None);
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn legacy_single_line_session_is_reused() {
+        let temp = unique_temp_dir("session-legacy");
+        let session_file = temp.join(".wrapper_session_codex_1");
+        fs::write(&session_file, "session-one").unwrap();
+
+        assert_eq!(
+            read_recent_session(&session_file, "ignored").as_deref(),
+            Some("session-one")
+        );
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn pid_parser_rejects_init_and_invalid_values() {
+        assert_eq!(parse_pid("42"), Some(42));
+        assert_eq!(parse_pid("1"), None);
+        assert_eq!(parse_pid("nope"), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_stat_start_time_reads_field_22_after_comm() {
+        let stat =
+            "10 (bash with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 12345 678";
+        assert_eq!(linux_stat_start_time(stat).as_deref(), Some("12345"));
     }
 
     #[test]

--- a/vibeguard-runtime/src/wrapper_env.rs
+++ b/vibeguard-runtime/src/wrapper_env.rs
@@ -29,14 +29,24 @@ pub(crate) fn run(args: &[String]) -> Result<()> {
         .as_ref()
         .map(|path| path.to_string_lossy().to_string())
         .unwrap_or_else(|| "global".to_string());
-    let project_hash = env_nonempty("VIBEGUARD_PROJECT_HASH")
-        .unwrap_or_else(|| sha256_text_short(&project_root_text));
-    let project_log_dir = env_nonempty("VIBEGUARD_PROJECT_LOG_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| log_root.join("projects").join(&project_hash));
-    let log_file = env_nonempty("VIBEGUARD_LOG_FILE")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| project_log_dir.join("events.jsonl"));
+    let computed_project_hash = sha256_text_short(&project_root_text);
+    let explicit_project_log_dir = env_nonempty("VIBEGUARD_PROJECT_LOG_DIR").map(PathBuf::from);
+    let explicit_log_file = env_nonempty("VIBEGUARD_LOG_FILE").map(PathBuf::from);
+    let (project_hash, project_log_dir, log_file) =
+        match (explicit_project_log_dir, explicit_log_file) {
+            (Some(project_log_dir), Some(log_file)) => {
+                let project_hash = env_nonempty("VIBEGUARD_PROJECT_HASH")
+                    .or_else(|| hash_slug_from_log_dir(&project_log_dir))
+                    .unwrap_or_else(|| computed_project_hash.clone());
+                (project_hash, project_log_dir, log_file)
+            }
+            _ => {
+                let project_hash = computed_project_hash;
+                let project_log_dir = log_root.join("projects").join(&project_hash);
+                let log_file = project_log_dir.join("events.jsonl");
+                (project_hash, project_log_dir, log_file)
+            }
+        };
 
     fs::create_dir_all(&project_log_dir)?;
     if project_root.is_some() {
@@ -69,6 +79,15 @@ fn log_root() -> PathBuf {
         .map(PathBuf::from)
         .or_else(|| home_dir().map(|home| home.join(".vibeguard")))
         .unwrap_or_else(|| PathBuf::from(".vibeguard"))
+}
+
+fn hash_slug_from_log_dir(path: &Path) -> Option<String> {
+    let slug = path.file_name()?.to_string_lossy();
+    is_hash_slug(&slug).then(|| slug.to_string())
+}
+
+fn is_hash_slug(value: &str) -> bool {
+    (8..=64).contains(&value.len()) && value.chars().all(|ch| ch.is_ascii_hexdigit())
 }
 
 fn current_project_root() -> Option<PathBuf> {
@@ -318,6 +337,22 @@ mod tests {
         assert_eq!(parse_pid("42"), Some(42));
         assert_eq!(parse_pid("1"), None);
         assert_eq!(parse_pid("nope"), None);
+    }
+
+    #[test]
+    fn log_dir_hash_slug_requires_hex_length() {
+        assert_eq!(
+            hash_slug_from_log_dir(Path::new("/tmp/projects/abcdef12")).as_deref(),
+            Some("abcdef12")
+        );
+        assert_eq!(
+            hash_slug_from_log_dir(Path::new("/tmp/projects/short")),
+            None
+        );
+        assert_eq!(
+            hash_slug_from_log_dir(Path::new("/tmp/projects/not-hex1")),
+            None
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -67,6 +67,7 @@ fn help_lists_all_commands() {
         "runtime-policy-diag",
         "runtime-config-get-int",
         "runtime-config-get-str",
+        "wrapper-env",
         "project-config-validate",
         "project-config-value",
         "pre-write-check",


### PR DESCRIPTION
Closes #428.

## Summary
- add a `wrapper-env` runtime command that precomputes project hash/log file/session env without invoking git, shasum, or ps from the wrapper path
- source a shared wrapper env helper from Claude and Codex hook wrappers, while preserving runtime-unavailable fallback behavior
- propagate precomputed project hashes through log and circuit-breaker helpers and install the helper in setup flows
- cover wrapper xtrace behavior, hash propagation, runtime command help, and setup install paths

## Verification
- `bash -n hooks/run-hook.sh hooks/run-hook-codex.sh hooks/_lib/wrapper_env.sh hooks/log.sh hooks/circuit-breaker.sh scripts/setup/install.sh scripts/setup/targets/codex-home.sh tests/hooks/test_log_timer.sh tests/unit/test_circuit_breaker.sh tests/lib/hook_test_lib.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml wrapper_env`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml sha256_text_matches_known_digest`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml help_lists_all_commands`
- `bash tests/hooks/test_log_timer.sh`
- `bash tests/unit/test_circuit_breaker.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `git diff --check`
- `bash scripts/ci/self-application/check-codex-wrapper-thin.sh`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_manifest_contract.sh`
- `bash tests/test_hooks.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/bench_hook_latency.sh`
- `bash tests/test_setup.sh`