### PR TITLE
[codex] Remove legacy install and config migrations

### DIFF
--- a/scripts/lib/claude_md.py
+++ b/scripts/lib/claude_md.py
@@ -58,10 +58,6 @@ def render_injected(
             content += "\n" + after
         action = "UPDATED"
     else:
-        legacy_marker = "\n# VibeGuard"
-        legacy_idx = content.find(legacy_marker)
-        if legacy_idx >= 0:
-            content = content[:legacy_idx].rstrip()
         content = content.rstrip() + "\n\n" + rules.strip() + "\n"
         action = "APPENDED"
 
@@ -108,13 +104,6 @@ def remove(claude_md_path: str) -> str:
         content = content.rstrip() + "\n"
         claude_md.write_text(content)
         return "REMOVED"
-
-    legacy_marker = "\n# VibeGuard"
-    idx = content.find(legacy_marker)
-    if idx >= 0:
-        content = content[:idx].rstrip() + "\n"
-        claude_md.write_text(content)
-        return "REMOVED_LEGACY"
 
     return "NOT_FOUND"
 

--- a/scripts/lib/codex_config_toml.py
+++ b/scripts/lib/codex_config_toml.py
@@ -24,7 +24,6 @@ def _table_name(line: str) -> str | None:
 
 
 CODEX_HOOKS_FEATURE = "hooks"
-LEGACY_CODEX_HOOKS_FEATURE = "codex_hooks"
 
 
 def _ensure_hooks_enabled(text: str) -> tuple[str, bool]:
@@ -37,7 +36,6 @@ def _ensure_hooks_enabled(text: str) -> tuple[str, bool]:
     insert_idx: int | None = None
     in_features = False
     hooks_idx: int | None = None
-    legacy_indices: list[int] = []
 
     for idx, line in enumerate(lines):
         stripped = line.strip()
@@ -58,52 +56,17 @@ def _ensure_hooks_enabled(text: str) -> tuple[str, bool]:
                 if stripped != f"{CODEX_HOOKS_FEATURE} = true":
                     lines[idx] = f"{CODEX_HOOKS_FEATURE} = true"
                     changed = True
-            elif key == LEGACY_CODEX_HOOKS_FEATURE:
-                legacy_indices.append(idx)
 
     if features_idx is not None:
         assert insert_idx is not None
         if hooks_idx is None:
-            if legacy_indices:
-                hooks_idx = legacy_indices.pop(0)
-                lines[hooks_idx] = "hooks = true"
-                changed = True
-            else:
-                lines.insert(insert_idx, "hooks = true")
-                changed = True
-        for idx in reversed(legacy_indices):
-            del lines[idx]
+            lines.insert(insert_idx, "hooks = true")
             changed = True
         return "\n".join(lines).rstrip() + "\n", changed
 
     content = "\n".join(lines).rstrip()
     suffix = "\n\n" if content else ""
     return content + suffix + f"[features]\n{CODEX_HOOKS_FEATURE} = true\n", True
-
-
-def _remove_legacy_vibeguard_mcp(text: str) -> tuple[str, bool]:
-    lines = text.splitlines()
-    if not lines:
-        return "", False
-
-    kept: list[str] = []
-    in_legacy = False
-    changed = False
-    legacy_table = "mcp_servers.vibeguard"
-    for line in lines:
-        table_name = _table_name(line)
-        if table_name is not None:
-            if table_name == legacy_table or table_name.startswith(f"{legacy_table}."):
-                in_legacy = True
-                changed = True
-                continue
-            in_legacy = False
-        if in_legacy:
-            changed = True
-            continue
-        kept.append(line)
-    new_text = "\n".join(kept).strip()
-    return ((new_text + "\n") if new_text else ""), changed
 
 
 def _check_hooks_enabled(text: str) -> tuple[str, int]:
@@ -113,8 +76,6 @@ def _check_hooks_enabled(text: str) -> tuple[str, int]:
         return "INVALID", 1
 
     features = data.get("features")
-    if isinstance(features, dict) and LEGACY_CODEX_HOOKS_FEATURE in features:
-        return "LEGACY", 1
     if isinstance(features, dict) and features.get(CODEX_HOOKS_FEATURE) is True:
         return "OK", 0
     return "MISSING", 1
@@ -129,24 +90,6 @@ def cmd_enable_hooks(args: argparse.Namespace) -> int:
         print("CHANGED")
     else:
         print("SKIP")
-    return 0
-
-
-def cmd_remove_legacy_vibeguard_mcp(args: argparse.Namespace) -> int:
-    path = Path(args.config_file)
-    if not path.exists():
-        print("SKIP")
-        return 0
-    old = path.read_text(encoding="utf-8")
-    new, changed = _remove_legacy_vibeguard_mcp(old)
-    if not changed:
-        print("SKIP")
-        return 0
-    if new:
-        write_text_atomic(path, new)
-    else:
-        path.unlink(missing_ok=True)
-    print("CHANGED")
     return 0
 
 
@@ -177,26 +120,16 @@ def build_parser() -> argparse.ArgumentParser:
     check = sub.add_parser("check-hooks", help="Validate [features].hooks = true")
     check.add_argument("--config-file", required=True)
 
-    legacy_enable = sub.add_parser("enable-codex-hooks", help=argparse.SUPPRESS)
-    legacy_enable.add_argument("--config-file", required=True)
-
-    legacy_check = sub.add_parser("check-codex-hooks", help=argparse.SUPPRESS)
-    legacy_check.add_argument("--config-file", required=True)
-
-    remove = sub.add_parser("remove-legacy-vibeguard-mcp", help="Remove [mcp_servers.vibeguard] block")
-    remove.add_argument("--config-file", required=True)
     return parser
 
 
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    if args.command in {"enable-hooks", "enable-codex-hooks"}:
+    if args.command == "enable-hooks":
         return cmd_enable_hooks(args)
-    if args.command in {"check-hooks", "check-codex-hooks"}:
+    if args.command == "check-hooks":
         return cmd_check_hooks(args)
-    if args.command == "remove-legacy-vibeguard-mcp":
-        return cmd_remove_legacy_vibeguard_mcp(args)
     parser.error("unknown command")
     return 2
 

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from file_ops import write_json_atomic
 from hook_config_model import hook_command_identity
-from hooks_manifest import all_managed_script_names, codex_specs, load_manifest
+from hooks_manifest import codex_specs, load_manifest
 
 
 class HookSpec(dict):
@@ -21,26 +21,11 @@ class HookSpec(dict):
 MANIFEST = load_manifest()
 MANAGED_SPECS: list[HookSpec] = [HookSpec(spec) for spec in codex_specs(MANIFEST)]
 
-LEGACY_MARKERS = {
-    "pre-bash-guard.sh",
-    "post-build-check.sh",
-    "stop-guard.sh",
-    "learn-evaluator.sh",
-    "post-guard-check.sh",
-    "session-tagger.sh",
-    "cognitive-reminder.sh",
-}
-
-MANAGED_MARKERS = LEGACY_MARKERS | all_managed_script_names(MANIFEST)
-
 # Namespaced vibeguard-* script names from MANAGED_SPECS.  These are
 # unambiguous enough to identify VibeGuard entries without inspecting the
 # wrapper path, so removal works even when a non-standard wrapper is used.
 _MANAGED_SCRIPT_NAMES: frozenset[str] = frozenset(spec["script"] for spec in MANAGED_SPECS)
 _WRAPPER_NAMES: frozenset[str] = frozenset({"run-hook-codex.sh"})
-_STANDALONE_LEGACY_SCRIPTS: frozenset[str] = frozenset(
-    {"session-tagger.sh", "cognitive-reminder.sh", "post-guard-check.sh"}
-)
 
 
 def _display_path(path: Path, home: Path) -> str:
@@ -119,9 +104,7 @@ def _identity_for_hook(event: str, matcher: str | None, hook: dict[str, Any]) ->
         command=command,
         timeout=timeout,
         managed_scripts=_MANAGED_SCRIPT_NAMES,
-        legacy_scripts=MANAGED_MARKERS,
         wrapper_names=_WRAPPER_NAMES,
-        standalone_legacy_scripts=_STANDALONE_LEGACY_SCRIPTS,
     )
 
 

