### PR TITLE
fix(hooks): centralize Rust test path classification

### DIFF
--- a/guards/rust/check_unwrap_in_prod.sh
+++ b/guards/rust/check_unwrap_in_prod.sh
@@ -21,9 +21,6 @@ source "$(dirname "$0")/common.sh"
 parse_guard_args "$@"
 TMPFILE=$(create_tmpfile)
 
-# Path exclusion pattern (test file)
-TEST_PATH_PATTERN='(/tests/|/test_|_test\.rs$|tests\.rs$|test_helpers\.rs$|/examples/|/benches/)'
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RULES_DIR="${SCRIPT_DIR}/../ast-grep-rules"
 
@@ -32,8 +29,7 @@ if [[ -n "${VIBEGUARD_STAGED_FILES:-}" ]] && [[ -f "${VIBEGUARD_STAGED_FILES}" ]
   if ! grep -q '\.rs$' "${VIBEGUARD_STAGED_FILES}" 2>/dev/null; then
     STAGED_RS=""
   else
-    STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" \
-      | { grep -vE "${TEST_PATH_PATTERN}" || true; })
+    STAGED_RS=$(grep '\.rs$' "${VIBEGUARD_STAGED_FILES}" | filter_rs_prod_paths)
   fi
 
   if [[ -n "${STAGED_RS}" ]]; then
@@ -141,8 +137,7 @@ elif command -v ast-grep >/dev/null 2>&1; then
   if ! command -v python3 >/dev/null 2>&1; then
     echo "[RS-03] WARN: python3 is not available, use grep fallback" >&2
     # fall through to grep fallback below
-    list_rs_files "${TARGET_DIR}" \
-      | { grep -vE "${TEST_PATH_PATTERN}" || true; } \
+    list_rs_prod_files "${TARGET_DIR}" \
       | while IFS= read -r f; do
           if [[ -f "${f}" ]]; then
             awk '
@@ -249,8 +244,7 @@ for m in matches:
     msg = m.get('message', '')
     print('[RS-03] ' + fname + ':' + str(l) + ' ' + msg)
 PYEOF
-    list_rs_files "${TARGET_DIR}" \
-      | { grep -vE "${TEST_PATH_PATTERN}" || true; } \
+    list_rs_prod_files "${TARGET_DIR}" \
       | while IFS= read -r f; do
           [[ -f "${f}" ]] || continue
           _ASG_FILE_OUT=$(create_tmpfile)
@@ -321,8 +315,7 @@ PYEOF
 
 # --- Fallback: Use grep when ast-grep is not available ---
 else
-  list_rs_files "${TARGET_DIR}" \
-    | { grep -vE "${TEST_PATH_PATTERN}" || true; } \
+  list_rs_prod_files "${TARGET_DIR}" \
     | while IFS= read -r f; do
         if [[ -f "${f}" ]]; then
           # Fix RS-03: handle multiple #[cfg(test)] blocks by using awk to track

--- a/guards/rust/common.sh
+++ b/guards/rust/common.sh
@@ -9,8 +9,36 @@ set -euo pipefail
 # Paths to always exclude from scanning (worktrees, build artifacts, IDE caches).
 VIBEGUARD_EXCLUDE_PATHS='(.harness/worktrees/|/target/|/.git/|/node_modules/)'
 
-# Test file patterns — files that are exclusively test code.
-VIBEGUARD_TEST_FILE_PATTERN='(/tests/|/test_|_test\.rs$|tests\.rs$|test_helpers\.rs$|/examples/|/benches/)'
+# Fallback only. The authoritative test-path classifier is
+# `vibeguard-runtime test-path-filter`; keep this for old/unbuilt runtime paths.
+VIBEGUARD_TEST_FILE_PATTERN='((^|/)tests/|(^|/)test/|(^|/)__tests__/|(^|/)spec/|(^|/)fixtures/|(^|/)mocks/|(^|/)testdata/|(^|/)examples/|(^|/)benches/|(^|/)test_|_test\.rs$|tests\.rs$|test_helpers\.rs$)'
+
+vibeguard_rust_runtime_path() {
+  local script_dir repo_dir candidate
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_dir="$(cd "${script_dir}/../.." && pwd)"
+  for candidate in \
+    "${VIBEGUARD_RUNTIME:-}" \
+    "${repo_dir}/vibeguard-runtime/target/release/vibeguard-runtime" \
+    "${repo_dir}/vibeguard-runtime/target/debug/vibeguard-runtime" \
+    "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"; do
+    [[ -n "${candidate}" && -f "${candidate}" && -x "${candidate}" ]] || continue
+    printf '%s\n' "${candidate}"
+    return 0
+  done
+  return 1
+}
+
+filter_rs_prod_paths() {
+  local tmp runtime_path
+  tmp=$(create_tmpfile)
+  cat > "${tmp}"
+  if runtime_path="$(vibeguard_rust_runtime_path 2>/dev/null)" \
+    && "${runtime_path}" test-path-filter --prod < "${tmp}" 2>/dev/null; then
+    return 0
+  fi
+  grep -vE "${VIBEGUARD_TEST_FILE_PATTERN}" "${tmp}" || true
+}
 
 # List .rs source files
 # Priority: VIBEGUARD_STAGED_FILES (pre-commit mode, only scan staged) > git ls-files > find
@@ -32,7 +60,7 @@ list_rs_files() {
 
 # List non-test .rs files (exclude test files based on list_rs_files)
 list_rs_prod_files() {
-  list_rs_files "$1" | { grep -vE "${VIBEGUARD_TEST_FILE_PATTERN}" || true; }
+  list_rs_files "$1" | filter_rs_prod_paths
 }
 
 # Parse --strict flag and target_dir

--- a/hooks/_lib/post_edit_quality.sh
+++ b/hooks/_lib/post_edit_quality.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # Stateless content detectors for post-edit-guard.sh.
 
+vg_post_edit_is_test_path() {
+  local result
+  if result=$(printf '%s\n' "$1" | "$_VIBEGUARD_RUNTIME" test-path-filter --test 2>/dev/null); then
+    [[ "${result}" == "$1" ]]
+    return $?
+  fi
+  return 1
+}
+
 vg_post_edit_detect_rust() {
   [[ "$FILE_PATH" == *.rs ]] || return 0
-  case "$FILE_PATH" in
-    */tests/*|*_test.rs|*/test_*) return 0 ;;
-  esac
+  vg_post_edit_is_test_path "$FILE_PATH" && return 0
 
   local filtered unsafe_count safe_count real_count silent_count
   if [[ "$NEW_STRING" == *".unwrap("* || "$NEW_STRING" == *".expect("* ]]; then
@@ -101,9 +108,7 @@ DO NOT: Modify logging configuration or other files"
 vg_post_edit_detect_hardcoded_db_path() {
   [[ "$NEW_STRING" == *".db\""* || "$NEW_STRING" == *".sqlite\""* ]] || return 0
   printf '%s\n' "$NEW_STRING" | vg_filter_suppressed "U-11" | grep -qE '"[^"]*\.(db|sqlite)"' 2>/dev/null || return 0
-  case "$FILE_PATH" in
-    */tests/*|*_test.*|*.test.*|*.spec.*) return 0 ;;
-  esac
+  vg_post_edit_is_test_path "$FILE_PATH" && return 0
 
   vg_post_edit_append_warning "[U-11] [review] [this-line] OBSERVATION: hardcoded database path (.db/.sqlite) detected
 FIX: Extract to a shared default_db_path() function in core layer; use env var APP_DB_PATH for override
@@ -161,9 +166,7 @@ vg_post_edit_detect_u16_size() {
     *.rs|*.ts|*.tsx|*.js|*.jsx|*.py|*.go) ;;
     *) return 0 ;;
   esac
-  case "$FILE_PATH" in
-    */tests/*|*_test.*|*.test.*|*.spec.*|*_test.rs|*/test_*) return 0 ;;
-  esac
+  vg_post_edit_is_test_path "$FILE_PATH" && return 0
   [[ -f "$FILE_PATH" ]] || return 0
 
   local total limit dir exempt base_limit

--- a/scripts/ci/self-application/check-rust-test-path-classifier.sh
+++ b/scripts/ci/self-application/check-rust-test-path-classifier.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# #430 self-application: Rust hook/guard paths must use the runtime test classifier.
+set -euo pipefail
+
+REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+
+failures=0
+
+if grep -Eq 'TEST_PATH_PATTERN=' "${REPO_DIR}/guards/rust/check_unwrap_in_prod.sh"; then
+  echo "FAIL: check_unwrap_in_prod.sh must not define its own test path pattern"
+  failures=$((failures + 1))
+fi
+
+function_body() {
+  local fn_name="$1" file="$2"
+  awk -v fn="${fn_name}" '
+    $0 ~ "^" fn "\\(\\) \\{" { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { exit }
+  ' "${file}"
+}
+
+for fn in vg_post_edit_detect_rust vg_post_edit_detect_hardcoded_db_path vg_post_edit_detect_u16_size; do
+  body="$(function_body "${fn}" "${REPO_DIR}/hooks/_lib/post_edit_quality.sh")"
+  if ! grep -Fq 'vg_post_edit_is_test_path "$FILE_PATH"' <<< "${body}"; then
+    echo "FAIL: ${fn} must use vg_post_edit_is_test_path"
+    failures=$((failures + 1))
+  fi
+  if grep -Eq '\*/tests/\*|\*/examples/\*|\*/benches/\*|\*_test\.rs|\*/test_\*' <<< "${body}"; then
+    echo "FAIL: ${fn} must not reintroduce inline Rust test-path globs"
+    failures=$((failures + 1))
+  fi
+done
+
+if ! grep -Fq 'test-path-filter' "${REPO_DIR}/guards/rust/common.sh"; then
+  echo "FAIL: guards/rust/common.sh must consume vibeguard-runtime test-path-filter"
+  failures=$((failures + 1))
+fi
+
+if ! grep -Fq 'test-path-filter' "${REPO_DIR}/hooks/_lib/post_edit_quality.sh"; then
+  echo "FAIL: post_edit_quality.sh must consume vibeguard-runtime test-path-filter"
+  failures=$((failures + 1))
+fi
+
+if [[ "${failures}" -gt 0 ]]; then
+  exit 1
+fi
+
+echo "OK: Rust hook/guard test-path classification uses runtime classifier"

--- a/scripts/ci/self-application/run-all.sh
+++ b/scripts/ci/self-application/run-all.sh
@@ -15,6 +15,7 @@ checks=(
   "check-codex-wrapper-thin.sh"
   "check-hook-production-python-free.sh"
   "check-hook-output-rewriting.sh"
+  "check-rust-test-path-classifier.sh"
   "check-u22-coverage.sh"
 )
 

--- a/tests/hooks/test_post_edit_guard_basic.sh
+++ b/tests/hooks/test_post_edit_guard_basic.sh
@@ -23,6 +23,13 @@ assert_not_contains "$result" "RS-03" "Not false positive unwrap_or_default"
 result=$(echo '{"tool_input":{"file_path":"tests/test_main.rs","new_string":"let val = data.unwrap();"}}' | bash hooks/post-edit-guard.sh)
 assert_not_contains "$result" "RS-03" "Test file unwrap does not warn"
 
+# Rust guard test-only filenames should match pre-commit guard classification
+result=$(echo '{"tool_input":{"file_path":"src/tests.rs","new_string":"let val = data.expect(\"fixture\");"}}' | bash hooks/post-edit-guard.sh)
+assert_not_contains "$result" "RS-03" "tests.rs expect does not warn"
+
+result=$(echo '{"tool_input":{"file_path":"src/test_helpers.rs","new_string":"let db = \"fixture.db\";"}}' | bash hooks/post-edit-guard.sh)
+assert_not_contains "$result" "U-11" "test_helpers.rs hardcoded db path does not warn"
+
 # The new console.log in the TS file should warn (use absolute paths to avoid misjudgment of CLI projects)
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_test_app.ts","new_string":"console.log(data);"}}' | bash hooks/post-edit-guard.sh)
 assert_contains "$result" "DEBUG" "Detect TS console.log"

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -99,6 +99,25 @@ command="${1:-}"
 shift || true
 
 case "$command" in
+  test-path-filter)
+    mode="${1:-}"
+    while IFS= read -r path; do
+      [[ -n "$path" ]] || continue
+      normalized="${path//\\//}"
+      normalized="$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')"
+      base="${normalized##*/}"
+      is_test=0
+      case "$normalized" in
+        tests/*|test/*|__tests__/*|spec/*|fixtures/*|mocks/*|testdata/*|examples/*|benches/*|test_*|*/tests/*|*/test/*|*/__tests__/*|*/spec/*|*/fixtures/*|*/mocks/*|*/testdata/*|*/examples/*|*/benches/*|*/test_*) is_test=1 ;;
+      esac
+      case "$base" in
+        tests.rs|test_helpers.rs|test_*|*_test.*|*.test.*|*.spec.*|*_test.rs) is_test=1 ;;
+      esac
+      if [[ "$mode" == "--test" && "$is_test" -eq 1 ]] || [[ "$mode" == "--prod" && "$is_test" -eq 0 ]]; then
+        printf '%s\n' "$path"
+      fi
+    done
+    ;;
   codex-event-name)
     input="$(cat)"
     if [[ "$input" =~ \"hook_event_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then

--- a/tests/unit/test_rust_check_unwrap_in_prod.sh
+++ b/tests/unit/test_rust_check_unwrap_in_prod.sh
@@ -95,6 +95,35 @@ fn test_math() {
 EOF
 assert_ok "unwrap() in _test.rs file is ignored" bash "$GUARD" --strict "$proj5"
 
+# --- PASS: guard-only test file names also ignored by post-edit hook classifier ---
+proj5b="${tmpdir}/pass_rust_guard_test_names"
+mkdir -p "${proj5b}/src" "${proj5b}/examples" "${proj5b}/benches"
+cat > "${proj5b}/src/tests.rs" <<'EOF'
+fn fixture() {
+    let x: Option<i32> = Some(42);
+    let _ = x.expect("fixture");
+}
+EOF
+cat > "${proj5b}/src/test_helpers.rs" <<'EOF'
+fn helper() {
+    let x: Option<i32> = Some(42);
+    let _ = x.unwrap();
+}
+EOF
+cat > "${proj5b}/examples/demo.rs" <<'EOF'
+fn main() {
+    let x: Option<i32> = Some(42);
+    println!("{}", x.unwrap());
+}
+EOF
+cat > "${proj5b}/benches/bench.rs" <<'EOF'
+fn bench() {
+    let x: Option<i32> = Some(42);
+    let _ = x.expect("bench");
+}
+EOF
+assert_ok "tests.rs/test_helpers/examples/benches are ignored" bash "$GUARD" --strict "$proj5b"
+
 # --- PASS: empty project (no .rs files) ---
 proj6="${tmpdir}/pass_empty"
 mkdir -p "${proj6}/src"

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -273,6 +273,21 @@ pub fn u16_limit(args: &[String]) -> Result {
     Ok(())
 }
 
+pub fn test_path_filter(args: &[String]) -> Result {
+    if args.len() != 1 || !matches!(args[0].as_str(), "--test" | "--prod") {
+        return Err("Usage: vibeguard-runtime test-path-filter <--test|--prod>".into());
+    }
+    let want_test = args[0] == "--test";
+    let input = read_stdin()?;
+    for raw_path in input.lines() {
+        let path = raw_path.trim_end_matches('\r');
+        if !path.is_empty() && is_test_path(path) == want_test {
+            println!("{path}");
+        }
+    }
+    Ok(())
+}
+
 fn write_pre_edit_block(
     log_file: &str,
     log_reason: &str,

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -85,6 +85,7 @@ pub(crate) fn is_test_path(path: &str) -> bool {
         || has_path_segment(&normalized, "testdata")
         || has_path_segment(&normalized, "examples")
         || has_path_segment(&normalized, "benches")
+        || has_path_segment_with_prefix(&normalized, "test_")
         || basename == "tests.rs"
         || basename == "test_helpers.rs"
         || basename.starts_with("test_")
@@ -96,6 +97,10 @@ pub(crate) fn is_test_path(path: &str) -> bool {
 
 fn has_path_segment(path: &str, segment: &str) -> bool {
     path.split('/').any(|part| part == segment)
+}
+
+fn has_path_segment_with_prefix(path: &str, prefix: &str) -> bool {
+    path.split('/').any(|part| part.starts_with(prefix))
 }
 
 pub(crate) fn is_allowed_new_file(path: &str) -> bool {
@@ -595,6 +600,8 @@ mod tests {
             "tests/integration.rs",
             "src/tests.rs",
             "src/test_helpers.rs",
+            "src/test_helpers/mod.rs",
+            "src/test_utils/helper.rs",
             "examples/demo.rs",
             "benches/throughput.rs",
             "test_root.rs",
@@ -604,6 +611,7 @@ mod tests {
             assert!(is_test_path(path), "{path} should be classified as test");
         }
         assert!(!is_test_path("src/contest.rs"));
+        assert!(!is_test_path("src/contest_helpers/mod.rs"));
         assert!(!is_test_path("src/prod_helpers.rs"));
     }
 

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -74,18 +74,28 @@ pub(crate) fn is_pre_edit_u16_source(path: &str) -> bool {
 }
 
 pub(crate) fn is_test_path(path: &str) -> bool {
-    path.contains("/tests/")
-        || path.contains("/test/")
-        || path.contains("/__tests__/")
-        || path.contains("/spec/")
-        || path.contains("/fixtures/")
-        || path.contains("/mocks/")
-        || path.contains("/testdata/")
-        || path.contains("_test.")
-        || path.contains(".test.")
-        || path.contains(".spec.")
-        || path.contains("_test.rs")
-        || path.contains("/test_")
+    let normalized = path.replace('\\', "/").to_ascii_lowercase();
+    let basename = normalized.rsplit('/').next().unwrap_or("");
+    has_path_segment(&normalized, "tests")
+        || has_path_segment(&normalized, "test")
+        || has_path_segment(&normalized, "__tests__")
+        || has_path_segment(&normalized, "spec")
+        || has_path_segment(&normalized, "fixtures")
+        || has_path_segment(&normalized, "mocks")
+        || has_path_segment(&normalized, "testdata")
+        || has_path_segment(&normalized, "examples")
+        || has_path_segment(&normalized, "benches")
+        || basename == "tests.rs"
+        || basename == "test_helpers.rs"
+        || basename.starts_with("test_")
+        || basename.contains("_test.")
+        || basename.contains(".test.")
+        || basename.contains(".spec.")
+        || basename.ends_with("_test.rs")
+}
+
+fn has_path_segment(path: &str, segment: &str) -> bool {
+    path.split('/').any(|part| part == segment)
 }
 
 pub(crate) fn is_allowed_new_file(path: &str) -> bool {
@@ -577,6 +587,24 @@ mod tests {
         assert!(is_allowed_new_file("README.md"));
         assert!(is_allowed_new_file("/repo/tests/helper.py"));
         assert!(!is_allowed_new_file("src/new_service.py"));
+    }
+
+    #[test]
+    fn test_path_matches_rust_guard_exclusions() {
+        for path in [
+            "tests/integration.rs",
+            "src/tests.rs",
+            "src/test_helpers.rs",
+            "examples/demo.rs",
+            "benches/throughput.rs",
+            "test_root.rs",
+            "src/math_test.rs",
+            "src/lib.test.rs",
+        ] {
+            assert!(is_test_path(path), "{path} should be classified as test");
+        }
+        assert!(!is_test_path("src/contest.rs"));
+        assert!(!is_test_path("src/prod_helpers.rs"));
     }
 
     #[test]

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -306,6 +306,11 @@ static COMMANDS: &[Command] = &[
         handler: hook_checks::u16_limit,
     },
     Command {
+        name: "test-path-filter",
+        usage: "<--test|--prod>  — filter newline-separated paths by canonical test-path classification",
+        handler: hook_checks::test_path_filter,
+    },
+    Command {
         name: "post-edit-fast-check",
         usage: "<base-limit> <session> <agent> <log-file>  — fast-pass clean PostToolUse(Edit) inputs",
         handler: hook_checks::post_edit_fast_check,

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -73,6 +73,7 @@ fn help_lists_all_commands() {
         "pre-write-check",
         "pre-edit-check",
         "u16-limit",
+        "test-path-filter",
         "post-edit-fast-check",
         "post-write-fast-check",
         "post-write-check",


### PR DESCRIPTION
## Summary
- add `vibeguard-runtime test-path-filter` as the canonical test/prod path classifier
- route Rust unwrap guard and post-edit RS-03/U-11/U-16 detectors through the runtime classifier
- add self-application and regression coverage for `tests.rs`, `test_helpers.rs`, examples, and benches

Note: issue #430 references `vg-helper`, but current `origin/main` no longer contains that directory; the current fast path lives in `vibeguard-runtime`, so this makes the runtime command the source of truth.

Closes #430

## Verification
- `bash -n scripts/ci/self-application/check-rust-test-path-classifier.sh guards/rust/common.sh guards/rust/check_unwrap_in_prod.sh hooks/_lib/post_edit_quality.sh`
- `bash scripts/ci/self-application/check-rust-test-path-classifier.sh`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml help_lists_all_commands`
- `cargo build --manifest-path vibeguard-runtime/Cargo.toml`
- `printf ... | vibeguard-runtime/target/debug/vibeguard-runtime test-path-filter --prod`
- `bash tests/hooks/test_post_edit_guard_basic.sh`
- `bash tests/unit/test_rust_check_unwrap_in_prod.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_self_application_ci.sh`
- `bash tests/test_hooks.sh`
- `git diff --check`