### PR TITLE
fix(setup): verify onboarding trust surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Use this path to prove the install is active before changing another project:
 ```bash
 bash ~/vibeguard/setup.sh --check --strict
 bash ~/vibeguard/scripts/doctors/codex-doctor.sh
+bash ~/vibeguard/setup.sh demo safe-bash
 bash ~/vibeguard/scripts/hook-health.sh 24
 ```
 
-Expected result on a fully provisioned machine: `setup.sh --check --strict` exits 0 with `HEALTHY`, the Codex doctor reports configured rules and hooks, and hook health shows the latest local hook events or a no-data message that points to the log path. If optional language guard tools such as `ast-grep` are not installed, the strict check reports an explicit `MISSING` row and non-zero exit instead of silently treating that dependency gap as healthy.
+Expected result on a fully provisioned machine: `setup.sh --check --strict` exits 0 with `HEALTHY`, the Codex doctor reports configured rules and hooks, `setup.sh demo safe-bash` shows a side-effect-free block transcript, and hook health shows the latest local hook events or a no-data message that points to the log path. If optional language guard tools such as `ast-grep` are not installed, the strict check reports an explicit `MISSING` row and non-zero exit instead of silently treating that dependency gap as healthy.
 
 To protect another repository after VibeGuard is installed:
 

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -92,13 +92,7 @@ status_optional_missing_line() {
   case "$plain" in
     *"ast-grep not installed"*|\
     *"agents not in ~/.claude/agents/"*|\
-    *"context profiles not in ~/.claude/context-profiles/"*|\
-    *" skill not in ~/.codex/skills/"*|\
-    *"VibeGuard hooks not fully configured in ~/.codex/hooks.json"*|\
-    *"Codex hooks.json not installed"*|\
-    *"Codex hook wrapper not installed"*|\
-    *"Codex hook wrapper: "*|\
-    *"hooks feature not enabled"*)
+    *"context profiles not in ~/.claude/context-profiles/"*)
       return 0
       ;;
     *)

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -2,7 +2,7 @@
 # VibeGuard status reporter — shared library for `setup.sh --check`.
 #
 # Purpose
-#   Turn the existing free-form `[OK]/[INFO]/[WARN]/[FAIL]/[BROKEN]/[MISSING]`
+#   Turn the existing free-form `[OK]/[INFO]/[WARN]/[DRIFT]/[FAIL]/[BROKEN]/[MISSING]`
 #   lines into a structured, summarized, exit-code-aware health report
 #   without rewriting every call site (lib.sh, targets/*.sh, etc.).
 #
@@ -20,9 +20,9 @@
 #   status_exit_code                      — echo 0|1|2
 #
 # Exit-code policy
-#   0 — no [WARN]/[FAIL]/[BROKEN]/[MISSING]
+#   0 — no [WARN]/[DRIFT]/[FAIL]/[BROKEN]/[MISSING]
 #   1 — only [WARN] (degraded but functional)
-#   2 — at least one [FAIL]/[BROKEN]/required [MISSING] (broken — needs repair)
+#   2 — at least one [DRIFT]/[FAIL]/[BROKEN]/required [MISSING] (broken — needs repair)
 #
 # Per the VibeGuard "no silent degradation" rule (U-29), [INFO] is treated
 # as neutral and never affects exit code or verdict.
@@ -36,6 +36,7 @@ _VG_STATUS_BUFFER=""
 _VG_STATUS_OK=0
 _VG_STATUS_INFO=0
 _VG_STATUS_WARN=0
+_VG_STATUS_DRIFT=0
 _VG_STATUS_FAIL=0
 _VG_STATUS_BROKEN=0
 _VG_STATUS_MISSING=0
@@ -49,13 +50,14 @@ status_init() {
   _VG_STATUS_OK=0
   _VG_STATUS_INFO=0
   _VG_STATUS_WARN=0
+  _VG_STATUS_DRIFT=0
   _VG_STATUS_FAIL=0
   _VG_STATUS_BROKEN=0
   _VG_STATUS_MISSING=0
 }
 
 # status_classify_line <line>
