### PR TITLE
[codex] Remove legacy observe and stats mode

### DIFF
--- a/scripts/hook-health.sh
+++ b/scripts/hook-health.sh
@@ -67,8 +67,8 @@ if ! [[ "${HOURS}" =~ ^[0-9]+$ ]] || [[ "${HOURS}" -le 0 ]]; then
   exit 1
 fi
 
-RUNTIME="$(vg_resolve_runtime "${REPO_DIR}" observe_health_legacy)"
-CMD=("${RUNTIME}" observe health --legacy --limit all --hours "${HOURS}")
+RUNTIME="$(vg_resolve_runtime "${REPO_DIR}" observe_health)"
+CMD=("${RUNTIME}" observe health --limit all --hours "${HOURS}")
 
 if [[ "${SCOPE_EXPLICIT}" -eq 1 ]]; then
   CMD+=(--scope "${SCOPE}")

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -2,7 +2,7 @@
 
 vg_resolve_runtime() {
   local repo_dir="${1:?vg_resolve_runtime requires repo dir}"
-  local capability="${2:-observe_legacy}"
+  local capability="${2:-observe_summary}"
 
   local explicit_runtime="${VIBEGUARD_RUNTIME:-}"
   local candidates=()
@@ -66,10 +66,10 @@ vg_runtime_supports() {
   local candidate="$1"
   local capability="$2"
   case "${capability}" in
-    observe_legacy)
+    observe_summary)
       vg_runtime_supports_observe "${candidate}"
       ;;
-    observe_health_legacy)
+    observe_health)
       vg_runtime_supports_observe_health "${candidate}"
       ;;
     observe_export_prometheus)
