### PR TITLE
[codex] Return structured runtime policy JSON

### DIFF
--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -58,15 +58,36 @@ vg_policy_runtime_candidates() {
   fi
 }
 
+vg_policy_runtime_supports_cwd_json() {
+  local candidate="$1" probe_dir probe_output decision probe_cwd
+  probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-policy-probe-cwd.XXXXXX")" || return 1
+  probe_output="$(
+    VIBEGUARD_PROJECT_CONFIG="" \
+      VIBEGUARD_USER_CONFIG_FILE="" \
+      "${candidate}" runtime-policy-check --cwd "${probe_dir}" __vibeguard_policy_probe__ 2>/dev/null
+  )" || {
+    rm -rf "${probe_dir}" 2>/dev/null || true
+    return 1
+  }
+  decision="$(printf '%s' "${probe_output}" | "${candidate}" json-field --strict decision 2>/dev/null)" || {
+    rm -rf "${probe_dir}" 2>/dev/null || true
+    return 1
+  }
+  probe_cwd="$(printf '%s' "${probe_output}" | "${candidate}" json-field --strict cwd 2>/dev/null)" || {
+    rm -rf "${probe_dir}" 2>/dev/null || true
+    return 1
+  }
+  rm -rf "${probe_dir}" 2>/dev/null || true
+  [[ "${decision}" == "run" && "${probe_cwd}" == "${probe_dir}" ]]
+}
+
 vg_policy_runtime_supports() {
   local candidate="$1" probe_diag downgrade_probe codex_probe
-  if "${candidate}" runtime-policy-supports >/dev/null 2>&1; then
-    return 0
+  if ! "${candidate}" runtime-policy-supports >/dev/null 2>&1; then
+    return 1
   fi
+  vg_policy_runtime_supports_cwd_json "${candidate}" || return 1
   probe_diag="${TMPDIR:-/tmp}/vibeguard-policy-probe.$$.jsonl"
-  VIBEGUARD_PROJECT_CONFIG="${TMPDIR:-/tmp}/vibeguard-missing-policy-probe.json" \
-    VIBEGUARD_USER_CONFIG_FILE="" \
-    "${candidate}" runtime-policy-check __vibeguard_policy_probe__ >/dev/null 2>&1 || return 1
   downgrade_probe="$(printf '{"decision":"block","reason":"probe"}' \
     | "${candidate}" runtime-policy-downgrade-output 2>/dev/null)" || return 1
   [[ "${downgrade_probe}" == *'"decision"'* && "${downgrade_probe}" == *'"warn"'* ]] || return 1

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -91,10 +91,14 @@ vg_policy_json_field() {
 }
 
 vg_policy_payload_cwd() {
-  local payload_file="$1" runtime_path="$2" field value
-  [[ -n "${payload_file}" && -f "${payload_file}" ]] || return 1
+  local payload_ref="$1" runtime_path="$2" field value
+  [[ -n "${payload_ref}" ]] || return 1
   for field in cwd params.cwd workspace.cwd workspace.current_dir; do
-    value="$("${runtime_path}" json-field "${field}" < "${payload_file}" 2>/dev/null || true)"
+    if [[ -f "${payload_ref}" ]]; then
+      value="$("${runtime_path}" json-field "${field}" < "${payload_ref}" 2>/dev/null || true)"
+    else
+      value="$(printf '%s' "${payload_ref}" | "${runtime_path}" json-field "${field}" 2>/dev/null || true)"
+    fi
     if [[ -n "${value}" && "${value}" != "null" && "${value}" != \{* && "${value}" != \[* ]]; then
       printf '%s\n' "${value}"
       return 0
@@ -108,14 +112,14 @@ vg_policy_git_root() {
 }
 
 vg_policy_resolve_cwd() {
-  local payload_file="${1:-}" runtime_path="${2:-}" candidate
+  local payload_ref="${1:-}" runtime_path="${2:-}" candidate
   for candidate in "${VIBEGUARD_POLICY_CWD:-}" "${VIBEGUARD_PROJECT_ROOT:-}" "${VIBEGUARD_PROJECT_CWD:-}"; do
     if [[ -n "${candidate}" ]]; then
       printf '%s\n' "${candidate}"
       return 0
     fi
   done
-  if [[ -n "${runtime_path}" ]] && candidate="$(vg_policy_payload_cwd "${payload_file}" "${runtime_path}")" && [[ -n "${candidate}" ]]; then
+  if [[ -n "${runtime_path}" ]] && candidate="$(vg_policy_payload_cwd "${payload_ref}" "${runtime_path}")" && [[ -n "${candidate}" ]]; then
     printf '%s\n' "${candidate}"
     return 0
   fi
@@ -129,7 +133,7 @@ vg_policy_resolve_cwd() {
 
 vg_policy_check_hook() {
   local hook_name="$1"
-  local payload_file="${2:-}"
+  local payload_ref="${2:-}"
   local output stderr_output status runtime_path policy_cwd decision enforcement reason
   local stdout_file stderr_file
 
@@ -145,7 +149,7 @@ vg_policy_check_hook() {
     return 20
   fi
   VG_POLICY_RUNTIME_PATH="${runtime_path}"
-  policy_cwd="$(vg_policy_resolve_cwd "${payload_file}" "${runtime_path}")"
+  policy_cwd="$(vg_policy_resolve_cwd "${payload_ref}" "${runtime_path}")"
 
   stdout_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-policy-stdout.XXXXXX")" || {
     VG_POLICY_REASON="VibeGuard policy error: failed to allocate runtime policy stdout capture."

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -81,9 +81,57 @@ vg_policy_runtime_supports() {
   return 0
 }
 
+vg_policy_json_field() {
+  local runtime_path="$1" json_input="$2" field="$3" mode="${4:-}"
+  if [[ "${mode}" == "strict" ]]; then
+    printf '%s' "${json_input}" | "${runtime_path}" json-field --strict "${field}" 2>/dev/null
+  else
+    printf '%s' "${json_input}" | "${runtime_path}" json-field "${field}" 2>/dev/null
+  fi
+}
+
+vg_policy_payload_cwd() {
+  local payload_file="$1" runtime_path="$2" field value
+  [[ -n "${payload_file}" && -f "${payload_file}" ]] || return 1
+  for field in cwd params.cwd workspace.cwd workspace.current_dir; do
+    value="$("${runtime_path}" json-field "${field}" < "${payload_file}" 2>/dev/null || true)"
+    if [[ -n "${value}" && "${value}" != "null" && "${value}" != \{* && "${value}" != \[* ]]; then
+      printf '%s\n' "${value}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+vg_policy_git_root() {
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+vg_policy_resolve_cwd() {
+  local payload_file="${1:-}" runtime_path="${2:-}" candidate
+  for candidate in "${VIBEGUARD_POLICY_CWD:-}" "${VIBEGUARD_PROJECT_ROOT:-}" "${VIBEGUARD_PROJECT_CWD:-}"; do
+    if [[ -n "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  if [[ -n "${runtime_path}" ]] && candidate="$(vg_policy_payload_cwd "${payload_file}" "${runtime_path}")" && [[ -n "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+  candidate="$(vg_policy_git_root)"
+  if [[ -n "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+  pwd -P 2>/dev/null || pwd
+}
+
 vg_policy_check_hook() {
   local hook_name="$1"
-  local output status runtime_path
+  local payload_file="${2:-}"
+  local output stderr_output status runtime_path policy_cwd decision enforcement reason
+  local stdout_file stderr_file
 
   VG_POLICY_REASON=""
   VG_POLICY_KIND=""
@@ -97,17 +145,50 @@ vg_policy_check_hook() {
     return 20
   fi
   VG_POLICY_RUNTIME_PATH="${runtime_path}"
+  policy_cwd="$(vg_policy_resolve_cwd "${payload_file}" "${runtime_path}")"
 
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-policy-stdout.XXXXXX")" || {
+    VG_POLICY_REASON="VibeGuard policy error: failed to allocate runtime policy stdout capture."
+    VG_POLICY_KIND="policy_error"
+    return 20
+  }
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-policy-stderr.XXXXXX")" || {
+    rm -f "${stdout_file}" 2>/dev/null || true
+    VG_POLICY_REASON="VibeGuard policy error: failed to allocate runtime policy stderr capture."
+    VG_POLICY_KIND="policy_error"
+    return 20
+  }
+
+  local -a check_args
+  check_args=(runtime-policy-check)
+  if [[ -n "${policy_cwd}" ]]; then
+    check_args+=(--cwd "${policy_cwd}")
+  fi
+  check_args+=("${hook_name}")
   status=0
-  output="$(
-    VIBEGUARD_USER_CONFIG_FILE="$(vg_policy_user_config_file)" \
-      "${runtime_path}" runtime-policy-check "${hook_name}" 2>&1
-  )" || status=$?
+  VIBEGUARD_USER_CONFIG_FILE="$(vg_policy_user_config_file)" \
+    "${runtime_path}" "${check_args[@]}" >"${stdout_file}" 2>"${stderr_file}" || status=$?
+  output="$(cat "${stdout_file}")"
+  stderr_output="$(cat "${stderr_file}")"
+  rm -f "${stdout_file}" "${stderr_file}" 2>/dev/null || true
+
+  if ! decision="$(vg_policy_json_field "${runtime_path}" "${output}" "decision" "strict")"; then
+    VG_POLICY_REASON="${stderr_output:-${output:-VibeGuard policy error: runtime-policy-check did not return policy JSON.}}"
+    VG_POLICY_KIND="policy_error"
+    return 20
+  fi
+  enforcement="$(vg_policy_json_field "${runtime_path}" "${output}" "enforcement" || true)"
+  reason="$(vg_policy_json_field "${runtime_path}" "${output}" "reason" || true)"
 
   case "${status}" in
     0)
-      if [[ "${output}" == *"enforcement=warn"* ]]; then
-        VG_POLICY_REASON="${output}"
+      if [[ "${decision}" != "run" ]]; then
+        VG_POLICY_REASON="${reason:-VibeGuard policy error: runtime-policy-check returned decision=${decision} with allow exit.}"
+        VG_POLICY_KIND="policy_error"
+        return 20
+      fi
+      if [[ "${enforcement}" == "warn" ]]; then
+        VG_POLICY_REASON="${reason}"
         VG_POLICY_KIND="policy_warn"
         VG_POLICY_ENFORCEMENT="warn"
         export VIBEGUARD_POLICY_ENFORCEMENT="warn"
@@ -115,17 +196,22 @@ vg_policy_check_hook() {
       return 0
       ;;
     10)
-      VG_POLICY_REASON="${output}"
+      if [[ "${decision}" != "skip" ]]; then
+        VG_POLICY_REASON="${reason:-VibeGuard policy error: runtime-policy-check returned decision=${decision} with skip exit.}"
+        VG_POLICY_KIND="policy_error"
+        return 20
+      fi
+      VG_POLICY_REASON="${reason:-${stderr_output:-${output}}}"
       VG_POLICY_KIND="policy_skip"
       return 10
       ;;
     30)
-      VG_POLICY_REASON="${output}"
+      VG_POLICY_REASON="${reason:-${stderr_output:-${output}}}"
       VG_POLICY_KIND="config_parse_error"
       return 30
       ;;
     *)
-      VG_POLICY_REASON="${output:-VibeGuard policy error: unknown runtime policy failure.}"
+      VG_POLICY_REASON="${reason:-${stderr_output:-${output:-VibeGuard policy error: unknown runtime policy failure.}}}"
       VG_POLICY_KIND="policy_error"
       return 20
       ;;
@@ -207,8 +293,8 @@ vg_policy_codex_error_fallback() {
 }
 
 vg_policy_codex_gate() {
-  local hook_name="$1" event_name="$2" policy_status=0
-  vg_policy_check_hook "${hook_name}" || policy_status=$?
+  local hook_name="$1" event_name="$2" payload_file="${3:-}" policy_status=0
+  vg_policy_check_hook "${hook_name}" "${payload_file}" || policy_status=$?
   [[ ${policy_status} -eq 0 ]] && return 0
 
   vg_policy_diag "${hook_name}" "${event_name}" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -123,11 +123,6 @@ vg_policy_resolve_cwd() {
     printf '%s\n' "${candidate}"
     return 0
   fi
-  candidate="$(vg_policy_git_root)"
-  if [[ -n "${candidate}" ]]; then
-    printf '%s\n' "${candidate}"
-    return 0
-  fi
   pwd -P 2>/dev/null || pwd
 }
 

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -49,6 +49,21 @@ if ! declare -F codex_hook_status_from_output >/dev/null 2>&1; then
 fi
 
 INPUT=$(cat)
+_VG_CODEX_INPUT_FILE=""
+_vg_cleanup_codex_input() {
+  if [[ -n "${_VG_CODEX_INPUT_FILE}" ]]; then
+    rm -f "${_VG_CODEX_INPUT_FILE}" 2>/dev/null || true
+  fi
+}
+trap _vg_cleanup_codex_input EXIT
+if _VG_CODEX_INPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-input.XXXXXX")"; then
+  if ! printf '%s' "${INPUT}" >"${_VG_CODEX_INPUT_FILE}"; then
+    rm -f "${_VG_CODEX_INPUT_FILE}" 2>/dev/null || true
+    _VG_CODEX_INPUT_FILE=""
+  fi
+else
+  _VG_CODEX_INPUT_FILE=""
+fi
 EVENT_NAME=$(codex_raw_event_name "$INPUT")
 codex_set_caller_identity "${EVENT_NAME}"
 
@@ -102,7 +117,7 @@ if [[ ! -f "${POLICY_PATH}" ]]; then
 fi
 # shellcheck source=hooks/_lib/policy.sh
 source "${POLICY_PATH}"
-vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" || exit 0
+vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${_VG_CODEX_INPUT_FILE}" || exit 0
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -49,21 +49,6 @@ if ! declare -F codex_hook_status_from_output >/dev/null 2>&1; then
 fi
 
 INPUT=$(cat)
-_VG_CODEX_INPUT_FILE=""
-_vg_cleanup_codex_input() {
-  if [[ -n "${_VG_CODEX_INPUT_FILE}" ]]; then
-    rm -f "${_VG_CODEX_INPUT_FILE}" 2>/dev/null || true
-  fi
-}
-trap _vg_cleanup_codex_input EXIT
-if _VG_CODEX_INPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/vibeguard-codex-input.XXXXXX")"; then
-  if ! printf '%s' "${INPUT}" >"${_VG_CODEX_INPUT_FILE}"; then
-    rm -f "${_VG_CODEX_INPUT_FILE}" 2>/dev/null || true
-    _VG_CODEX_INPUT_FILE=""
-  fi
-else
-  _VG_CODEX_INPUT_FILE=""
-fi
 EVENT_NAME=$(codex_raw_event_name "$INPUT")
 codex_set_caller_identity "${EVENT_NAME}"
 
@@ -117,7 +102,7 @@ if [[ ! -f "${POLICY_PATH}" ]]; then
 fi
 # shellcheck source=hooks/_lib/policy.sh
 source "${POLICY_PATH}"
-vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${_VG_CODEX_INPUT_FILE}" || exit 0
+vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${INPUT}" || exit 0
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -72,7 +72,7 @@ fi
 # shellcheck source=hooks/_lib/policy.sh
 source "${POLICY_PATH}"
 policy_status=0
-vg_policy_check_hook "${HOOK_NAME}" || policy_status=$?
+vg_policy_check_hook "${HOOK_NAME}" "${_VG_HOOK_STDIN_FILE:-}" || policy_status=$?
 export VIBEGUARD_POLICY_ENFORCEMENT="${VG_POLICY_ENFORCEMENT:-block}"
 if [[ ${policy_status} -eq 10 ]]; then
   vg_policy_diag "${HOOK_NAME}" "Claude" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -113,8 +113,31 @@ explicit_runtime="${WORK_DIR}/explicit-runtime"
 cat > "${explicit_runtime}" <<'SH'
 #!/usr/bin/env bash
 case "${1:-}" in
-  runtime-policy-check)
+  runtime-policy-supports)
     exit 0
+    ;;
+  runtime-policy-check)
+    shift
+    cwd=""
+    hook_name=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        --cwd)
+          shift
+          cwd="${1:-}"
+          shift || true
+          ;;
+        *)
+          hook_name="$1"
+          shift
+          ;;
+      esac
+    done
+    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":null}\n' "${hook_name:-unknown}" "${cwd}"
+    ;;
+  json-field)
+    shift
+    exec "${REAL_RUNTIME:?}" json-field "$@"
     ;;
   runtime-policy-downgrade-output)
     printf '{"decision":"warn","reason":"probe"}\n'
@@ -132,7 +155,10 @@ esac
 SH
 chmod +x "${explicit_runtime}"
 resolver_out="$(
-  WRAPPER_DIR="${REPO_DIR}/hooks" VIBEGUARD_POLICY_RUNTIME="${explicit_runtime}" bash -c '
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${explicit_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
+  bash -c '
     source hooks/_lib/policy.sh
     vg_policy_runtime_path
   '
@@ -148,9 +174,44 @@ case "${1:-}" in
     printf 'supports\n' >>"${OPTIMIZED_PROBE_LOG:?}"
     exit 0
     ;;
-  runtime-policy-check|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
-    printf 'unexpected:%s\n' "${1:-}" >>"${OPTIMIZED_PROBE_LOG:?}"
-    exit 70
+  runtime-policy-check)
+    printf 'check:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
+    shift
+    cwd=""
+    hook_name=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        --cwd)
+          shift
+          cwd="${1:-}"
+          shift || true
+          ;;
+        *)
+          hook_name="$1"
+          shift
+          ;;
+      esac
+    done
+    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":null}\n' "${hook_name:-unknown}" "${cwd}"
+    ;;
+  json-field)
+    shift
+    printf 'json-field:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
+    exec "${REAL_RUNTIME:?}" json-field "$@"
+    ;;
+  runtime-policy-downgrade-output)
+    printf 'downgrade\n' >>"${OPTIMIZED_PROBE_LOG:?}"
+    exec "${REAL_RUNTIME:?}" runtime-policy-downgrade-output
+    ;;
+  runtime-policy-codex-error)
+    shift
+    printf 'codex-error:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
+    exec "${REAL_RUNTIME:?}" runtime-policy-codex-error "$@"
+    ;;
+  runtime-policy-diag)
+    shift
+    printf 'diag:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
+    exec "${REAL_RUNTIME:?}" runtime-policy-diag "$@"
     ;;
   *)
     exit 2
@@ -161,15 +222,54 @@ chmod +x "${optimized_runtime}"
 resolver_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" \
   VIBEGUARD_POLICY_RUNTIME="${optimized_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
   OPTIMIZED_PROBE_LOG="${optimized_probe_log}" \
   bash -c '
     source hooks/_lib/policy.sh
     vg_policy_runtime_path
   '
 )"
-assert_contains "${resolver_out}" "${optimized_runtime}" "runtime policy resolver accepts batched support probe"
-assert_contains "$(cat "${optimized_probe_log}")" "supports" "runtime policy resolver calls batched support probe"
-assert_not_contains "$(cat "${optimized_probe_log}")" "unexpected:" "runtime policy resolver skips legacy semantic probes when batched probe passes"
+assert_contains "${resolver_out}" "${optimized_runtime}" "runtime policy resolver accepts support probe with cwd JSON protocol"
+assert_contains "$(cat "${optimized_probe_log}")" "supports" "runtime policy resolver calls support probe"
+assert_contains "$(cat "${optimized_probe_log}")" "check:runtime-policy-check --cwd" "runtime policy resolver probes runtime-policy-check --cwd"
+assert_contains "$(cat "${optimized_probe_log}")" "json-field:--strict decision" "runtime policy resolver validates structured decision JSON"
+assert_contains "$(cat "${optimized_probe_log}")" "json-field:--strict cwd" "runtime policy resolver validates structured cwd JSON"
+
+stale_protocol_runtime="${WORK_DIR}/stale-protocol-runtime"
+cat > "${stale_protocol_runtime}" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  runtime-policy-supports)
+    exit 0
+    ;;
+  runtime-policy-check)
+    shift
+    if [[ "$#" -ne 1 || "${1:-}" == --* ]]; then
+      printf 'Usage: vibeguard-runtime runtime-policy-check <hook-name>\n' >&2
+      exit 2
+    fi
+    exit 0
+    ;;
+  json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
+    exit 2
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${stale_protocol_runtime}"
+resolver_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${stale_protocol_runtime}" \
+  VIBEGUARD_RUNTIME="${RUNTIME_BIN}" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_runtime_path
+  '
+)"
+assert_not_contains "${resolver_out}" "${stale_protocol_runtime}" "runtime policy resolver rejects stale support probe without cwd JSON protocol"
+assert_contains "${resolver_out}" "${RUNTIME_BIN}" "runtime policy resolver falls through after stale support probe"
 
 resolver_home="${WORK_DIR}/home-resolver"
 mkdir -p "${resolver_home}/.vibeguard/installed/bin"