-#   Echo the level (OK|INFO|WARN|FAIL|BROKEN|MISSING) or empty string.
+#   Echo the level (OK|INFO|WARN|DRIFT|FAIL|BROKEN|MISSING) or empty string.
 #   Strips ANSI color codes before matching. Pure function — no globals.
 status_plain_line() {
   local line="$1"
@@ -78,6 +80,7 @@ status_classify_line() {
     "[OK]"*)      printf 'OK' ;;
     "[INFO]"*)    printf 'INFO' ;;
     "[WARN]"*)    printf 'WARN' ;;
+    "[DRIFT]"*)   printf 'DRIFT' ;;
     "[FAIL]"*)    printf 'FAIL' ;;
     "[BROKEN]"*)  printf 'BROKEN' ;;
     "[MISSING]"*) printf 'MISSING' ;;
@@ -120,6 +123,7 @@ status_record_buffer() {
   _VG_STATUS_OK=0
   _VG_STATUS_INFO=0
   _VG_STATUS_WARN=0
+  _VG_STATUS_DRIFT=0
   _VG_STATUS_FAIL=0
   _VG_STATUS_BROKEN=0
   _VG_STATUS_MISSING=0
@@ -131,6 +135,7 @@ status_record_buffer() {
       OK)      _VG_STATUS_OK=$((_VG_STATUS_OK + 1)) ;;
       INFO)    _VG_STATUS_INFO=$((_VG_STATUS_INFO + 1)) ;;
       WARN)    _VG_STATUS_WARN=$((_VG_STATUS_WARN + 1)) ;;
+      DRIFT)   _VG_STATUS_DRIFT=$((_VG_STATUS_DRIFT + 1)) ;;
       FAIL)    _VG_STATUS_FAIL=$((_VG_STATUS_FAIL + 1)) ;;
       BROKEN)  _VG_STATUS_BROKEN=$((_VG_STATUS_BROKEN + 1)) ;;
       MISSING) _VG_STATUS_MISSING=$((_VG_STATUS_MISSING + 1)) ;;
@@ -139,7 +144,7 @@ status_record_buffer() {
 }
 
 # status_filter_problems
-#   Emit only [WARN]/[FAIL]/[BROKEN]/[MISSING] rows from the buffer, in
+#   Emit only [WARN]/[DRIFT]/[FAIL]/[BROKEN]/[MISSING] rows from the buffer, in
 #   their original captured form (color preserved).
 status_filter_problems() {
   [[ -n "${_VG_STATUS_BUFFER}" && -f "${_VG_STATUS_BUFFER}" ]] || return 0
@@ -147,7 +152,7 @@ status_filter_problems() {
   while IFS= read -r line; do
     level="$(status_classify_line "$line")"
     case "$level" in
-      WARN|FAIL|BROKEN|MISSING) printf '%s\n' "$line" ;;
+      WARN|DRIFT|FAIL|BROKEN|MISSING) printf '%s\n' "$line" ;;
     esac
   done < "${_VG_STATUS_BUFFER}"
 }