--- a/scripts/lib/hook_config_model.py
+++ b/scripts/lib/hook_config_model.py
@@ -114,15 +114,10 @@ def hook_command_identity(
     command: str,
     timeout: int | None,
     managed_scripts: Iterable[str],
-    legacy_scripts: Iterable[str] = (),
     wrapper_names: Iterable[str] = (),
-    standalone_legacy_scripts: Iterable[str] = (),
 ) -> HookIdentity:
     managed_set = frozenset(managed_scripts)
-    legacy_set = frozenset(legacy_scripts)
-    all_known_scripts = managed_set | legacy_set
     wrapper_set = frozenset(wrapper_names)
-    standalone_legacy_set = frozenset(standalone_legacy_scripts)
 
     script: str | None = None
     wrapper: str | None = None
@@ -141,7 +136,7 @@ def hook_command_identity(
         if index + 1 >= len(parts):
             continue
         next_script = _basename(parts[index + 1])
-        if next_script in all_known_scripts:
+        if next_script in managed_set:
             script = next_script
             break
 
@@ -153,11 +148,8 @@ def hook_command_identity(
             ):
                 script = token_base
                 break
-            if token_base in standalone_legacy_set and _looks_like_direct_script(parts, index):
-                script = token_base
-                break
 
-    managed_id = _script_id(script) if script in all_known_scripts else None
+    managed_id = _script_id(script) if script in managed_set else None
     return HookIdentity(
         platform=platform,
         event=event,
@@ -176,9 +168,7 @@ def normalize_hook_entry(
     event: str,
     entry: Any,
     managed_scripts: Iterable[str],
-    legacy_scripts: Iterable[str] = (),
     wrapper_names: Iterable[str] = (),
-    standalone_legacy_scripts: Iterable[str] = (),
 ) -> list[HookIdentity]:
     if not isinstance(entry, dict):
         return []
@@ -205,9 +195,7 @@ def normalize_hook_entry(
                 command=command,
                 timeout=timeout,
                 managed_scripts=managed_scripts,
-                legacy_scripts=legacy_scripts,
                 wrapper_names=wrapper_names,
-                standalone_legacy_scripts=standalone_legacy_scripts,
             )
         )
     return identities

--- a/scripts/lib/settings_json.py
+++ b/scripts/lib/settings_json.py
@@ -19,9 +19,6 @@ from hooks_manifest import all_managed_script_names, claude_specs, load_manifest
 MANIFEST = load_manifest()
 MANAGED_SCRIPT_NAMES = all_managed_script_names(MANIFEST)
 CLAUDE_PROFILE_SCRIPT_NAMES = frozenset(spec["script"] for spec in claude_specs(MANIFEST, None))
-LEGACY_SCRIPT_NAMES: frozenset[str] = frozenset(
-    {"post-guard-check.sh", "session-tagger.sh", "cognitive-reminder.sh"}
-)
 WRAPPER_NAMES: frozenset[str] = frozenset({"run-hook.sh"})
 
 
@@ -60,9 +57,7 @@ def _entry_identities(event: str, entry: Any) -> list[Any]:
         event=event,
         entry=entry,
         managed_scripts=MANAGED_SCRIPT_NAMES,
-        legacy_scripts=LEGACY_SCRIPT_NAMES,
         wrapper_names=WRAPPER_NAMES,
-        standalone_legacy_scripts=LEGACY_SCRIPT_NAMES,
     )
 
 
@@ -79,9 +74,7 @@ def _hook_identity(event: str, matcher: str | None, hook: dict[str, Any]) -> Any
         command=command,
         timeout=timeout,
         managed_scripts=MANAGED_SCRIPT_NAMES,
-        legacy_scripts=LEGACY_SCRIPT_NAMES,
         wrapper_names=WRAPPER_NAMES,
-        standalone_legacy_scripts=LEGACY_SCRIPT_NAMES,
     )
 
 
@@ -325,15 +318,7 @@ def _is_canonical_hook_command(command: str, script_name: str) -> bool:
             and parts[1].endswith("/.vibeguard/run-hook.sh")
             and parts[2] == script_name
         )
-    if len(parts) <= 3 or parts[0] != "bash" or parts[-1] != script_name:
-        return False
-    wrapper_parts = parts[1:-1]
-    path_prefixes = ("/", "~/", "$HOME/", "${HOME}/")
-    return (
-        wrapper_parts[0].startswith(path_prefixes)
-        and not any(part.startswith(("-", *path_prefixes)) for part in wrapper_parts[1:])
-        and " ".join(wrapper_parts).endswith("/.vibeguard/run-hook.sh")
-    )
+    return False
 
 
 def _record_customized_command(state: dict[str, Any], script_name: str, command: str) -> None:
@@ -345,47 +330,6 @@ def _record_customized_command(state: dict[str, Any], script_name: str, command:
         "use --force-overwrite to replace it",
         file=sys.stderr,
     )
-
-
-def _remove_legacy_mcp_server(data: dict[str, Any]) -> bool:
-    mcp_servers = data.get("mcpServers")
-    if not isinstance(mcp_servers, dict) or "vibeguard" not in mcp_servers:
-        return False
-
-    del mcp_servers["vibeguard"]
-    if not mcp_servers:
-        data.pop("mcpServers", None)
-    return True
-
-
-def _remove_legacy_hook_entries(data: dict[str, Any]) -> bool:
-    hooks = data.get("hooks")
-    if not isinstance(hooks, dict):
-        return False
-
-    changed = False
-    for event in ("PreToolUse", "PostToolUse", "Stop", "SessionStart"):
-        entries = hooks.get(event)
-        if not isinstance(entries, list):
-            continue
-
-        filtered = [
-            entry for entry in entries
-            if not _entry_has_script(str(event), entry, LEGACY_SCRIPT_NAMES)
-        ]
-        if len(filtered) == len(entries):
-            continue
-
-        changed = True
-        if filtered:
-            hooks[event] = filtered
-        else:
-            hooks.pop(event, None)
-
-    if not hooks:
-        data.pop("hooks", None)
-
-    return changed
 
 
 def remove_hook(hooks: dict[str, Any], event: str, script_name: str, state: dict[str, bool]) -> None:
@@ -562,10 +506,6 @@ def cmd_upsert_vibeguard(args: argparse.Namespace) -> int:
     data = load_settings(settings_path)
     state: dict[str, Any] = {"changed": False}
 
-    if _remove_legacy_mcp_server(data):
-        state["changed"] = True
-    if _remove_legacy_hook_entries(data):
-        state["changed"] = True
     if _remove_stale_installed_hook_entries(data, Path.home()):
         state["changed"] = True
 
@@ -616,16 +556,11 @@ def cmd_remove_vibeguard(args: argparse.Namespace) -> int:
     data = load_settings(settings_path)
     changed = False
 
-    if _remove_legacy_mcp_server(data):
-        changed = True
-    if _remove_legacy_hook_entries(data):
-        changed = True
-
     hooks = data.get("hooks")
     if isinstance(hooks, dict):
         event_scripts: dict[str, frozenset[str]] = {
             "PreToolUse": frozenset(MANAGED_SCRIPT_NAMES),
-            "PostToolUse": frozenset(MANAGED_SCRIPT_NAMES | {"post-guard-check.sh"}),
+            "PostToolUse": frozenset(MANAGED_SCRIPT_NAMES),
             "Stop": frozenset(MANAGED_SCRIPT_NAMES),
             "SessionStart": frozenset(MANAGED_SCRIPT_NAMES),
             "PreCompact": frozenset(MANAGED_SCRIPT_NAMES),
@@ -683,7 +618,7 @@ def build_parser() -> argparse.ArgumentParser:
     upsert.add_argument("--force-overwrite", action="store_true", help="Replace customized managed hook commands")
     upsert.set_defaults(func=cmd_upsert_vibeguard)
 
-    remove = sub.add_parser("remove-vibeguard", help="Remove VibeGuard hooks config and legacy MCP entries")
+    remove = sub.add_parser("remove-vibeguard", help="Remove VibeGuard hooks config")
     remove.add_argument("--settings-file", required=True)
     remove.set_defaults(func=cmd_remove_vibeguard)
 

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -632,9 +632,6 @@ echo
 
 configure_claude_home_runtime
 
-# 9.2. Remove legacy Codex MCP config from previous installs
-configure_codex_home_runtime
-
 # 9.5. Scheduled GC is opt-in. Default setup must not create launchd/systemd jobs.
 echo "Step 9.5: Scheduled GC"
 if [[ "${WITH_SCHEDULER}" != "1" ]]; then

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -546,7 +546,7 @@ clean_claude_home_installation() {
     local result
     result=$(setup_runtime setup-md-remove "${CLAUDE_DIR}/CLAUDE.md" 2>/dev/null || echo "ERROR")
     case "${result}" in
-      REMOVED|REMOVED_LEGACY) yellow "Removed VibeGuard rules from ~/.claude/CLAUDE.md" ;;
+      REMOVED) yellow "Removed VibeGuard rules from ~/.claude/CLAUDE.md" ;;
       NOT_FOUND) yellow "No VibeGuard rules found in ~/.claude/CLAUDE.md" ;;
       *) red "Failed to clean CLAUDE.md" ;;
     esac
@@ -595,7 +595,7 @@ clean_claude_home_installation() {
     local clean_result
     if clean_result=$(settings_remove "${SETTINGS_FILE}" 2>/dev/null); then
       if [[ "${clean_result}" == "CHANGED" ]]; then
-        yellow "Removed VibeGuard hooks and legacy MCP entries from settings.json"
+        yellow "Removed VibeGuard hooks from settings.json"
       fi
     fi
   fi

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -125,16 +125,6 @@ _enable_codex_hooks_feature() {
   esac
 }
 
-_remove_legacy_codex_mcp_config() {
-  local config="${CODEX_DIR}/config.toml"
-  setup_runtime setup-codex-config-remove-legacy-mcp "${config}"
-}
-
-_has_legacy_codex_mcp_config() {
-  local config="${CODEX_DIR}/config.toml"
-  [[ -f "${config}" ]] && grep -q '^\[mcp_servers\.vibeguard\]' "${config}" 2>/dev/null
-}
-
 codex_native_capability_summary() {
   printf '%s\n' "Codex native support: PreToolUse(Bash/apply_patch), PermissionRequest(Bash/apply_patch), PostToolUse(Bash/apply_patch), Stop"
 }
@@ -143,24 +133,6 @@ inject_codex_home_rules() {
   echo "Step 10.1: Update VibeGuard rules in ~/.codex/AGENTS.md"
   local agents_md="${CODEX_DIR}/AGENTS.md"
   inject_vibeguard_rules "${agents_md}" "~/.codex/AGENTS.md" "generated/AGENTS.md"
-}
-
-configure_codex_home_runtime() {
-  echo "Step 9.2: Remove legacy Codex MCP config"
-  local cleanup_result
-  if ! cleanup_result="$(_remove_legacy_codex_mcp_config 2>/dev/null)"; then
-    red "  Failed to remove legacy Codex MCP config from ~/.codex/config.toml"
-    return 1
-  fi
-  if [[ -f "${CODEX_DIR}/config.toml" ]]; then
-    state_record_file "${CODEX_DIR}/config.toml" "generated/codex-config.toml" "copy"
-  fi
-  if [[ "${cleanup_result}" == "CHANGED" ]]; then
-    green "  Removed legacy VibeGuard MCP block from ~/.codex/config.toml"
-  else
-    green "  No legacy Codex MCP config found"
-  fi
-  echo
 }
 
 check_codex_home_installation() {
@@ -241,18 +213,10 @@ check_codex_home_installation() {
   fi
   if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] hooks feature enabled in config.toml"
-  elif [[ "${codex_hooks_status}" == "LEGACY" ]]; then
-    yellow "[LEGACY] deprecated codex_hooks feature still present in ~/.codex/config.toml (repair: bash setup.sh --yes)"
   elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
     red "[BROKEN] ~/.codex/config.toml is malformed TOML"
   else
     yellow "[MISSING] hooks feature not enabled in ~/.codex/config.toml"
-  fi
-
-  if _has_legacy_codex_mcp_config; then
-    yellow "[LEGACY] Legacy VibeGuard MCP block still present in ~/.codex/config.toml"
-  else
-    green "[OK] No legacy VibeGuard MCP block in ~/.codex/config.toml"
   fi
 }
 
@@ -266,7 +230,7 @@ codex_semantic_drift_message() {
     if [[ -f "${config}" ]]; then
       codex_hooks_status="$(setup_runtime setup-codex-config-check-hooks "${config}" 2>/dev/null || true)"
     fi
-    if [[ "${codex_hooks_status}" == "OK" ]] && ! _has_legacy_codex_mcp_config; then
+    if [[ "${codex_hooks_status}" == "OK" ]]; then
       printf '%s\n' "${path} (checksum drift; Codex config semantics OK)"
       return 0
     fi
@@ -378,18 +342,10 @@ print_codex_status() {
   fi
   if [[ "${codex_hooks_status}" == "OK" ]]; then
     green "[OK] hooks feature enabled"
-  elif [[ "${codex_hooks_status}" == "LEGACY" ]]; then
-    yellow "[LEGACY] deprecated codex_hooks feature still present"
   elif [[ "${codex_hooks_status}" == "INVALID" ]]; then
     red "[BROKEN] ~/.codex/config.toml is malformed TOML"
   else
     yellow "[MISSING] hooks feature not enabled"
-  fi
-
-  if _has_legacy_codex_mcp_config; then
-    yellow "[LEGACY] Legacy VibeGuard MCP block still present"
-  else
-    green "[OK] No legacy VibeGuard MCP block"
   fi
 
   local latest_event
@@ -508,7 +464,7 @@ clean_codex_home_installation() {
     local agents_md_result
     agents_md_result=$(setup_runtime setup-md-remove "${CODEX_DIR}/AGENTS.md" 2>/dev/null || echo "ERROR")
     case "${agents_md_result}" in
-      REMOVED|REMOVED_LEGACY) yellow "Removed VibeGuard rules from ~/.codex/AGENTS.md" ;;
+      REMOVED) yellow "Removed VibeGuard rules from ~/.codex/AGENTS.md" ;;
       NOT_FOUND) yellow "No VibeGuard rules found in ~/.codex/AGENTS.md" ;;
       *) red "Failed to clean ~/.codex/AGENTS.md" ;;
     esac