@@ -180,6 +280,7 @@ resolver_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" \
   HOME="${resolver_home}" \
   VIBEGUARD_RUNTIME="${explicit_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
   bash -c '
     source hooks/_lib/policy.sh
     vg_policy_runtime_path
@@ -193,6 +294,7 @@ cp "${explicit_runtime}" "${installed_wrapper_home}/.vibeguard/installed/bin/vib
 resolver_out="$(
   WRAPPER_DIR="${installed_wrapper_home}/.vibeguard" \
   HOME="${installed_wrapper_home}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
   env -u VIBEGUARD_POLICY_RUNTIME -u VIBEGUARD_RUNTIME bash -c '
     source hooks/_lib/policy.sh
     vg_policy_runtime_path

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -222,6 +222,61 @@ resolver_out="$(
 assert_not_contains "${resolver_out}" "${partial_runtime}" "runtime policy resolver rejects runtimes missing helper commands"
 assert_contains "${resolver_out}" "${RUNTIME_BIN}" "runtime policy resolver falls through to helper-capable runtime"
 
+header "runtime policy — structured JSON parsing"
+json_policy_runtime="${WORK_DIR}/json-policy-runtime"
+cat > "${json_policy_runtime}" <<'SH'
+#!/usr/bin/env bash
+command="${1:-}"
+shift || true
+case "${command}" in
+  runtime-policy-supports)
+    exit 0
+    ;;
+  runtime-policy-check)
+    hook_name="${*: -1}"
+    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name}"
+    ;;
+  json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
+    exec "${REAL_RUNTIME:?}" "${command}" "$@"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${json_policy_runtime}"
+structured_block_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${json_policy_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
+  VG_STUB_ENFORCEMENT="block" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_check_hook pre-bash-guard.sh
+    status=$?
+    printf "status=%s enforcement=%s kind=%s reason=%s\n" "$status" "$VG_POLICY_ENFORCEMENT" "$VG_POLICY_KIND" "$VG_POLICY_REASON"
+  '
+)"
+assert_contains "${structured_block_out}" "status=0" "policy helper accepts structured allow JSON"
+assert_contains "${structured_block_out}" "enforcement=block" "policy helper ignores warn-looking compatibility reason when enforcement is block"
+assert_not_contains "${structured_block_out}" "kind=policy_warn" "policy helper does not infer warn mode from reason substring"
+
+structured_warn_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${json_policy_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
+  VG_STUB_ENFORCEMENT="warn" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_check_hook pre-bash-guard.sh
+    status=$?
+    printf "status=%s enforcement=%s kind=%s reason=%s\n" "$status" "$VG_POLICY_ENFORCEMENT" "$VG_POLICY_KIND" "$VG_POLICY_REASON"
+  '
+)"
+assert_contains "${structured_warn_out}" "status=0" "policy helper accepts structured warn JSON"
+assert_contains "${structured_warn_out}" "enforcement=warn" "policy helper enables warn mode from JSON enforcement"
+assert_contains "${structured_warn_out}" "kind=policy_warn" "policy helper records warn kind from JSON enforcement"
+
 header "runtime policy — disabled hooks"
 disabled_home="${WORK_DIR}/home-disabled"
 disabled_project="${WORK_DIR}/project-disabled"