@@ -158,7 +163,7 @@ status_filter_problems() {
 status_print_summary() {
   local quiet=0
   [[ "${1:-}" == "--quiet" ]] && quiet=1
-  local total_problems=$((_VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
+  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
   local total_warnings=${_VG_STATUS_WARN}
 
   if [[ "${quiet}" -eq 1 ]] && (( total_problems + total_warnings > 0 )); then
@@ -172,6 +177,7 @@ status_print_summary() {
   printf '  OK      : %d\n' "${_VG_STATUS_OK}"
   printf '  INFO    : %d\n' "${_VG_STATUS_INFO}"
   printf '  WARN    : %d\n' "${_VG_STATUS_WARN}"
+  printf '  DRIFT   : %d\n' "${_VG_STATUS_DRIFT}"
   printf '  FAIL    : %d\n' "${_VG_STATUS_FAIL}"
   printf '  BROKEN  : %d\n' "${_VG_STATUS_BROKEN}"
   printf '  MISSING : %d\n' "${_VG_STATUS_MISSING}"
@@ -190,7 +196,7 @@ status_print_summary() {
 #   Emit a stable JSON document with counts, verdict, and the full event
 #   list. Designed for CI consumers and the /vibeguard:check skill.
 status_emit_json() {
-  local total_problems=$((_VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
+  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
   local verdict
   if (( total_problems > 0 )); then
     verdict="broken"
@@ -203,8 +209,8 @@ status_emit_json() {
   if ! command -v python3 >/dev/null 2>&1; then
     # Conservative fallback. We escape backslash, double-quote, and control
     # characters so the result is valid JSON without python3.
-    printf '{"schema_version":1,"verdict":"%s","counts":{"ok":%d,"info":%d,"warn":%d,"fail":%d,"broken":%d,"missing":%d},"events":[' \
-      "$verdict" "$_VG_STATUS_OK" "$_VG_STATUS_INFO" "$_VG_STATUS_WARN" "$_VG_STATUS_FAIL" "$_VG_STATUS_BROKEN" "$_VG_STATUS_MISSING"
+    printf '{"schema_version":1,"verdict":"%s","counts":{"ok":%d,"info":%d,"warn":%d,"drift":%d,"fail":%d,"broken":%d,"missing":%d},"events":[' \
+      "$verdict" "$_VG_STATUS_OK" "$_VG_STATUS_INFO" "$_VG_STATUS_WARN" "$_VG_STATUS_DRIFT" "$_VG_STATUS_FAIL" "$_VG_STATUS_BROKEN" "$_VG_STATUS_MISSING"
     local first=1 line level message esc
     if [[ -n "${_VG_STATUS_BUFFER}" && -f "${_VG_STATUS_BUFFER}" ]]; then
       while IFS= read -r line; do
@@ -227,14 +233,14 @@ status_emit_json() {
   fi
 
   VG_VERDICT="$verdict" \
-  VG_OK="$_VG_STATUS_OK" VG_INFO="$_VG_STATUS_INFO" VG_WARN="$_VG_STATUS_WARN" \
+  VG_OK="$_VG_STATUS_OK" VG_INFO="$_VG_STATUS_INFO" VG_WARN="$_VG_STATUS_WARN" VG_DRIFT="$_VG_STATUS_DRIFT" \
   VG_FAIL="$_VG_STATUS_FAIL" VG_BROKEN="$_VG_STATUS_BROKEN" VG_MISSING="$_VG_STATUS_MISSING" \
   VG_BUFFER="${_VG_STATUS_BUFFER:-}" \
   python3 - <<'PY'
 import json, os, re, sys
 
 ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
-LEVELS = ("OK", "INFO", "WARN", "FAIL", "BROKEN", "MISSING")
+LEVELS = ("OK", "INFO", "WARN", "DRIFT", "FAIL", "BROKEN", "MISSING")
 
 def classify(line: str):
     plain = ANSI.sub("", line)
@@ -261,6 +267,7 @@ doc = {
         "ok": int(os.environ["VG_OK"]),
         "info": int(os.environ["VG_INFO"]),
         "warn": int(os.environ["VG_WARN"]),
+        "drift": int(os.environ["VG_DRIFT"]),
         "fail": int(os.environ["VG_FAIL"]),
         "broken": int(os.environ["VG_BROKEN"]),
         "missing": int(os.environ["VG_MISSING"]),
@@ -274,7 +281,7 @@ PY
 
 # status_exit_code — echo 0|1|2 per the policy at top of file.
 status_exit_code() {
-  local total_problems=$((_VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
+  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
   if (( total_problems > 0 )); then
     printf '2\n'
   elif (( _VG_STATUS_WARN > 0 )); then
@@ -290,7 +297,7 @@ status_exit_code() {
 status_install_exit_code() {
   local required_missing
   required_missing="$(status_required_missing_count)"
-  local total_problems=$((_VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
+  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
   if (( total_problems > 0 )); then
     printf '2\n'
   else

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -464,6 +464,17 @@ vibeguard_managed_rule_banner_count() {
   ' "${file}"
 }
 
+vibeguard_managed_rules_block_matches_source() {
+  local target_file="$1" rule_count="$2"
+  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
+  local diff_output
+  [[ -f "${target_file}" ]] || return 2
+  if ! diff_output=$(setup_runtime setup-md-diff-inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>/dev/null); then
+    return 2
+  fi
+  [[ "${diff_output}" == "SKIP" ]]
+}
+
 inject_vibeguard_rules() {
   local target_file="$1" display_label="$2" state_source="$3"
   local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -451,6 +451,18 @@ check_claude_home_installation() {
         yellow "[DRIFT] CLAUDE.md missing VibeGuard rule count banner, actual: ${actual_rule_count}"
         yellow "[INFO] Re-run 'bash setup.sh' to repair the rule count banner in ~/.claude/CLAUDE.md"
       fi
+      local block_check_rc=0
+      if vibeguard_managed_rules_block_matches_source "${claude_md}" "${actual_rule_count}"; then
+        green "[OK] CLAUDE.md managed VibeGuard block matches current rules"
+      else
+        block_check_rc=$?
+        if [[ "${block_check_rc}" -eq 1 ]]; then
+          yellow "[DRIFT] CLAUDE.md managed VibeGuard block differs from current rules"
+          yellow "[INFO] Re-run 'bash setup.sh' to repair the managed block in ~/.claude/CLAUDE.md"
+        else
+          yellow "[WARN] CLAUDE.md managed block semantic check unavailable (repair: bash setup.sh --yes)"
+        fi
+      fi
     fi
   else
     red "[MISSING] Native rules not in ~/.claude/rules/vibeguard/"

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -438,6 +438,18 @@ check_codex_agents_hygiene() {
       yellow "[DRIFT] ~/.codex/AGENTS.md missing VibeGuard rule count banner, actual: ${actual_rule_count}"
       yellow "[INFO] Re-run 'bash setup.sh' to repair the rule count banner in ~/.codex/AGENTS.md"
     fi
+    local block_check_rc=0
+    if vibeguard_managed_rules_block_matches_source "${agents_md}" "${actual_rule_count}"; then
+      green "[OK] ~/.codex/AGENTS.md managed VibeGuard block matches current rules"
+    else
+      block_check_rc=$?
+      if [[ "${block_check_rc}" -eq 1 ]]; then
+        yellow "[DRIFT] ~/.codex/AGENTS.md managed VibeGuard block differs from current rules"
+        yellow "[INFO] Re-run 'bash setup.sh' to repair the managed block in ~/.codex/AGENTS.md"
+      else
+        yellow "[WARN] ~/.codex/AGENTS.md managed block semantic check unavailable (repair: bash setup.sh --yes)"
+      fi
+    fi
   else
     yellow "[INFO] Rule count in ~/.codex/AGENTS.md not checked because ~/.claude/rules/vibeguard/ is missing"
   fi

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -156,6 +156,27 @@ external_rule_count_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 cp "${_VALID_CLAUDE_MD}" "${HOME}/.claude/CLAUDE.md"
 assert_contains "${external_rule_count_check_out}" "[OK] Rule count in sync:" "--check ignores unmanaged Claude rule count text"
 assert_not_contains "${external_rule_count_check_out}" "CLAUDE.md declares 5 rules" "--check does not read rule count outside the VibeGuard Claude block"
+python3 - <<'PY' "${HOME}/.claude/CLAUDE.md" "${HOME}/.codex/AGENTS.md"
+from pathlib import Path
+import sys
+
+for arg in sys.argv[1:]:
+    path = Path(arg)
+    text = path.read_text(encoding="utf-8")
+    updated = text.replace(
+        "Compact Chat Contract: progress updates, concise answers, plain formatting.",
+        "Compact Chat Contract: progress updates, concise answers, ornate formatting.",
+        1,
+    )
+    if updated == text:
+        raise SystemExit(1)
+    path.write_text(updated, encoding="utf-8")
+PY
+semantic_block_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+cp "${_VALID_CLAUDE_MD}" "${HOME}/.claude/CLAUDE.md"
+cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
+assert_contains "${semantic_block_check_out}" "[DRIFT] CLAUDE.md managed VibeGuard block differs from current rules" "--check reports semantic drift in CLAUDE.md managed block"
+assert_contains "${semantic_block_check_out}" "[DRIFT] ~/.codex/AGENTS.md managed VibeGuard block differs from current rules" "--check reports semantic drift in Codex AGENTS managed block"
 
 header "setup --check stays read-only"
 python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -173,10 +173,14 @@ for arg in sys.argv[1:]:
     path.write_text(updated, encoding="utf-8")
 PY
 semantic_block_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
+semantic_block_strict_rc=0
+semantic_block_strict_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1)" || semantic_block_strict_rc=$?
 cp "${_VALID_CLAUDE_MD}" "${HOME}/.claude/CLAUDE.md"
 cp "${_VALID_CODEX_AGENTS}" "${HOME}/.codex/AGENTS.md"
 assert_contains "${semantic_block_check_out}" "[DRIFT] CLAUDE.md managed VibeGuard block differs from current rules" "--check reports semantic drift in CLAUDE.md managed block"
 assert_contains "${semantic_block_check_out}" "[DRIFT] ~/.codex/AGENTS.md managed VibeGuard block differs from current rules" "--check reports semantic drift in Codex AGENTS managed block"
+assert_contains "${semantic_block_strict_out}" "[DRIFT] CLAUDE.md managed VibeGuard block differs from current rules" "--check --strict reports managed block drift"
+assert_cmd "--check --strict exits broken for managed block drift" test "${semantic_block_strict_rc}" -eq 2
 
 header "setup --check stays read-only"
 python3 - <<'PY' "${HOME}/.claude/CLAUDE.md"

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -42,7 +42,7 @@ header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
 assert_contains() {
   local output="$1" expected="$2" desc="$3"
   TOTAL=$((TOTAL + 1))
-  if printf '%s' "$output" | grep -qF -- "$expected"; then
+  if grep -qF -- "$expected" <<< "$output"; then
     green "$desc"; PASS=$((PASS + 1))
   else
     red "$desc (expected to contain: $expected)"; FAIL=$((FAIL + 1))
@@ -52,7 +52,7 @@ assert_contains() {
 assert_not_contains() {
   local output="$1" forbidden="$2" desc="$3"
   TOTAL=$((TOTAL + 1))
-  if printf '%s' "$output" | grep -qF -- "$forbidden"; then
+  if grep -qF -- "$forbidden" <<< "$output"; then
     red "$desc (must not contain: $forbidden)"; FAIL=$((FAIL + 1))
   else
     green "$desc"; PASS=$((PASS + 1))
@@ -155,9 +155,15 @@ assert_contains "$broken_summary" "BROKEN"       "broken: verdict is BROKEN"
 broken_rc="$(run_with_buffer "$broken_buf" 'status_exit_code')"
 assert_eq "$broken_rc" "2" "broken: exit code 2"
 
-optional_missing_buf=$'[OK] base\n[MISSING] ast-grep not installed — TS/Rust AST guards will SKIP\n[MISSING] agents not in ~/.claude/agents/\n[MISSING] Codex hooks.json not installed\n'
+optional_missing_buf=$'[OK] base\n[MISSING] ast-grep not installed — TS/Rust AST guards will SKIP\n[MISSING] agents not in ~/.claude/agents/\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
 optional_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
 assert_eq "$optional_install_rc" "0" "install mode: optional missing rows do not fail"
+codex_required_missing_buf=$'[OK] base\n[MISSING] Codex hooks.json not installed\n[MISSING] Codex hook wrapper not installed\n[MISSING] hooks feature not enabled in ~/.codex/config.toml\n'
+codex_required_install_rc="$(run_with_buffer "$codex_required_missing_buf" 'status_install_exit_code')"
+assert_eq "$codex_required_install_rc" "2" "install mode: Codex missing rows fail"
+codex_skill_missing_buf=$'[OK] base\n[MISSING] vibeguard skill not in ~/.codex/skills/\n'
+codex_skill_install_rc="$(run_with_buffer "$codex_skill_missing_buf" 'status_install_exit_code')"
+assert_eq "$codex_skill_install_rc" "2" "install mode: Codex skill missing rows fail"
 required_missing_buf=$'[OK] base\n[MISSING] vibeguard-runtime runtime binary (~/.vibeguard/installed/bin/vibeguard-runtime)\n'
 required_install_rc="$(run_with_buffer "$required_missing_buf" 'status_install_exit_code')"
 assert_eq "$required_install_rc" "2" "install mode: required missing rows still fail"

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -155,6 +155,16 @@ assert_contains "$broken_summary" "BROKEN"       "broken: verdict is BROKEN"
 broken_rc="$(run_with_buffer "$broken_buf" 'status_exit_code')"
 assert_eq "$broken_rc" "2" "broken: exit code 2"
 
+# Drift — stale managed content must require repair, including install checks.
+drift_buf=$'[OK] base\n[DRIFT] managed VibeGuard block differs from current rules\n'
+drift_summary="$(run_with_buffer "$drift_buf" 'status_print_summary')"
+assert_contains "$drift_summary" "DRIFT   : 1" "drift: drift count"
+assert_contains "$drift_summary" "BROKEN" "drift: verdict is BROKEN"
+drift_rc="$(run_with_buffer "$drift_buf" 'status_exit_code')"
+assert_eq "$drift_rc" "2" "drift: strict exit code 2"
+drift_install_rc="$(run_with_buffer "$drift_buf" 'status_install_exit_code')"
+assert_eq "$drift_install_rc" "2" "drift: install exit code 2"
+
 optional_missing_buf=$'[OK] base\n[MISSING] ast-grep not installed — TS/Rust AST guards will SKIP\n[MISSING] agents not in ~/.claude/agents/\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
 optional_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
 assert_eq "$optional_install_rc" "0" "install mode: optional missing rows do not fail"
@@ -184,6 +194,9 @@ assert_contains "$quiet_out" "[BROKEN]"            "quiet: includes BROKEN row"
 assert_contains "$quiet_out" "[MISSING]"           "quiet: includes MISSING row"
 assert_contains "$quiet_out" "[FAIL]"              "quiet: includes FAIL row"
 assert_not_contains "$quiet_out" "[OK] foo"        "quiet: drops OK rows"
+quiet_drift="$(run_with_buffer "$drift_buf" 'status_print_summary --quiet')"
+assert_contains "$quiet_drift" "Problems"          "quiet+drift: shows Problems header"
+assert_contains "$quiet_drift" "[DRIFT]"           "quiet+drift: includes DRIFT row"
 
 # Healthy + quiet → no Problems block.
 quiet_healthy="$(run_with_buffer "$healthy_buf" 'status_print_summary --quiet')"
@@ -198,10 +211,15 @@ assert_json_path "$json_out" 'd["schema_version"]' "1"      "json: schema_versio
 assert_json_path "$json_out" 'd["verdict"]'        "broken" "json: verdict=broken"
 assert_json_path "$json_out" 'd["counts"]["broken"]'  "1"   "json: counts.broken=1"
 assert_json_path "$json_out" 'd["counts"]["missing"]' "1"   "json: counts.missing=1"
+assert_json_path "$json_out" 'd["counts"]["drift"]'   "0"   "json: counts.drift=0"
 assert_json_path "$json_out" 'd["counts"]["fail"]'    "1"   "json: counts.fail=1"
 assert_json_path "$json_out" 'd["counts"]["ok"]'      "1"   "json: counts.ok=1"
 assert_json_path "$json_out" 'len(d["events"])'       "4"   "json: 4 events captured"
 assert_json_path "$json_out" 'sorted({e["level"] for e in d["events"]})' "['BROKEN', 'FAIL', 'MISSING', 'OK']" "json: event levels"
+drift_json="$(run_with_buffer "$drift_buf" 'status_emit_json')"
+assert_json_path "$drift_json" 'd["counts"]["drift"]' "1" "json: drift count"
+assert_json_path "$drift_json" 'd["verdict"]' "broken" "json: drift verdict"
+assert_json_path "$drift_json" 'd["events"][1]["level"]' "DRIFT" "json: drift event level"
 
 # JSON must be parseable.
 TOTAL=$((TOTAL + 1))


### PR DESCRIPTION
## Summary
- add first-run proof for `setup.sh demo safe-bash` to the README onboarding path
- treat missing Codex hooks, wrapper, hook feature, and Codex skill rows as required install failures
- verify installed Claude/Codex managed VibeGuard blocks against the current source rules, not just anchors and rule-count banners

Closes #425.

## Verification
- `bash -n scripts/lib/status_report.sh scripts/setup/lib.sh scripts/setup/targets/claude-home.sh scripts/setup/targets/codex-home.sh tests/test_setup_check.sh tests/setup/protection_clean_tests.sh`
- `bash tests/test_setup_check.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash tests/test_guard_packs.sh`
- `bash tests/test_setup.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `git diff --check`
