### PR TITLE
[codex] Fix open VibeGuard issue backlog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 env:
-  RUST_VERSION: "stable"
+  RUST_VERSION: "1.95.0"
   CROSS_VERSION: "0.2.5"
   RUNTIME_MANIFEST: vibeguard-runtime/Cargo.toml
   RUNTIME_VERSION_FILE: vibeguard-runtime/VERSION
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -64,6 +64,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: validate-runtime-version
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     strategy:
       fail-fast: false
@@ -88,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -138,11 +142,16 @@ jobs:
           test "${output}" = "Bash"
 
       - name: Upload runtime artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vibeguard-runtime-${{ matrix.target }}
           path: dist/${{ matrix.target }}/vibeguard-runtime-${{ matrix.target }}
           if-no-files-found: error
+
+      - name: Attest runtime artifact
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/${{ matrix.target }}/vibeguard-runtime-${{ matrix.target }}
 
   publish-release:
     name: Publish release assets
@@ -154,7 +163,7 @@ jobs:
 
     steps:
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true

--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ bash ~/vibeguard/setup.sh --yes
 
 On supported macOS/Linux targets, the production install/check/clean path is
 Python-free: setup downloads a prebuilt `vibeguard-runtime` release binary and
-verifies it with `SHA256SUMS`, so Rust/Cargo is not required by default.
+verifies it with `SHA256SUMS`, then verifies GitHub artifact provenance when
+`gh` authentication is available. If provenance cannot be checked, setup reports
+`checksum-only` instead of treating it as verified provenance. Rust/Cargo is not
+required by default.
 Python still supports evals, docs generation, developer tools, and optional
 language-specific guard packs.
 
-Open a new Claude Code or Codex session. Run `bash ~/vibeguard/setup.sh --check --strict` to verify.
+Open a new Claude Code or Codex session. Run `bash ~/vibeguard/setup.sh verify-install` to verify.
 
 ### First 5 minutes
 
@@ -41,12 +44,13 @@ Use this path to prove the install is active before changing another project:
 
 ```bash
 bash ~/vibeguard/setup.sh --check --strict
+bash ~/vibeguard/setup.sh verify-install
 bash ~/vibeguard/scripts/doctors/codex-doctor.sh
 bash ~/vibeguard/setup.sh demo safe-bash
 bash ~/vibeguard/scripts/hook-health.sh 24
 ```
 
-Expected result on a fully provisioned machine: `setup.sh --check --strict` exits 0 with `HEALTHY`, the Codex doctor reports configured rules and hooks, `setup.sh demo safe-bash` shows a side-effect-free block transcript, and hook health shows the latest local hook events or a no-data message that points to the log path. If optional language guard tools such as `ast-grep` are not installed, the strict check reports an explicit `MISSING` row and non-zero exit instead of silently treating that dependency gap as healthy.
+Expected result on a fully provisioned machine: `setup.sh verify-install` exits 0, `setup.sh doctor` shows a `HEALTHY` rollup, the Codex doctor reports configured rules and hooks, `setup.sh demo safe-bash` shows a side-effect-free block transcript, and hook health shows the latest local hook events or a no-data message that points to the log path. If optional language guard tools such as `ast-grep` are not installed, strict verification reports an explicit `MISSING` row and non-zero exit instead of silently treating that dependency gap as healthy.
 
 To protect another repository after VibeGuard is installed:
 
@@ -59,7 +63,7 @@ bash ~/vibeguard/scripts/project-init.sh /path/to/project
 The current mainline is install-verified on macOS and CI-verified on Ubuntu, macOS, and Windows.
 
 - Latest release train: `v1.1.x`
-- Local health gate: `bash setup.sh --check --strict`
+- Local health gate: `bash setup.sh verify-install`
 - Expected verdict after a healthy install: `HEALTHY`
 - Claude Code: native rules, skills, commands, hooks, and git hooks are installed by `setup.sh`; scheduled GC is opt-in with `--with-scheduler`
 - Codex CLI: `~/.codex/AGENTS.md`, copied skills, native Bash/apply_patch/PermissionRequest/PostToolUse/Stop hooks, and `~/.vibeguard/run-hook-codex.sh` are installed by `setup.sh`
@@ -352,20 +356,27 @@ bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
 
 # Runtime / scheduler
 bash ~/vibeguard/setup.sh --build-from-source          # Force local Cargo build
+bash ~/vibeguard/setup.sh --dev-linked                 # Opt in to live-repo hook execution
 bash ~/vibeguard/setup.sh --with-scheduler             # Opt in to launchd/systemd scheduled GC
 
 # Verify / Uninstall
-bash ~/vibeguard/setup.sh --check                     # Verify installation
+bash ~/vibeguard/setup.sh doctor                      # Human-friendly diagnosis
+bash ~/vibeguard/setup.sh verify-install              # CI/install verification
+bash ~/vibeguard/setup.sh verify-project              # Project config verification
+bash ~/vibeguard/setup.sh verify-dev-repo             # Repo development hook verification
+bash ~/vibeguard/setup.sh --check                     # Compatibility status wrapper
 bash ~/vibeguard/setup.sh --check --quiet             # Show only problems + rollup
 bash ~/vibeguard/setup.sh --check --json              # Machine-readable JSON for CI
 bash ~/vibeguard/setup.sh --check --strict            # Exit 1/2 on warn/broken
 bash ~/vibeguard/setup.sh --clean                     # Uninstall
 ```
 
-`--check` reports a structured rollup (OK / INFO / WARN / FAIL / BROKEN / MISSING)
-plus a final `Verdict` line of `HEALTHY`, `DEGRADED`, or `BROKEN`. The default mode
-always exits 0 for backwards compatibility — add `--strict` (or use `--json`,
-which implies it) to make CI fail when the install is broken.
+`doctor` reports a structured rollup (OK / INFO / WARN / FAIL / BROKEN / MISSING)
+plus a final `Verdict` line of `HEALTHY`, `DEGRADED`, or `BROKEN`. Use
+`verify-install` for CI or setup automation; it returns non-zero on broken required
+state. `--check` remains a compatibility wrapper and always exits 0 by default.
+Stable installs execute hooks from `~/.vibeguard/installed/`; `--dev-linked`
+is the explicit opt-in for live-repo hook execution during VibeGuard development.
 
 | Profile | Hooks Installed | Use Case |
 |---------|----------------|----------|

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -5,6 +5,8 @@ VibeGuard supports Linux via **systemd user units** as the scheduled task mechan
 ## Requirements
 
 - `gh` or `curl` for the default prebuilt `vibeguard-runtime` download.
+  Authenticated `gh` also enables artifact provenance verification; without it,
+  setup reports `checksum-only` after SHA-256 verification.
 - Python 3 is not required for default production install/check/clean on
   supported release targets. It remains used by evals, docs generation,
   developer tools, and optional Python-backed guard tools.
@@ -22,7 +24,9 @@ bash setup.sh --yes
 
 On `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`, the default
 runtime path downloads a release binary and verifies it against `SHA256SUMS`, so
-Rust/Cargo is not required. To force a local build:
+Rust/Cargo is not required. Stable installs execute hooks from
+`~/.vibeguard/installed/`. Use `--dev-linked` only when you intentionally want
+hooks to execute from the live repo checkout. To force a local build:
 
 ```bash
 bash setup.sh --yes --build-from-source