@@ -247,6 +302,36 @@ assert_contains "${disabled_large_stdin_out}" '"stdout":""' "Claude wrapper disa
 assert_contains "${disabled_large_stdin_out}" '"stderr":""' "Claude wrapper disabled hook produces no stderr after large stdin"
 
 assert_contains "$(cat "${disabled_home}/.vibeguard/policy.jsonl")" "policy_skip" "runtime policy emits policy_skip telemetry"
+
+header "runtime policy — explicit wrapper cwd"
+payload_cwd_home="${WORK_DIR}/home-payload-cwd"
+payload_cwd_project="${WORK_DIR}/project-payload-cwd"
+payload_cwd_process="${WORK_DIR}/process-payload-cwd"
+make_home "${payload_cwd_home}"
+make_project "${payload_cwd_project}" '{"disabled_hooks":["pre-bash-guard"]}'
+mkdir -p "${payload_cwd_process}"
+
+set +e
+payload_cwd_claude_out="$(
+  cd "${payload_cwd_process}" && printf '{"cwd":"%s","tool_input":{"command":"git push --force"}}' "${payload_cwd_project}" \
+    | HOME="${payload_cwd_home}" VIBEGUARD_LOG_DIR="${payload_cwd_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
+      bash "${REPO_DIR}/hooks/run-hook.sh" pre-bash-guard.sh 2>&1
+)"
+payload_cwd_claude_status=$?
+set -e
+assert_empty_success "${payload_cwd_claude_status}" "${payload_cwd_claude_out}" "Claude wrapper uses payload cwd for runtime policy"
+
+set +e
+payload_cwd_codex_out="$(
+  cd "${payload_cwd_process}" && printf '{"hook_event_name":"PreToolUse","cwd":"%s","tool_input":{"command":"git push --force"}}' "${payload_cwd_project}" \
+    | HOME="${payload_cwd_home}" VIBEGUARD_LOG_DIR="${payload_cwd_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
+      bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh 2>&1
+)"
+payload_cwd_codex_status=$?
+set -e
+assert_empty_success "${payload_cwd_codex_status}" "${payload_cwd_codex_out}" "Codex wrapper uses payload cwd for runtime policy"
 
 header "runtime policy — warn enforcement"
 warn_home="${WORK_DIR}/home-warn"

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -110,50 +110,7 @@ codex_pretool_danger_input='{"hook_event_name":"PreToolUse","tool_input":{"comma
 
 header "runtime policy — runtime resolver"
 explicit_runtime="${WORK_DIR}/explicit-runtime"