@@ -83,12 +83,12 @@ vg_runtime_supports() {
 
 vg_runtime_supports_observe() {
   local candidate="$1"
-  "${candidate}" observe summary --legacy --days all --limit all --log-file /dev/null >/dev/null 2>&1
+  "${candidate}" observe summary --days all --limit all --log-file /dev/null >/dev/null 2>&1
 }
 
 vg_runtime_supports_observe_health() {
   local candidate="$1"
-  "${candidate}" observe health --legacy --limit all --hours 24 --log-file /dev/null >/dev/null 2>&1
+  "${candidate}" observe health --hours all --limit all --log-file /dev/null >/dev/null 2>&1
 }
 
 vg_runtime_supports_observe_export_prometheus() {

--- a/scripts/stats.sh
+++ b/scripts/stats.sh
@@ -69,7 +69,7 @@ if [[ "${DAYS}" != "all" ]] && { ! [[ "${DAYS}" =~ ^[0-9]+$ ]] || [[ "${DAYS}" -
 fi
 
 RUNTIME="$(vg_resolve_runtime "${REPO_DIR}")"
-CMD=("${RUNTIME}" observe summary --legacy --limit all --days "${DAYS}")
+CMD=("${RUNTIME}" observe summary --limit all --days "${DAYS}")
 
 if [[ "${SCOPE_EXPLICIT}" -eq 1 ]]; then
   CMD+=(--scope "${SCOPE}")

--- a/tests/test_hook_health.sh
+++ b/tests/test_hook_health.sh
@@ -115,7 +115,7 @@ exit 2
 SH
 chmod +x "${summary_only_runtime}"
 health_probe_out="$(VIBEGUARD_RUNTIME="${summary_only_runtime}" bash "${SCRIPT}" --log-file /dev/null 24 2>&1 || true)"
-assert_contains "${health_probe_out}" "VIBEGUARD_RUNTIME does not support required capability: observe_health_legacy" "Health wrapper rejects runtime without observe health support"
+assert_contains "${health_probe_out}" "VIBEGUARD_RUNTIME does not support required capability: observe_health" "Health wrapper rejects runtime without observe health support"
 
 header "No log file"
 no_log_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/missing" bash "${SCRIPT}" 2>&1 || true)"
@@ -335,7 +335,7 @@ assert_contains "${malformed_out}" "Total triggers: 3" "Recoverable malformed UT
 assert_contains "${malformed_out}" "Risk (non-pass): 2" "Malformed UTF-8 line still contributes to decision counts"
 assert_contains "${malformed_out}" "pre-bash-guard: 1" "Recovered line participates in non-pass hook aggregation"
 
-header "Legacy wrapper reads beyond observe default limit"
+header "Health wrapper reads beyond observe default limit"
 mkdir -p "${TMP_DIR}/large-health-log"
 python3 - "${TMP_DIR}/large-health-log/events.jsonl" <<'PY'
 import json

--- a/tests/test_observe.sh
+++ b/tests/test_observe.sh
@@ -147,8 +147,8 @@ PY
 
 header "human output"
 human_out="$("${RUNTIME}" observe summary --days all --log-file "${EVENT_LOG}" --slow-ms 2000 2>&1)"
-assert_contains "${human_out}" "VibeGuard observe summary" "human: summary has concise title"
-assert_contains "${human_out}" "Top hooks:" "human: summary includes top hooks"
+assert_contains "${human_out}" "VibeGuard Statistics (all history)" "human: summary has stats title"
+assert_contains "${human_out}" "Distributed by Hook:" "human: summary includes hook distribution"
 
 header "missing explicit log"
 missing_log="${TMP_DIR}/missing-events.jsonl"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -80,34 +80,34 @@ assert_cmd "vibeguard-runtime builds for observe wrappers" \
 
 header "Runtime support probe"
 source "${REPO_DIR}/scripts/lib/runtime.sh"
-old_observe_runtime="${TMP_DIR}/old-observe-runtime"
-cat > "${old_observe_runtime}" <<'SH'
+unsupported_observe_runtime="${TMP_DIR}/unsupported-observe-runtime"
+cat > "${unsupported_observe_runtime}" <<'SH'
 #!/usr/bin/env bash
 if [[ "$#" -eq 0 ]]; then
   printf 'observe\n'
   exit 0
 fi
 if [[ "$1" == "observe" ]]; then
-  printf 'unknown argument: --legacy\n' >&2
+  printf 'unknown argument: observe summary\n' >&2
   exit 2
 fi
 exit 2
 SH
-chmod +x "${old_observe_runtime}"
+chmod +x "${unsupported_observe_runtime}"
 
-legacy_observe_runtime="${TMP_DIR}/legacy-observe-runtime"
-cat > "${legacy_observe_runtime}" <<'SH'
+summary_observe_runtime="${TMP_DIR}/summary-observe-runtime"
+cat > "${summary_observe_runtime}" <<'SH'
 #!/usr/bin/env bash
 if [[ "$#" -eq 0 ]]; then
   printf 'observe\n'
   exit 0
 fi
-if [[ "$*" == "observe summary --legacy --days all --limit all --log-file /dev/null" ]]; then
+if [[ "$*" == "observe summary --days all --limit all --log-file /dev/null" ]]; then
   exit 0
 fi
 exit 2
 SH
-chmod +x "${legacy_observe_runtime}"
+chmod +x "${summary_observe_runtime}"
 
 export_observe_runtime="${TMP_DIR}/export-observe-runtime"
 cat > "${export_observe_runtime}" <<'SH'
@@ -120,7 +120,7 @@ if [[ "$*" == "observe export prometheus --since all --input-file /dev/null" ]];
   exit 0
 fi
 if [[ "$1" == "observe" ]]; then
-  printf 'unknown argument: --legacy\n' >&2
+  printf 'unknown argument: observe summary\n' >&2
   exit 2
 fi
 exit 2
@@ -130,7 +130,7 @@ chmod +x "${export_observe_runtime}"
 full_observe_runtime="${TMP_DIR}/full-observe-runtime"
 cat > "${full_observe_runtime}" <<'SH'
 #!/usr/bin/env bash
-if [[ "$*" == "observe summary --legacy --days all --limit all --log-file /dev/null" ]]; then
+if [[ "$*" == "observe summary --days all --limit all --log-file /dev/null" ]]; then
   exit 0
 fi
 if [[ "$*" == "observe export prometheus --since all --input-file /dev/null" ]]; then
@@ -140,11 +140,11 @@ exit 2
 SH
 chmod +x "${full_observe_runtime}"
 
-assert_cmd_fails "Probe rejects runtimes without legacy observe options" \
-  vg_runtime_supports_observe "${old_observe_runtime}"
-assert_cmd "Probe accepts runtimes with legacy observe options" \
-  vg_runtime_supports_observe "${legacy_observe_runtime}"
-assert_cmd_fails "Legacy probe rejects export-only runtimes" \
+assert_cmd_fails "Probe rejects runtimes without observe summary support" \
+  vg_runtime_supports_observe "${unsupported_observe_runtime}"
+assert_cmd "Probe accepts runtimes with observe summary support" \
+  vg_runtime_supports_observe "${summary_observe_runtime}"
+assert_cmd_fails "Summary probe rejects export-only runtimes" \
   vg_runtime_supports_observe "${export_observe_runtime}"
 assert_cmd "Export probe accepts export-only runtimes" \
   vg_runtime_supports_observe_export_prometheus "${export_observe_runtime}"
@@ -155,14 +155,14 @@ mkdir -p \
   "${resolver_repo}/vibeguard-runtime/target/debug" \
   "${resolver_home}/.vibeguard/installed/bin"
 cp "${export_observe_runtime}" "${resolver_repo}/vibeguard-runtime/target/debug/vibeguard-runtime"
-cp "${legacy_observe_runtime}" "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime"
-selected_legacy_runtime="$(
+cp "${summary_observe_runtime}" "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime"
+selected_summary_runtime="$(
   env -u VIBEGUARD_RUNTIME HOME="${resolver_home}" bash -c '
     source "$1"
-    vg_resolve_runtime "$2" observe_legacy
+    vg_resolve_runtime "$2" observe_summary
   ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}"
 )"
-assert_contains "${selected_legacy_runtime}" "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime" "Resolver skips export-only repo runtime for legacy stats"
+assert_contains "${selected_summary_runtime}" "${resolver_home}/.vibeguard/installed/bin/vibeguard-runtime" "Resolver skips export-only repo runtime for stats"
 selected_export_runtime="$(
   env -u VIBEGUARD_RUNTIME HOME="${resolver_home}" bash -c '
     source "$1"
@@ -182,12 +182,12 @@ selected_installed_export_runtime="$(
 )"
 assert_contains "${selected_installed_export_runtime}" "${resolver_full_home}/.vibeguard/installed/bin/vibeguard-runtime" "Resolver prefers installed runtime when capability matches"
 assert_cmd_fails "Resolver rejects explicit runtime without requested exporter capability" \
-  env VIBEGUARD_RUNTIME="${legacy_observe_runtime}" HOME="${resolver_full_home}" bash -c '
+  env VIBEGUARD_RUNTIME="${summary_observe_runtime}" HOME="${resolver_full_home}" bash -c '
     source "$1"
     vg_resolve_runtime "$2" observe_export_prometheus >/dev/null
   ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}"
 explicit_bad_runtime_out="$(
-  env VIBEGUARD_RUNTIME="${legacy_observe_runtime}" HOME="${resolver_full_home}" bash -c '
+  env VIBEGUARD_RUNTIME="${summary_observe_runtime}" HOME="${resolver_full_home}" bash -c '
     source "$1"
     vg_resolve_runtime "$2" observe_export_prometheus
   ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_repo}" 2>&1 || true
