### PR TITLE
[codex] Fix VibeGuard hook orphan timeouts

### DIFF
--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -59,5 +59,8 @@ silently attributed to Claude or Codex.
 
 - All hooks must introduce shared functions in `source log.sh`
 - Use `vg_log` to record events instead of writing to files directly
-- Pass data to python3 through environment variables to avoid injection risks
+- Configured hook production paths must stay Python-free. Use `vibeguard-runtime`
+  for structured parsing, policy, and adapter logic; Python helpers are allowed
+  only for tests, CI, eval, install-support tooling, or deprecated compatibility
+  artifacts that are not called by configured hooks.
 - When adding a hook, synchronously check whether it can be deployed to Codex (see matcher support)

--- a/hooks/_lib/post_edit_quality.sh
+++ b/hooks/_lib/post_edit_quality.sh
@@ -169,7 +169,7 @@ vg_post_edit_detect_u16_size() {
   vg_post_edit_is_test_path "$FILE_PATH" && return 0
   [[ -f "$FILE_PATH" ]] || return 0
 
-  local total limit dir exempt base_limit
+  local total limit dir parent exempt base_limit
   # Base U-16 limit resolved from env var > ~/.vibeguard/config.json > built-in 800.
   vg_config_get_int_result base_limit VG_U16_LIMIT u16.limit 800
   local warn_limit
@@ -178,12 +178,14 @@ vg_post_edit_detect_u16_size() {
   [[ "$total" -gt "$warn_limit" ]] || return 0
 
   limit="$base_limit"
-  dir="$FILE_PATH"
-  while [[ "$dir" != "/" ]]; do
-    dir=$(dirname "$dir")
+  dir="$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && pwd -P)" || dir="$(dirname "$FILE_PATH")"
+  while [[ "$dir" != "/" && "$dir" != "." ]]; do
     [[ -d "$dir/.git" ]] && break
+    parent=$(dirname "$dir")
+    [[ "$parent" == "$dir" ]] && { dir="/"; break; }
+    dir="$parent"
   done
-  if [[ "$dir" != "/" && -f "$dir/CLAUDE.md" ]]; then
+  if [[ "$dir" != "/" && "$dir" != "." && -f "$dir/CLAUDE.md" ]]; then
     exempt=$("$_VIBEGUARD_RUNTIME" u16-limit "$FILE_PATH" "$base_limit" 2>/dev/null | tr -d '[:space:]' || echo "$base_limit")
     exempt="${exempt:-$base_limit}"
     if [[ "$exempt" =~ ^[0-9]+$ && "$exempt" -gt 0 ]]; then

--- a/hooks/_lib/timeout.sh
+++ b/hooks/_lib/timeout.sh
@@ -31,18 +31,28 @@ vg_run_with_timeout() {
     return $?
   fi
 
-  local flag stdin_file pid watchdog command_status
+  local flag stdin_file pid watchdog command_status stdin_is_tty
   flag="$(mktemp "${TMPDIR:-/tmp}/vibeguard-timeout.XXXXXX")"
   stdin_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-timeout-stdin.XXXXXX")"
-  if [[ -t 0 ]]; then
-    : > "${stdin_file}"
-  elif ! cat > "${stdin_file}"; then
+
+  stdin_is_tty=0
+  [[ -t 0 ]] && stdin_is_tty=1
+  if ! exec 9<&0; then
     rm -f "${flag}" "${stdin_file}" 2>/dev/null || true
     return 1
   fi
 
-  "$@" < "${stdin_file}" &
+  (
+    if [[ "${stdin_is_tty}" -eq 1 ]]; then
+      : > "${stdin_file}"
+    elif ! cat <&9 > "${stdin_file}"; then
+      exit 1
+    fi
+    exec 9<&-
+    exec "$@" < "${stdin_file}"
+  ) &
   pid=$!
+  exec 9<&-
   (
     local sleep_pid
     sleep "${seconds}" 2>/dev/null &

--- a/hooks/_lib/timeout.sh
+++ b/hooks/_lib/timeout.sh
@@ -6,6 +6,18 @@ if [[ -n "${_VG_TIMEOUT_SH_LOADED:-}" ]]; then
 fi
 _VG_TIMEOUT_SH_LOADED=1
 
+vg_timeout_kill_tree() {
+  local signal="$1" root_pid="$2" child
+  [[ -n "${root_pid}" ]] || return 0
+
+  if command -v pgrep >/dev/null 2>&1; then
+    for child in $(pgrep -P "${root_pid}" 2>/dev/null || true); do
+      vg_timeout_kill_tree "${signal}" "${child}"
+    done
+  fi
+  kill "-${signal}" "${root_pid}" 2>/dev/null || true
+}
+
 vg_run_with_timeout() {
   local seconds="$1"
   shift
@@ -19,9 +31,17 @@ vg_run_with_timeout() {
     return $?
   fi
 
-  local flag pid watchdog status
+  local flag stdin_file pid watchdog command_status
   flag="$(mktemp "${TMPDIR:-/tmp}/vibeguard-timeout.XXXXXX")"
-  "$@" &
+  stdin_file="$(mktemp "${TMPDIR:-/tmp}/vibeguard-timeout-stdin.XXXXXX")"
+  if [[ -t 0 ]]; then
+    : > "${stdin_file}"
+  elif ! cat > "${stdin_file}"; then
+    rm -f "${flag}" "${stdin_file}" 2>/dev/null || true
+    return 1
+  fi
+
+  "$@" < "${stdin_file}" &
   pid=$!
   (
     local sleep_pid
@@ -31,22 +51,22 @@ vg_run_with_timeout() {
     wait "${sleep_pid}" 2>/dev/null || true
     if kill -0 "${pid}" 2>/dev/null; then
       printf 'timeout\n' >"${flag}" 2>/dev/null || true
-      kill -TERM "${pid}" 2>/dev/null || true
+      vg_timeout_kill_tree TERM "${pid}"
       sleep 0.2 2>/dev/null || true
-      kill -KILL "${pid}" 2>/dev/null || true
+      vg_timeout_kill_tree KILL "${pid}"
     fi
   ) &
   watchdog=$!
 
   wait "${pid}" 2>/dev/null
-  status=$?
+  command_status=$?
   kill "${watchdog}" 2>/dev/null || true
   wait "${watchdog}" 2>/dev/null || true
 
   if [[ -s "${flag}" ]]; then
-    rm -f "${flag}" 2>/dev/null || true
+    rm -f "${flag}" "${stdin_file}" 2>/dev/null || true
     return 124
   fi
-  rm -f "${flag}" 2>/dev/null || true
-  return "${status}"
+  rm -f "${flag}" "${stdin_file}" 2>/dev/null || true
+  return "${command_status}"
 }

--- a/tests/codex_runtime/protocol_helper_tests.sh
+++ b/tests/codex_runtime/protocol_helper_tests.sh
@@ -331,6 +331,50 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+NO_TIMEOUT_BIN="${TMP_DIR}/no-timeout-bin"
+mkdir -p "${NO_TIMEOUT_BIN}"
+for _tool in bash cat mktemp pgrep sleep; do
+  _tool_path="$(command -v "${_tool}")"
+  ln -s "${_tool_path}" "${NO_TIMEOUT_BIN}/${_tool}"
+done
+
+timeout_stdin_out="$(
+  bash -c '
+    set -euo pipefail
+    PATH="$1"
+    source "$2"
+    printf "abc\n" | vg_run_with_timeout 2 bash -c '"'"'IFS= read -r line || true; printf "line=%s\n" "$line"'"'"'
+  ' -- "${NO_TIMEOUT_BIN}" "${REPO_DIR}/hooks/_lib/timeout.sh"
+)"
+assert_contains "${timeout_stdin_out}" "line=abc" "timeout fallback preserves pipeline stdin"
+
+timeout_child_pid_file="${TMP_DIR}/timeout-child.pid"
+timeout_tree_out="$(
+  bash -c '
+    set -euo pipefail
+    PATH="$1"
+    source "$2"
+    pid_file="$3"
+    run_status=0
+    vg_run_with_timeout 1 bash -c '"'"'/bin/sleep 60 & echo $! > "$1"; wait'"'"' _ "$pid_file" || run_status=$?
+    printf "status=%s\n" "$run_status"
+  ' -- "${NO_TIMEOUT_BIN}" "${REPO_DIR}/hooks/_lib/timeout.sh" "${timeout_child_pid_file}"
+)"
+assert_contains "${timeout_tree_out}" "status=124" "timeout fallback returns 124 after killing slow command"
+timeout_child_pid="$(cat "${timeout_child_pid_file}" 2>/dev/null || true)"
+sleep 0.5
+TOTAL=$((TOTAL + 1))
+if [[ -n "${timeout_child_pid}" ]] && ps -p "${timeout_child_pid}" >/dev/null 2>&1; then
+  kill "${timeout_child_pid}" 2>/dev/null || true
+  sleep 0.1
+  kill -KILL "${timeout_child_pid}" 2>/dev/null || true
+  red "timeout fallback kills descendant processes"
+  FAIL=$((FAIL + 1))
+else
+  green "timeout fallback kills descendant processes"
+  PASS=$((PASS + 1))
+fi
+
 old_normalizer_runtime="${TMP_DIR}/old-normalizer-runtime"
 cat > "${old_normalizer_runtime}" <<'SH'
 #!/usr/bin/env bash

--- a/tests/codex_runtime/protocol_helper_tests.sh
+++ b/tests/codex_runtime/protocol_helper_tests.sh
@@ -333,7 +333,7 @@ fi
 
 NO_TIMEOUT_BIN="${TMP_DIR}/no-timeout-bin"
 mkdir -p "${NO_TIMEOUT_BIN}"
-for _tool in bash cat mktemp pgrep sleep; do
+for _tool in bash cat mktemp pgrep sleep yes; do
   _tool_path="$(command -v "${_tool}")"
   ln -s "${_tool_path}" "${NO_TIMEOUT_BIN}/${_tool}"
 done
@@ -347,6 +347,28 @@ timeout_stdin_out="$(
   ' -- "${NO_TIMEOUT_BIN}" "${REPO_DIR}/hooks/_lib/timeout.sh"
 )"
 assert_contains "${timeout_stdin_out}" "line=abc" "timeout fallback preserves pipeline stdin"
+
+timeout_unclosed_stdin_started="$(date +%s)"
+timeout_unclosed_stdin_out="$(
+  bash -c '
+    set -euo pipefail
+    PATH="$1"
+    source "$2"
+    run_status=0
+    yes | vg_run_with_timeout 1 cat >/dev/null || run_status=$?
+    printf "status=%s\n" "$run_status"
+  ' -- "${NO_TIMEOUT_BIN}" "${REPO_DIR}/hooks/_lib/timeout.sh"
+)"
+timeout_unclosed_stdin_elapsed=$(( $(date +%s) - timeout_unclosed_stdin_started ))
+assert_contains "${timeout_unclosed_stdin_out}" "status=124" "timeout fallback bounds unclosed pipeline stdin"
+TOTAL=$((TOTAL + 1))
+if [[ "${timeout_unclosed_stdin_elapsed}" -lt 3 ]]; then
+  green "timeout fallback returns promptly for unclosed pipeline stdin"
+  PASS=$((PASS + 1))
+else
+  red "timeout fallback returns promptly for unclosed pipeline stdin"
+  FAIL=$((FAIL + 1))
+fi
 
 timeout_child_pid_file="${TMP_DIR}/timeout-child.pid"
 timeout_tree_out="$(

--- a/tests/hooks/test_u16_config.sh
+++ b/tests/hooks/test_u16_config.sh
@@ -211,6 +211,30 @@ result=$(run_post_edit_medium)
 assert_contains "$result" "[U-16]" "default 400/800: 450-line post-edit emits U-16 advisory"
 assert_contains "$result" "400-line typical range" "post-edit advisory cites typical threshold"
 
+non_git_dir="$WORK_DIR/non_git_relative"
+mkdir -p "$non_git_dir"
+large_relative_target="$non_git_dir/large.py"
+i=0
+while [[ "$i" -lt 850 ]]; do
+  printf 'x = %s\n' "$i"
+  i=$((i + 1))
+done > "$large_relative_target"
+
+relative_result="$(
+  cd "$non_git_dir"
+  WARNINGS=""
+  FILE_PATH="large.py"
+  NEW_STRING="x = 849
+x = 850"
+  source "$REPO_DIR/hooks/log.sh"
+  source "$REPO_DIR/hooks/_lib/post_edit_common.sh"
+  source "$REPO_DIR/hooks/_lib/post_edit_quality.sh"
+  vg_post_edit_detect_u16_size
+  printf '%s\n' "$WARNINGS"
+)"
+assert_contains "$relative_result" "[U-16]" "post-edit U-16 handles non-git relative file paths"
+assert_contains "$relative_result" "850 lines" "post-edit U-16 reports non-git relative file size"
+
 export VG_U16_WARN_LIMIT=600
 result=$(run_post_edit_medium)
 assert_not_contains "$result" "[U-16]" "VG_U16_WARN_LIMIT=600: 450-line post-edit is silent"


### PR DESCRIPTION
## Summary

Fixes #473.

This PR hardens hook runtime behavior around the high-CPU orphaned post-edit hook incident:

- terminate U-16 post-edit project-root traversal for non-git relative paths by resolving the file directory and stopping on `.` / self-parent
- preserve stdin in the `vg_run_with_timeout` Bash fallback used when `timeout`/`gtimeout` are unavailable
- recursively terminate descendant processes on fallback timeout so timed-out hook children are not left orphaned
- add regression coverage for non-git relative U-16, fallback stdin preservation, and descendant cleanup

## Root Cause

`vg_post_edit_detect_u16_size` started from a relative `FILE_PATH` and repeatedly called `dirname` until `/`. In a non-git cwd, `dirname .` remains `.`, so the loop never terminated. Separately, the macOS timeout fallback backgrounded the wrapped command, which dropped pipeline stdin, and killed only the direct child PID.

## Validation

- `bash -n hooks/_lib/timeout.sh hooks/_lib/post_edit_quality.sh tests/hooks/test_u16_config.sh tests/codex_runtime/protocol_helper_tests.sh`
- `cargo build --manifest-path vibeguard-runtime/Cargo.toml --quiet`
- `VIBEGUARD_RUNTIME="$PWD/vibeguard-runtime/target/debug/vibeguard-runtime" bash tests/hooks/test_u16_config.sh`
- `bash tests/test_codex_runtime.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_hooks.sh`
- `git diff --check`
- `bash scripts/ci/self-application/check-hook-production-python-free.sh`