-cat > "${explicit_runtime}" <<'SH'
-#!/usr/bin/env bash
-case "${1:-}" in
-  runtime-policy-supports)
-    exit 0
-    ;;
-  runtime-policy-check)
-    shift
-    cwd=""
-    hook_name=""
-    while [[ $# -gt 0 ]]; do
-      case "${1:-}" in
-        --cwd)
-          shift
-          cwd="${1:-}"
-          shift || true
-          ;;
-        *)
-          hook_name="$1"
-          shift
-          ;;
-      esac
-    done
-    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":null}\n' "${hook_name:-unknown}" "${cwd}"
-    ;;
-  json-field)
-    shift
-    exec "${REAL_RUNTIME:?}" json-field "$@"
-    ;;
-  runtime-policy-downgrade-output)
-    printf '{"decision":"warn","reason":"probe"}\n'
-    ;;
-  runtime-policy-codex-error)
-    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"probe"}}\n'
-    ;;
-  runtime-policy-diag)
-    printf '{"kind":"policy_error"}\n' >>"${2:?}"
-    ;;
-  *)
-    exit 2
-    ;;
-esac
-SH
-chmod +x "${explicit_runtime}"
+hook_test_write_policy_runtime_probe_stub "${explicit_runtime}"
 resolver_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" \
   VIBEGUARD_POLICY_RUNTIME="${explicit_runtime}" \
@@ -167,63 +124,12 @@ assert_contains "${resolver_out}" "${explicit_runtime}" "runtime policy resolver
 
 optimized_runtime="${WORK_DIR}/optimized-runtime"
 optimized_probe_log="${WORK_DIR}/optimized-runtime.log"
-cat > "${optimized_runtime}" <<'SH'
-#!/usr/bin/env bash
-case "${1:-}" in
-  runtime-policy-supports)
-    printf 'supports\n' >>"${OPTIMIZED_PROBE_LOG:?}"
-    exit 0
-    ;;
-  runtime-policy-check)
-    printf 'check:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
-    shift
-    cwd=""
-    hook_name=""
-    while [[ $# -gt 0 ]]; do
-      case "${1:-}" in
-        --cwd)
-          shift
-          cwd="${1:-}"
-          shift || true
-          ;;
-        *)
-          hook_name="$1"
-          shift
-          ;;
-      esac
-    done
-    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":null}\n' "${hook_name:-unknown}" "${cwd}"
-    ;;
-  json-field)
-    shift
-    printf 'json-field:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
-    exec "${REAL_RUNTIME:?}" json-field "$@"
-    ;;
-  runtime-policy-downgrade-output)
-    printf 'downgrade\n' >>"${OPTIMIZED_PROBE_LOG:?}"
-    exec "${REAL_RUNTIME:?}" runtime-policy-downgrade-output
-    ;;
-  runtime-policy-codex-error)
-    shift
-    printf 'codex-error:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
-    exec "${REAL_RUNTIME:?}" runtime-policy-codex-error "$@"
-    ;;
-  runtime-policy-diag)
-    shift
-    printf 'diag:%s\n' "$*" >>"${OPTIMIZED_PROBE_LOG:?}"
-    exec "${REAL_RUNTIME:?}" runtime-policy-diag "$@"
-    ;;
-  *)
-    exit 2
-    ;;
-esac
-SH
-chmod +x "${optimized_runtime}"
+hook_test_write_policy_runtime_probe_stub "${optimized_runtime}"
 resolver_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" \
   VIBEGUARD_POLICY_RUNTIME="${optimized_runtime}" \
   REAL_RUNTIME="${RUNTIME_BIN}" \
-  OPTIMIZED_PROBE_LOG="${optimized_probe_log}" \
+  VG_STUB_LOG="${optimized_probe_log}" \
   bash -c '
     source hooks/_lib/policy.sh
     vg_policy_runtime_path
@@ -236,33 +142,12 @@ assert_contains "$(cat "${optimized_probe_log}")" "json-field:--strict decision"
 assert_contains "$(cat "${optimized_probe_log}")" "json-field:--strict cwd" "runtime policy resolver validates structured cwd JSON"
 
 stale_protocol_runtime="${WORK_DIR}/stale-protocol-runtime"