@@ -88,7 +92,13 @@ journalctl --user -u vibeguard-gc.service
 ## Status check
 
 ```bash
-# Via VibeGuard check script
+# Human diagnosis
+bash setup.sh doctor
+
+# Machine install verification for CI or setup automation
+bash setup.sh verify-install
+
+# Compatibility status wrapper
 bash setup.sh --check
 
 # Via systemctl directly

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -59,14 +59,18 @@ vg_policy_runtime_candidates() {
 }
 
 vg_policy_runtime_supports() {
-  local candidate="$1" probe_diag downgrade_probe codex_probe
-  if "${candidate}" runtime-policy-supports >/dev/null 2>&1; then
+  local candidate="$1" support_probe policy_probe probe_diag downgrade_probe codex_probe
+  support_probe="$("${candidate}" runtime-policy-supports 2>/dev/null)" || support_probe=""
+  if [[ "${support_probe}" == *"runtime-policy-json-v1"* ]]; then
     return 0
   fi
   probe_diag="${TMPDIR:-/tmp}/vibeguard-policy-probe.$$.jsonl"
-  VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
+  policy_probe="$(
+    VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
     VIBEGUARD_USER_CONFIG_FILE="" \
-    "${candidate}" runtime-policy-check __vibeguard_policy_probe__ >/dev/null 2>&1 || return 1
+      "${candidate}" runtime-policy-check --cwd "${TMPDIR:-/tmp}" __vibeguard_policy_probe__ 2>/dev/null
+  )" || return 1
+  [[ "${policy_probe}" == *'"decision"'* && "${policy_probe}" == *'"run"'* ]] || return 1
   downgrade_probe="$(printf '{"decision":"block","reason":"probe"}' \
     | "${candidate}" runtime-policy-downgrade-output 2>/dev/null)" || return 1
   [[ "${downgrade_probe}" == *'"decision"'* && "${downgrade_probe}" == *'"warn"'* ]] || return 1
@@ -81,9 +85,28 @@ vg_policy_runtime_supports() {
   return 0
 }
 
+vg_policy_current_cwd() {
+  pwd -P 2>/dev/null || pwd
+}
+
+vg_policy_json_field() {
+  local runtime_path="$1" output="$2" field_path="$3"
+  printf '%s' "${output}" | "${runtime_path}" json-field "${field_path}" 2>/dev/null || true
+}
+
+vg_policy_reason_from_output() {
+  local runtime_path="$1" output="$2" reason
+  reason="$(vg_policy_json_field "${runtime_path}" "${output}" reason)"
+  if [[ -n "${reason}" ]]; then
+    printf '%s' "${reason}"
+  else
+    printf '%s' "${output}"
+  fi
+}
+
 vg_policy_check_hook() {
   local hook_name="$1"
-  local output status runtime_path
+  local output status runtime_path project_cwd enforcement
 
   VG_POLICY_REASON=""
   VG_POLICY_KIND=""
@@ -99,15 +122,17 @@ vg_policy_check_hook() {
   VG_POLICY_RUNTIME_PATH="${runtime_path}"
 
   status=0
+  project_cwd="$(vg_policy_current_cwd)"
   output="$(
     VIBEGUARD_USER_CONFIG_FILE="$(vg_policy_user_config_file)" \
-      "${runtime_path}" runtime-policy-check "${hook_name}" 2>&1
+      "${runtime_path}" runtime-policy-check --cwd "${project_cwd}" "${hook_name}" 2>&1
   )" || status=$?
 
   case "${status}" in
     0)
-      if [[ "${output}" == *"enforcement=warn"* ]]; then
-        VG_POLICY_REASON="${output}"
+      enforcement="$(vg_policy_json_field "${runtime_path}" "${output}" enforcement)"
+      if [[ "${enforcement}" == "warn" || "${output}" == *"enforcement=warn"* ]]; then
+        VG_POLICY_REASON="$(vg_policy_reason_from_output "${runtime_path}" "${output}")"
         VG_POLICY_KIND="policy_warn"
         VG_POLICY_ENFORCEMENT="warn"
         export VIBEGUARD_POLICY_ENFORCEMENT="warn"
@@ -115,17 +140,18 @@ vg_policy_check_hook() {
       return 0
       ;;
     10)
-      VG_POLICY_REASON="${output}"
+      VG_POLICY_REASON="$(vg_policy_reason_from_output "${runtime_path}" "${output}")"
       VG_POLICY_KIND="policy_skip"
       return 10
       ;;
     30)
-      VG_POLICY_REASON="${output}"
+      VG_POLICY_REASON="$(vg_policy_reason_from_output "${runtime_path}" "${output}")"
       VG_POLICY_KIND="config_parse_error"
       return 30
       ;;
     *)
-      VG_POLICY_REASON="${output:-VibeGuard policy error: unknown runtime policy failure.}"
+      VG_POLICY_REASON="$(vg_policy_reason_from_output "${runtime_path}" "${output}")"
+      VG_POLICY_REASON="${VG_POLICY_REASON:-VibeGuard policy error: unknown runtime policy failure.}"
       VG_POLICY_KIND="policy_error"
       return 20
       ;;

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -8,11 +8,22 @@ HOOK_NAME="${1:?Usage: run-hook-codex.sh <hook-name>}"
 shift
 
 INSTALLED_DIR="${HOME}/.vibeguard/installed/hooks"
+INSTALL_MODE_FILE="${HOME}/.vibeguard/install-mode"
+
+vg_dev_linked_enabled() {
+  [[ "${VIBEGUARD_DEV_LINKED:-0}" == "1" ]] && return 0
+  [[ -f "${INSTALL_MODE_FILE}" && "$(<"${INSTALL_MODE_FILE}")" == "dev-linked" ]]
+}
+
+vg_source_checkout_wrapper() {
+  [[ ! -f "${INSTALL_MODE_FILE}" && -f "${WRAPPER_DIR}/${HOOK_NAME}" && -d "${WRAPPER_DIR}/_lib" ]]
+}
+
 DIAG_PATH="${WRAPPER_DIR}/_lib/codex_diag.sh"
 if [[ ! -f "${DIAG_PATH}" && -f "${INSTALLED_DIR}/_lib/codex_diag.sh" ]]; then
   DIAG_PATH="${INSTALLED_DIR}/_lib/codex_diag.sh"
 fi
-if [[ ! -f "${DIAG_PATH}" ]]; then
+if [[ ! -f "${DIAG_PATH}" ]] && vg_dev_linked_enabled; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ -f "${REPO_PATH_FILE}" ]]; then
     REPO_DIR=$(<"${REPO_PATH_FILE}")
@@ -73,11 +84,11 @@ RUNNER_PATH="${WRAPPER_DIR}/_lib/codex_runner.sh"
 TIMEOUT_PATH="${WRAPPER_DIR}/_lib/timeout.sh"
 [[ -f "${TIMEOUT_PATH}" || ! -f "${INSTALLED_DIR}/_lib/timeout.sh" ]] || TIMEOUT_PATH="${INSTALLED_DIR}/_lib/timeout.sh"
 
-if [[ ! -d "$INSTALLED_DIR" ]]; then
+if vg_dev_linked_enabled; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ ! -f "$REPO_PATH_FILE" ]]; then
     codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-repo-path" "${REPO_PATH_FILE}"
-    codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD install incomplete: missing repo-path."
+    codex_visible_failure_raw "${EVENT_NAME}" "VIBEGUARD dev-linked mode requires repo-path. Re-run stable setup or reinstall with --dev-linked."
     exit 0
   fi
   REPO_DIR=$(<"$REPO_PATH_FILE")
@@ -85,6 +96,8 @@ if [[ ! -d "$INSTALLED_DIR" ]]; then
   [[ -n "${VIBEGUARD_CODEX_ADAPTER_PATH:-}" || -f "${ADAPTER_PATH}" || ! -f "${REPO_DIR}/hooks/_lib/codex_adapter.sh" ]] || ADAPTER_PATH="${REPO_DIR}/hooks/_lib/codex_adapter.sh"
   [[ -f "${RUNNER_PATH}" || ! -f "${REPO_DIR}/hooks/_lib/codex_runner.sh" ]] || RUNNER_PATH="${REPO_DIR}/hooks/_lib/codex_runner.sh"
   [[ -f "${TIMEOUT_PATH}" || ! -f "${REPO_DIR}/hooks/_lib/timeout.sh" ]] || TIMEOUT_PATH="${REPO_DIR}/hooks/_lib/timeout.sh"
+elif vg_source_checkout_wrapper; then
+  HOOK_PATH="${WRAPPER_DIR}/${HOOK_NAME}"
 fi
 
 WRAPPER_ENV_PATH="${WRAPPER_DIR}/_lib/wrapper_env.sh"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -2,7 +2,8 @@
 # VibeGuard Hook Wrapper — A hook distributor compatible with all platforms
 #
 # All hooks in settings.json are called indirectly through this wrapper.
-# Avoid hardcoding absolute paths. Repo relocation only requires updating ~/.vibeguard/repo-path.
+# Stable installs execute the installed snapshot. Dev-linked mode can opt into
+# executing the live repo recorded in ~/.vibeguard/repo-path.
 #
 # Usage: bash ~/.vibeguard/run-hook.sh <hook-script-name> [args...]
 # Example: bash ~/.vibeguard/run-hook.sh stop-guard.sh
@@ -35,22 +36,29 @@ if [[ ! -t 0 ]]; then
 fi
 
 INSTALLED_DIR="${HOME}/.vibeguard/installed/hooks"
-HOOK_PATH="${INSTALLED_DIR}/${HOOK_NAME}"
+INSTALL_MODE_FILE="${HOME}/.vibeguard/install-mode"
 
-if [[ ! -d "$INSTALLED_DIR" ]]; then
-  # Fallback: legacy direct-repo mode
+vg_dev_linked_enabled() {
+  [[ "${VIBEGUARD_DEV_LINKED:-0}" == "1" ]] && return 0
+  [[ -f "${INSTALL_MODE_FILE}" && "$(<"${INSTALL_MODE_FILE}")" == "dev-linked" ]]
+}
+
+vg_source_checkout_wrapper() {
+  [[ ! -f "${INSTALL_MODE_FILE}" && -f "${WRAPPER_DIR}/${HOOK_NAME}" && -f "${WRAPPER_DIR}/_lib/policy.sh" ]]
+}
+
+if vg_dev_linked_enabled; then
   REPO_PATH_FILE="${HOME}/.vibeguard/repo-path"
   if [[ ! -f "$REPO_PATH_FILE" ]]; then
-    echo "ERROR: ${REPO_PATH_FILE} not found. Re-run: bash <vibeguard-repo>/scripts/setup/install.sh" >&2
+    echo "ERROR: dev-linked mode requires ${REPO_PATH_FILE}. Re-run stable setup or reinstall with --dev-linked." >&2
     exit 1
   fi
   REPO_DIR=$(<"$REPO_PATH_FILE")
   HOOK_PATH="${REPO_DIR}/hooks/${HOOK_NAME}"
-fi
-
-if [[ ! -f "$HOOK_PATH" ]]; then
-  echo "ERROR: hook not found: ${HOOK_PATH}" >&2
-  exit 1
+elif vg_source_checkout_wrapper; then
+  HOOK_PATH="${WRAPPER_DIR}/${HOOK_NAME}"
+else
+  HOOK_PATH="${INSTALLED_DIR}/${HOOK_NAME}"
 fi
 
 WRAPPER_ENV_PATH="${WRAPPER_DIR}/_lib/wrapper_env.sh"
@@ -80,6 +88,11 @@ if [[ ${policy_status} -eq 10 ]]; then
 elif [[ ${policy_status} -ne 0 ]]; then
   vg_policy_diag "${HOOK_NAME}" "Claude" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
   printf '%s\n' "${VG_POLICY_REASON}" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HOOK_PATH" ]]; then
+  echo "ERROR: hook not found: ${HOOK_PATH}" >&2
   exit 1
 fi
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -8,6 +8,9 @@
 #   bash setup.sh --check --json         # machine-readable JSON, no TTY output
 #   bash setup.sh --check --no-summary   # legacy behavior (no rollup, exit 0)
 #   bash setup.sh --check --install      # install final verification, fail on broken required state
+#   bash setup.sh doctor                 # human report, exit 0 unless the command fails
+#   bash setup.sh verify-project         # project config verification, non-zero on failure
+#   bash setup.sh verify-dev-repo        # repo development hook verification, non-zero on failure
 #   bash setup.sh --check --profile full # verify profile-specific hook coverage
 #
 # Exit code
@@ -40,12 +43,16 @@ STRICT=0
 WITH_SUMMARY=1
 INSTALL=0
 PROFILE="${VIBEGUARD_SETUP_PROFILE:-}"
+CHECK_MODE="${VIBEGUARD_CHECK_MODE:-full}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --quiet|-q)     QUIET=1; shift ;;
     --json)         JSON=1; shift ;;
     --strict)       STRICT=1; shift ;;
     --install)      INSTALL=1; shift ;;
+    --doctor)       CHECK_MODE="doctor"; shift ;;
+    --verify-project) CHECK_MODE="verify-project"; STRICT=1; shift ;;
+    --verify-dev-repo) CHECK_MODE="verify-dev-repo"; STRICT=1; shift ;;
     --no-summary)   WITH_SUMMARY=0; shift ;;
     --profile)
       [[ $# -lt 2 ]] && { red "ERROR: --profile requires a value (minimal|core|full|strict)"; exit 64; }
@@ -54,8 +61,15 @@ while [[ $# -gt 0 ]]; do
       PROFILE="${1#*=}"; shift ;;
     --help|-h)
       cat <<'USAGE'
-Usage: setup.sh --check [--quiet | --json | --strict | --install | --no-summary] [--profile minimal|core|full|strict]
+Usage: setup.sh --check [--quiet | --json | --strict | --install | --doctor | --verify-project | --verify-dev-repo | --no-summary] [--profile minimal|core|full|strict]
 
+  --doctor       Human report mode; exits 0 unless the command itself fails.
+  --verify-project
+                 Verify project .vibeguard.json readiness; exits non-zero on
+                 broken required state.
+  --verify-dev-repo
+                 Verify repository development hooks; exits non-zero on broken
+                 required state.
   --quiet        Suppress healthy [OK] rows; only print problems + summary.
   --strict       Reflect health in the exit code: 0 healthy, 1 degraded,
                  2 broken (FAIL/BROKEN/MISSING). Without --strict the exit
@@ -135,6 +149,18 @@ fi
 PROFILE="${PROFILE:-core}"
 validate_setup_profile "${PROFILE}"
 
+check_install_mode() {
+  local mode_file="${HOME}/.vibeguard/install-mode"
+  local mode="stable"
+  if [[ -f "${mode_file}" ]]; then
+    mode="$(tr -d '[:space:]' < "${mode_file}")"
+  fi
+  case "${mode}" in
+    stable|dev-linked) printf '%s\n' "${mode}" ;;
+    *) printf 'stable\n' ;;
+  esac
+}
+
 _check_repo_git_hook() {
   local hook_name="$1"
   local expected_target="$2"
@@ -167,21 +193,42 @@ _check_repo_git_hook() {
     red "[BROKEN] VibeGuard repo ${hook_name} hook target not executable: ${actual_target}"
     return 0
   fi
-  if [[ "${hook_name}" == "pre-push" && "${expected_target}" == "${HOME}/.vibeguard/pre-push" ]]; then
-    local wrapper_repo_path="${HOME}/.vibeguard/repo-path"
-    local wrapper_repo=""
-    local wrapper_source=""
-    if [[ -f "${wrapper_repo_path}" ]]; then
-      wrapper_repo="$(<"${wrapper_repo_path}")"
-    fi
-    wrapper_source="${wrapper_repo}/hooks/git/pre-push"
-    if [[ -z "${wrapper_repo}" || ! -f "${wrapper_source}" ]]; then
-      red "[BROKEN] VibeGuard repo pre-push hook wrapper source missing: ${wrapper_source}"
-      return 0
-    fi
-    if [[ ! -r "${wrapper_source}" ]]; then
-      red "[BROKEN] VibeGuard repo pre-push hook wrapper source not readable: ${wrapper_source}"
-      return 0
+  if [[ "${expected_target}" == "${HOME}/.vibeguard/${hook_name}" ]]; then
+    local mode wrapper_repo_path wrapper_repo wrapper_source
+    mode="$(check_install_mode)"
+    if [[ "${mode}" == "dev-linked" ]]; then
+      wrapper_repo_path="${HOME}/.vibeguard/repo-path"
+      wrapper_repo=""
+      if [[ -f "${wrapper_repo_path}" ]]; then
+        wrapper_repo="$(<"${wrapper_repo_path}")"
+      fi
+      if [[ "${hook_name}" == "pre-push" ]]; then
+        wrapper_source="${wrapper_repo}/hooks/git/pre-push"
+      else
+        wrapper_source="${wrapper_repo}/hooks/pre-commit-guard.sh"
+      fi
+      if [[ -z "${wrapper_repo}" || ! -f "${wrapper_source}" ]]; then
+        red "[BROKEN] VibeGuard repo ${hook_name} hook dev-linked source missing: ${wrapper_source}"
+        return 0
+      fi
+      if [[ ! -r "${wrapper_source}" ]]; then
+        red "[BROKEN] VibeGuard repo ${hook_name} hook dev-linked source not readable: ${wrapper_source}"
+        return 0
+      fi
+    else
+      if [[ "${hook_name}" == "pre-push" ]]; then
+        wrapper_source="${HOME}/.vibeguard/installed/hooks/git/pre-push"
+      else
+        wrapper_source="${HOME}/.vibeguard/installed/hooks/pre-commit-guard.sh"
+      fi
+      if [[ ! -f "${wrapper_source}" ]]; then
+        red "[BROKEN] VibeGuard repo ${hook_name} hook stable source missing: ${wrapper_source}"
+        return 0
+      fi
+      if [[ ! -r "${wrapper_source}" ]]; then
+        red "[BROKEN] VibeGuard repo ${hook_name} hook stable source not readable: ${wrapper_source}"
+        return 0
+      fi
     fi
   fi
 
@@ -247,15 +294,28 @@ _check_installed_runtime_version() {
 run_legacy_checks() {
   echo "VibeGuard Installation Status"
   echo "=============================="
+  if [[ "${VIBEGUARD_CHECK_COMPAT:-0}" == "1" ]]; then
+    yellow "[INFO] setup.sh --check is compatibility mode; use 'setup.sh doctor' for human reports or 'setup.sh verify-install' for machine install verification"
+  fi
 
   # Check hook wrapper
   VIBEGUARD_HOME="${HOME}/.vibeguard"
-  if [[ -f "${VIBEGUARD_HOME}/repo-path" ]] && [[ -f "${VIBEGUARD_HOME}/run-hook.sh" ]]; then
-    _repo=$(<"${VIBEGUARD_HOME}/repo-path")
-    if [[ -d "$_repo/hooks" ]]; then
-      green "[OK] Hook wrapper ready (repo: ${_repo})"
+  _mode="$(check_install_mode)"
+  if [[ -f "${VIBEGUARD_HOME}/run-hook.sh" ]]; then
+    if [[ "${_mode}" == "dev-linked" ]]; then
+      _repo=""
+      [[ ! -f "${VIBEGUARD_HOME}/repo-path" ]] || _repo="$(<"${VIBEGUARD_HOME}/repo-path")"
+      if [[ -n "${_repo}" && -d "$_repo/hooks" ]]; then
+        green "[OK] Hook wrapper ready (execution source: dev-linked repo ${_repo})"
+      else
+        red "[BROKEN] dev-linked repo-path points to missing hooks directory: ${_repo}"
+      fi
     else
-      red "[BROKEN] repo-path points to missing directory: ${_repo}"
+      if [[ -d "${VIBEGUARD_HOME}/installed/hooks" ]]; then
+        green "[OK] Hook wrapper ready (execution source: installed snapshot ${VIBEGUARD_HOME}/installed/hooks)"
+      else
+        red "[BROKEN] stable hook wrapper missing installed snapshot: ${VIBEGUARD_HOME}/installed/hooks"
+      fi
     fi
   else
     yellow "[MISSING] Hook wrapper not installed (~/.vibeguard/run-hook.sh)"
@@ -410,6 +470,52 @@ run_legacy_checks() {
   rm -f "$_awk_violations" 2>/dev/null || true
 }
 
+run_project_checks() {
+  echo "VibeGuard Project Verification"
+  echo "=============================="
+  project_config_file="$(vg_project_config_file)"
+  if [[ -z "${project_config_file}" || ! -f "${project_config_file}" ]]; then
+    yellow "[INFO] No project config found (.vibeguard.json optional)"
+    return 0
+  fi
+  if project_config_out="$(vg_validate_project_config "${project_config_file}" 2>&1)"; then
+    green "[OK] Project config valid (${project_config_file})"
+  else
+    red "[FAIL] Project config invalid (${project_config_file})"
+    while IFS= read -r line; do
+      red "  ${line}"
+    done <<< "${project_config_out}"
+  fi
+}
+
+run_dev_repo_checks() {
+  echo "VibeGuard Dev Repo Verification"
+  echo "=============================="
+  if _vg_hook_dir="$(git -C "${REPO_DIR}" rev-parse --path-format=absolute --git-path hooks 2>/dev/null)"; then
+    _check_repo_git_hook "pre-commit" "${HOME}/.vibeguard/pre-commit"
+    _check_repo_git_hook "pre-push" "${HOME}/.vibeguard/pre-push"
+  else
+    red "[FAIL] Repository git hooks not checked because this is not a git repository"
+  fi
+}
+
+run_selected_checks() {
+  case "${CHECK_MODE}" in
+    doctor|full)
+      run_legacy_checks
+      ;;
+    verify-project)
+      run_project_checks
+      ;;
+    verify-dev-repo)
+      run_dev_repo_checks
+      ;;
+    *)
+      red "[FAIL] Unknown check mode: ${CHECK_MODE}"
+      ;;
+  esac
+}
+
 # --- Capture and dispatch ---
 # We capture stdout once, mirror it (or suppress it for --json/--quiet),
 # then post-process for the summary, JSON, and exit code.
@@ -419,13 +525,13 @@ status_init "${capture_buf}"
 
 if [[ "${JSON}" -eq 1 ]]; then
   # JSON mode: probe output goes only to the buffer; nothing leaks to stdout.
-  run_legacy_checks > "${capture_buf}" 2>&1
+  run_selected_checks > "${capture_buf}" 2>&1
 elif [[ "${QUIET}" -eq 1 ]]; then
   # Quiet mode: capture everything, then re-emit only problems + summary.
-  run_legacy_checks > "${capture_buf}" 2>&1
+  run_selected_checks > "${capture_buf}" 2>&1
 else
   # Default mode: stream to user AND capture for the summary.
-  run_legacy_checks 2>&1 | tee "${capture_buf}"
+  run_selected_checks 2>&1 | tee "${capture_buf}"
 fi
 
 status_record_buffer

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # bash setup.sh --yes # Apply high-context diffs non-interactively
 # bash setup.sh --build-from-source # Build vibeguard-runtime with cargo instead of downloading a release binary
 # bash setup.sh --runtime-version v1.2.3 # Download a specific vibeguard-runtime release tag
+# bash setup.sh --dev-linked # Run hooks from the live repo checkout instead of the stable installed snapshot
 # bash setup.sh --with-scheduler # Opt in to launchd/systemd scheduled GC
 # bash setup.sh --force-overwrite # Replace user-customized managed files/commands
 # bash setup.sh --check # Check status only
@@ -42,6 +43,7 @@ VIBEGUARD_SETUP_AUTO="${VIBEGUARD_SETUP_AUTO:-0}"
 VIBEGUARD_SETUP_FORCE_OVERWRITE="${VIBEGUARD_SETUP_FORCE_OVERWRITE:-0}"
 WITH_SCHEDULER="${VIBEGUARD_SETUP_WITH_SCHEDULER:-0}"
 BUILD_FROM_SOURCE="${VIBEGUARD_SETUP_BUILD_FROM_SOURCE:-0}"
+DEV_LINKED="${VIBEGUARD_SETUP_DEV_LINKED:-0}"
 VIBEGUARD_HOME="${HOME}/.vibeguard"
 _INSTALL_TMP=""
 _INSTALL_FINAL_TMP=""
@@ -64,6 +66,8 @@ while [[ $# -gt 0 ]]; do
       RUNTIME_VERSION_OVERRIDE="$2"; RUNTIME_VERSION_OVERRIDE_SET=1; shift 2 ;;
     --runtime-version=*)
       RUNTIME_VERSION_OVERRIDE="${1#*=}"; RUNTIME_VERSION_OVERRIDE_SET=1; shift ;;
+    --dev-linked)
+      DEV_LINKED=1; shift ;;
     --with-scheduler)
       WITH_SCHEDULER=1; shift ;;
     --force-overwrite)
@@ -173,6 +177,7 @@ download_prebuilt_runtime() {
   local asset="vibeguard-runtime-${target}"
   local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
   local download_dir downloaded reason expected actual
+  local provenance_rc provenance_note
   local -a errors=()
 
   download_dir="$(mktemp -d "$(dirname "${dest}")/runtime_download_XXXXXX")"
@@ -240,12 +245,29 @@ download_prebuilt_runtime() {
     rm -rf "${download_dir}"
     return 10
   fi
+  provenance_rc=0
+  setup_runtime_verify_release_provenance "${download_dir}/${asset}" "${release_repo}" "${tag}" || provenance_rc=$?
+  case "${provenance_rc}" in
+    0)
+      provenance_note="provenance=verified-provenance"
+      ;;
+    2)
+      provenance_note="provenance=checksum-only (${SETUP_RUNTIME_PROVENANCE_REASON:-verifier unavailable})"
+      yellow "  Runtime provenance is checksum-only: ${SETUP_RUNTIME_PROVENANCE_REASON:-verifier unavailable}."
+      ;;
+    *)
+      red "  ERROR: vibeguard-runtime provenance verification failed for ${asset}."
+      red "  ${SETUP_RUNTIME_PROVENANCE_REASON:-unknown provenance verification failure}"
+      rm -rf "${download_dir}"
+      return 10
+      ;;
+  esac
 
   mkdir -p "$(dirname "${dest}")"
   cp "${download_dir}/${asset}" "${dest}"
   chmod +x "${dest}"
   rm -rf "${download_dir}"
-  green "  vibeguard-runtime downloaded and verified (${tag}, ${target})"
+  green "  vibeguard-runtime downloaded and verified (${tag}, ${target}; ${provenance_note})"
 }
 
 runtime_version_mismatch_reason() {
@@ -426,6 +448,11 @@ fi
 if [[ "${BUILD_FROM_SOURCE}" == "1" ]]; then
   echo "Mode: build-from-source (vibeguard-runtime will be built with cargo)"
 fi
+if [[ "${DEV_LINKED}" == "1" ]]; then
+  echo "Mode: dev-linked (hooks execute from the live repo checkout)"
+else
+  echo "Mode: stable (hooks execute from ~/.vibeguard/installed/)"
+fi
 if [[ -n "${RUNTIME_VERSION_OVERRIDE}" ]]; then
   echo "Runtime version override: ${RUNTIME_VERSION_OVERRIDE}"
 fi
@@ -457,13 +484,18 @@ green "  ~/.claude/ ready"
 #Write repo path + install hook wrapper (compatible with all platforms, no symlink dependencies)
 mkdir -p "${VIBEGUARD_HOME}"
 printf '%s' "${REPO_DIR}" > "${VIBEGUARD_HOME}/repo-path"
+if [[ "${DEV_LINKED}" == "1" ]]; then
+  printf 'dev-linked\n' > "${VIBEGUARD_HOME}/install-mode"
+else
+  printf 'stable\n' > "${VIBEGUARD_HOME}/install-mode"
+fi
 cp "${REPO_DIR}/hooks/run-hook.sh" "${VIBEGUARD_HOME}/run-hook.sh"
 cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${VIBEGUARD_HOME}/run-hook-codex.sh"
 mkdir -p "${VIBEGUARD_HOME}/_lib"
 cp "${REPO_DIR}/hooks/_lib/codex_diag.sh" "${VIBEGUARD_HOME}/_lib/codex_diag.sh"
 cp "${REPO_DIR}/hooks/_lib/wrapper_env.sh" "${VIBEGUARD_HOME}/_lib/wrapper_env.sh"
 chmod +x "${VIBEGUARD_HOME}/run-hook.sh" "${VIBEGUARD_HOME}/run-hook-codex.sh"
-green "  ~/.vibeguard/repo-path + run-hook.sh + run-hook-codex.sh ready"
+green "  ~/.vibeguard/repo-path + install-mode + run-hook.sh + run-hook-codex.sh ready"
 
 # Create user-rules directory for custom rules
 mkdir -p "${VIBEGUARD_HOME}/user-rules"
@@ -519,6 +551,7 @@ fi
 state_init "$PROFILE" "$LANGUAGES"
 state_record_tree "${INSTALLED_DIR}" "installed"
 state_record_file "${VIBEGUARD_HOME}/repo-path" "generated/repo-path" "copy"
+state_record_file "${VIBEGUARD_HOME}/install-mode" "generated/install-mode" "copy"
 state_record_file "${VIBEGUARD_HOME}/run-hook.sh" "hooks/run-hook.sh" "copy"
 state_record_file "${VIBEGUARD_HOME}/_lib/codex_diag.sh" "hooks/_lib/codex_diag.sh" "copy"
 state_record_file "${VIBEGUARD_HOME}/_lib/wrapper_env.sh" "hooks/_lib/wrapper_env.sh" "copy"
@@ -591,11 +624,26 @@ cat > "${PRE_COMMIT_WRAPPER}" <<'WRAPPER'
 #!/usr/bin/env bash
 # VibeGuard Pre-Commit Hook Wrapper — auto-installed by setup.sh
 set -euo pipefail
-VIBEGUARD_DIR="$(cat "$HOME/.vibeguard/repo-path" 2>/dev/null)" || true
-if [[ -n "$VIBEGUARD_DIR" ]] && [[ -f "$VIBEGUARD_DIR/hooks/pre-commit-guard.sh" ]]; then
-  export VIBEGUARD_DIR
-  exec bash "$VIBEGUARD_DIR/hooks/pre-commit-guard.sh"
+MODE_FILE="$HOME/.vibeguard/install-mode"
+dev_linked_enabled() {
+  [[ "${VIBEGUARD_DEV_LINKED:-0}" == "1" ]] && return 0
+  [[ -f "$MODE_FILE" && "$(<"$MODE_FILE")" == "dev-linked" ]]
+}
+if dev_linked_enabled; then
+  VIBEGUARD_DIR="$(cat "$HOME/.vibeguard/repo-path" 2>/dev/null)" || true
+  if [[ -n "$VIBEGUARD_DIR" && -f "$VIBEGUARD_DIR/hooks/pre-commit-guard.sh" ]]; then
+    export VIBEGUARD_DIR
+    exec bash "$VIBEGUARD_DIR/hooks/pre-commit-guard.sh"
+  fi
+else
+  INSTALLED_HOOK="$HOME/.vibeguard/installed/hooks/pre-commit-guard.sh"
+  if [[ -f "$INSTALLED_HOOK" ]]; then
+    export VIBEGUARD_DIR="$HOME/.vibeguard/installed"
+    exec bash "$INSTALLED_HOOK"
+  fi
 fi
+echo "vibeguard: pre-commit hook source not found; re-run bash setup.sh --yes" >&2
+exit 1
 WRAPPER
 chmod +x "${PRE_COMMIT_WRAPPER}"
 state_record_file "${PRE_COMMIT_WRAPPER}" "generated/pre-commit-wrapper" "copy"
@@ -606,10 +654,22 @@ cat > "${PRE_PUSH_WRAPPER}" <<'WRAPPER'
 #!/usr/bin/env bash
 # VibeGuard Pre-Push Hook Wrapper — auto-installed by setup.sh
 set -euo pipefail
-VIBEGUARD_DIR="$(cat "$HOME/.vibeguard/repo-path" 2>/dev/null)" || true
-if [[ -n "$VIBEGUARD_DIR" ]] && [[ -f "$VIBEGUARD_DIR/hooks/git/pre-push" ]]; then
-  export VIBEGUARD_DIR
-  exec bash "$VIBEGUARD_DIR/hooks/git/pre-push" "$@"
+MODE_FILE="$HOME/.vibeguard/install-mode"
+dev_linked_enabled() {
+  [[ "${VIBEGUARD_DEV_LINKED:-0}" == "1" ]] && return 0
+  [[ -f "$MODE_FILE" && "$(<"$MODE_FILE")" == "dev-linked" ]]
+}
+if dev_linked_enabled; then
+  VIBEGUARD_DIR="$(cat "$HOME/.vibeguard/repo-path" 2>/dev/null)" || true
+  if [[ -n "$VIBEGUARD_DIR" && -f "$VIBEGUARD_DIR/hooks/git/pre-push" ]]; then
+    export VIBEGUARD_DIR
+    exec bash "$VIBEGUARD_DIR/hooks/git/pre-push" "$@"
+  fi
+else
+  INSTALLED_HOOK="$HOME/.vibeguard/installed/hooks/git/pre-push"
+  if [[ -f "$INSTALLED_HOOK" ]]; then
+    exec bash "$INSTALLED_HOOK" "$@"
+  fi
 fi
 echo "vibeguard: pre-push hook source not found; re-run bash setup.sh --yes" >&2
 exit 1

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -150,11 +150,38 @@ setup_runtime_sha256_file() {
   fi
 }
 
+setup_runtime_verify_release_provenance() {
+  local asset_path="$1" release_repo="$2" tag="$3"
+  SETUP_RUNTIME_PROVENANCE_STATUS="checksum-only"
+  SETUP_RUNTIME_PROVENANCE_REASON=""
+
+  if ! command -v gh >/dev/null 2>&1; then
+    SETUP_RUNTIME_PROVENANCE_REASON="gh not found"
+    return 2
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    SETUP_RUNTIME_PROVENANCE_REASON="gh auth unavailable"
+    return 2
+  fi
+
+  if gh attestation verify "${asset_path}" \
+    --repo "${release_repo}" \
+    --signer-workflow "github.com/${release_repo}/.github/workflows/release.yml" \
+    --source-ref "refs/tags/${tag}" \
+    --deny-self-hosted-runners >/dev/null 2>&1; then
+    SETUP_RUNTIME_PROVENANCE_STATUS="verified-provenance"
+    return 0
+  fi
+
+  SETUP_RUNTIME_PROVENANCE_REASON="gh attestation verify failed"
+  return 1
+}
+
 setup_download_prebuilt_runtime_quiet() {
   local target="$1" tag="$2" dest="$3"
   local asset="vibeguard-runtime-${target}"
   local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
-  local download_dir downloaded expected actual
+  local download_dir downloaded expected actual provenance_rc
 
   download_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-runtime-download_XXXXXX")"
   downloaded=0
@@ -188,6 +215,12 @@ setup_download_prebuilt_runtime_quiet() {
     return 1
   fi
   if ! actual="$(setup_runtime_sha256_file "${download_dir}/${asset}")" || [[ "${actual}" != "${expected}" ]]; then
+    rm -rf "${download_dir}"
+    return 1
+  fi
+  provenance_rc=0
+  setup_runtime_verify_release_provenance "${download_dir}/${asset}" "${release_repo}" "${tag}" || provenance_rc=$?
+  if [[ "${provenance_rc}" -eq 1 ]]; then
     rm -rf "${download_dir}"
     return 1
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,11 @@ Usage: bash setup.sh [command] [options]
 
 Commands:
   install              Install VibeGuard (default when no command is given)
-  --check             Verify installation health
+  doctor              Human-friendly installation diagnosis
+  verify-install      Machine install verification (non-zero on broken required state)
+  verify-project      Project config verification
+  verify-dev-repo     Repository development hook verification
+  --check             Compatibility health check wrapper
   --clean             Uninstall managed VibeGuard assets
   --codex-status      Show read-only Codex-specific status
   packs               Manage guard packs
@@ -29,6 +33,7 @@ Install options:
   --dry-run
   --build-from-source
   --runtime-version vX.Y.Z
+  --dev-linked
   --with-scheduler
   --force-overwrite
   --profile minimal|core|full|strict
@@ -39,6 +44,8 @@ Check options:
 
 Examples:
   bash setup.sh --yes
+  bash setup.sh doctor
+  bash setup.sh verify-install
   bash setup.sh --check --strict
   bash setup.sh --check --profile strict
   bash setup.sh --profile strict --languages rust,python
@@ -54,7 +61,7 @@ run_setup() {
     exit 1
   fi
 
-  VIBEGUARD_REPO_DIR="${REPO_DIR}" bash "${SETUP_DIR}/${script}" "$@"
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" VIBEGUARD_CHECK_COMPAT="${VIBEGUARD_CHECK_COMPAT:-0}" bash "${SETUP_DIR}/${script}" "$@"
 }
 
 case "${1:-}" in
@@ -63,7 +70,23 @@ case "${1:-}" in
     ;;
   --check)
     shift || true
-    run_setup "check.sh" "$@"
+    VIBEGUARD_CHECK_COMPAT=1 run_setup "check.sh" "$@"
+    ;;
+  doctor|--doctor)
+    shift || true
+    run_setup "check.sh" --doctor "$@"
+    ;;
+  verify-install)
+    shift || true
+    run_setup "check.sh" --install "$@"
+    ;;
+  verify-project)
+    shift || true
+    run_setup "check.sh" --verify-project "$@"
+    ;;
+  verify-dev-repo)
+    shift || true
+    run_setup "check.sh" --verify-dev-repo "$@"
     ;;
   --clean)
     shift || true

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -114,6 +114,7 @@ cat > "${explicit_runtime}" <<'SH'
 #!/usr/bin/env bash
 case "${1:-}" in
   runtime-policy-check)
+    printf '{"decision":"run","enforcement":"block","hook":"probe","profile":"core","config_path":null,"reason":null,"warn_mode":false}\n'
     exit 0
     ;;
   runtime-policy-downgrade-output)
@@ -146,6 +147,7 @@ cat > "${optimized_runtime}" <<'SH'
 case "${1:-}" in
   runtime-policy-supports)
     printf 'supports\n' >>"${OPTIMIZED_PROBE_LOG:?}"
+    printf 'runtime-policy-json-v1\n'
     exit 0
     ;;
   runtime-policy-check|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -338,6 +338,7 @@ assert_cmd "no-Python setup --clean removes install state" test ! -e "${no_pytho
 
 install_out="$(VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
+assert_contains "${install_out}" "Mode: stable" "default setup reports stable execution mode"
 assert_contains "${install_out}" "vibeguard-runtime downloaded and verified" "default setup uses verified prebuilt runtime without cargo"
 assert_contains "${install_out}" "Scheduled GC not installed by default" "default setup reports scheduled GC opt-in"
 assert_cmd "default setup does not install scheduled GC" assert_scheduled_gc_absent
@@ -359,10 +360,12 @@ assert_contains "${install_out}" "[OK] vibeguard-runtime version matches repo VE
 assert_contains "${install_out}" "[OK] Installed hooks+guards snapshot matches repo HEAD" "setup install reports current installed snapshot"
 assert_contains "${install_out}" "~/.vibeguard/config.json present (preserved)" "setup preserves seeded runtime config during install"
 assert_cmd "pre-push wrapper is installed after setup" test -x "${HOME}/.vibeguard/pre-push"
+assert_cmd "default install records stable mode" bash -c 'test "$(cat "$HOME/.vibeguard/install-mode")" = stable'
 assert_cmd "repo pre-commit hook is installed after setup" assert_repo_git_hook_target "pre-commit" "${HOME}/.vibeguard/pre-commit"
 assert_cmd "repo pre-push hook is installed after setup" assert_repo_git_hook_target "pre-push" "${HOME}/.vibeguard/pre-push"
 default_scheduler_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 assert_contains "${default_scheduler_check_out}" "[INFO] Scheduled GC not installed (optional, opt in: bash setup.sh --yes --with-scheduler)" "--check reports absent scheduled GC as INFO"
+assert_contains "${default_scheduler_check_out}" "execution source: installed snapshot" "--check reports stable installed snapshot execution source"
 assert_contains "${default_scheduler_check_out}" "[OK] vibeguard-runtime version matches repo VERSION" "--check reports runtime version health"
 assert_not_contains "${default_scheduler_check_out}" "[WARN] Scheduled GC" "--check does not warn when scheduled GC is absent"
 scheduler_fail_home="${TMP_HOME}/scheduler-enable-fail-home"
@@ -480,9 +483,11 @@ assert_contains "${installed_git_hook_check_out}" "[OK] VibeGuard repo pre-push 
 fake_wrapper_repo="${TMP_HOME}/fake-wrapper-repo"
 mkdir -p "${fake_wrapper_repo}/hooks/git"
 printf '%s' "${fake_wrapper_repo}" > "${HOME}/.vibeguard/repo-path"
+printf 'dev-linked\n' > "${HOME}/.vibeguard/install-mode"
 missing_wrapper_source_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
-assert_contains "${missing_wrapper_source_check_out}" "[BROKEN] VibeGuard repo pre-push hook wrapper source missing" "--check reports missing pre-push wrapper source"
+assert_contains "${missing_wrapper_source_check_out}" "[BROKEN] VibeGuard repo pre-push hook dev-linked source missing" "--check reports missing dev-linked pre-push wrapper source"
 printf '%s' "${REPO_DIR}" > "${HOME}/.vibeguard/repo-path"
+printf 'stable\n' > "${HOME}/.vibeguard/install-mode"
 ln -sfn "${TMP_HOME}/unexpected-pre-commit" "${REPO_GIT_HOOK_DIR}/pre-commit"
 drift_git_hook_check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
 assert_contains "${drift_git_hook_check_out}" "[BROKEN] VibeGuard repo pre-commit hook target drift" "--check reports repo pre-commit hook target drift"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -7,6 +7,9 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="${REPO_DIR}/.github/workflows/release.yml"
 VERSION_FILE="${REPO_DIR}/vibeguard-runtime/VERSION"
 CARGO_TOML="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
+RUST_TOOLCHAIN="${REPO_DIR}/rust-toolchain.toml"
+INSTALL_SH="${REPO_DIR}/scripts/setup/install.sh"
+SETUP_LIB="${REPO_DIR}/scripts/setup/lib.sh"
 
 PASS=0
 FAIL=0
@@ -53,6 +56,18 @@ assert_not_contains() {
   fi
 }
 
+assert_regex() {
+  local text="$1" regex="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -Eq -- "$regex" <<< "$text"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected regex: $regex)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 ensure_runtime_tag_available() {
   local tag="$1"
   if git -C "${REPO_DIR}" rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
@@ -65,6 +80,9 @@ ensure_runtime_tag_available() {
 }
 
 workflow_text="$(<"${WORKFLOW}")"
+toolchain_text="$(<"${RUST_TOOLCHAIN}")"
+install_text="$(<"${INSTALL_SH}")"
+setup_lib_text="$(<"${SETUP_LIB}")"
 runtime_version="$(tr -d '[:space:]' < "${VERSION_FILE}")"
 cargo_version="$(
   python3 - "${CARGO_TOML}" <<'PY'
@@ -90,9 +108,23 @@ assert_contains "$workflow_text" "refusing to mutate release assets" "existing r
 assert_contains "$workflow_text" "git merge-base --is-ancestor" "tag must be reachable from main"
 assert_contains "$workflow_text" "RUNTIME_VERSION_FILE" "workflow reads runtime VERSION file"
 assert_contains "$workflow_text" "release tag \${TAG_NAME} does not match" "tag/version mismatch fails loudly"
-assert_contains "$workflow_text" 'RUST_VERSION: "stable"' "release workflow uses latest stable Rust"
+assert_contains "$workflow_text" 'RUST_VERSION: "1.95.0"' "release workflow pins Rust release toolchain"
+assert_contains "$toolchain_text" 'channel = "1.95.0"' "repo rust-toolchain pins the same release toolchain"
+assert_not_contains "$workflow_text" 'RUST_VERSION: "stable"' "release workflow does not use moving stable Rust"
+assert_regex "$workflow_text" 'uses: actions/checkout@[0-9a-f]{40}[[:space:]]*# v6\.0\.2' "checkout action is pinned to a full commit SHA"
+assert_regex "$workflow_text" 'uses: actions/upload-artifact@[0-9a-f]{40}[[:space:]]*# v7\.0\.1' "upload-artifact action is pinned to a full commit SHA"
+assert_regex "$workflow_text" 'uses: actions/download-artifact@[0-9a-f]{40}[[:space:]]*# v8\.0\.1' "download-artifact action is pinned to a full commit SHA"
+assert_regex "$workflow_text" 'uses: actions/attest-build-provenance@[0-9a-f]{40}[[:space:]]*# v4\.1\.0' "attestation action is pinned to a full commit SHA"
+assert_contains "$workflow_text" "attestations: write" "build job can publish artifact attestations"
+assert_contains "$workflow_text" "id-token: write" "build job can request OIDC token for attestations"
+assert_contains "$workflow_text" "subject-path: dist/\${{ matrix.target }}/vibeguard-runtime-\${{ matrix.target }}" "release workflow attests each runtime artifact"
 assert_contains "$workflow_text" "sha256sum vibeguard-runtime-* | sort -k2 > SHA256SUMS" "checksums use deterministic sorted layout"
 assert_contains "$workflow_text" 'GH_REPO: ${{ github.repository }}' "publish job pins gh target repository"
+assert_contains "$setup_lib_text" "gh attestation verify" "setup verifies runtime release attestations when gh is available"
+assert_contains "$setup_lib_text" "--signer-workflow" "setup pins provenance signer workflow"
+assert_contains "$setup_lib_text" '--source-ref "refs/tags/${tag}"' "setup pins provenance to the release tag"
+assert_contains "$install_text" "provenance=verified-provenance" "install output reports verified provenance"
+assert_contains "$install_text" "provenance=checksum-only" "install output reports checksum-only fallback explicitly"
 
 for target in \
   aarch64-apple-darwin \

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -274,6 +274,13 @@ assert_eq "$help_rc" "0" "check --help: exit 0"
 assert_contains "$help_out" "Usage: setup.sh --check" "check --help: prints usage"
 assert_contains "$help_out" "Exit codes"             "check --help: documents exit codes"
 assert_contains "$help_out" "--install"              "check --help: documents install verification mode"
+assert_contains "$help_out" "--verify-project"       "check --help: documents project verification mode"
+
+top_help_out="$(bash "${SETUP_SCRIPT}" --help 2>&1)"
+assert_contains "$top_help_out" "doctor" "setup --help: documents doctor command"
+assert_contains "$top_help_out" "verify-install" "setup --help: documents verify-install command"
+assert_contains "$top_help_out" "verify-project" "setup --help: documents verify-project command"
+assert_contains "$top_help_out" "verify-dev-repo" "setup --help: documents verify-dev-repo command"
 
 # Unknown flag should exit 64 (sysexits.h EX_USAGE).
 err_out="$(bash "${SETUP_SCRIPT}" --check --bogus 2>&1)"
@@ -301,11 +308,34 @@ header "check.sh end-to-end"
 # we only assert the structural pieces we promised the user.
 default_out="$(bash "${SETUP_SCRIPT}" --check 2>&1 || true)"
 assert_contains "$default_out" "VibeGuard Installation Status" "default: legacy header preserved"
+assert_contains "$default_out" "setup.sh --check is compatibility mode" "default: --check reports compatibility mode"
 assert_contains "$default_out" "Summary"        "default: summary block present"
 assert_contains "$default_out" "Verdict :"      "default: verdict line present"
 assert_contains "$default_out" "[OK] All awk blocks use POSIX-compatible regex" "default: Python heredoc regexes do not trip awk portability"
 assert_not_contains "$default_out" "check_dependency_changes.sh:147" "default: dependency Python regex not reported as awk"
 assert_not_contains "$default_out" "check_test_weakening.sh:118" "default: test weakening Python regex not reported as awk"
+
+doctor_home="$(mktemp -d)"
+doctor_out="$(HOME="${doctor_home}" bash "${SETUP_SCRIPT}" doctor 2>&1 || true)"
+assert_contains "$doctor_out" "VibeGuard Installation Status" "doctor: routes to human status report"
+assert_not_contains "$doctor_out" "compatibility mode" "doctor: does not report --check compatibility mode"
+rm -rf "${doctor_home}"
+
+verify_project_home="$(mktemp -d)"
+verify_project_out="$(HOME="${verify_project_home}" bash "${SETUP_SCRIPT}" verify-project 2>&1 || true)"
+assert_contains "$verify_project_out" "VibeGuard Project Verification" "verify-project: routes to project verifier"
+assert_contains "$verify_project_out" "No project config found" "verify-project: reports missing optional project config"
+rm -rf "${verify_project_home}"
+
+bad_verify_home="$(mktemp -d)"
+bad_verify_config="${bad_verify_home}/bad-vibeguard.json"
+printf '{"profile":"strictest"}\n' > "${bad_verify_config}"
+set +e
+bad_verify_out="$(HOME="${bad_verify_home}" VIBEGUARD_PROJECT_CONFIG="${bad_verify_config}" bash "${SETUP_SCRIPT}" verify-project 2>&1)"
+bad_verify_rc=$?
+assert_cmd "verify-project exits nonzero for invalid config" test "${bad_verify_rc}" -ne 0
+assert_contains "$bad_verify_out" "Project config invalid" "verify-project: reports invalid project config"
+rm -rf "${bad_verify_home}"
 
 AWK_PORTABILITY_FIXTURE="${REPO_DIR}/guards/universal/vg-test-non-posix-awk.sh"
 cat > "${AWK_PORTABILITY_FIXTURE}" <<'SH'

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -1,6 +1,9 @@
 use crate::project_config::{load_project_config, project_config_path};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
+
+const HOOKS_MANIFEST_JSON: &str = include_str!("../../hooks/manifest.json");
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HookPolicyDecision {
@@ -12,27 +15,141 @@ pub enum HookPolicyDecision {
     Error(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookPolicyReport {
+    pub decision: String,
+    pub enforcement: String,
+    pub hook: String,
+    pub profile: String,
+    pub config_path: Option<String>,
+    pub reason: Option<String>,
+    pub warn_mode: bool,
+}
+
+impl HookPolicyReport {
+    fn run(
+        hook: String,
+        enforcement: String,
+        profile: String,
+        config_path: Option<String>,
+        reason: Option<String>,
+        warn_mode: bool,
+    ) -> Self {
+        Self {
+            decision: "run".to_string(),
+            enforcement,
+            hook,
+            profile,
+            config_path,
+            reason,
+            warn_mode,
+        }
+    }
+
+    fn skip(
+        hook: String,
+        enforcement: String,
+        profile: String,
+        config_path: Option<String>,
+        reason: String,
+    ) -> Self {
+        Self {
+            decision: "skip".to_string(),
+            enforcement,
+            hook,
+            profile,
+            config_path,
+            reason: Some(reason),
+            warn_mode: false,
+        }
+    }
+
+    fn error(
+        hook: String,
+        enforcement: String,
+        profile: String,
+        config_path: Option<String>,
+        reason: String,
+    ) -> Self {
+        Self {
+            decision: "error".to_string(),
+            enforcement,
+            hook,
+            profile,
+            config_path,
+            reason: Some(reason),
+            warn_mode: false,
+        }
+    }
+
+    pub fn to_decision(&self) -> HookPolicyDecision {
+        match self.decision.as_str() {
+            "run" => HookPolicyDecision::Run {
+                warn_mode: self.warn_mode,
+                reason: self.reason.clone(),
+            },
+            "skip" => HookPolicyDecision::Skip(
+                self.reason
+                    .clone()
+                    .unwrap_or_else(|| "VibeGuard policy skip".to_string()),
+            ),
+            _ => HookPolicyDecision::Error(
+                self.reason
+                    .clone()
+                    .unwrap_or_else(|| "VibeGuard policy error".to_string()),
+            ),
+        }
+    }
+}
+
 pub fn evaluate_hook_policy(
     hook_name: &str,
     cwd: Option<&str>,
     env_overrides: &HashMap<String, String>,
 ) -> HookPolicyDecision {
+    evaluate_hook_policy_report(hook_name, cwd, env_overrides).to_decision()
+}
+
+pub fn evaluate_hook_policy_report(
+    hook_name: &str,
+    cwd: Option<&str>,
+    env_overrides: &HashMap<String, String>,
+) -> HookPolicyReport {
+    let canonical_hook = app_server_canonical_hook_name(hook_name);
     let Some(path) = project_config_path(cwd, env_overrides) else {
-        return HookPolicyDecision::Run {
-            warn_mode: false,
-            reason: None,
-        };
+        return HookPolicyReport::run(
+            canonical_hook,
+            "block".to_string(),
+            "core".to_string(),
+            None,
+            None,
+            false,
+        );
     };
+    let config_path = Some(path.display().to_string());
 
     let config = match load_project_config(&path) {
         Ok(config) => config,
-        Err(reason) => return HookPolicyDecision::Error(reason),
+        Err(reason) => {
+            return HookPolicyReport::error(
+                canonical_hook,
+                "block".to_string(),
+                "core".to_string(),
+                config_path,
+                reason,
+            );
+        }
     };
 
-    let canonical_hook = app_server_canonical_hook_name(hook_name);
     let enforcement = config.enforcement.as_deref().unwrap_or("block");
     if enforcement == "off" {
-        return HookPolicyDecision::Skip("VibeGuard policy skip: enforcement=off".into());
+        return HookPolicyReport::skip(
+            canonical_hook,
+            enforcement.to_string(),
+            config.profile.as_deref().unwrap_or("core").to_string(),
+            config_path,
+            "VibeGuard policy skip: enforcement=off".into(),
+        );
     }
 
     if config
@@ -40,29 +157,57 @@ pub fn evaluate_hook_policy(
         .iter()
         .any(|hook| hook == &canonical_hook)
     {
-        return HookPolicyDecision::Skip(format!(
-            "VibeGuard policy skip: disabled_hooks contains {canonical_hook}"
-        ));
+        return HookPolicyReport::skip(
+            canonical_hook.clone(),
+            enforcement.to_string(),
+            config.profile.as_deref().unwrap_or("core").to_string(),
+            config_path,
+            format!("VibeGuard policy skip: disabled_hooks contains {canonical_hook}"),
+        );
     }
 
     let profile = config.profile.as_deref().unwrap_or("core");
-    if !profile_allows_hook(profile, &canonical_hook) {
-        return HookPolicyDecision::Skip(format!(
-            "VibeGuard policy skip: profile={profile} excludes {canonical_hook}"
-        ));
+    let profile_allowed = match manifest_profile_allows_hook(profile, &canonical_hook) {
+        Ok(allowed) => allowed,
+        Err(reason) => {
+            return HookPolicyReport::error(
+                canonical_hook,
+                enforcement.to_string(),
+                profile.to_string(),
+                config_path,
+                reason,
+            );
+        }
+    };
+    if !profile_allowed {
+        return HookPolicyReport::skip(
+            canonical_hook.clone(),
+            enforcement.to_string(),
+            profile.to_string(),
+            config_path,
+            format!("VibeGuard policy skip: profile={profile} excludes {canonical_hook}"),
+        );
     }
 
     if enforcement == "warn" {
-        return HookPolicyDecision::Run {
-            warn_mode: true,
-            reason: Some("VibeGuard policy warn: enforcement=warn".into()),
-        };
+        return HookPolicyReport::run(
+            canonical_hook,
+            enforcement.to_string(),
+            profile.to_string(),
+            config_path,
+            Some("VibeGuard policy warn: enforcement=warn".into()),
+            true,
+        );
     }
 
-    HookPolicyDecision::Run {
-        warn_mode: false,
-        reason: None,
-    }
+    HookPolicyReport::run(
+        canonical_hook,
+        enforcement.to_string(),
+        profile.to_string(),
+        config_path,
+        None,
+        false,
+    )
 }
 
 pub fn required_hook_missing_message(hook_name: &str, hook_path: &Path) -> Option<String> {
@@ -90,15 +235,55 @@ fn app_server_canonical_hook_name(hook_name: &str) -> String {
         .replace('_', "-")
 }
 
-fn profile_allows_hook(profile: &str, hook_name: &str) -> bool {
-    match hook_name {
-        "analysis-paralysis-guard" => matches!(profile, "core" | "full" | "strict"),
-        "count-active-constraints" => profile == "strict",
-        "post-build-check" | "stop-guard" | "learn-evaluator" => {
-            matches!(profile, "full" | "strict")
-        }
-        _ => true,
+fn manifest_profile_allows_hook(profile: &str, hook_name: &str) -> Result<bool, String> {
+    let Some((_, profiles)) = manifest_hook_profiles()?
+        .into_iter()
+        .find(|(name, _)| name == hook_name)
+    else {
+        return Ok(true);
+    };
+    Ok(profiles.iter().any(|candidate| candidate == profile))
+}
+
+fn manifest_hook_profiles() -> Result<Vec<(String, Vec<String>)>, String> {
+    let manifest = serde_json::from_str::<Value>(HOOKS_MANIFEST_JSON)
+        .map_err(|err| format!("hooks/manifest.json invalid JSON: {err}"))?;
+    let hooks = manifest
+        .get("hooks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "hooks/manifest.json missing hooks array".to_string())?;
+
+    let mut entries = Vec::new();
+    for hook in hooks {
+        let name = hook
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "hooks/manifest.json hook entry missing string name".to_string())?;
+        let Some(profiles_value) = hook
+            .get("claude")
+            .and_then(Value::as_object)
+            .and_then(|claude| claude.get("profiles"))
+        else {
+            continue;
+        };
+        let profiles = profiles_value
+            .as_array()
+            .ok_or_else(|| {
+                format!("hooks/manifest.json hook {name} claude.profiles must be a list")
+            })?
+            .iter()
+            .map(|profile| {
+                profile.as_str().map(str::to_string).ok_or_else(|| {
+                    format!("hooks/manifest.json hook {name} claude.profiles contains non-string")
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        entries.push((name.to_string(), profiles));
     }
+    if entries.is_empty() {
+        return Err("hooks/manifest.json contains no hook profile entries".to_string());
+    }
+    Ok(entries)
 }
 
 #[cfg(test)]
@@ -242,6 +427,24 @@ mod tests {
         );
         if let Err(err) = fs::remove_dir_all(&repo) {
             panic!("temp policy dir should be removed: {err}");
+        }
+    }
+
+    #[test]
+    fn runtime_profile_filter_matches_manifest_for_all_profiled_hooks() {
+        for (hook_name, profiles) in
+            manifest_hook_profiles().expect("manifest profiles should parse")
+        {
+            for profile in ["minimal", "core", "full", "strict"] {
+                let expected = profiles.iter().any(|candidate| candidate == profile);
+                let actual = manifest_profile_allows_hook(profile, &hook_name)
+                    .expect("profile lookup should succeed");
+
+                assert_eq!(
+                    actual, expected,
+                    "profile={profile} hook={hook_name} should follow hooks/manifest.json"
+                );
+            }
         }
     }
 

--- a/vibeguard-runtime/src/runtime_policy.rs
+++ b/vibeguard-runtime/src/runtime_policy.rs
@@ -1,5 +1,5 @@
 use crate::HandlerResult;
-use crate::codex_app_server_policy::{HookPolicyDecision, evaluate_hook_policy};
+use crate::codex_app_server_policy::{HookPolicyReport, evaluate_hook_policy_report};
 use crate::runtime_config::validate_runtime_config_file;
 use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
 use serde_json::{Value, json};
@@ -18,37 +18,133 @@ pub fn runtime_policy_supports(args: &[String]) -> HandlerResult {
     if !args.is_empty() {
         return Err("Usage: vibeguard-runtime runtime-policy-supports".into());
     }
+    println!("runtime-policy-json-v1");
     Ok(())
 }
 
 pub fn runtime_policy_check(args: &[String]) -> HandlerResult {
-    if args.len() != 1 {
-        return Err("Usage: vibeguard-runtime runtime-policy-check <hook-name>".into());
-    }
+    let args = parse_runtime_policy_check_args(args)?;
 
     let user_config = std::env::var("VIBEGUARD_USER_CONFIG_FILE").unwrap_or_default();
     if let Err(err) = validate_runtime_config_file(&user_config) {
-        eprintln!("{}", err.message);
+        let report = HookPolicyReport {
+            decision: "error".to_string(),
+            enforcement: "block".to_string(),
+            hook: args.hook_name.clone(),
+            profile: "core".to_string(),
+            config_path: None,
+            reason: Some(err.message),
+            warn_mode: false,
+        };
+        print_policy_report(&report, true, args.output_format)?;
         process::exit(err.exit_code);
     }
 
-    let decision = evaluate_hook_policy(&args[0], None, &HashMap::new());
+    let decision =
+        evaluate_hook_policy_report(&args.hook_name, args.cwd.as_deref(), &HashMap::new());
     match decision {
-        HookPolicyDecision::Run { reason, .. } => {
-            if let Some(reason) = reason {
-                println!("{reason}");
-            }
+        report if report.decision == "run" => {
+            print_policy_report(&report, false, args.output_format)?;
             process::exit(ALLOW);
         }
-        HookPolicyDecision::Skip(reason) => {
-            println!("{reason}");
+        report if report.decision == "skip" => {
+            print_policy_report(&report, false, args.output_format)?;
             process::exit(SKIP);
         }
-        HookPolicyDecision::Error(reason) => {
-            eprintln!("{reason}");
-            process::exit(policy_error_exit_code(&reason));
+        report => {
+            let reason = report.reason.as_deref().unwrap_or("");
+            print_policy_report(&report, true, args.output_format)?;
+            process::exit(policy_error_exit_code(reason));
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PolicyOutputFormat {
+    Json,
+    Text,
+}
+
+struct RuntimePolicyCheckArgs {
+    hook_name: String,
+    cwd: Option<String>,
+    output_format: PolicyOutputFormat,
+}
+
+fn parse_runtime_policy_check_args(args: &[String]) -> Result<RuntimePolicyCheckArgs, String> {
+    let mut cwd = None;
+    let mut output_format = PolicyOutputFormat::Json;
+    let mut hook_name = None;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--cwd" | "--project-root" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(runtime_policy_check_usage());
+                };
+                cwd = Some(value.clone());
+                index += 2;
+            }
+            "--format" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(runtime_policy_check_usage());
+                };
+                output_format = match value.as_str() {
+                    "json" => PolicyOutputFormat::Json,
+                    "text" => PolicyOutputFormat::Text,
+                    _ => return Err(runtime_policy_check_usage()),
+                };
+                index += 2;
+            }
+            value if value.starts_with('-') => return Err(runtime_policy_check_usage()),
+            value => {
+                if hook_name.replace(value.to_string()).is_some() {
+                    return Err(runtime_policy_check_usage());
+                }
+                index += 1;
+            }
+        }
+    }
+
+    let Some(hook_name) = hook_name else {
+        return Err(runtime_policy_check_usage());
+    };
+
+    Ok(RuntimePolicyCheckArgs {
+        hook_name,
+        cwd,
+        output_format,
+    })
+}
+
+fn runtime_policy_check_usage() -> String {
+    "Usage: vibeguard-runtime runtime-policy-check [--cwd <path>|--project-root <path>] [--format json|text] <hook-name>".into()
+}
+
+fn print_policy_report(
+    report: &HookPolicyReport,
+    stderr: bool,
+    output_format: PolicyOutputFormat,
+) -> HandlerResult {
+    let text = match output_format {
+        PolicyOutputFormat::Json => serde_json::to_string(&json!({
+            "decision": report.decision,
+            "enforcement": report.enforcement,
+            "hook": report.hook,
+            "profile": report.profile,
+            "config_path": report.config_path,
+            "reason": report.reason,
+            "warn_mode": report.warn_mode,
+        }))?,
+        PolicyOutputFormat::Text => report.reason.clone().unwrap_or_default(),
+    };
+    if stderr {
+        eprintln!("{text}");
+    } else {
+        println!("{text}");
+    }
+    Ok(())
 }
 
 pub fn runtime_policy_downgrade_output(args: &[String]) -> HandlerResult {

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -53,6 +53,14 @@ fn run_runtime_policy(repo: &Path, hook_name: &str) -> std::process::Output {
         .expect("runtime policy command should run")
 }
 
+fn policy_stdout(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).expect("policy stdout should be JSON")
+}
+
+fn policy_stderr(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stderr).expect("policy stderr should be JSON")
+}
+
 #[test]
 fn runtime_policy_check_allows_when_no_project_config_exists() {
     let repo = unique_temp_dir("allow_no_config");
@@ -61,7 +69,12 @@ fn runtime_policy_check_allows_when_no_project_config_exists() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    let value = policy_stdout(&output);
+    assert_eq!(value["decision"], "run");
+    assert_eq!(value["enforcement"], "block");
+    assert_eq!(value["profile"], "core");
+    assert_eq!(value["hook"], "pre-bash-guard");
+    assert!(value["config_path"].is_null());
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
     let _ = fs::remove_dir_all(repo);
 }
@@ -74,8 +87,14 @@ fn runtime_policy_check_skips_disabled_hook() {
     let output = run_runtime_policy(&repo, "vibeguard-pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(10));
+    let value = policy_stdout(&output);
+    assert_eq!(value["decision"], "skip");
+    assert_eq!(value["hook"], "pre-bash-guard");
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains("disabled_hooks contains pre-bash-guard")
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("disabled_hooks contains pre-bash-guard")
     );
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
     let _ = fs::remove_dir_all(repo);
@@ -89,7 +108,72 @@ fn runtime_policy_check_reports_warn_enforcement() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(0));
-    assert!(String::from_utf8_lossy(&output.stdout).contains("enforcement=warn"));
+    let value = policy_stdout(&output);
+    assert_eq!(value["decision"], "run");
+    assert_eq!(value["enforcement"], "warn");
+    assert_eq!(value["warn_mode"], true);
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("enforcement=warn")
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_uses_explicit_cwd_argument() {
+    let repo = unique_temp_dir("explicit_cwd_repo");
+    let other = unique_temp_dir("explicit_cwd_other");
+    write_policy(&repo, r#"{"disabled_hooks":["pre-bash-guard"]}"#);
+    fs::create_dir_all(&other).expect("other temp dir should be created");
+
+    let output = bin()
+        .arg("runtime-policy-check")
+        .arg("--cwd")
+        .arg(&repo)
+        .arg("pre-bash-guard.sh")
+        .current_dir(&other)
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env_remove("VIBEGUARD_USER_CONFIG_FILE")
+        .output()
+        .expect("runtime policy command should run");
+
+    assert_eq!(output.status.code(), Some(10));
+    let value = policy_stdout(&output);
+    assert_eq!(value["decision"], "skip");
+    assert!(
+        value["config_path"]
+            .as_str()
+            .unwrap_or("")
+            .ends_with(".vibeguard.json")
+    );
+    let _ = fs::remove_dir_all(repo);
+    let _ = fs::remove_dir_all(other);
+}
+
+#[test]
+fn runtime_policy_check_keeps_text_format_for_humans() {
+    let repo = unique_temp_dir("text_format");
+    write_policy(&repo, r#"{"enforcement":"warn"}"#);
+
+    let output = bin()
+        .arg("runtime-policy-check")
+        .arg("--format")
+        .arg("text")
+        .arg("pre-bash-guard.sh")
+        .current_dir(&repo)
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env_remove("VIBEGUARD_USER_CONFIG_FILE")
+        .output()
+        .expect("runtime policy command should run");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "VibeGuard policy warn: enforcement=warn\n"
+    );
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
     let _ = fs::remove_dir_all(repo);
 }
@@ -111,7 +195,14 @@ fn runtime_policy_check_validates_user_runtime_config_before_policy() {
         .expect("runtime policy command should run");
 
     assert_eq!(output.status.code(), Some(30));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("runtime config invalid JSON"));
+    let value = policy_stderr(&output);
+    assert_eq!(value["decision"], "error");
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("runtime config invalid JSON")
+    );
     let _ = fs::remove_dir_all(repo);
 }
 
@@ -123,8 +214,12 @@ fn runtime_policy_check_reports_project_schema_errors_as_policy_errors() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(20));
+    let value = policy_stderr(&output);
+    assert_eq!(value["decision"], "error");
     assert!(
-        String::from_utf8_lossy(&output.stderr)
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
             .contains("disabled_hooks contains unsupported hook")
     );
     let _ = fs::remove_dir_all(repo);
@@ -138,7 +233,13 @@ fn runtime_policy_check_reports_project_json_parse_errors_as_config_parse_errors
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(30));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("project config invalid JSON"));
+    let value = policy_stderr(&output);
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("project config invalid JSON")
+    );
     let _ = fs::remove_dir_all(repo);
 }
 
@@ -152,7 +253,13 @@ fn runtime_policy_check_reports_project_utf8_errors_as_config_parse_errors() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(30));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("project config invalid UTF-8"));
+    let value = policy_stderr(&output);
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("project config invalid UTF-8")
+    );
     let _ = fs::remove_dir_all(repo);
 }
 
@@ -164,8 +271,12 @@ fn runtime_policy_check_uses_shared_profile_filtering_for_strict_only_hooks() {
     let output = run_runtime_policy(&repo, "count_active_constraints.sh");
 
     assert_eq!(output.status.code(), Some(10));
+    let value = policy_stdout(&output);
+    assert_eq!(value["decision"], "skip");
     assert!(
-        String::from_utf8_lossy(&output.stdout)
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
             .contains("profile=core excludes count-active-constraints")
     );
     let _ = fs::remove_dir_all(repo);


### PR DESCRIPTION
## Summary

This PR fixes the current open VibeGuard issue backlog.

- Derive runtime hook/profile policy from hooks/manifest.json instead of a hard-coded Rust allowlist.
- Make runtime-policy-check emit structured JSON by default and use explicit project cwd plumbing from wrappers.
- Split setup health flows into human doctor and machine verify commands.
- Make stable installs execute the installed snapshot and keep live repo execution behind explicit dev-linked mode.
- Harden release provenance with a pinned Rust toolchain, pinned action SHAs, artifact attestations, and setup-side provenance verification.

## Root Cause

The open issues were connected by stale coupling between setup, runtime policy, release provenance, and wrapper execution mode. Policy decisions were duplicated in Rust and manifest data, setup checks mixed human and machine concerns, stable installs could still depend on the live checkout, and release verification stopped at same-release checksums.

## Validation

- bash tests/test_setup.sh
- bash tests/hooks/test_runtime_policy.sh
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/test_manifest_contract.sh
- bash tests/test_release_workflow.sh
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- git diff --check

Fixes #460
Fixes #461
Fixes #462
Fixes #463
Fixes #464
