### PR TITLE
[codex] Remove legacy worktree base fallback

### DIFF
--- a/scripts/gc/gc-worktrees.sh
+++ b/scripts/gc/gc-worktrees.sh
@@ -2,8 +2,8 @@
 # VibeGuard GC — Worktree Cleanup
 #
 # Scan the active worktree base (VIBEGUARD_WORKTREE_BASE, default <repo>.wt/)
-# plus the legacy in-repo path (.vibeguard/worktrees/) and delete worktrees
-# that have been inactive for more than the specified number of days.
+# and delete worktrees that have been inactive for more than the specified
+# number of days.
 # Worktrees with unmerged changes will only be warned but not deleted.
 #
 # Usage:
@@ -60,20 +60,10 @@ normalize_worktree_base() {
   printf '%s\n' "$base"
 }
 
-same_path() {
-  [[ "${1%/}" == "${2%/}" ]]
-}
-
 WORKTREE_BASE="$(normalize_worktree_base "${VIBEGUARD_WORKTREE_BASE:-${REPO_ROOT}.wt}")"
-LEGACY_WORKTREE_BASE="$(normalize_worktree_base "${REPO_ROOT}/.vibeguard/worktrees")"
 
 WORKTREE_DIRS=()
 [[ -d "$WORKTREE_BASE" ]] && WORKTREE_DIRS+=("$WORKTREE_BASE")