-cat > "${stale_protocol_runtime}" <<'SH'
-#!/usr/bin/env bash
-case "${1:-}" in
-  runtime-policy-supports)
-    exit 0
-    ;;
-  runtime-policy-check)
-    shift
-    if [[ "$#" -ne 1 || "${1:-}" == --* ]]; then
-      printf 'Usage: vibeguard-runtime runtime-policy-check <hook-name>\n' >&2
-      exit 2
-    fi
-    exit 0
-    ;;
-  json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
-    exit 2
-    ;;
-  *)
-    exit 2
-    ;;
-esac
-SH
-chmod +x "${stale_protocol_runtime}"
+hook_test_write_policy_runtime_probe_stub "${stale_protocol_runtime}"
 resolver_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" \
   VIBEGUARD_POLICY_RUNTIME="${stale_protocol_runtime}" \
   VIBEGUARD_RUNTIME="${RUNTIME_BIN}" \
+  VG_STUB_STALE_PROTOCOL=1 \
   bash -c '
     source hooks/_lib/policy.sh
     vg_policy_runtime_path

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -222,61 +222,6 @@ resolver_out="$(
 assert_not_contains "${resolver_out}" "${partial_runtime}" "runtime policy resolver rejects runtimes missing helper commands"
 assert_contains "${resolver_out}" "${RUNTIME_BIN}" "runtime policy resolver falls through to helper-capable runtime"
 
-header "runtime policy — structured JSON parsing"
-json_policy_runtime="${WORK_DIR}/json-policy-runtime"
-cat > "${json_policy_runtime}" <<'SH'
-#!/usr/bin/env bash
-command="${1:-}"
-shift || true
-case "${command}" in
-  runtime-policy-supports)
-    exit 0
-    ;;
-  runtime-policy-check)
-    hook_name="${*: -1}"
-    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name}"
-    ;;
-  json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
-    exec "${REAL_RUNTIME:?}" "${command}" "$@"
-    ;;
-  *)
-    exit 2
-    ;;
-esac
-SH
-chmod +x "${json_policy_runtime}"
-structured_block_out="$(
-  WRAPPER_DIR="${REPO_DIR}/hooks" \
-  VIBEGUARD_POLICY_RUNTIME="${json_policy_runtime}" \
-  REAL_RUNTIME="${RUNTIME_BIN}" \
-  VG_STUB_ENFORCEMENT="block" \
-  bash -c '
-    source hooks/_lib/policy.sh
-    vg_policy_check_hook pre-bash-guard.sh
-    status=$?
-    printf "status=%s enforcement=%s kind=%s reason=%s\n" "$status" "$VG_POLICY_ENFORCEMENT" "$VG_POLICY_KIND" "$VG_POLICY_REASON"
-  '
-)"
-assert_contains "${structured_block_out}" "status=0" "policy helper accepts structured allow JSON"
-assert_contains "${structured_block_out}" "enforcement=block" "policy helper ignores warn-looking compatibility reason when enforcement is block"
-assert_not_contains "${structured_block_out}" "kind=policy_warn" "policy helper does not infer warn mode from reason substring"
-
-structured_warn_out="$(
-  WRAPPER_DIR="${REPO_DIR}/hooks" \
-  VIBEGUARD_POLICY_RUNTIME="${json_policy_runtime}" \
-  REAL_RUNTIME="${RUNTIME_BIN}" \
-  VG_STUB_ENFORCEMENT="warn" \
-  bash -c '
-    source hooks/_lib/policy.sh
-    vg_policy_check_hook pre-bash-guard.sh
-    status=$?
-    printf "status=%s enforcement=%s kind=%s reason=%s\n" "$status" "$VG_POLICY_ENFORCEMENT" "$VG_POLICY_KIND" "$VG_POLICY_REASON"
-  '
-)"
-assert_contains "${structured_warn_out}" "status=0" "policy helper accepts structured warn JSON"
-assert_contains "${structured_warn_out}" "enforcement=warn" "policy helper enables warn mode from JSON enforcement"
-assert_contains "${structured_warn_out}" "kind=policy_warn" "policy helper records warn kind from JSON enforcement"
-
 header "runtime policy — disabled hooks"
 disabled_home="${WORK_DIR}/home-disabled"
 disabled_project="${WORK_DIR}/project-disabled"
@@ -302,36 +247,6 @@ assert_contains "${disabled_large_stdin_out}" '"stdout":""' "Claude wrapper disa
 assert_contains "${disabled_large_stdin_out}" '"stderr":""' "Claude wrapper disabled hook produces no stderr after large stdin"
 
 assert_contains "$(cat "${disabled_home}/.vibeguard/policy.jsonl")" "policy_skip" "runtime policy emits policy_skip telemetry"
-
-header "runtime policy — explicit wrapper cwd"
-payload_cwd_home="${WORK_DIR}/home-payload-cwd"
-payload_cwd_project="${WORK_DIR}/project-payload-cwd"
-payload_cwd_process="${WORK_DIR}/process-payload-cwd"
-make_home "${payload_cwd_home}"
-make_project "${payload_cwd_project}" '{"disabled_hooks":["pre-bash-guard"]}'
-mkdir -p "${payload_cwd_process}"
-
-set +e
-payload_cwd_claude_out="$(
-  cd "${payload_cwd_process}" && printf '{"cwd":"%s","tool_input":{"command":"git push --force"}}' "${payload_cwd_project}" \
-    | HOME="${payload_cwd_home}" VIBEGUARD_LOG_DIR="${payload_cwd_home}/.vibeguard" \
-      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
-      bash "${REPO_DIR}/hooks/run-hook.sh" pre-bash-guard.sh 2>&1
-)"
-payload_cwd_claude_status=$?
-set -e
-assert_empty_success "${payload_cwd_claude_status}" "${payload_cwd_claude_out}" "Claude wrapper uses payload cwd for runtime policy"
-
-set +e
-payload_cwd_codex_out="$(
-  cd "${payload_cwd_process}" && printf '{"hook_event_name":"PreToolUse","cwd":"%s","tool_input":{"command":"git push --force"}}' "${payload_cwd_project}" \
-    | HOME="${payload_cwd_home}" VIBEGUARD_LOG_DIR="${payload_cwd_home}/.vibeguard" \
-      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
-      bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh 2>&1
-)"
-payload_cwd_codex_status=$?
-set -e
-assert_empty_success "${payload_cwd_codex_status}" "${payload_cwd_codex_out}" "Codex wrapper uses payload cwd for runtime policy"
 
 header "runtime policy — warn enforcement"
 warn_home="${WORK_DIR}/home-warn"