@@ -305,9 +305,9 @@ assert_contains "${stats_out}" "post-edit-guard: 1 times" "Secondary hook aggreg
 stats_all_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/log" bash "${SCRIPT}" --scope global all 2>&1)"
 assert_contains "${stats_all_out}" "Total triggers: 3 times" "Non-object JSONL records are skipped for all-history stats"
 
-header "Legacy stats analyses are preserved"
-mkdir -p "${TMP_DIR}/legacy-sections-log"
-python3 - "${TMP_DIR}/legacy-sections-log/events.jsonl" <<'PY'
+header "Stats analyses are preserved"
+mkdir -p "${TMP_DIR}/stats-sections-log"
+python3 - "${TMP_DIR}/stats-sections-log/events.jsonl" <<'PY'
 import json
 import sys
 from datetime import datetime, timedelta, timezone
@@ -363,21 +363,21 @@ with open(path, "w", encoding="utf-8") as f:
         f.write(json.dumps(event) + "\n")
 PY
 
-legacy_sections_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/legacy-sections-log" bash "${SCRIPT}" --scope global 7 2>&1)"
-assert_contains "${legacy_sections_out}" "== Warn compliance rate analysis ==" "Warn compliance section is preserved"
-assert_contains "${legacy_sections_out}" "pre-bash-guard: warn=1 pass=1 compliance rate=50% [LOW]" "Warn compliance computes pass ratio"
-assert_contains "${legacy_sections_out}" "Distributed by file type:" "File type section is preserved"
-assert_contains "${legacy_sections_out}" ".rs: 2 times" "File type distribution counts details"
-assert_contains "${legacy_sections_out}" "Distributed by time period:" "Time period section is preserved"
-assert_contains "${legacy_sections_out}" "working time (09-18): 2 times (50%)" "Working-hour distribution is computed"
-assert_contains "${legacy_sections_out}" "== Performance analysis ==" "Performance section is preserved"
-assert_contains "${legacy_sections_out}" "Total number of sessions: 2" "Session count is preserved"
-assert_contains "${legacy_sections_out}" "Average triggers per session: 2.0 times" "Average trigger count is preserved"
-assert_contains "${legacy_sections_out}" "Deterministic node estimated savings: ~2K tokens" "Token savings estimate is preserved"
-assert_contains "${legacy_sections_out}" "Conversations with the most questions Top 3:" "Problem sessions section is preserved"
-assert_contains "${legacy_sections_out}" "session-b: 2 issues / 2 triggers" "Problem sessions are ranked"
+stats_sections_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/stats-sections-log" bash "${SCRIPT}" --scope global 7 2>&1)"
+assert_contains "${stats_sections_out}" "== Warn compliance rate analysis ==" "Warn compliance section is preserved"
+assert_contains "${stats_sections_out}" "pre-bash-guard: warn=1 pass=1 compliance rate=50% [LOW]" "Warn compliance computes pass ratio"
+assert_contains "${stats_sections_out}" "Distributed by file type:" "File type section is preserved"
+assert_contains "${stats_sections_out}" ".rs: 2 times" "File type distribution counts details"
+assert_contains "${stats_sections_out}" "Distributed by time period:" "Time period section is preserved"
+assert_contains "${stats_sections_out}" "working time (09-18): 2 times (50%)" "Working-hour distribution is computed"
+assert_contains "${stats_sections_out}" "== Performance analysis ==" "Performance section is preserved"
+assert_contains "${stats_sections_out}" "Total number of sessions: 2" "Session count is preserved"
+assert_contains "${stats_sections_out}" "Average triggers per session: 2.0 times" "Average trigger count is preserved"
+assert_contains "${stats_sections_out}" "Deterministic node estimated savings: ~2K tokens" "Token savings estimate is preserved"
+assert_contains "${stats_sections_out}" "Conversations with the most questions Top 3:" "Problem sessions section is preserved"
+assert_contains "${stats_sections_out}" "session-b: 2 issues / 2 triggers" "Problem sessions are ranked"
 