@@ -546,13 +502,4 @@ clean_codex_home_installation() {
   yellow "Removed Codex hook wrapper"
 
   # Keep the Codex hooks feature flag untouched to avoid affecting other toolchains.
-
-  local cleanup_result
-  if ! cleanup_result="$(_remove_legacy_codex_mcp_config 2>/dev/null)"; then
-    red "Failed to remove legacy Codex MCP config from ~/.codex/config.toml"
-    return 1
-  fi
-  if [[ "${cleanup_result}" == "CHANGED" ]]; then
-    yellow "Removed legacy VibeGuard MCP block from ~/.codex/config.toml"
-  fi
 }

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -123,6 +123,7 @@ _enable_codex_hooks_feature() {
       return 1
       ;;
   esac
+  state_record_file "${config}" "generated/codex-config.toml" "copy"
 }
 
 codex_native_capability_summary() {

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -8,50 +8,13 @@ assert_cmd "scheduled GC script exists at canonical path" test -x "${REPO_DIR}/s
 assert_cmd "launchd plist points to canonical GC script path" grep -q "__VIBEGUARD_DIR__/scripts/gc/gc-scheduled.sh" "${REPO_DIR}/scripts/setup/com.vibeguard.gc.plist"
 assert_cmd "systemd service points to canonical GC script path" grep -q "__VIBEGUARD_DIR__/scripts/gc/gc-scheduled.sh" "${REPO_DIR}/scripts/systemd/vibeguard-gc.service"
 assert_cmd "systemd installer chmods canonical GC script path" grep -q 'scripts/gc/gc-scheduled.sh' "${REPO_DIR}/scripts/install-systemd.sh"
-assert_cmd "scheduled GC installers do not reference legacy root path" bash -c "! grep -q 'scripts/gc-scheduled.sh' '${REPO_DIR}/scripts/setup/com.vibeguard.gc.plist' '${REPO_DIR}/scripts/systemd/vibeguard-gc.service' '${REPO_DIR}/scripts/install-systemd.sh'"
+assert_cmd "scheduled GC installers do not reference retired root path" bash -c "! grep -q 'scripts/gc-scheduled.sh' '${REPO_DIR}/scripts/setup/com.vibeguard.gc.plist' '${REPO_DIR}/scripts/systemd/vibeguard-gc.service' '${REPO_DIR}/scripts/install-systemd.sh'"
 
-header "seed legacy config"
+header "seed existing config"
 mkdir -p "${HOME}/.claude" "${HOME}/.codex"
 cat > "${HOME}/.claude/settings.json" <<'JSON'
 {
-  "mcpServers": {
-    "vibeguard": {
-      "type": "stdio",
-      "command": "node",
-      "args": ["/legacy/mcp-server/dist/index.js"]
-    }
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "mcp__vibeguard__guard_check",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash /legacy/post-guard-check.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash /legacy/session-tagger.sh"
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash /legacy/cognitive-reminder.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }
 JSON
 cat > "${HOME}/.codex/hooks.json" <<'JSON'
@@ -66,37 +29,15 @@ cat > "${HOME}/.codex/hooks.json" <<'JSON'
             "command": "node /existing/non-vibeguard.js"
           }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash /legacy/run-hook-codex.sh pre-bash-guard.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash /legacy/session-tagger.sh"
-          }
-        ]
       }
     ]
   }
 }
 JSON
 cat > "${HOME}/.codex/config.toml" <<'TOML'
-[mcp_servers.vibeguard]
-command = "node"
-args = ["/legacy/mcp-server/dist/index.js"]
+[features]
+hooks = true
 TOML
-assert_cmd "Legacy Claude MCP configuration has been written" grep -q "mcp-server/dist/index.js" "${HOME}/.claude/settings.json"
-assert_cmd "Legacy Codex MCP configuration written" grep -q '^\[mcp_servers\.vibeguard\]' "${HOME}/.codex/config.toml"
 assert_cmd "Pre-existing non-VibeGuard Codex hook is present" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 
 header "setup --check"
@@ -587,24 +528,17 @@ assert_cmd "~/.codex/skills/agentsmd-audit is copied after installation" bash -c
 assert_cmd "~/.codex/skills/trajectory-review is copied after installation" bash -c "test -d '${HOME}/.codex/skills/trajectory-review' && test ! -L '${HOME}/.codex/skills/trajectory-review'"
 assert_cmd "all manifest Claude skill links are installed" assert_manifest_skill_links_installed "~/.claude/skills/" "${HOME}/.claude/skills"
 assert_cmd "all manifest Codex skill links are installed" assert_manifest_skill_links_installed "~/.codex/skills/" "${HOME}/.codex/skills"
-assert_cmd "Clean legacy Claude MCP block after installation" bash -c "! grep -q 'mcp-server/dist/index.js' '${HOME}/.claude/settings.json'"
 assert_cmd "No longer write to mcpServers after installation" bash -c "! grep -q 'mcpServers' '${HOME}/.claude/settings.json'"
 assert_cmd "settings helper detects pre hooks configured" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target pre-hooks
 assert_cmd "settings helper detects post hooks configured" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target post-hooks