--- a/tests/hooks/test_runtime_policy_json.sh
+++ b/tests/hooks/test_runtime_policy_json.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Structured runtime-policy-check JSON protocol and explicit cwd handoff.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
+hook_test_init
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
+RUNTIME_BIN="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
+
+make_home() {
+  local home_dir="$1"
+  mkdir -p "${home_dir}/.vibeguard"
+  printf '%s' "${REPO_DIR}" > "${home_dir}/.vibeguard/repo-path"
+  hook_test_install_runtime_stub "${home_dir}"
+}
+
+make_project() {
+  local project_dir="$1" config_body="$2"
+  mkdir -p "${project_dir}"
+  printf '%s\n' "${config_body}" > "${project_dir}/.vibeguard.json"
+}
+
+assert_empty_success() {
+  local status="$1" output="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "${status}" -eq 0 && -z "${output}" ]]; then
+    green "${desc}"
+    PASS=$((PASS + 1))
+  else
+    red "${desc} (status=${status}, output=${output})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+header "runtime policy — structured JSON parsing"
+json_policy_runtime="${WORK_DIR}/json-policy-runtime"
+cat > "${json_policy_runtime}" <<'SH'
+#!/usr/bin/env bash
+command="${1:-}"
+shift || true
+case "${command}" in
+  runtime-policy-supports)
+    exit 0
+    ;;
+  runtime-policy-check)
+    hook_name="${*: -1}"
+    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name}"
+    ;;
+  json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
+    exec "${REAL_RUNTIME:?}" "${command}" "$@"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${json_policy_runtime}"
+
+structured_block_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${json_policy_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
+  VG_STUB_ENFORCEMENT="block" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_check_hook pre-bash-guard.sh
+    status=$?
+    printf "status=%s enforcement=%s kind=%s reason=%s\n" "$status" "$VG_POLICY_ENFORCEMENT" "$VG_POLICY_KIND" "$VG_POLICY_REASON"
+  '
+)"
+assert_contains "${structured_block_out}" "status=0" "policy helper accepts structured allow JSON"
+assert_contains "${structured_block_out}" "enforcement=block" "policy helper ignores warn-looking compatibility reason when enforcement is block"
+assert_not_contains "${structured_block_out}" "kind=policy_warn" "policy helper does not infer warn mode from reason substring"
+
+structured_warn_out="$(
+  WRAPPER_DIR="${REPO_DIR}/hooks" \
+  VIBEGUARD_POLICY_RUNTIME="${json_policy_runtime}" \
+  REAL_RUNTIME="${RUNTIME_BIN}" \
+  VG_STUB_ENFORCEMENT="warn" \
+  bash -c '
+    source hooks/_lib/policy.sh
+    vg_policy_check_hook pre-bash-guard.sh
+    status=$?
+    printf "status=%s enforcement=%s kind=%s reason=%s\n" "$status" "$VG_POLICY_ENFORCEMENT" "$VG_POLICY_KIND" "$VG_POLICY_REASON"
+  '
+)"
+assert_contains "${structured_warn_out}" "status=0" "policy helper accepts structured warn JSON"
+assert_contains "${structured_warn_out}" "enforcement=warn" "policy helper enables warn mode from JSON enforcement"
+assert_contains "${structured_warn_out}" "kind=policy_warn" "policy helper records warn kind from JSON enforcement"
+
+header "runtime policy — explicit wrapper cwd"
+payload_cwd_home="${WORK_DIR}/home-payload-cwd"
+payload_cwd_project="${WORK_DIR}/project-payload-cwd"
+payload_cwd_process="${WORK_DIR}/process-payload-cwd"
+make_home "${payload_cwd_home}"
+make_project "${payload_cwd_project}" '{"disabled_hooks":["pre-bash-guard"]}'
+mkdir -p "${payload_cwd_process}"
+
+set +e
+payload_cwd_claude_out="$(
+  cd "${payload_cwd_process}" && printf '{"cwd":"%s","tool_input":{"command":"git push --force"}}' "${payload_cwd_project}" \
+    | HOME="${payload_cwd_home}" VIBEGUARD_LOG_DIR="${payload_cwd_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
+      bash "${REPO_DIR}/hooks/run-hook.sh" pre-bash-guard.sh 2>&1
+)"
+payload_cwd_claude_status=$?
+set -e
+assert_empty_success "${payload_cwd_claude_status}" "${payload_cwd_claude_out}" "Claude wrapper uses payload cwd for runtime policy"
+
+set +e
+payload_cwd_codex_out="$(
+  cd "${payload_cwd_process}" && printf '{"hook_event_name":"PreToolUse","cwd":"%s","tool_input":{"command":"git push --force"}}' "${payload_cwd_project}" \
+    | HOME="${payload_cwd_home}" VIBEGUARD_LOG_DIR="${payload_cwd_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
+      bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh 2>&1
+)"
+payload_cwd_codex_status=$?
+set -e
+assert_empty_success "${payload_cwd_codex_status}" "${payload_cwd_codex_out}" "Codex wrapper uses payload cwd for runtime policy"
+
+hook_test_finish

--- a/tests/hooks/test_runtime_policy_json.sh
+++ b/tests/hooks/test_runtime_policy_json.sh
@@ -47,8 +47,22 @@ case "${command}" in
     exit 0
     ;;
   runtime-policy-check)
-    hook_name="${*: -1}"
-    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name}"
+    cwd=""
+    hook_name=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        --cwd)
+          shift
+          cwd="${1:-}"
+          shift || true
+          ;;
+        *)
+          hook_name="$1"
+          shift
+          ;;
+      esac
+    done
+    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name:-unknown}" "${cwd}"
     ;;
   json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
     exec "${REAL_RUNTIME:?}" "${command}" "$@"

--- a/tests/hooks/test_runtime_policy_json.sh
+++ b/tests/hooks/test_runtime_policy_json.sh
@@ -38,41 +38,7 @@ assert_empty_success() {
 
 header "runtime policy — structured JSON parsing"
 json_policy_runtime="${WORK_DIR}/json-policy-runtime"
-cat > "${json_policy_runtime}" <<'SH'
-#!/usr/bin/env bash
-command="${1:-}"
-shift || true
-case "${command}" in
-  runtime-policy-supports)
-    exit 0
-    ;;
-  runtime-policy-check)
-    cwd=""
-    hook_name=""
-    while [[ $# -gt 0 ]]; do
-      case "${1:-}" in
-        --cwd)
-          shift
-          cwd="${1:-}"
-          shift || true
-          ;;
-        *)
-          hook_name="$1"
-          shift
-          ;;
-      esac
-    done
-    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name:-unknown}" "${cwd}"
-    ;;
-  json-field|runtime-policy-downgrade-output|runtime-policy-codex-error|runtime-policy-diag)
-    exec "${REAL_RUNTIME:?}" "${command}" "$@"
-    ;;
-  *)
-    exit 2
-    ;;
-esac
-SH
-chmod +x "${json_policy_runtime}"
+hook_test_write_policy_runtime_probe_stub "${json_policy_runtime}"
 
 structured_block_out="$(
   WRAPPER_DIR="${REPO_DIR}/hooks" \

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -142,11 +142,13 @@ case "$command" in
   runtime-policy-supports)
     ;;
   runtime-policy-check)
+    cwd=""
     hook_name=""
     while [[ $# -gt 0 ]]; do
       case "${1:-}" in
         --cwd)
           shift
+          cwd="${1:-}"
           [[ $# -gt 0 ]] && shift
           ;;
         *)
@@ -155,7 +157,7 @@ case "$command" in
           ;;
       esac
     done
-    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"reason":null}\n' "${hook_name:-unknown}"
+    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":null}\n' "${hook_name:-unknown}" "${cwd}"
     ;;
   append-jsonl-mirror)
     primary_file="${1:?append-jsonl-mirror requires a primary file path}"
@@ -216,6 +218,73 @@ PY
     ;;
   *)
     cat >/dev/null || true
