### PR TITLE
[codex] Tag hook latency benchmark surface

### DIFF
--- a/docs/internal/benchmarks/benchmark-design.md
+++ b/docs/internal/benchmarks/benchmark-design.md
@@ -59,6 +59,19 @@
 | F1 | 2×P×R / (P+R) | Comprehensive index |
 | Latency | ms/case | Hook execution time |
 
+### 3.1.1 Latency surfaces
+
+Benchmark results must name the measured surface so microsecond core claims are
+not mixed with hook end-to-end SLAs:
+
+| Surface | Unit | Measures | Excludes |
+|---------|------|----------|----------|
+| `hook_e2e_ms` | ms | Hook end-to-end latency, including wrapper/process startup, stdin/stdout handling, config lookup, event-log reads, logging/status output, runtime dispatch, and hook logic | Pure in-process classifier-only claims |
+| `core_us` | us | Pure Rust/core classifier microbenchmarks running in process | Hook wrappers, shell process startup, stdin/stdout adaptation, config discovery, event-log I/O, and logging overhead |
+
+`tests/bench_hook_latency.sh` owns the `hook_e2e_ms` SLA gate. A Criterion or
+Rust microbench harness for `core_us` is intentionally separate work.
+
 **Judgment Criteria**:
 - `exit 2` = Block → counts as TP (for illegal input) or FP (for legal input)
 - `stderr` with expected keywords = Warn → count as TP (for violating input)
@@ -423,6 +436,5 @@ The `standard` mode (daily) uses the `haiku` model, with a full volume of about 
 ---
 
 *This document is a design plan, and the implementation details will be adjusted as needed during the execution of each phase. *
-
 
 

--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -4,6 +4,17 @@ VibeGuard hooks run in the critical path of Claude Code and Codex sessions. A co
 
 ## Budgets
 
+The benchmark surface is `hook_e2e_ms`: end-to-end hook latency in milliseconds.
+It includes shell wrapper/process startup, stdin/stdout handling, config lookup,
+event-log access, status/logging work, runtime dispatch, and the hook logic
+itself. These numbers are SLA budgets for the installed hook path, not claims
+about pure core classifier speed.
+
+Future pure Rust/core classifier microbenchmarks must use the separate
+`core_us` surface. `core_us` is reserved for in-process core logic measured in
+microseconds and must not include hook wrappers, shell process startup,
+stdin/stdout adaptation, config discovery, or logging overhead.
+
 The latency gate measures P50, P95, P99, and max for each benchmark fixture. CI fails when `--fail-on-regression` is enabled and any fixture exceeds its P95 budget.
 
 These are cross-OS CI budgets, not ideal-machine optimization targets. Static performance gates still block dangerous patterns before they can hide behind a broad absolute budget.
@@ -42,7 +53,12 @@ Post-build fixtures use fake build commands and disable the post-build cache so 
 
 ## Hotspot Attribution
 
-Benchmark output includes a `hotspot=` field and `bench-output.json` publishes P95/P99 samples for GitHub benchmark reporting. When a regression fails, the failing row must identify both the hook and fixture size, such as `post-write-guard (5000)`.
+Benchmark output includes `surface=hook_e2e_ms` and a `hotspot=` field.
+`bench-output.json` prefixes benchmark-action sample names with
+`hook_e2e_ms`, and JSON output carries the same surface marker at the top level
+and per result. When a regression fails, the failing row must identify both the
+surface and fixture size, such as `hook_e2e_ms post-write-guard (5000)` or
+`surface=hook_e2e_ms ... post-write-guard (5000)`.
 
 Synthetic slow fixtures are part of the regression suite:
 

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HOOKS_DIR="${REPO_DIR}/hooks"
+BENCH_SURFACE="hook_e2e_ms"
 RESULTS_FILE=""
 FAIL_ON_REGRESSION=false
 GLOBAL_SLA_MS=""