-# Back-compat: pre-feature/wt-base-config worktrees lived in-repo. Scan them too
-# so they still get cleaned, even when the new base is set elsewhere.
-if ! same_path "$LEGACY_WORKTREE_BASE" "$WORKTREE_BASE" && [[ -d "$LEGACY_WORKTREE_BASE" ]]; then
-  WORKTREE_DIRS+=("$LEGACY_WORKTREE_BASE")
-fi
 
 if [[ ${#WORKTREE_DIRS[@]} -eq 0 ]]; then
   green "No worktree directory, skip"
@@ -101,13 +91,10 @@ mtime_or_now() {
 }
 
 for base in "${WORKTREE_DIRS[@]}"; do
-  base_tag=""
-  [[ "$base" == "$LEGACY_WORKTREE_BASE" ]] && base_tag=" [legacy]"
-
   for wt_dir in "${base}"/*/; do
     [[ -d "$wt_dir" ]] || continue
     NAME=$(basename "$wt_dir")
-    LABEL="${NAME}${base_tag}"
+    LABEL="${NAME}"
 
     # Get the latest modification time (get the latest file in the .git file or directory)
     if [[ -f "${wt_dir}.git" ]]; then

--- a/scripts/worktree-guard.sh
+++ b/scripts/worktree-guard.sh
@@ -48,11 +48,6 @@ normalize_worktree_base() {
 # Default base sits next to the repo (<repo>.wt/) to keep the repo tree clean.
 # Override with VIBEGUARD_WORKTREE_BASE for external SSDs, alternate hosts, etc.
 WORKTREE_BASE="$(normalize_worktree_base "${VIBEGUARD_WORKTREE_BASE:-${REPO_ROOT}.wt}")"
-LEGACY_WORKTREE_BASE="$(normalize_worktree_base "${REPO_ROOT}/.vibeguard/worktrees")"
-
-same_path() {
-  [[ "${1%/}" == "${2%/}" ]]
-}
 
 resolve_worktree_path() {
   local name="$1"
@@ -60,12 +55,6 @@ resolve_worktree_path() {
 
   if [[ -d "$path" ]]; then
     printf '%s\n' "$path"
-    return 0
-  fi
-
-  local legacy_path="${LEGACY_WORKTREE_BASE}/${name}"
-  if ! same_path "$legacy_path" "$path" && [[ -d "$legacy_path" ]]; then
-    printf '%s\n' "$legacy_path"
     return 0
   fi
 
@@ -98,35 +87,16 @@ case "$ACTION" in
     ;;
 
   list)
-    LIST_BASES=()
-
-    for base in "$WORKTREE_BASE" "$LEGACY_WORKTREE_BASE"; do
-      duplicate=0
-      # ${arr[@]+...} idiom so empty arrays don't trip `set -u` on bash 3.2.
-      for existing in ${LIST_BASES[@]+"${LIST_BASES[@]}"}; do
-        if same_path "$base" "$existing"; then
-          duplicate=1
-          break
-        fi
-      done
-
-      if [[ "$duplicate" -eq 0 && -d "$base" ]]; then
-        LIST_BASES+=("$(cd "$base" && pwd -P)")
-      fi
-    done
-
     found=0
-    if [[ "${#LIST_BASES[@]}" -gt 0 ]]; then
+    if [[ -d "$WORKTREE_BASE" ]]; then
+      LIST_BASE="$(cd "$WORKTREE_BASE" && pwd -P)"
       while IFS= read -r line; do
         [[ "$line" == worktree\ * ]] || continue
         path="${line#worktree }"
-        for base in "${LIST_BASES[@]}"; do
-          if [[ "$path" == "$base" || "$path" == "$base"/* ]]; then
-            echo "$path"
-            found=1
-            break
-          fi
-        done
+        if [[ "$path" == "$LIST_BASE" || "$path" == "$LIST_BASE"/* ]]; then
+          echo "$path"
+          found=1
+        fi
       done < <(git worktree list --porcelain)
     fi
 

--- a/tests/test_gc_config.sh
+++ b/tests/test_gc_config.sh
@@ -189,16 +189,16 @@ assert_contains "$invalid_gc_logs_out" "VibeGuard project config invalid" "gc-lo
 header "gc-worktrees.sh reads project config"
 
 repo="${TMP_ROOT}/repo"
-mkdir -p "${repo}/.vibeguard/worktrees/old"
+mkdir -p "$repo"
 git -C "$repo" init -q
+mkdir -p "${repo}.wt/old" "${repo}/.vibeguard/worktrees/ignored"
 cp "$cfg" "${repo}/.vibeguard.json"
-perl -e 'utime(time - 10 * 86400, time - 10 * 86400, $ARGV[0])' "${repo}/.vibeguard/worktrees/old"
+perl -e 'utime(time - 10 * 86400, time - 10 * 86400, $ARGV[0])' "${repo}.wt/old"
+perl -e 'utime(time - 10 * 86400, time - 10 * 86400, $ARGV[0])' "${repo}/.vibeguard/worktrees/ignored"
 worktree_out="$(cd "$repo" && bash "$REPO_DIR/scripts/gc/gc-worktrees.sh" --dry-run)"
-assert_contains "$worktree_out" "old [legacy]: 10 days" "gc-worktrees inspects old legacy worktree"
+assert_contains "$worktree_out" "old: 10 days" "gc-worktrees inspects configured default worktree base"
 assert_contains "$worktree_out" "reserved" "configured 42-day retention prevents deletion"
-
-legacy_override_out="$(cd "$repo" && VIBEGUARD_WORKTREE_BASE=".vibeguard/worktrees/" bash "$REPO_DIR/scripts/gc/gc-worktrees.sh" --dry-run)"
-assert_occurrences "$legacy_override_out" "old [legacy]: 10 days" 1 "gc-worktrees deduplicates legacy base with trailing slash"
+assert_occurrences "$worktree_out" "ignored" 0 "gc-worktrees ignores old in-repo worktree base"
 
 relative_repo="${TMP_ROOT}/relative-repo"
 relative_base_abs="${TMP_ROOT}/relative-repo.wt"
@@ -211,7 +211,7 @@ relative_gc_out="$(
 assert_contains "$relative_gc_out" "current: 0 days" "gc-worktrees resolves relative base against repo root"
 
 linux_stat_repo="${TMP_ROOT}/linux-stat-repo"
-mkdir -p "${linux_stat_repo}/.vibeguard/worktrees/current" "${TMP_ROOT}/bin"
+mkdir -p "$linux_stat_repo" "${linux_stat_repo}.wt/current" "${TMP_ROOT}/bin"
 git -C "$linux_stat_repo" init -q
 cat > "${TMP_ROOT}/bin/stat" <<'SH'
 #!/usr/bin/env bash
@@ -227,7 +227,7 @@ exec /usr/bin/stat "$@"
 SH
 chmod +x "${TMP_ROOT}/bin/stat"
 linux_stat_out="$(cd "$linux_stat_repo" && PATH="${TMP_ROOT}/bin:$PATH" VIBEGUARD_GC_WORKTREE_MAX_DAYS=42 bash "$REPO_DIR/scripts/gc/gc-worktrees.sh" --dry-run)"
-assert_contains "$linux_stat_out" "current [legacy]: 0 days" "gc-worktrees ignores GNU stat -f filesystem output"
+assert_contains "$linux_stat_out" "current: 0 days" "gc-worktrees ignores GNU stat -f filesystem output"
 
 header "schema exposes gc contract"
 

--- a/tests/test_worktree_guard.sh
+++ b/tests/test_worktree_guard.sh
@@ -48,7 +48,6 @@ header "worktree-guard.sh list"
 
 fixture_repo="${TMP_ROOT}/repo"
 worktree_base="${TMP_ROOT}/repo.wt"
-legacy_worktree_base="${fixture_repo}/.vibeguard/worktrees"
 git init -q "$fixture_repo"
 git -C "$fixture_repo" config user.email "test@example.com"
 git -C "$fixture_repo" config user.name "Test User"
@@ -61,9 +60,7 @@ git -C "$fixture_repo" commit -qm "init"
   VIBEGUARD_WORKTREE_BASE="$worktree_base" bash "$REPO_DIR/scripts/worktree-guard.sh" create sample >/dev/null
 )
 
-mkdir -p "$legacy_worktree_base"
-git -C "$fixture_repo" worktree add -b vg/legacy "${legacy_worktree_base}/legacy" HEAD >/dev/null 2>&1
-legacy_status_path="$(cd "${legacy_worktree_base}/legacy" && pwd -P)"
+mkdir -p "${fixture_repo}/.vibeguard/worktrees/ignored"
 
 list_output="$(
   cd "$fixture_repo"
@@ -71,15 +68,16 @@ list_output="$(
 )"
 
 assert_contains "$list_output" "${worktree_base}/sample" "list shows worktree under configured base"
-assert_contains "$list_output" "${legacy_worktree_base}/legacy" "list shows legacy worktree fallback"
+assert_not_contains "$list_output" ".vibeguard/worktrees/ignored" "list ignores old in-repo worktree base"
 assert_not_contains "$list_output" "No active VibeGuard worktree" "list does not report empty when configured-base worktree exists"
 
-status_output="$(
+missing_status_output="$(
   cd "$fixture_repo"
-  VIBEGUARD_WORKTREE_BASE="$worktree_base" bash "$REPO_DIR/scripts/worktree-guard.sh" status legacy
+  VIBEGUARD_WORKTREE_BASE="$worktree_base" bash "$REPO_DIR/scripts/worktree-guard.sh" status ignored 2>&1 || true
 )"
 
-assert_contains "$status_output" "Path: ${legacy_status_path}" "status resolves legacy worktree fallback"
+assert_contains "$missing_status_output" "Error: worktree does not exist:" "status errors for old in-repo worktree base"
+assert_contains "$missing_status_output" "repo.wt/ignored" "status resolves missing worktree against configured base"
 
 header "worktree-guard.sh relative base"
 


### PR DESCRIPTION
## Summary
- Stops GC from scanning the old in-repo `.vibeguard/worktrees` base.
- Stops `worktree-guard.sh list/status` from resolving worktrees through the old fallback base.
- Updates GC and worktree guard tests so the old in-repo base is ignored.

Closes #476.

## Compatibility
No backward compatibility is preserved for `.vibeguard/worktrees`. Only the configured/current worktree base is considered.

## Validation
- `bash -n scripts/gc/gc-worktrees.sh scripts/worktree-guard.sh tests/test_gc_config.sh tests/test_worktree_guard.sh`
- `bash tests/test_gc_config.sh` (24/24)
- `bash tests/test_worktree_guard.sh` (7/7)
- `git diff --check`