-assert_cmd "post-guard-check is not enabled in the default installation" bash -c "! grep -q 'post-guard-check.sh' '${HOME}/.claude/settings.json'"
 assert_cmd "skills-loader is not enabled in the default installation" bash -c "! grep -q 'skills-loader.sh' '${HOME}/.claude/settings.json'"
 assert_cmd "The default core profile does not enable full hooks" bash -c "python3 '${SETTINGS_HELPER}' check --settings-file '${HOME}/.claude/settings.json' --target full-hooks >/dev/null 2>&1; test \$? -ne 0"
 assert_cmd "~/.codex/hooks.json exists after installation" test -f "${HOME}/.codex/hooks.json"
 assert_cmd "Enable hooks feature after installation" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${HOME}/.codex/config.toml"
-assert_cmd "Remove deprecated codex_hooks feature after installation" bash -c "! grep -Eq '^codex_hooks[[:space:]]*=' '${HOME}/.codex/config.toml'"
-assert_cmd "Clean legacy Codex MCP block after installation" bash -c "! grep -q '^\[mcp_servers\.vibeguard\]' '${HOME}/.codex/config.toml'"
 assert_cmd "Codex hooks are namespaced (vibeguard prefix)" bash -c "grep -q 'vibeguard-pre-bash-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-pre-edit-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-pre-write-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-post-edit-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-post-write-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-post-build-check.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-stop-guard.sh' '${HOME}/.codex/hooks.json' && grep -q 'vibeguard-learn-evaluator.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "Codex hooks include PermissionRequest native gates" bash -c "grep -q '\"PermissionRequest\"' '${HOME}/.codex/hooks.json' && grep -q '\"matcher\": \"Edit\"' '${HOME}/.codex/hooks.json' && grep -q '\"matcher\": \"Write\"' '${HOME}/.codex/hooks.json'"
 assert_cmd "Codex helper validates managed hooks" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${HOME}/.codex/hooks.json" --wrapper "${HOME}/.vibeguard/run-hook-codex.sh"
-assert_cmd "Legacy non-namespaced Codex hook command is removed" bash -c "! grep -q 'run-hook-codex.sh pre-bash-guard.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "run-hook-codex rejects non-namespaced hook names" bash -c "out=\$(printf '{\"hook_event_name\":\"PreToolUse\",\"tool_input\":{\"command\":\"rm -rf /\"}}' | bash '${REPO_DIR}/hooks/run-hook-codex.sh' pre-bash-guard.sh); test -z \"\$out\""
-assert_cmd "Codex hooks do not contain cognitive-reminder" bash -c "! grep -q 'cognitive-reminder.sh' '${HOME}/.codex/hooks.json'"
-assert_cmd "Codex hooks do not contain session-tagger" bash -c "! grep -q 'session-tagger.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 assert_cmd "~/.claude/CLAUDE.md includes the chat contract anchor after installation" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${HOME}/.claude/CLAUDE.md"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -71,7 +71,6 @@ assert_cmd "VibeGuard managed Codex AGENTS block removed after cleaning" bash -c
 assert_cmd "Unmanaged Codex AGENTS content remains after cleaning" grep -q 'user codex note' "${HOME}/.codex/AGENTS.md"
 assert_cmd "VibeGuard managed Codex hooks removed after cleaning" bash -c "! grep -qE 'vibeguard-(pre-bash-guard|pre-edit-guard|pre-write-guard|post-edit-guard|post-write-guard|post-build-check|stop-guard|learn-evaluator)\\.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "Pre-existing non-VibeGuard hook remains after cleaning" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
-assert_cmd "legacy Codex MCP block has been removed after cleaning" bash -c "[ ! -f '${HOME}/.codex/config.toml' ] || ! grep -q '^\[mcp_servers\.vibeguard\]' '${HOME}/.codex/config.toml'"
 
 header "setup install default languages before rust filter"
 install_default_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core)"
@@ -293,8 +292,6 @@ assert_contains "${install_strict_out}" "Profile: strict" "strict profile parame
 assert_cmd "strict profile still configures full hooks" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target full-hooks
 assert_cmd "strict profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:strict
 assert_cmd "strict profile enables U-32 constraint budget hook" grep -q "count_active_constraints.sh" "${HOME}/.claude/settings.json"
-assert_cmd "strict profile does not enable session-tagger" bash -c "! grep -q 'session-tagger.sh' '${HOME}/.claude/settings.json' && ! grep -q 'session-tagger.sh' '${HOME}/.codex/hooks.json'"
-assert_cmd "strict profile does not enable cognitive-reminder" bash -c "! grep -q 'cognitive-reminder.sh' '${HOME}/.claude/settings.json' && ! grep -q 'cognitive-reminder.sh' '${HOME}/.codex/hooks.json'"
 assert_cmd "strict profile check catches missing U-32 constraint hook" assert_profile_hook_missing_after_remove count_active_constraints.sh profile-hooks:strict
 strict_missing_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
 assert_contains "${strict_missing_out}" "[MISSING] Claude hooks missing for strict profile" "setup --check reports missing strict profile hook"

--- a/tests/setup/syntax_manifest_tests.sh
+++ b/tests/setup/syntax_manifest_tests.sh
@@ -199,11 +199,6 @@ touch "${broken_clean_home}/.claude/rules/vibeguard/common/security.md"
 touch "${broken_clean_home}/.vibeguard/run-hook-codex.sh"
 python3 "${SETTINGS_HELPER}" upsert-vibeguard --settings-file "${broken_clean_home}/.claude/settings.json" --repo-dir "${REPO_DIR}" --profile full >/dev/null
 python3 "${CODEX_HOOKS_HELPER}" upsert-vibeguard --hooks-file "${broken_clean_home}/.codex/hooks.json" --wrapper "${broken_clean_home}/.vibeguard/run-hook-codex.sh" >/dev/null
-cat > "${broken_clean_home}/.codex/config.toml" <<'TOML'
-[mcp_servers.vibeguard]
-command = "node"
-args = ["/legacy/mcp-server/dist/index.js"]
-TOML
 broken_clean_out="$(
   HOME="${broken_clean_home}" bash -c "
     set -euo pipefail
@@ -224,7 +219,6 @@ assert_cmd "clean removes Claude rules after manifest failure" test ! -e "${brok
 assert_cmd "clean removes Claude hooks after manifest failure" bash -c "! grep -q 'pre-bash-guard.sh' '${broken_clean_home}/.claude/settings.json'"
 assert_cmd "clean continues after Codex manifest failure" bash -c "! grep -q 'vibeguard-pre-bash-guard.sh' '${broken_clean_home}/.codex/hooks.json'"
 assert_cmd "clean removes Codex wrapper after manifest failure" test ! -e "${broken_clean_home}/.vibeguard/run-hook-codex.sh"