@@ -236,9 +237,13 @@ bench_hook() {
       "VIBEGUARD_PROJECT_HASH=bench000"
       "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
     )
+    local -a run_env=("${hook_env[@]}")
+    if [[ ${#extra_env[@]} -gt 0 ]]; then
+      run_env+=("${extra_env[@]}")
+    fi
 
     local start=$(_now_ms)
-    env "${hook_env[@]}" "${extra_env[@]}" bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
+    env "${run_env[@]}" bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
     local end=$(_now_ms)
     local elapsed=$((end - start))
     latencies+=("$elapsed")
@@ -270,9 +275,9 @@ bench_hook() {
     fi
   fi
 
-  printf "  %-35s P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
+  printf "  %-35s surface=%s  P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$BENCH_SURFACE" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
 
-  RESULTS+=("{\"name\":\"$name\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
+  RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
 }
 
 bench_codex_wrapper() {
@@ -331,13 +336,14 @@ bench_codex_wrapper() {
     fi
   fi
 
-  printf "  %-35s P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
+  printf "  %-35s surface=%s  P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$BENCH_SURFACE" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
 
-  RESULTS+=("{\"name\":\"$name\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
+  RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
 }
 
 echo "======================================"
 echo "VibeGuard Hook Latency Benchmark"
+echo "Surface: ${BENCH_SURFACE} (end-to-end hook process latency)"
 if [[ -n "$GLOBAL_SLA_MS" ]]; then
   echo "Budget mode: global <${GLOBAL_SLA_MS}ms (P95)  Runs: ${RUNS}  Tail: P99/max reported"
 else
@@ -409,8 +415,9 @@ fi
 # --- JSON output (internal format) ---
 if [[ -n "$RESULTS_FILE" ]]; then
   mkdir -p "$(dirname "$RESULTS_FILE")"
-  printf '{"date":"%s","budget_mode":"%s","global_sla_ms":"%s","runs":%d,"spawn_baseline_ms":%d,"environment_distorted":%s,"results":[%s]}\n' \
+  printf '{"date":"%s","surface":"%s","budget_mode":"%s","global_sla_ms":"%s","runs":%d,"spawn_baseline_ms":%d,"environment_distorted":%s,"results":[%s]}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$BENCH_SURFACE" \
     "$([[ -n "$GLOBAL_SLA_MS" ]] && printf global || printf per-hook)" \
     "${GLOBAL_SLA_MS}" \
     "$RUNS" \
@@ -433,11 +440,11 @@ _first=true
     _p95=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p95'])" 2>/dev/null || echo "0")
     _p99=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p99'])" 2>/dev/null || echo "0")
     if [[ "$_first" == "true" ]]; then _first=false; else echo ","; fi
-    printf '  {"name": "%s (P50)", "unit": "ms", "value": %s}' "$_name" "$_p50"
+    printf '  {"name": "%s %s (P50)", "unit": "ms", "value": %s}' "$BENCH_SURFACE" "$_name" "$_p50"
     echo ","
-    printf '  {"name": "%s (P95)", "unit": "ms", "value": %s}' "$_name" "$_p95"
+    printf '  {"name": "%s %s (P95)", "unit": "ms", "value": %s}' "$BENCH_SURFACE" "$_name" "$_p95"
     echo ","
-    printf '  {"name": "%s (P99)", "unit": "ms", "value": %s}' "$_name" "$_p99"
+    printf '  {"name": "%s %s (P99)", "unit": "ms", "value": %s}' "$BENCH_SURFACE" "$_name" "$_p99"
   done
   echo ""
   echo "]"

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -13,8 +13,20 @@ PASS=0
 FAIL=0
 TOTAL=0
 TMP_DIR="$(mktemp -d)"
+BENCH_JSON_FILE="${REPO_DIR}/data/bench-latency-$(date +%Y%m%d).json"
+BENCH_JSON_EXISTED=false
+BENCH_JSON_BACKUP="${TMP_DIR}/bench-latency-existing.json"
+if [[ -e "${BENCH_JSON_FILE}" ]]; then
+  BENCH_JSON_EXISTED=true
+  cp "${BENCH_JSON_FILE}" "${BENCH_JSON_BACKUP}"
+fi
 
 cleanup() {
+  if [[ "${BENCH_JSON_EXISTED}" == "true" ]]; then
+    cp "${BENCH_JSON_BACKUP}" "${BENCH_JSON_FILE}" 2>/dev/null || true
+  else
+    rm -f "${BENCH_JSON_FILE}"
+  fi
   rm -rf "${TMP_DIR}"
 }
 trap cleanup EXIT
@@ -126,17 +138,25 @@ assert_file_contains "${TMP_DIR}/bad-loop.out" "bad-loop-hook.sh" "loop subproce
 
 header "dynamic latency gate"
 assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
+assert_file_contains "${TMP_DIR}/slow.out" "Surface: hook_e2e_ms" "latency gate declares hook e2e surface"
+assert_file_contains "${TMP_DIR}/slow.out" "surface=hook_e2e_ms" "latency rows include hook e2e surface marker"
 assert_file_contains "${TMP_DIR}/slow.out" "exceeded latency budget" "slow hook output explains budget failure"
 assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "slow hook output includes hotspot attribution"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper pre-bash-guard" "latency gate includes Codex PreToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper post-edit-guard (100)" "latency gate includes Codex PostToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "post-build-check (fake cargo)" "latency gate includes post-build fake command fixture"
+assert_success_contains "JSON latency output is written" "Results: ${BENCH_JSON_FILE}" "${TMP_DIR}/json.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --json --sla=100000
+assert_file_contains "${BENCH_JSON_FILE}" '"surface":"hook_e2e_ms"' "JSON latency output declares hook e2e surface"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P50)" "benchmark action output includes P50 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P95)" "benchmark action output includes P95 samples"
 assert_file_contains "${REPO_DIR}/bench-output.json" "(P99)" "benchmark action output includes P99 samples"
-assert_file_contains "${REPO_DIR}/bench-output.json" "codex-wrapper pre-bash-guard (P95)" "benchmark action output includes Codex wrapper samples"
-assert_file_contains "${REPO_DIR}/bench-output.json" "post-build-check (fake cargo) (P95)" "benchmark action output includes post-build samples"
+assert_file_contains "${REPO_DIR}/bench-output.json" "hook_e2e_ms codex-wrapper pre-bash-guard (P95)" "benchmark action output includes surfaced Codex wrapper samples"
+assert_file_contains "${REPO_DIR}/bench-output.json" "hook_e2e_ms post-build-check (fake cargo) (P95)" "benchmark action output includes surfaced post-build samples"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "Codex wrapper hooks" "latency contract documents wrapper coverage"
+assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "core_us" "latency contract documents core microbench surface"
+assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "hook_e2e_ms" "latency contract documents hook e2e surface"
+assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "core_us" "benchmark design documents core microbench surface"
+assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "hook_e2e_ms" "benchmark design documents hook e2e surface"
 assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
 
 echo ""


### PR DESCRIPTION
## Summary

- Tag hook latency benchmark output with the explicit `hook_e2e_ms` surface in console rows, JSON output, and benchmark-action sample names.
- Document the boundary between hook end-to-end millisecond SLAs and future pure-core `core_us` microbenchmarks.
- Extend the hook performance contract test to assert the surface marker and restore any pre-existing same-day benchmark JSON after local runs.

Closes #485.
Closes #487.

## Out of scope

- Rust Criterion/core microbench harness work remains in #486.
- Timeout/orphan hook work remains in #473/#474.
- No hook runtime behavior or latency budgets changed.

## Validation

- `cargo build --manifest-path vibeguard-runtime/Cargo.toml --quiet`
- `bash tests/test_hook_perf_contract.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`