-header "Legacy wrapper reads beyond observe default limit"
+header "Stats wrapper reads beyond observe default limit"
 mkdir -p "${TMP_DIR}/large-log"
 python3 - "${TMP_DIR}/large-log/events.jsonl" <<'PY'
 import json
@@ -443,7 +443,7 @@ PY
 
 prom_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/prom-log" VIBEGUARD_RUNTIME="${RUNTIME}" bash "${EXPORTER}" --since all 2>&1)"
 assert_contains "${prom_out}" "vibeguard_event_total" "Prometheus event counter is emitted"
-assert_contains "${prom_out}" 'vibeguard_tool_total{tool="Edit"} 1' "Legacy tool counter is preserved"
+assert_contains "${prom_out}" 'vibeguard_tool_total{tool="Edit"} 1' "Tool counter is preserved"
 assert_contains "${prom_out}" 'rule_id="U-16"' "Rule id is derived safely"
 assert_contains "${prom_out}" 'reason_code="rule_violation"' "Reason code is derived safely"
 assert_contains "${prom_out}" 'file_ext="rs"' "File extension is derived safely"

--- a/vibeguard-runtime/src/observe/mod.rs
+++ b/vibeguard-runtime/src/observe/mod.rs
@@ -1,11 +1,11 @@
 //! Canonical observability queries over VibeGuard JSONL event logs.
 
 mod aggregate;
-mod legacy_stats;
 mod model;
 mod prometheus;
 mod read;
 mod render;
+mod stats_summary;
 
 use crate::event_schema::field;
 use crate::time_utils::now_unix_secs;