+    ;;
+esac
+STUB
+  chmod +x "$runtime"
+}
+
+hook_test_write_policy_runtime_probe_stub() {
+  local runtime="$1"
+  cat > "$runtime" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-}"
+shift || true
+
+log_probe() {
+  [[ -z "${VG_STUB_LOG:-}" ]] || printf '%s\n' "$1" >>"${VG_STUB_LOG}"
+}
+
+case "$command" in
+  runtime-policy-supports)
+    log_probe "supports"
+    ;;
+  runtime-policy-check)
+    if [[ "${VG_STUB_STALE_PROTOCOL:-0}" == "1" ]]; then
+      if [[ "$#" -ne 1 || "${1:-}" == --* ]]; then
+        printf 'Usage: vibeguard-runtime runtime-policy-check <hook-name>\n' >&2
+        exit 2
+      fi
+      exit 0
+    fi
+    log_probe "check:runtime-policy-check $*"
+    cwd=""
+    hook_name=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        --cwd)
+          shift
+          cwd="${1:-}"
+          shift || true
+          ;;
+        *)
+          hook_name="$1"
+          shift
+          ;;
+      esac
+    done
+    printf '{"decision":"run","enforcement":"%s","hook":"%s","profile":"core","config_path":null,"cwd":"%s","reason":"compat text says enforcement=warn"}\n' "${VG_STUB_ENFORCEMENT:-block}" "${hook_name:-unknown}" "${cwd}"
+    ;;
+  json-field)
+    log_probe "json-field:$*"
+    exec "${REAL_RUNTIME:?}" json-field "$@"
+    ;;
+  runtime-policy-downgrade-output)
+    log_probe "downgrade"
+    exec "${REAL_RUNTIME:?}" runtime-policy-downgrade-output
+    ;;
+  runtime-policy-codex-error)
+    log_probe "codex-error:$*"
+    exec "${REAL_RUNTIME:?}" runtime-policy-codex-error "$@"
+    ;;
+  runtime-policy-diag)
+    log_probe "diag:$*"
+    exec "${REAL_RUNTIME:?}" runtime-policy-diag "$@"
+    ;;
+  *)
+    exit 2
     ;;
 esac
 STUB

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -139,6 +139,24 @@ case "$command" in
     printf 'VIBEGUARD_LOG_FILE=%s\n' "$log_file"
     printf 'VIBEGUARD_SESSION_ID=%s\n' "$session_id"
     ;;
+  runtime-policy-supports)
+    ;;
+  runtime-policy-check)
+    hook_name=""
+    while [[ $# -gt 0 ]]; do
+      case "${1:-}" in
+        --cwd)
+          shift
+          [[ $# -gt 0 ]] && shift
+          ;;
+        *)
+          hook_name="$1"
+          shift
+          ;;
+      esac
+    done
+    printf '{"decision":"run","enforcement":"block","hook":"%s","profile":"core","config_path":null,"reason":null}\n' "${hook_name:-unknown}"
+    ;;
   append-jsonl-mirror)
     primary_file="${1:?append-jsonl-mirror requires a primary file path}"
     mirror_file="${2:?append-jsonl-mirror requires a mirror file path}"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -36,6 +36,7 @@ shards=(
   "tests/hooks/test_post_edit_w15.sh"
   "tests/hooks/test_runtime_config.sh"
   "tests/hooks/test_runtime_policy.sh"
+  "tests/hooks/test_runtime_policy_json.sh"
   "tests/hooks/test_count_active_constraints.sh"
   "tests/hooks/test_u16_config.sh"
 )

--- a/vibeguard-runtime/src/runtime_policy.rs
+++ b/vibeguard-runtime/src/runtime_policy.rs
@@ -1,5 +1,6 @@
 use crate::HandlerResult;
 use crate::codex_app_server_policy::{HookPolicyDecision, evaluate_hook_policy};
+use crate::project_config::{load_project_config, project_config_path};
 use crate::runtime_config::validate_runtime_config_file;
 use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
 use serde_json::{Value, json};
@@ -22,31 +23,39 @@ pub fn runtime_policy_supports(args: &[String]) -> HandlerResult {
 }
 
 pub fn runtime_policy_check(args: &[String]) -> HandlerResult {
-    if args.len() != 1 {
-        return Err("Usage: vibeguard-runtime runtime-policy-check <hook-name>".into());
-    }
+    let parsed = parse_runtime_policy_check_args(args)?;
 
     let user_config = std::env::var("VIBEGUARD_USER_CONFIG_FILE").unwrap_or_default();
     if let Err(err) = validate_runtime_config_file(&user_config) {
+        let payload = runtime_policy_error_payload(
+            &parsed.hook_name,
+            parsed.cwd.as_deref(),
+            None,
+            &err.message,
+        );
         eprintln!("{}", err.message);
-        process::exit(err.exit_code);
+        exit_with_policy_payload(payload, err.exit_code);
     }
 
-    let decision = evaluate_hook_policy(&args[0], None, &HashMap::new());
+    let env_overrides = HashMap::new();
+    let config_path = project_config_path(parsed.cwd.as_deref(), &env_overrides);
+    let decision = evaluate_hook_policy(&parsed.hook_name, parsed.cwd.as_deref(), &env_overrides);
+    let payload = runtime_policy_payload(
+        &parsed.hook_name,
+        parsed.cwd.as_deref(),
+        config_path.as_deref(),
+        &decision,
+    );
     match decision {
-        HookPolicyDecision::Run { reason, .. } => {
-            if let Some(reason) = reason {
-                println!("{reason}");
-            }
-            process::exit(ALLOW);
+        HookPolicyDecision::Run { .. } => {
+            exit_with_policy_payload(payload, ALLOW);
         }
-        HookPolicyDecision::Skip(reason) => {
-            println!("{reason}");
-            process::exit(SKIP);
+        HookPolicyDecision::Skip(_) => {
+            exit_with_policy_payload(payload, SKIP);
         }
         HookPolicyDecision::Error(reason) => {
             eprintln!("{reason}");
-            process::exit(policy_error_exit_code(&reason));
+            exit_with_policy_payload(payload, policy_error_exit_code(&reason));
         }
     }
 }
@@ -189,6 +198,118 @@ fn policy_error_exit_code(reason: &str) -> i32 {
     } else {
         POLICY_ERROR
     }
+}
+
+struct RuntimePolicyCheckArgs {
+    hook_name: String,
+    cwd: Option<String>,
+}
+
+fn parse_runtime_policy_check_args(args: &[String]) -> Result<RuntimePolicyCheckArgs, String> {
+    let mut cwd: Option<String> = None;
+    let mut hook_name: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--cwd" | "--project-root" => {
+                i += 1;
+                let Some(value) = args.get(i) else {
+                    return Err(runtime_policy_check_usage());
+                };
+                if value.is_empty() || cwd.replace(value.clone()).is_some() {
+                    return Err(runtime_policy_check_usage());
+                }
+            }
+            "--" => {
+                i += 1;
+                if i >= args.len() || hook_name.is_some() || i + 1 != args.len() {
+                    return Err(runtime_policy_check_usage());
+                }
+                hook_name = Some(args[i].clone());
+            }
+            arg if arg.starts_with("--") => return Err(runtime_policy_check_usage()),
+            value => {
+                if hook_name.replace(value.to_string()).is_some() {
+                    return Err(runtime_policy_check_usage());
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let Some(hook_name) = hook_name else {
+        return Err(runtime_policy_check_usage());
+    };
+    Ok(RuntimePolicyCheckArgs { hook_name, cwd })
+}
+
+fn runtime_policy_check_usage() -> String {
+    "Usage: vibeguard-runtime runtime-policy-check [--cwd <path>] <hook-name>".into()
+}
+
+fn runtime_policy_payload(
+    hook_name: &str,
+    cwd: Option<&str>,
+    config_path: Option<&Path>,
+    decision: &HookPolicyDecision,
+) -> Value {
+    let (enforcement, profile) = config_path
+        .and_then(|path| load_project_config(path).ok())
+        .map(|config| {
+            (
+                config.enforcement.unwrap_or_else(|| "block".to_string()),
+                config.profile.unwrap_or_else(|| "core".to_string()),
+            )
+        })
+        .map(|(enforcement, profile)| (json!(enforcement), json!(profile)))
+        .unwrap_or_else(|| {
+            if config_path.is_some() {
+                (Value::Null, Value::Null)
+            } else {
+                (json!("block"), json!("core"))
+            }
+        });
+
+    let (decision_text, reason) = match decision {
+        HookPolicyDecision::Run { reason, .. } => ("run", reason.clone()),
+        HookPolicyDecision::Skip(reason) => ("skip", Some(reason.clone())),
+        HookPolicyDecision::Error(reason) => ("error", Some(reason.clone())),
+    };
+
+    json!({
+        "decision": decision_text,
+        "enforcement": enforcement,
+        "hook": hook_name,
+        "profile": profile,
+        "config_path": config_path.map(|path| path.to_string_lossy().to_string()),
+        "cwd": cwd,
+        "reason": reason,
+    })
+}
+
+fn runtime_policy_error_payload(
+    hook_name: &str,
+    cwd: Option<&str>,
+    config_path: Option<&Path>,
+    reason: &str,
+) -> Value {
+    json!({
+        "decision": "error",
+        "enforcement": Value::Null,
+        "hook": hook_name,
+        "profile": Value::Null,
+        "config_path": config_path.map(|path| path.to_string_lossy().to_string()),
+        "cwd": cwd,
+        "reason": reason,
+    })
+}
+
+fn exit_with_policy_payload(payload: Value, exit_code: i32) -> ! {
+    match serde_json::to_string(&payload) {
+        Ok(text) => println!("{text}"),
+        Err(err) => eprintln!("VibeGuard policy error: could not serialize policy JSON: {err}"),
+    }
+    process::exit(exit_code);
 }
 
 fn read_stdin() -> io::Result<String> {

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -45,12 +45,24 @@ fn run_runtime_with_stdin(args: &[&str], input: &str) -> std::process::Output {
 fn run_runtime_policy(repo: &Path, hook_name: &str) -> std::process::Output {
     bin()
         .arg("runtime-policy-check")
+        .arg("--cwd")
+        .arg(repo)
         .arg(hook_name)
         .current_dir(repo)
         .env_remove("VIBEGUARD_PROJECT_CONFIG")
         .env_remove("VIBEGUARD_USER_CONFIG_FILE")
         .output()
         .expect("runtime policy command should run")
+}
+
+fn policy_json(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "runtime-policy-check stdout should be JSON: {err}; stdout={}; stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
 }
 
 #[test]
@@ -61,9 +73,47 @@ fn runtime_policy_check_allows_when_no_project_config_exists() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "run");
+    assert_eq!(value["enforcement"], "block");
+    assert_eq!(value["hook"], "pre-bash-guard.sh");
+    assert_eq!(value["profile"], "core");
+    assert!(value["config_path"].is_null());
+    assert!(value["reason"].is_null());
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
     let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_uses_explicit_cwd_instead_of_process_cwd() {
+    let repo = unique_temp_dir("explicit_cwd");
+    let other = unique_temp_dir("process_cwd");
+    write_policy(&repo, r#"{"enforcement":"warn"}"#);
+    fs::create_dir_all(&other).expect("process cwd should be created");
+
+    let output = bin()
+        .arg("runtime-policy-check")
+        .arg("--cwd")
+        .arg(&repo)
+        .arg("pre-bash-guard.sh")
+        .current_dir(&other)
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env_remove("VIBEGUARD_USER_CONFIG_FILE")
+        .output()
+        .expect("runtime policy command should run");
+
+    assert_eq!(output.status.code(), Some(0));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "run");
+    assert_eq!(value["enforcement"], "warn");
+    assert_eq!(value["cwd"], repo.to_string_lossy().as_ref());
+    assert_eq!(
+        value["config_path"],
+        repo.join(".vibeguard.json").to_string_lossy().as_ref()
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let _ = fs::remove_dir_all(repo);
+    let _ = fs::remove_dir_all(other);
 }
 
 #[test]
@@ -74,8 +124,14 @@ fn runtime_policy_check_skips_disabled_hook() {
     let output = run_runtime_policy(&repo, "vibeguard-pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(10));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "skip");
+    assert_eq!(value["enforcement"], "block");
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains("disabled_hooks contains pre-bash-guard")
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("disabled_hooks contains pre-bash-guard")
     );
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
     let _ = fs::remove_dir_all(repo);
@@ -89,7 +145,10 @@ fn runtime_policy_check_reports_warn_enforcement() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(0));
-    assert!(String::from_utf8_lossy(&output.stdout).contains("enforcement=warn"));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "run");
+    assert_eq!(value["enforcement"], "warn");
+    assert_eq!(value["reason"], "VibeGuard policy warn: enforcement=warn");
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
     let _ = fs::remove_dir_all(repo);
 }
@@ -103,6 +162,8 @@ fn runtime_policy_check_validates_user_runtime_config_before_policy() {
 
     let output = bin()
         .arg("runtime-policy-check")
+        .arg("--cwd")
+        .arg(&repo)
         .arg("pre-bash-guard.sh")
         .current_dir(&repo)
         .env_remove("VIBEGUARD_PROJECT_CONFIG")
@@ -111,6 +172,14 @@ fn runtime_policy_check_validates_user_runtime_config_before_policy() {
         .expect("runtime policy command should run");
 
     assert_eq!(output.status.code(), Some(30));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "error");
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("runtime config invalid JSON")
+    );
     assert!(String::from_utf8_lossy(&output.stderr).contains("runtime config invalid JSON"));
     let _ = fs::remove_dir_all(repo);
 }
@@ -123,6 +192,16 @@ fn runtime_policy_check_reports_project_schema_errors_as_policy_errors() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(20));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "error");
+    assert!(value["enforcement"].is_null());
+    assert!(value["profile"].is_null());
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("disabled_hooks contains unsupported hook")
+    );
     assert!(
         String::from_utf8_lossy(&output.stderr)
             .contains("disabled_hooks contains unsupported hook")
@@ -138,6 +217,15 @@ fn runtime_policy_check_reports_project_json_parse_errors_as_config_parse_errors
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(30));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "error");
+    assert!(value["enforcement"].is_null());
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("project config invalid JSON")
+    );
     assert!(String::from_utf8_lossy(&output.stderr).contains("project config invalid JSON"));
     let _ = fs::remove_dir_all(repo);
 }