-assert_cmd "clean removes legacy Codex MCP after manifest failure" bash -c "! grep -q '^\[mcp_servers\.vibeguard\]' '${broken_clean_home}/.codex/config.toml'"
 
 header "clean preserves unmanaged Claude command paths"
 unmanaged_commands_home="${TMP_HOME}/unmanaged-commands-home"

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -354,17 +354,17 @@ assert_cmd "enable-hooks writes hooks = true" grep -Eq '^hooks[[:space:]]*=[[:sp
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
-codex_hooks_beta = false
+hooks_beta = false
 foo = true
 TOML
 enable_prefixed_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${enable_prefixed_out}" "CHANGED" "enable-hooks adds canonical key when only prefixed keys exist"
-assert_cmd "enable-hooks preserves prefixed feature keys" grep -Eq '^codex_hooks_beta[[:space:]]*=[[:space:]]*false$' "${CONFIG_FILE}"
+assert_cmd "enable-hooks preserves prefixed feature keys" grep -Eq '^hooks_beta[[:space:]]*=[[:space:]]*false$' "${CONFIG_FILE}"
 assert_cmd "enable-hooks adds exact hooks key" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features] # user comment
-codex_hooks_beta = false
+hooks_beta = false
 TOML
 enable_commented_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${enable_commented_out}" "CHANGED" "enable-hooks recognizes commented features table"
@@ -374,56 +374,9 @@ assert_cmd "enable-hooks adds exact key under commented features table" grep -Eq
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]
 hooks = true
-codex_hooks = true
-foo = true
-TOML
-enable_legacy_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-hooks --config-file "${CONFIG_FILE}")"
-assert_contains "${enable_legacy_out}" "CHANGED" "enable-hooks removes deprecated codex_hooks when canonical hooks exists"
-assert_cmd "enable-hooks keeps hooks enabled during legacy cleanup" grep -Eq '^hooks[[:space:]]*=[[:space:]]*true$' "${CONFIG_FILE}"
-assert_cmd "enable-hooks removes exact deprecated codex_hooks key" bash -c "! grep -Eq '^codex_hooks[[:space:]]*=' '${CONFIG_FILE}'"
-
-alias_out="$(python3 "${CODEX_CONFIG_HELPER}" enable-codex-hooks --config-file "${CONFIG_FILE}")"
-assert_contains "${alias_out}" "SKIP" "enable-codex-hooks remains a compatibility alias"
-
-cat > "${CONFIG_FILE}" <<'TOML'
-[features]
-foo = true
-
-[mcp_servers.vibeguard] # legacy comment
-command = "node"
-args = ["/legacy/mcp-server/dist/index.js"]
-
-[mcp_servers.vibeguard.env]
-VIBEGUARD_MODE = "legacy"
-
-[mcp_servers.vibeguard.env.deep]
-NESTED = "true"
-
-[other]
-value = 1
-TOML
-remove_out="$(python3 "${CODEX_CONFIG_HELPER}" remove-legacy-vibeguard-mcp --config-file "${CONFIG_FILE}")"
-assert_contains "${remove_out}" "CHANGED" "remove-legacy-vibeguard-mcp reports change"
-assert_cmd "legacy vibeguard mcp tables removed recursively" bash -c "! grep -qE '^\[mcp_servers\\.vibeguard([.]|\\])' '${CONFIG_FILE}'"
-assert_cmd "non-legacy tables remain after recursive cleanup" grep -Eq '^\[other\]$' "${CONFIG_FILE}"
-
-cat > "${CONFIG_FILE}" <<'TOML'
-[features]
-hooks = true
 TOML
 check_ok_out="$(python3 "${CODEX_CONFIG_HELPER}" check-hooks --config-file "${CONFIG_FILE}")"
 assert_contains "${check_ok_out}" "OK" "check-hooks accepts valid TOML with feature enabled"
-
-cat > "${CONFIG_FILE}" <<'TOML'
-[features]
-hooks = true
-codex_hooks = true
-TOML
-check_legacy_out="$(python3 "${CODEX_CONFIG_HELPER}" check-hooks --config-file "${CONFIG_FILE}" || true)"
-assert_contains "${check_legacy_out}" "LEGACY" "check-hooks rejects deprecated codex_hooks even when hooks is enabled"
-
-check_legacy_alias_out="$(python3 "${CODEX_CONFIG_HELPER}" check-codex-hooks --config-file "${CONFIG_FILE}" || true)"
-assert_contains "${check_legacy_alias_out}" "LEGACY" "check-codex-hooks remains a compatibility alias"
 
 cat > "${CONFIG_FILE}" <<'TOML'
 [features]

--- a/tests/test_setup_hardening.sh
+++ b/tests/test_setup_hardening.sh
@@ -176,8 +176,8 @@ assert parts == [
     "pre-bash-guard.sh",
 ]
 assert settings_json._is_canonical_hook_command(command, "pre-bash-guard.sh")