--- a/vibeguard-runtime/src/observe/model.rs
+++ b/vibeguard-runtime/src/observe/model.rs
@@ -40,7 +40,6 @@ impl TimeWindow {
 pub(super) struct ObserveOptions {
     pub(super) command: ObserveCommand,
     pub(super) json: bool,
-    pub(super) legacy: bool,
     pub(super) log_file: Option<PathBuf>,
     pub(super) scope: LogScope,
     pub(super) scope_explicit: bool,
@@ -62,7 +61,6 @@ impl ObserveOptions {
         Self {
             command,
             json: false,
-            legacy: false,
             log_file: None,
             scope: LogScope::Project,
             scope_explicit: false,
@@ -115,7 +113,6 @@ fn parse_common_args(args: &[String], options: &mut ObserveOptions) -> Result {
     while index < args.len() {
         match args[index].as_str() {
             "--json" => options.json = true,
-            "--legacy" => options.legacy = true,
             "--log-file" => {
                 index += 1;
                 options.log_file = Some(PathBuf::from(value_arg(args, index, "--log-file")?));
@@ -203,7 +200,7 @@ fn parse_hours_window(value: &str) -> Result<TimeWindow> {
 }
 
 fn usage() -> &'static str {
-    "Usage: vibeguard-runtime observe <summary|health|session|export prometheus> [--json] [--legacy] [--scope project|global] [--project PATH_OR_HASH] [--log-file PATH] [--days N|all] [--hours N|all] [--limit N|all] [--slow-ms MS] [--top N]"
+    "Usage: vibeguard-runtime observe <summary|health|session|export prometheus> [--json] [--scope project|global] [--project PATH_OR_HASH] [--log-file PATH] [--days N|all] [--hours N|all] [--limit N|all] [--slow-ms MS] [--top N]"
 }
 
 #[cfg(test)]
@@ -261,5 +258,19 @@ mod tests {
         };
 
         assert_eq!(options.limit, usize::MAX);
+    }
+
+    #[test]
+    fn legacy_argument_is_rejected() {
+        let error = match parse_observe_args(&args(&["summary", "--legacy"])) {
+            Ok(_) => panic!("legacy flag should fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("unknown observe argument: --legacy")
+        );
     }
 }

--- a/vibeguard-runtime/src/observe/read.rs
+++ b/vibeguard-runtime/src/observe/read.rs
@@ -32,7 +32,7 @@ pub(super) fn read_log_events(options: &ObserveOptions) -> Result<LogEvents> {
     };
     let log_path = observe_display_path(&resolved);
     if !resolved.exists() {
-        if options.log_file.is_some() && !options.legacy {
+        if options.log_file.is_some() {
             return Err(format!("Log file does not exist: {}", resolved.display()).into());
         }
         return Ok(LogEvents {

--- a/vibeguard-runtime/src/observe/render.rs
+++ b/vibeguard-runtime/src/observe/render.rs
@@ -12,9 +12,9 @@ use super::aggregate::{
     observe_is_diagnostic_event, observe_non_empty_or, observe_normalized_decision,
     observe_string_field,
 };
-use super::legacy_stats;
 use super::model::{ObserveCommand, ObserveOptions, TimeWindow};
 use super::read::LogEvents;
+use super::stats_summary;
 
 pub(super) fn render_summary(
     options: &ObserveOptions,
@@ -27,27 +27,7 @@ pub(super) fn render_summary(
             serde_json::to_string_pretty(&observe_summary_json(options, log_events, aggregate))?
         ));
     }
-    if options.legacy {
-        return legacy_stats::render_legacy_summary(options, log_events, aggregate);
-    }
-    if aggregate.event_count == 0 {
-        return Ok(format!(
-            "No observe events found in {} for {}.\n",
-            log_events.log_path,
-            options.window.label()
-        ));
-    }
-    Ok(format!(
-        "VibeGuard observe summary ({})\nTime range: {} ~ {}\nEvents: {} | Attention: {} ({:.1}%)\nTop hooks: {}\nTop reasons: {}\n",
-        options.window.label(),
-        observe_blank_as_unknown(&aggregate.first_ts),
-        observe_blank_as_unknown(&aggregate.last_ts),
-        aggregate.event_count,
-        aggregate.attention_count,
-        observe_percentage(aggregate.attention_count, aggregate.event_count),
-        observe_top_human(&aggregate.hook_counts, 5),
-        observe_top_human(&aggregate.reason_codes, 5)
-    ))
+    stats_summary::render_stats_summary(options, log_events, aggregate)
 }
 
 pub(super) fn render_health(
@@ -74,28 +54,10 @@ pub(super) fn render_health(
         output["diagnostics"] = Value::Array(diagnostics);
         return Ok(format!("{}\n", serde_json::to_string_pretty(&output)?));
     }
-    if options.legacy {
-        return render_legacy_health(options, log_events, aggregate);
-    }
-    if aggregate.event_count == 0 {
-        return Ok(format!(
-            "No observe health events found in {} for {}.\n",
-            log_events.log_path,
-            options.window.label()
-        ));
-    }
-    Ok(format!(
-        "VibeGuard observe health ({})\nEvents: {} | Attention: {} ({:.1}%)\nAttention states: {}\nDiagnostics: {}\n",
-        options.window.label(),
-        aggregate.event_count,
-        aggregate.attention_count,
-        observe_percentage(aggregate.attention_count, aggregate.event_count),
-        attention_states.len(),
-        diagnostics.len()
-    ))
+    render_health_human(options, log_events, aggregate)
 }
 
-fn render_legacy_health(
+fn render_health_human(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
@@ -114,15 +76,15 @@ fn render_legacy_health(
         });
     }
 
-    let pass_count = legacy_decision_count(aggregate, decision::PASS);
+    let pass_count = observe_decision_count(aggregate, decision::PASS);
     let risk_count = aggregate.event_count as u64 - pass_count;
-    let by_cli = legacy_count_by(&log_events.events, |event| {
+    let by_cli = observe_count_by(&log_events.events, |event| {
         observe_non_empty_or(observe_string_field(event, field::CLI), UNKNOWN)
     });
-    let by_client = legacy_count_by(&log_events.events, |event| {
+    let by_client = observe_count_by(&log_events.events, |event| {
         observe_non_empty_or(observe_client_name(event), UNKNOWN)
     });
-    let (first_ts, last_ts) = legacy_parsed_time_range(&log_events.events)
+    let (first_ts, last_ts) = observe_parsed_time_range(&log_events.events)
         .unwrap_or_else(|| (aggregate.first_ts.clone(), aggregate.last_ts.clone()));
     let mut non_pass_events = log_events
         .events
@@ -131,7 +93,7 @@ fn render_legacy_health(
         .collect::<Vec<_>>();
     non_pass_events
         .sort_by_key(|event| parse_iso_ts(&observe_string_field(event, field::TS)).unwrap_or(0));
-    let risk_hook_counts = legacy_count_by_refs(&non_pass_events, |event| {
+    let risk_hook_counts = observe_count_by_refs(&non_pass_events, |event| {
         observe_non_empty_or(observe_string_field(event, field::HOOK), UNKNOWN)
     });
 
@@ -160,7 +122,7 @@ fn render_legacy_health(
     ] {
         output.push_str(&format!(
             "  {status}: {}\n",
-            legacy_decision_count(aggregate, status)
+            observe_decision_count(aggregate, status)
         ));
     }
 
@@ -193,13 +155,19 @@ fn render_legacy_health(
                 client,
                 observe_non_empty_or(observe_string_field(event, field::SESSION), "?")
             ));
-            let reason = legacy_clean_detail(&observe_string_field(event, field::REASON));
-            let detail = legacy_clean_detail(&observe_string_field(event, field::DETAIL));
+            let reason = observe_clean_detail(&observe_string_field(event, field::REASON));
+            let detail = observe_clean_detail(&observe_string_field(event, field::DETAIL));
             if !reason.is_empty() {
-                output.push_str(&format!("     reason: {}\n", legacy_truncate(&reason, 100)));
+                output.push_str(&format!(
+                    "     reason: {}\n",
+                    observe_truncate(&reason, 100)
+                ));
             }
             if !detail.is_empty() {
-                output.push_str(&format!("     detail: {}\n", legacy_truncate(&detail, 100)));
+                output.push_str(&format!(
+                    "     detail: {}\n",
+                    observe_truncate(&detail, 100)
+                ));
             }
         }
     }
@@ -208,11 +176,11 @@ fn render_legacy_health(
     Ok(output)
 }
 
-pub(super) fn legacy_decision_count(aggregate: &ObserveAggregate, status: &str) -> u64 {
+pub(super) fn observe_decision_count(aggregate: &ObserveAggregate, status: &str) -> u64 {
     aggregate.decision_counts.get(status).copied().unwrap_or(0)
 }
 
-pub(super) fn legacy_count_by<F>(events: &[Value], mut mapper: F) -> BTreeMap<String, u64>
+pub(super) fn observe_count_by<F>(events: &[Value], mut mapper: F) -> BTreeMap<String, u64>
 where
     F: FnMut(&Value) -> String,
 {
@@ -223,7 +191,7 @@ where
     counts
 }
 
-fn legacy_count_by_refs<F>(events: &[&Value], mut mapper: F) -> BTreeMap<String, u64>
+fn observe_count_by_refs<F>(events: &[&Value], mut mapper: F) -> BTreeMap<String, u64>
 where
     F: FnMut(&Value) -> String,
 {
@@ -234,7 +202,7 @@ where
     counts
 }
 
-fn legacy_parsed_time_range(events: &[Value]) -> Option<(String, String)> {
+fn observe_parsed_time_range(events: &[Value]) -> Option<(String, String)> {
     let mut timestamps = events
         .iter()
         .filter_map(|event| {
@@ -252,11 +220,11 @@ pub(super) fn observe_increment(map: &mut BTreeMap<String, u64>, key: String) {
     *map.entry(key).or_default() += 1;
 }
 
-fn legacy_clean_detail(value: &str) -> String {
+fn observe_clean_detail(value: &str) -> String {
     value.replace('\n', " ").trim().to_string()
 }
 
-pub(super) fn legacy_truncate(value: &str, max_chars: usize) -> String {
+pub(super) fn observe_truncate(value: &str, max_chars: usize) -> String {
     let mut chars = value.chars();
     let prefix = chars.by_ref().take(max_chars).collect::<String>();
     if chars.next().is_some() && max_chars >= 3 {

--- a/vibeguard-runtime/src/observe/stats_summary.rs
+++ b/vibeguard-runtime/src/observe/stats_summary.rs
@@ -10,11 +10,11 @@ use super::aggregate::{
 use super::model::{ObserveOptions, TimeWindow};
 use super::read::LogEvents;
 use super::render::{
-    legacy_count_by, legacy_decision_count, legacy_truncate, observe_blank_as_unknown,
-    observe_increment, observe_sorted_counts,
+    observe_blank_as_unknown, observe_count_by, observe_decision_count, observe_increment,
+    observe_sorted_counts, observe_truncate,
 };
 
-pub(super) fn render_legacy_summary(
+pub(super) fn render_stats_summary(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
@@ -33,16 +33,16 @@ pub(super) fn render_legacy_summary(
         });
     }
 
-    let hook_counts = legacy_count_by(&log_events.events, |event| {
+    let hook_counts = observe_count_by(&log_events.events, |event| {
         observe_non_empty_or(observe_string_field(event, field::HOOK), UNKNOWN)
     });
-    let cli_counts = legacy_count_by(&log_events.events, |event| {
+    let cli_counts = observe_count_by(&log_events.events, |event| {
         observe_non_empty_or(observe_string_field(event, field::CLI), UNKNOWN)
     });
-    let block_reasons = legacy_count_by_matching(&log_events.events, decision::BLOCK, |event| {
+    let block_reasons = stats_count_by_matching(&log_events.events, decision::BLOCK, |event| {
         observe_non_empty_or(observe_string_field(event, field::REASON), "Unknown")
     });
-    let warn_reasons = legacy_count_by_matching(&log_events.events, decision::WARN, |event| {
+    let warn_reasons = stats_count_by_matching(&log_events.events, decision::WARN, |event| {
         observe_non_empty_or(observe_string_field(event, field::REASON), "Unknown")
     });
 
@@ -63,15 +63,15 @@ pub(super) fn render_legacy_summary(
     ));
     output.push_str(&format!(
         "  Interception (block): {} times\n",
-        legacy_decision_count(aggregate, decision::BLOCK)
+        observe_decision_count(aggregate, decision::BLOCK)
     ));
     output.push_str(&format!(
         "  Warning: {} times\n",
-        legacy_decision_count(aggregate, decision::WARN)
+        observe_decision_count(aggregate, decision::WARN)
     ));
     output.push_str(&format!(
         "  Pass (pass): {} times\n\n",
-        legacy_decision_count(aggregate, decision::PASS)
+        observe_decision_count(aggregate, decision::PASS)
     ));
 
     output.push_str("Distributed by Hook:\n");
@@ -87,14 +87,14 @@ pub(super) fn render_legacy_summary(
     if !block_reasons.is_empty() {
         output.push_str("\nInterception reasons Top 5:\n");
         for (reason, count) in observe_sorted_counts(&block_reasons).into_iter().take(5) {
-            output.push_str(&format!("  {count}x  {}\n", legacy_truncate(&reason, 60)));
+            output.push_str(&format!("  {count}x  {}\n", observe_truncate(&reason, 60)));
         }
     }
 
     if !warn_reasons.is_empty() {
         output.push_str("\nWarning reasons Top 5:\n");
         for (reason, count) in observe_sorted_counts(&warn_reasons).into_iter().take(5) {
-            output.push_str(&format!("  {count}x  {}\n", legacy_truncate(&reason, 60)));
+            output.push_str(&format!("  {count}x  {}\n", observe_truncate(&reason, 60)));
         }
     }
 
@@ -109,7 +109,7 @@ pub(super) fn render_legacy_summary(
 }
 
 fn append_daily_counts(output: &mut String, events: &[Value]) {
-    let day_counts = legacy_count_by_day(events);
+    let day_counts = stats_count_by_day(events);
     if day_counts.len() <= 1 {
         return;
     }
@@ -182,7 +182,7 @@ fn append_warn_compliance(output: &mut String, events: &[Value]) {
 fn append_file_type_distribution(output: &mut String, events: &[Value]) {
     let mut ext_counts = BTreeMap::new();
     for event in events {
-        if let Some(ext) = legacy_file_extension(&observe_string_field(event, field::DETAIL)) {
+        if let Some(ext) = stats_file_extension(&observe_string_field(event, field::DETAIL)) {
             observe_increment(&mut ext_counts, ext);
         }
     }
@@ -250,8 +250,8 @@ fn append_performance_analysis(output: &mut String, events: &[Value]) {
     let mut warn_rate_sum = 0.0_f64;
     for events in sessions.values() {
         let total = events.len() as f64;
-        block_rate_sum += legacy_decision_ref_count(events, decision::BLOCK) as f64 / total * 100.0;
-        warn_rate_sum += legacy_decision_ref_count(events, decision::WARN) as f64 / total * 100.0;
+        block_rate_sum += stats_decision_ref_count(events, decision::BLOCK) as f64 / total * 100.0;
+        warn_rate_sum += stats_decision_ref_count(events, decision::WARN) as f64 / total * 100.0;
     }
     output.push_str(&format!(
         "Average block rate per session: {:.1}%\n",
@@ -273,7 +273,7 @@ fn append_performance_analysis(output: &mut String, events: &[Value]) {
         .count() as u64;
     output.push_str(&format!(
         "Deterministic node estimated savings: ~{} tokens\n",
-        legacy_token_savings_label(deterministic_checks * 500)
+        stats_token_savings_label(deterministic_checks * 500)
     ));
 
     append_problem_sessions(output, &sessions);
@@ -286,8 +286,8 @@ fn append_problem_sessions(output: &mut String, sessions: &BTreeMap<String, Vec<
             (
                 session,
                 events,
-                legacy_decision_ref_count(events, decision::BLOCK)
-                    + legacy_decision_ref_count(events, decision::WARN),
+                stats_decision_ref_count(events, decision::BLOCK)
+                    + stats_decision_ref_count(events, decision::WARN),
             )
         })
         .collect::<Vec<_>>();
@@ -307,11 +307,11 @@ fn append_problem_sessions(output: &mut String, sessions: &BTreeMap<String, Vec<
         }
         let ts_start = events
             .first()
-            .map(|event| legacy_ts_prefix(event))
+            .map(|event| stats_ts_prefix(event))
             .unwrap_or_else(|| "?".to_string());
         let ts_end = events
             .last()
-            .map(|event| legacy_ts_prefix(event))
+            .map(|event| stats_ts_prefix(event))
             .unwrap_or_else(|| "?".to_string());
         output.push_str(&format!(
             " {session}: {issues} issues / {} triggers ({ts_start} ~ {ts_end})\n",
@@ -320,7 +320,7 @@ fn append_problem_sessions(output: &mut String, sessions: &BTreeMap<String, Vec<
     }
 }
 
-fn legacy_count_by_matching<F>(
+fn stats_count_by_matching<F>(
     events: &[Value],
     decision_value: &str,
     mut mapper: F,
@@ -337,7 +337,7 @@ where
     counts
 }
 
-fn legacy_count_by_day(events: &[Value]) -> BTreeMap<String, u64> {
+fn stats_count_by_day(events: &[Value]) -> BTreeMap<String, u64> {
     let mut counts = BTreeMap::new();
     for event in events {
         let ts = observe_string_field(event, field::TS);
@@ -348,14 +348,14 @@ fn legacy_count_by_day(events: &[Value]) -> BTreeMap<String, u64> {
     counts
 }
 
-fn legacy_decision_ref_count(events: &[&Value], decision_value: &str) -> u64 {
+fn stats_decision_ref_count(events: &[&Value], decision_value: &str) -> u64 {
     events
         .iter()
         .filter(|event| observe_normalized_decision(event) == decision_value)
         .count() as u64
 }
 
-fn legacy_file_extension(detail: &str) -> Option<String> {
+fn stats_file_extension(detail: &str) -> Option<String> {
     for part in detail.split_whitespace() {
         let Some((_, ext)) = part.rsplit_once('.') else {
             continue;
@@ -368,7 +368,7 @@ fn legacy_file_extension(detail: &str) -> Option<String> {
     None
 }
 
-fn legacy_token_savings_label(tokens: u64) -> String {
+fn stats_token_savings_label(tokens: u64) -> String {
     if tokens >= 1_000_000 {
         format!("{:.1}M", tokens as f64 / 1_000_000.0)
     } else if tokens >= 1_000 {
@@ -378,7 +378,7 @@ fn legacy_token_savings_label(tokens: u64) -> String {
     }
 }
 
-fn legacy_ts_prefix(event: &Value) -> String {
+fn stats_ts_prefix(event: &Value) -> String {
     let ts = observe_string_field(event, field::TS);
     if ts.is_empty() {
         "?".to_string()
@@ -400,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_summary_includes_restored_analysis_sections() {
+    fn stats_summary_includes_analysis_sections() {
         let events = vec![
             json!({
                 "ts": "2026-06-05T10:00:00Z",
@@ -443,9 +443,9 @@ mod tests {
                 "cli": "claude"
             }),
         ];
-        let options = match parse_observe_args(&args(&["summary", "--legacy", "--days", "all"])) {
+        let options = match parse_observe_args(&args(&["summary", "--days", "all"])) {
             Ok(options) => options,
-            Err(error) => panic!("legacy summary options should parse: {error}"),
+            Err(error) => panic!("stats summary options should parse: {error}"),
         };
         let log_events = LogEvents {
             events,
@@ -454,9 +454,9 @@ mod tests {
         };
         let aggregate = aggregate_events(&log_events.events, 2_000);
 
-        let output = match render_legacy_summary(&options, &log_events, &aggregate) {
+        let output = match render_stats_summary(&options, &log_events, &aggregate) {
             Ok(output) => output,
-            Err(error) => panic!("legacy summary should render: {error}"),
+            Err(error) => panic!("stats summary should render: {error}"),
         };
 
         assert!(output.contains("== Warn compliance rate analysis =="));


### PR DESCRIPTION
## Summary

- remove the `observe --legacy` flag and the legacy observe capability names
- promote the detailed stats and hook-health human renderers to the current default non-JSON output
- rename `legacy_stats` to `stats_summary` and update wrapper/runtime support probes
- keep a negative parser test so the removed `--legacy` flag stays rejected

Closes #478.

## Validation

- `bash -n scripts/lib/runtime.sh scripts/stats.sh scripts/hook-health.sh tests/test_stats.sh tests/test_hook_health.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml observe -- --nocapture`
- `bash tests/test_stats.sh`
- `bash tests/test_hook_health.sh`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `git diff --check`