@@ -152,6 +240,14 @@ fn runtime_policy_check_reports_project_utf8_errors_as_config_parse_errors() {
     let output = run_runtime_policy(&repo, "pre-bash-guard.sh");
 
     assert_eq!(output.status.code(), Some(30));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "error");
+    assert!(
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("project config invalid UTF-8")
+    );
     assert!(String::from_utf8_lossy(&output.stderr).contains("project config invalid UTF-8"));
     let _ = fs::remove_dir_all(repo);
 }
@@ -164,8 +260,13 @@ fn runtime_policy_check_uses_shared_profile_filtering_for_strict_only_hooks() {
     let output = run_runtime_policy(&repo, "count_active_constraints.sh");
 
     assert_eq!(output.status.code(), Some(10));
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "skip");
+    assert_eq!(value["profile"], "core");
     assert!(
-        String::from_utf8_lossy(&output.stdout)
+        value["reason"]
+            .as_str()
+            .unwrap_or("")
             .contains("profile=core excludes count-active-constraints")
     );
     let _ = fs::remove_dir_all(repo);


### PR DESCRIPTION
Fixes #461.

Stacked on #468 / codex/issue-460-manifest-runtime-policy.

Scope:
- runtime-policy-check emits structured JSON and accepts --cwd / --project-root.
- Shell policy code parses JSON fields through vibeguard-runtime json-field instead of substring matching.
- Claude/Codex wrappers pass explicit cwd from hook payload or project root fallback.
- Tests cover missing config, explicit cwd selection, invalid config, JSON parsing, and wrapper cwd behavior.

Validation:
- cargo test --manifest-path vibeguard-runtime/Cargo.toml --test runtime_policy_cli
- cargo test --manifest-path vibeguard-runtime/Cargo.toml codex_app_server_policy
- bash tests/hooks/test_runtime_policy.sh
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- bash -n hooks/_lib/policy.sh hooks/run-hook.sh hooks/run-hook-codex.sh
- git diff --check