-legacy_command = f"bash {os.environ['HOME']}/.vibeguard/run-hook.sh pre-bash-guard.sh"
-assert settings_json._is_canonical_hook_command(legacy_command, "pre-bash-guard.sh")
+unquoted_command = f"bash {os.environ['HOME']}/.vibeguard/run-hook.sh pre-bash-guard.sh"
+assert not settings_json._is_canonical_hook_command(unquoted_command, "pre-bash-guard.sh")
 custom_bash_command = f"bash -x {os.environ['HOME']}/.vibeguard/run-hook.sh pre-bash-guard.sh"
 assert not settings_json._is_canonical_hook_command(custom_bash_command, "pre-bash-guard.sh")
 PY

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -426,11 +426,6 @@ static COMMANDS: &[Command] = &[
         handler: setup_codex_config::check_hooks,
     },
     Command {
-        name: "setup-codex-config-remove-legacy-mcp",
-        usage: "<config-file>  — remove legacy VibeGuard Codex MCP config",
-        handler: setup_codex_config::remove_legacy_mcp,
-    },
-    Command {
         name: "setup-codex-hooks-upsert",
         usage: "<repo-dir> <hooks-file> <wrapper>  — upsert Codex hooks",
         handler: setup_codex_hooks::codex_hooks_upsert,

--- a/vibeguard-runtime/src/setup_codex_config.rs
+++ b/vibeguard-runtime/src/setup_codex_config.rs
@@ -45,10 +45,6 @@ pub fn check_hooks(args: &[String]) -> SetupResult<()> {
             println!("OK");
             Ok(())
         }
-        ConfigStatus::Legacy => {
-            println!("LEGACY");
-            std::process::exit(1);
-        }
         ConfigStatus::Missing => {
             println!("MISSING");
             std::process::exit(1);
@@ -60,36 +56,9 @@ pub fn check_hooks(args: &[String]) -> SetupResult<()> {
     }
 }
 
-pub fn remove_legacy_mcp(args: &[String]) -> SetupResult<()> {
-    if args.len() != 1 {
-        return Err(
-            "Usage: vibeguard-runtime setup-codex-config-remove-legacy-mcp <config-file>".into(),
-        );
-    }
-    let path = Path::new(&args[0]);
-    if !path.exists() {
-        println!("SKIP");
-        return Ok(());
-    }
-    let old = std::fs::read_to_string(path)?;
-    let (new, changed) = remove_legacy_vibeguard_mcp(&old)?;
-    if !changed {
-        println!("SKIP");
-        return Ok(());
-    }
-    if new.is_empty() {
-        std::fs::remove_file(path)?;
-    } else {
-        write_text_atomic(path, &new)?;
-    }
-    println!("CHANGED");
-    Ok(())
-}
-
 #[derive(Debug, PartialEq, Eq)]
 enum ConfigStatus {
     Ok,
-    Legacy,
     Missing,
     Invalid,
 }
@@ -101,26 +70,7 @@ fn ensure_hooks_enabled(text: &str) -> SetupResult<(String, bool)> {
     let features = doc["features"]
         .as_table_mut()
         .ok_or("config.toml [features] must be a table")?;
-    features.remove("codex_hooks");
     features["hooks"] = value(true);
-    let after = normalized_doc_string(&doc);
-    Ok((after.clone(), after != before))
-}
-
-fn remove_legacy_vibeguard_mcp(text: &str) -> SetupResult<(String, bool)> {
-    let mut doc = parse_document(text)?;
-    let before = normalized_doc_string(&doc);
-    let mut remove_mcp_servers = false;
-    if let Some(mcp_servers) = doc.get_mut("mcp_servers") {
-        let table = mcp_servers
-            .as_table_mut()
-            .ok_or("config.toml [mcp_servers] must be a table")?;
-        table.remove("vibeguard");
-        remove_mcp_servers = table.is_empty();
-    }
-    if remove_mcp_servers {
-        doc.as_table_mut().remove("mcp_servers");
-    }
     let after = normalized_doc_string(&doc);
     Ok((after.clone(), after != before))
 }
@@ -132,9 +82,6 @@ fn check_hooks_status(text: &str) -> ConfigStatus {
     let Some(features) = doc.get("features").and_then(Item::as_table) else {
         return ConfigStatus::Missing;
     };
-    if features.get("codex_hooks").is_some() {
-        return ConfigStatus::Legacy;
-    }
     let hooks_true = features
         .get("hooks")
         .and_then(Item::as_value)
@@ -175,10 +122,9 @@ mod tests {
 
     #[test]
     fn enables_hooks_in_existing_features() -> SetupResult<()> {
-        let (text, changed) = ensure_hooks_enabled("[features]\ncodex_hooks = true\nx = 1\n")?;
+        let (text, changed) = ensure_hooks_enabled("[features]\nx = 1\n")?;
         assert!(changed);
         assert!(text.contains("hooks = true"));
-        assert!(!text.contains("codex_hooks"));
         Ok(())
     }
 
@@ -205,16 +151,6 @@ mod tests {
         assert!(changed);
         assert!(updated.contains("title = \"a # b\""));
         assert_eq!(check_hooks_status(&updated), ConfigStatus::Ok);
-        Ok(())
-    }
-
-    #[test]
-    fn removes_legacy_mcp_structurally() -> SetupResult<()> {
-        let text = "[mcp_servers.vibeguard]\ncommand = \"node\"\n\n[mcp_servers.other]\ncommand = \"keep\"\n";
-        let (updated, changed) = remove_legacy_vibeguard_mcp(text)?;
-        assert!(changed);
-        assert!(!updated.contains("vibeguard"));
-        assert!(updated.contains("[mcp_servers.other]"));
         Ok(())
     }
 }

--- a/vibeguard-runtime/src/setup_codex_hooks.rs
+++ b/vibeguard-runtime/src/setup_codex_hooks.rs
@@ -14,16 +14,6 @@ struct CodexSpec {
     timeout: Option<i64>,
 }
 
-const CODEX_LEGACY_MARKERS: &[&str] = &[
-    "pre-bash-guard.sh",
-    "post-build-check.sh",
-    "stop-guard.sh",
-    "learn-evaluator.sh",
-    "post-guard-check.sh",
-    "session-tagger.sh",
-    "cognitive-reminder.sh",
-];
-
 pub fn codex_hooks_upsert(args: &[String]) -> SetupResult<()> {
     if args.len() != 3 {
         return Err(
@@ -431,7 +421,7 @@ fn codex_command_is_managed(repo_dir: &Path, command: &str) -> bool {
             }
         }
         let base = basename(token);
-        if scripts.contains(base) || CODEX_LEGACY_MARKERS.contains(&base) {
+        if scripts.contains(base) {
             return true;
         }
     }
@@ -439,10 +429,7 @@ fn codex_command_is_managed(repo_dir: &Path, command: &str) -> bool {
 }
 
 fn codex_managed_scripts(repo_dir: &Path) -> BTreeSet<String> {
-    let mut scripts = CODEX_LEGACY_MARKERS
-        .iter()
-        .map(|item| (*item).to_string())
-        .collect::<BTreeSet<_>>();
+    let mut scripts = BTreeSet::new();
     if let Ok(specs) = codex_specs(repo_dir) {
         scripts.extend(specs.into_iter().map(|spec| spec.script));
     }
@@ -559,9 +546,13 @@ fn codex_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
 mod tests {
     use super::*;
 
+    fn repo_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("..")
+    }
+
     #[test]
-    fn prune_managed_keeps_third_party_hooks_in_mixed_entry() {
-        let repo_dir = Path::new("/tmp/vibeguard-test-repo");
+    fn prune_current_managed_keeps_third_party_hooks_in_mixed_entry() {
+        let repo_dir = repo_dir();
         let mut data = json!({
             "hooks": {
                 "PreToolUse": [
@@ -570,7 +561,7 @@ mod tests {
                         "hooks": [
                             {
                                 "type": "command",
-                                "command": "bash /tmp/run-hook-codex.sh pre-bash-guard.sh"
+                                "command": "bash /tmp/run-hook-codex.sh vibeguard-pre-bash-guard.sh"
                             },
                             {
                                 "type": "command",
@@ -582,7 +573,7 @@ mod tests {
             }
         });
 
-        codex_prune_managed(&mut data, repo_dir);
+        codex_prune_managed(&mut data, &repo_dir);
 
         let hooks = data
             .pointer("/hooks/PreToolUse/0/hooks")
@@ -626,8 +617,8 @@ mod tests {
 
     #[test]
     fn managed_entry_check_requires_expected_timeout() {
-        let repo_dir = Path::new("/tmp/vibeguard-test-repo");
-        let command = "bash /tmp/run-hook-codex.sh stop-guard.sh";
+        let repo_dir = repo_dir();
+        let command = "bash /tmp/run-hook-codex.sh vibeguard-stop-guard.sh";
         let entries = vec![json!({
             "hooks": [
                 {
@@ -640,11 +631,17 @@ mod tests {
 
         assert!(!codex_has_entry(
             &entries,
-            repo_dir,
+            &repo_dir,
             command,
             None,
             Some(15)
         ));
-        assert!(codex_has_entry(&entries, repo_dir, command, None, Some(99)));
+        assert!(codex_has_entry(
+            &entries,
+            &repo_dir,
+            command,
+            None,
+            Some(99)
+        ));
     }
 }

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -2,7 +2,6 @@ use crate::setup_support::{
     SetupResult, basename, display_home_path, home_dir, read_json_object, shell_quote, shell_split,
     simple_unified_diff, write_json_atomic, write_text_atomic,
 };
-use regex::Regex;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -69,13 +68,7 @@ pub fn remove(args: &[String]) -> SetupResult<()> {
         return Ok(());
     }
 
-    if let Some(index) = original.find("\n# VibeGuard") {
-        let content = original[..index].trim_end().to_string() + "\n";
-        write_text_atomic(path, &content)?;
-        println!("REMOVED_LEGACY");
-    } else {
-        println!("NOT_FOUND");
-    }
+    println!("NOT_FOUND");
     Ok(())
 }
 
@@ -97,12 +90,7 @@ fn render_injected(
         let content = replace_managed_block(&original, &rules);
         return Ok(("UPDATED".to_string(), original, content));
     }
-    let legacy_re = Regex::new(r"\n# VibeGuard").expect("legacy regex compiles");
-    let base = legacy_re
-        .find(&original)
-        .map(|found| &original[..found.start()])
-        .unwrap_or(&original)
-        .trim_end();
+    let base = original.trim_end();
     let content = if base.is_empty() {
         format!("{}\n", rules.trim())
     } else {
@@ -143,12 +131,6 @@ struct ClaudeSpec {
     matcher: String,
     script: String,
 }
-
-const CLAUDE_LEGACY_SCRIPTS: &[&str] = &[
-    "post-guard-check.sh",
-    "session-tagger.sh",
-    "cognitive-reminder.sh",
-];
 
 pub fn settings_check(args: &[String]) -> SetupResult<()> {
     if args.len() != 3 {
@@ -192,8 +174,6 @@ pub fn settings_upsert(args: &[String]) -> SetupResult<()> {
     let before_text = std::fs::read_to_string(settings_path).unwrap_or_default();
     let mut data = Value::Object(read_json_object(settings_path, true)?);
     let mut changed = false;
-    changed |= settings_remove_legacy_mcp(&mut data);
-    changed |= settings_remove_legacy_hooks(&mut data, repo_dir)?;
     changed |= settings_remove_stale_installed(&mut data);
     if data.get("hooks").and_then(Value::as_object).is_none() {
         data.as_object_mut()
@@ -244,8 +224,6 @@ pub fn settings_remove(args: &[String]) -> SetupResult<()> {
     let repo_dir = Path::new(&args[0]);
     let mut data = Value::Object(read_json_object(settings_path, false)?);
     let before = serde_json::to_string(&data)?;
-    settings_remove_legacy_mcp(&mut data);
-    settings_remove_legacy_hooks(&mut data, repo_dir)?;
     for script in claude_managed_scripts(repo_dir)? {
         for event in [
             "PreToolUse",
@@ -541,30 +519,6 @@ fn settings_remove_unprofiled_hooks(
     Ok(changed)
 }
 
-fn settings_remove_legacy_mcp(data: &mut Value) -> bool {
-    let Some(object) = data.as_object_mut() else {
-        return false;
-    };
-    let Some(mcp) = object.get_mut("mcpServers").and_then(Value::as_object_mut) else {
-        return false;
-    };
-    let changed = mcp.remove("vibeguard").is_some();
-    if mcp.is_empty() {
-        object.remove("mcpServers");
-    }
-    changed
-}
-
-fn settings_remove_legacy_hooks(data: &mut Value, _repo_dir: &Path) -> SetupResult<bool> {
-    let mut changed = false;
-    for script in CLAUDE_LEGACY_SCRIPTS {
-        for event in ["PreToolUse", "PostToolUse", "Stop", "SessionStart"] {
-            changed |= settings_remove_hook(data, event, script);
-        }
-    }
-    Ok(changed)
-}
-
 fn settings_remove_stale_installed(data: &mut Value) -> bool {
     let Some(hooks) = data.get_mut("hooks").and_then(Value::as_object_mut) else {
         return false;
@@ -671,28 +625,7 @@ fn settings_is_canonical(command: &str, script: &str) -> bool {
                 .is_some_and(|part| part.ends_with("/.vibeguard/run-hook.sh"))
             && parts.get(2).is_some_and(|part| part == script);
     }
-    if parts.len() <= 3
-        || !parts.first().is_some_and(|part| basename(part) == "bash")
-        || !parts.last().is_some_and(|part| part == script)
-    {
-        return false;
-    }
-    let wrapper_parts = &parts[1..parts.len() - 1];
-    wrapper_parts
-        .first()
-        .is_some_and(|part| settings_legacy_wrapper_part_starts_path(part))
-        && wrapper_parts
-            .iter()
-            .skip(1)
-            .all(|part| !part.starts_with('-') && !settings_legacy_wrapper_part_starts_path(part))
-        && wrapper_parts.join(" ").ends_with("/.vibeguard/run-hook.sh")
-}
-
-fn settings_legacy_wrapper_part_starts_path(part: &str) -> bool {
-    part.starts_with('/')
-        || part.starts_with("~/")
-        || part.starts_with("$HOME/")
-        || part.starts_with("${HOME}/")
+    false
 }
 
 fn settings_stale_findings(data: &Value, config: &Path) -> Vec<String> {

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -219,9 +219,9 @@ mod setup_markdown_tests {
     }
 
     #[test]
-    fn canonical_settings_command_accepts_legacy_unquoted_home_spaces() {
+    fn canonical_settings_command_rejects_unquoted_home_spaces() {
         let command = "bash /tmp/home with spaces/.vibeguard/run-hook.sh pre-bash-guard.sh";
-        assert!(settings_is_canonical(command, "pre-bash-guard.sh"));
+        assert!(!settings_is_canonical(command, "pre-bash-guard.sh"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove deprecated Codex config helper aliases and `codex_hooks` migration/removal behavior.
- Remove legacy Claude/Codex hook cleanup for retired script names, unmarked VibeGuard blocks, legacy MCP configs, and old wrapper command shapes.
- Update setup tests to seed only current config and require strict canonical hook commands.

Closes #479

## Validation
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml setup_ -- --nocapture`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `python3 -m py_compile scripts/lib/codex_config_toml.py scripts/lib/settings_json.py scripts/lib/codex_hooks_json.py scripts/lib/hook_config_model.py scripts/lib/claude_md.py`
- `bash -n scripts/setup/install.sh scripts/setup/targets/codex-home.sh scripts/setup/targets/claude-home.sh tests/test_manifest_contract.sh tests/test_setup_hardening.sh tests/setup/install_flow_tests.sh tests/setup/profile_flow_tests.sh tests/setup/syntax_manifest_tests.sh`
- `bash tests/test_manifest_contract.sh`
- `bash tests/test_setup_hardening.sh`
- `bash tests/test_setup.sh` (377/377)
- `git diff --check`
- scoped `rg` for removed legacy commands/markers in changed setup files: no hits