### PR TITLE
ci: harden hook performance gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,10 +281,14 @@ jobs:
 
       - name: Hook precision tests
         shell: bash
-        run: bash tests/run_precision.sh --all --csv
+        run: |
+          set -o pipefail
+          bash tests/run_precision.sh --all --csv | tee precision-results.csv
 
       - name: Validate precision thresholds
         shell: bash
+        env:
+          VG_PRECISION_CSV_FILE: precision-results.csv
         run: bash scripts/ci/validate-precision-thresholds.sh
 
       - name: Precision tracker regression tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,8 @@ jobs:
 
       - name: VibeGuard Benchmark (fast)
         shell: bash
+        env:
+          VG_PRECISION_CSV_FILE: precision-results.csv
         run: bash scripts/benchmark.sh --mode=fast
 
   windows-smoke:

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -129,6 +129,7 @@ vg_policy_payload_cwd() {
 }
 
 vg_policy_git_root() {
+  # PERF-OK: policy checks need the current repo root; failures fall back upstream.
   git rev-parse --show-toplevel 2>/dev/null || true
 }
 

--- a/hooks/_lib/post_edit_history.sh
+++ b/hooks/_lib/post_edit_history.sh
@@ -5,6 +5,7 @@ VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && p
 
 vg_post_edit_count_build_failures() {
   local project_root
+  # PERF-OK: build-failure history is repo-scoped; outside git uses an empty root.
   project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
   tail -200 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
     | "$_VIBEGUARD_RUNTIME" build-fails "$VIBEGUARD_SESSION_ID" "$project_root" \

--- a/hooks/circuit-breaker.sh
+++ b/hooks/circuit-breaker.sh
@@ -78,6 +78,7 @@ _vg_cb_state_file() {
     slug="$VIBEGUARD_PROJECT_HASH"
   else
     local root
+    # PERF-OK: circuit state is repo-scoped; this falls back to global outside git.
     root=$(git rev-parse --show-toplevel 2>/dev/null || echo "global")
     slug=$(printf '%s' "$root" | shasum -a 256 2>/dev/null | cut -c1-8) || slug="fallback0"
   fi

--- a/hooks/count_active_constraints.sh
+++ b/hooks/count_active_constraints.sh
@@ -18,6 +18,7 @@ INPUT=$(cat 2>/dev/null || true)
 
 PROJECT_ROOT="${VIBEGUARD_PROJECT_ROOT:-}"
 if [[ -z "${PROJECT_ROOT}" ]]; then
+  # PERF-OK: SessionStart constraint counts are repo-scoped; fallback supports non-git dirs.
   PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 fi
 

--- a/hooks/git/pre-push
+++ b/hooks/git/pre-push
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 # Construct zero OID matching current repo's object format (SHA-1: 40, SHA-256: 64)
+# PERF-OK: pre-push needs object format once to parse zero object IDs.
 _obj_format=$(git rev-parse --show-object-format 2>/dev/null || echo sha1)
 if [[ "$_obj_format" == "sha256" ]]; then
   ZEROS="0000000000000000000000000000000000000000000000000000000000000000"
@@ -34,6 +35,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
   # Remote branch already exists — check for non-fast-forward push
   if [[ "$remote_sha" != "$ZEROS" ]]; then
+    # PERF-OK: pre-push compares exactly one remote/local ref pair to block rewrites.
     merge_base=$(git merge-base "$remote_sha" "$local_sha" 2>/dev/null || true)
     if [[ "$merge_base" != "$remote_sha" ]]; then
       echo "vibeguard: force push blocked — non-fast-forward push to $remote_ref" >&2

--- a/hooks/learn-evaluator.sh
+++ b/hooks/learn-evaluator.sh
@@ -64,7 +64,7 @@ vg_learn_is_ci && exit 0
 INPUT=$(cat 2>/dev/null || true)
 vg_learn_stop_hook_active_fast "$INPUT" && exit 0
 
-# Not in git repository → skip
+# PERF-OK: Stop hook skips metrics outside git; this is a single cheap probe.
 if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
   exit 0
 fi

--- a/hooks/log.sh
+++ b/hooks/log.sh
@@ -25,6 +25,7 @@ export VIBEGUARD_LOG_DIR
 # Benchmarks and app-server wrappers use these env overrides to avoid reading a
 # large ambient project log on every hook invocation.
 if [[ -z "${VIBEGUARD_PROJECT_LOG_DIR:-}" || -z "${VIBEGUARD_LOG_FILE:-}" ]]; then
+  # PERF-OK: hook logs are project-scoped; env overrides skip this discovery path.
   _vg_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "global")
   _vg_project_hash=$(printf '%s' "$_vg_repo_root" | shasum -a 256 2>/dev/null | cut -c1-8) || _vg_project_hash="fallback0"
   VIBEGUARD_PROJECT_HASH="$_vg_project_hash"

--- a/hooks/post-build-check.sh
+++ b/hooks/post-build-check.sh
@@ -60,13 +60,19 @@ post_build_worktree_state() {
   local project_root="$1" file_path="$2"
   local state_root="${project_root:-$(dirname "$file_path")}"
 
+  # PERF-OK: post-build snapshots only run after build commands and fail open outside git.
   if [[ -n "$state_root" && -d "$state_root" ]] && git -C "$state_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     {
       printf 'git\n'
+      # PERF-OK: bounded one-shot HEAD read for build-state fingerprinting.
       git -C "$state_root" rev-parse HEAD 2>/dev/null || true
+      # PERF-OK: bounded path-scoped status for build-state fingerprinting.
       git -C "$state_root" status --porcelain=v1 --untracked-files=all -- . 2>/dev/null || true
+      # PERF-OK: path-scoped diff hash input for build-state fingerprinting.
       git -C "$state_root" diff --no-ext-diff --binary -- . 2>/dev/null || true
+      # PERF-OK: path-scoped cached diff hash input for build-state fingerprinting.
       git -C "$state_root" diff --cached --no-ext-diff --binary -- . 2>/dev/null || true
+      # PERF-OK: path-scoped untracked-file hash input for build-state fingerprinting.
       (cd "$state_root" && git ls-files --others --exclude-standard -z -- . 2>/dev/null | xargs -0 shasum -a 256 2>/dev/null || true)
     } | post_build_hash_stream
     return 0

--- a/hooks/pre-commit-guard.sh
+++ b/hooks/pre-commit-guard.sh
@@ -51,6 +51,7 @@ fi
 command -v python3 >/dev/null 2>&1 && HAS_PYTHON3=1
 
 # --- Collect staged source code files (single git diff, filter by extension) ---
+# PERF-OK: pre-commit must inspect the cached index once; errors are non-blocking outside git.
 _ALL_STAGED=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
 STAGED_FILES=""
 while IFS= read -r file; do
@@ -78,6 +79,7 @@ _cleanup_staged() {
   rm -f "$_STAGED_TMPFILE" "$_DIFF_ADDED_TMPFILE" 2>/dev/null
 }
 trap '_cleanup_staged' EXIT
+# PERF-OK: pre-commit needs the repo root for absolute staged paths; falls back to pwd.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 while IFS= read -r f; do
   [[ -n "$f" ]] && echo "${REPO_ROOT}/${f}"
@@ -89,7 +91,7 @@ export VIBEGUARD_STAGED_FILES="$_STAGED_TMPFILE"
 # VIBEGUARD_DIFF_ADDED_LINES — points to a temporary file containing all staged new lines (+ prefix removed)
 # The guard script can choose to read this file instead of scanning the entire file, so that only the new lines of code are checked.
 export VIBEGUARD_DIFF_ONLY=1
-# Single git diff call for all staged files (avoids O(n) git invocations)
+# PERF-OK: single cached diff for all staged files avoids O(n) git invocations.
 git diff --cached -U0 2>/dev/null \
   | grep '^+' \
   | grep -v '^+++' \
@@ -100,6 +102,7 @@ export VIBEGUARD_DIFF_ADDED_LINES="$_DIFF_ADDED_TMPFILE"
 # --- Language and project-root detection (driven by the staged tree, not the working tree) ---
 index_has_path() {
   local path="$1"
+  # PERF-OK: indexed marker lookup is scoped to one path and runs only for staged files.
   git cat-file -e ":${path}" 2>/dev/null
 }
 

--- a/hooks/stop-guard.sh
+++ b/hooks/stop-guard.sh
@@ -37,7 +37,7 @@ INPUT=$(cat 2>/dev/null || true)
 # Checking it breaks the feedback → Stop hook → feedback → Stop hook infinite loop.
 vg_stop_hook_active_fast "$INPUT" && exit 0
 
-# Not in git repository → skip
+# PERF-OK: Stop hook skips source-change counting outside git; single cheap probe.
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then
   exit 0
 fi
@@ -48,7 +48,10 @@ while IFS= read -r file; do
   if [[ -n "$file" ]] && vg_is_source_file "$file"; then
     changed_source_files="${changed_source_files}${file}"$'\n'
   fi
-done < <(git diff --name-only HEAD 2>/dev/null || git diff --name-only --cached 2>/dev/null)
+done < <(
+  # PERF-OK: Stop hook only needs changed file names to count source edits.
+  git diff --name-only HEAD 2>/dev/null || git diff --name-only --cached 2>/dev/null
+)
 
 # Remove duplicates
 if [[ -n "$changed_source_files" ]]; then

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -33,6 +33,20 @@ done
 
 mkdir -p "$RESULTS_DIR"
 
+load_layer1_csv() {
+  if [[ -n "${VG_PRECISION_CSV_FILE:-}" ]]; then
+    if [[ ! -f "${VG_PRECISION_CSV_FILE}" ]]; then
+      echo "FAIL: VG_PRECISION_CSV_FILE does not exist: ${VG_PRECISION_CSV_FILE}" >&2
+      exit 1
+    fi
+    cat "${VG_PRECISION_CSV_FILE}"
+  elif [[ -n "${VG_PRECISION_CSV:-}" ]]; then
+    printf '%s\n' "${VG_PRECISION_CSV}"
+  else
+    bash "$REPO_DIR/tests/run_precision.sh" --all --csv 2>/dev/null
+  fi
+}
+
 echo "====== VibeGuard Benchmark ======"
 echo "Date: $DATE"
 echo "Run: $RUN_ID"
@@ -44,7 +58,7 @@ echo ""
 # ============================================================
 
 echo "[Layer 1: Hook precision]"
-L1_CSV=$(bash "$REPO_DIR/tests/run_precision.sh" --all --csv 2>/dev/null)
+L1_CSV="$(load_layer1_csv)"
 
 # Parse CSV calculation indicators
 L1_RESULT=$(echo "$L1_CSV" | python3 -c "

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -41,7 +41,48 @@ line_is_output_literal() {
   local line="$1"
   [[ "${line}" =~ ^[[:space:]]*(echo|printf)[[:space:]] ]] || return 1
   [[ "${line}" == *'$('* || "${line}" == *'`'* ]] && return 1
+  line_has_unquoted_command_separator "$line" && return 1
   return 0
+}
+
+line_has_unquoted_command_separator() {
+  local line="$1"
+  local quote=""
+  local char next prev
+  local i
+
+  for ((i = 0; i < ${#line}; i++)); do
+    char="${line:i:1}"
+
+    if [[ -n "$quote" ]]; then
+      if [[ "$quote" == '"' && "$char" == "\\" ]]; then
+        i=$((i + 1))
+        continue
+      fi
+      if [[ "$char" == "$quote" ]]; then
+        quote=""
+      fi
+      continue
+    fi
+
+    case "$char" in
+      "'"|'"')
+        quote="$char" ;;
+      ';'|'|')
+        return 0 ;;
+      '&')
+        next="${line:i+1:1}"
+        prev=""
+        if [[ "$i" -gt 0 ]]; then
+          prev="${line:i-1:1}"
+        fi
+        if [[ "$next" == "&" || "$prev" =~ [[:space:]] || "$next" =~ [[:space:]] ]]; then
+          return 0
+        fi ;;
+    esac
+  done
+
+  return 1
 }
 
 line_has_odd_quote() {

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -41,6 +41,7 @@ line_is_output_literal() {
   local line="$1"
   [[ "${line}" =~ ^[[:space:]]*(echo|printf)[[:space:]] ]] || return 1
   [[ "${line}" == *'$('* || "${line}" == *'`'* ]] && return 1
+  [[ "${line}" == *'<('* || "${line}" == *'>('* ]] && return 1
   line_has_unquoted_command_separator "$line" && return 1
   return 0
 }
@@ -85,6 +86,63 @@ line_has_unquoted_command_separator() {
   return 1
 }
 
+line_command_segments() {
+  local line="$1"
+  local quote=""
+  local segment=""
+  local char next prev
+  local i
+
+  for ((i = 0; i < ${#line}; i++)); do
+    char="${line:i:1}"
+
+    if [[ -n "$quote" ]]; then
+      segment+="$char"
+      if [[ "$quote" == '"' && "$char" == "\\" ]]; then
+        i=$((i + 1))
+        segment+="${line:i:1}"
+        continue
+      fi
+      if [[ "$char" == "$quote" ]]; then
+        quote=""
+      fi
+      continue
+    fi
+
+    case "$char" in
+      "'"|'"')
+        quote="$char"
+        segment+="$char" ;;
+      ';'|'|')
+        printf '%s\n' "$segment"
+        segment=""
+        next="${line:i+1:1}"
+        if [[ "$char" == "|" && "$next" == "|" ]]; then
+          i=$((i + 1))
+        fi ;;
+      '&')
+        next="${line:i+1:1}"
+        prev=""
+        if [[ "$i" -gt 0 ]]; then
+          prev="${line:i-1:1}"
+        fi
+        if [[ "$next" == "&" || "$prev" =~ [[:space:]] || "$next" =~ [[:space:]] ]]; then
+          printf '%s\n' "$segment"
+          segment=""
+          if [[ "$next" == "&" ]]; then
+            i=$((i + 1))
+          fi
+        else
+          segment+="$char"
+        fi ;;
+      *)
+        segment+="$char" ;;
+    esac
+  done
+
+  printf '%s\n' "$segment"
+}
+
 line_has_odd_quote() {
   local line="$1"
   local quote="$2"
@@ -127,6 +185,23 @@ git_command_is_safe() {
   if [[ "$line" =~ $timeout_git_re ]]; then
     return 0
   fi
+
+  return 1
+}
+
+line_has_unsafe_git_command() {
+  local line="$1"
+  local segment
+
+  while IFS= read -r segment; do
+    [[ -n "${segment//[[:space:]]/}" ]] || continue
+    if line_is_output_literal "$segment"; then
+      continue
+    fi
+    if line_has_git_command "$segment" && ! git_command_is_safe "$segment"; then
+      return 0
+    fi
+  done < <(line_command_segments "$line")
 
   return 1
 }
@@ -208,7 +283,7 @@ while IFS= read -r file; do
     if line_has_git_command "$line"; then
       if perf_ok_nearby "$file" "$LINE_NUM"; then
         green "${file##*/}:${LINE_NUM}: documented git call"
-      elif git_command_is_safe "$line"; then
+      elif ! line_has_unsafe_git_command "$line"; then
         green "${file##*/}:${LINE_NUM}: bounded git call"
       else
         red "${file##*/}:${LINE_NUM}: unsafe git call — ${line:0:80}"

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -66,17 +66,6 @@ git_command_is_safe() {
     return 0
   fi
 
-  # Existing hooks rely on suppressed git failures when running outside a worktree
-  # or against partially initialized repos.
-  if [[ "$line" == *"2>/dev/null"* || "$line" == *"&>/dev/null"* || "$line" == *">/dev/null 2>&1"* ]]; then
-    return 0
-  fi
-
-  # Explicit fallback keeps hook execution moving when git cannot answer.
-  if [[ "$line" == *"|| true"* || "$line" == *"|| echo"* || "$line" == *"|| pwd"* ]]; then
-    return 0
-  fi
-
   return 1
 }
 
@@ -147,7 +136,7 @@ while IFS= read -r file; do
     if perf_ok_nearby "$file" "$line_no"; then
       green "${file##*/}:${line_no}: documented git call"
     elif git_command_is_safe "$line"; then
-      green "${file##*/}:${line_no}: bounded or error-suppressed git call"
+      green "${file##*/}:${line_no}: bounded git call"
     else
       red "${file##*/}:${line_no}: unsafe git call — ${line:0:80}"
       VIOLATIONS=$((VIOLATIONS + 1))

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -37,6 +37,11 @@ line_is_comment() {
   [[ "${line}" =~ ^[[:space:]]*# ]]
 }
 
+line_is_output_literal() {
+  local line="$1"
+  [[ "${line}" =~ ^[[:space:]]*(echo|printf)[[:space:]] ]]
+}
+
 find_command_has_maxdepth() {
   local file="$1"
   local line_no="$2"
@@ -51,6 +56,28 @@ find_command_has_maxdepth() {
   done
 
   [[ "${command}" == *"-maxdepth"* ]]
+}
+
+git_command_is_safe() {
+  local line="$1"
+
+  # timeout-wrapped git calls have a bounded wall-clock budget.
+  if printf '%s\n' "$line" | grep -Eq '(^|[[:space:];|&({])(gtimeout|timeout)[[:space:]][^;&|]*git[[:space:]]'; then
+    return 0
+  fi
+
+  # Existing hooks rely on suppressed git failures when running outside a worktree
+  # or against partially initialized repos.
+  if [[ "$line" == *"2>/dev/null"* || "$line" == *"&>/dev/null"* || "$line" == *">/dev/null 2>&1"* ]]; then
+    return 0
+  fi
+
+  # Explicit fallback keeps hook execution moving when git cannot answer.
+  if [[ "$line" == *"|| true"* || "$line" == *"|| echo"* || "$line" == *"|| pwd"* ]]; then
+    return 0
+  fi
+
+  return 1
 }
 
 echo "======================================"
@@ -110,17 +137,27 @@ echo ""
 
 # --- Rule 3: Git commands that could hang (no timeout context) ---
 echo "[PERF-03] Git commands without timeout safety"
-# We check for git diff/log/status in main hook scripts (not log.sh which has a simple rev-parse)
-for file in "$HOOKS_DIR"/stop-guard.sh "$HOOKS_DIR"/pre-commit-guard.sh; do
-  [[ ! -f "$file" ]] && continue
-  basename="${file##*/}"
-  # Count git commands that aren't wrapped in timeout or have 2>/dev/null fallback
-  GIT_CALLS=$(grep -cn 'git ' "$file" 2>/dev/null || echo 0)
-  GIT_SAFE=$(grep -c 'git.*2>/dev/null' "$file" 2>/dev/null || echo 0)
-  if [[ "$GIT_CALLS" -gt 0 ]]; then
-    green "${basename}: ${GIT_CALLS} git calls, ${GIT_SAFE} with error suppression"
+while IFS= read -r file; do
+  UNSAFE_GIT=false
+  while IFS=: read -r line_no line; do
+    [[ -z "${line_no}" ]] && continue
+    if line_is_comment "$line" || line_is_output_literal "$line"; then
+      continue
+    fi
+    if perf_ok_nearby "$file" "$line_no"; then
+      green "${file##*/}:${line_no}: documented git call"
+    elif git_command_is_safe "$line"; then
+      green "${file##*/}:${line_no}: bounded or error-suppressed git call"
+    else
+      red "${file##*/}:${line_no}: unsafe git call — ${line:0:80}"
+      VIOLATIONS=$((VIOLATIONS + 1))
+      UNSAFE_GIT=true
+    fi
+  done < <(grep -nE '(^|[^[:alnum:]_./-])git[[:space:]]+' "$file" 2>/dev/null || true)
+  if [[ "$UNSAFE_GIT" == "false" ]]; then
+    green "${file##*/}: no unsafe git calls"
   fi
-done
+done < <(find "$HOOKS_DIR" -maxdepth 1 -name '*.sh' | sort)
 echo ""
 
 # --- Rule 4: Python subprocess in for/while loop ---

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -180,10 +180,13 @@ find_command_has_maxdepth() {
 git_command_is_safe() {
   local line="$1"
   local timeout_git_re='(^|[[:space:];|&({])(gtimeout|timeout)[[:space:]][^;&|]*[[:space:]](/?[[:alnum:]_.-]+/)*git[[:space:]]'
+  local remaining
 
   # timeout-wrapped git calls have a bounded wall-clock budget.
   if [[ "$line" =~ $timeout_git_re ]]; then
-    return 0
+    remaining="${line#*"${BASH_REMATCH[0]}"}"
+    ! line_has_git_command "$remaining"
+    return
   fi
 
   return 1

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -42,6 +42,14 @@ line_is_output_literal() {
   [[ "${line}" =~ ^[[:space:]]*(echo|printf)[[:space:]] ]]
 }
 
+line_has_odd_quote() {
+  local line="$1"
+  local quote="$2"
+  local without="${line//${quote}/}"
+  local count=$(( ${#line} - ${#without} ))
+  [[ $((count % 2)) -eq 1 ]]
+}
+
 find_command_has_maxdepth() {
   local file="$1"
   local line_no="$2"
@@ -128,25 +136,44 @@ echo ""
 echo "[PERF-03] Git commands without timeout safety"
 while IFS= read -r file; do
   UNSAFE_GIT=false
-  while IFS=: read -r line_no line; do
-    [[ -z "${line_no}" ]] && continue
+  IN_QUOTED_BLOCK=false
+  QUOTE_CHAR=""
+  LINE_NUM=0
+  while IFS= read -r line; do
+    LINE_NUM=$((LINE_NUM + 1))
+    if [[ "${IN_QUOTED_BLOCK}" == "true" ]]; then
+      if line_has_odd_quote "$line" "$QUOTE_CHAR"; then
+        IN_QUOTED_BLOCK=false
+        QUOTE_CHAR=""
+      fi
+      continue
+    fi
     if line_is_comment "$line" || line_is_output_literal "$line"; then
       continue
     fi
-    if perf_ok_nearby "$file" "$line_no"; then
-      green "${file##*/}:${line_no}: documented git call"
-    elif git_command_is_safe "$line"; then
-      green "${file##*/}:${line_no}: bounded git call"
-    else
-      red "${file##*/}:${line_no}: unsafe git call — ${line:0:80}"
-      VIOLATIONS=$((VIOLATIONS + 1))
-      UNSAFE_GIT=true
+    if printf '%s\n' "$line" | grep -qE '(^|[^[:alnum:]_./-])git[[:space:]]+'; then
+      if perf_ok_nearby "$file" "$LINE_NUM"; then
+        green "${file##*/}:${LINE_NUM}: documented git call"
+      elif git_command_is_safe "$line"; then
+        green "${file##*/}:${LINE_NUM}: bounded git call"
+      else
+        red "${file##*/}:${LINE_NUM}: unsafe git call — ${line:0:80}"
+        VIOLATIONS=$((VIOLATIONS + 1))
+        UNSAFE_GIT=true
+      fi
     fi
-  done < <(grep -nE '(^|[^[:alnum:]_./-])git[[:space:]]+' "$file" 2>/dev/null || true)
+    if line_has_odd_quote "$line" "'"; then
+      IN_QUOTED_BLOCK=true
+      QUOTE_CHAR="'"
+    elif line_has_odd_quote "$line" '"'; then
+      IN_QUOTED_BLOCK=true
+      QUOTE_CHAR='"'
+    fi
+  done < "$file"
   if [[ "$UNSAFE_GIT" == "false" ]]; then
     green "${file##*/}: no unsafe git calls"
   fi
-done < <(find "$HOOKS_DIR" -maxdepth 1 -name '*.sh' | sort)
+done < <(find "$HOOKS_DIR" -name '*.sh' | sort)
 echo ""
 
 # --- Rule 4: Python subprocess in for/while loop ---

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -39,7 +39,9 @@ line_is_comment() {
 
 line_is_output_literal() {
   local line="$1"
-  [[ "${line}" =~ ^[[:space:]]*(echo|printf)[[:space:]] ]]
+  [[ "${line}" =~ ^[[:space:]]*(echo|printf)[[:space:]] ]] || return 1
+  [[ "${line}" == *'$('* || "${line}" == *'`'* ]] && return 1
+  return 0
 }
 
 line_has_odd_quote() {
@@ -48,6 +50,16 @@ line_has_odd_quote() {
   local without="${line//${quote}/}"
   local count=$(( ${#line} - ${#without} ))
   [[ $((count % 2)) -eq 1 ]]
+}
+
+hook_script_files() {
+  find "$HOOKS_DIR" -type f \( -name '*.sh' -o -perm -111 \) | sort
+}
+
+line_has_git_command() {
+  local line="$1"
+  local git_re='(^|[[:space:];|&({])(/?[[:alnum:]_.-]+/)*git[[:space:]]'
+  [[ "$line" =~ $git_re ]]
 }
 
 find_command_has_maxdepth() {
@@ -68,9 +80,10 @@ find_command_has_maxdepth() {
 
 git_command_is_safe() {
   local line="$1"
+  local timeout_git_re='(^|[[:space:];|&({])(gtimeout|timeout)[[:space:]][^;&|]*[[:space:]](/?[[:alnum:]_.-]+/)*git[[:space:]]'
 
   # timeout-wrapped git calls have a bounded wall-clock budget.
-  if printf '%s\n' "$line" | grep -Eq '(^|[[:space:];|&({])(gtimeout|timeout)[[:space:]][^;&|]*git[[:space:]]'; then
+  if [[ "$line" =~ $timeout_git_re ]]; then
     return 0
   fi
 
@@ -151,7 +164,7 @@ while IFS= read -r file; do
     if line_is_comment "$line" || line_is_output_literal "$line"; then
       continue
     fi
-    if printf '%s\n' "$line" | grep -qE '(^|[^[:alnum:]_./-])git[[:space:]]+'; then
+    if line_has_git_command "$line"; then
       if perf_ok_nearby "$file" "$LINE_NUM"; then
         green "${file##*/}:${LINE_NUM}: documented git call"
       elif git_command_is_safe "$line"; then
@@ -173,7 +186,7 @@ while IFS= read -r file; do
   if [[ "$UNSAFE_GIT" == "false" ]]; then
     green "${file##*/}: no unsafe git calls"
   fi
-done < <(find "$HOOKS_DIR" -name '*.sh' | sort)
+done < <(hook_script_files)
 echo ""
 
 # --- Rule 4: Python subprocess in for/while loop ---

--- a/scripts/ci/validate-precision-thresholds.sh
+++ b/scripts/ci/validate-precision-thresholds.sh
@@ -5,10 +5,20 @@ REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 MIN_PRECISION="${MIN_PRECISION:-75}"
 MIN_RECALL="${MIN_RECALL:-75}"
 MIN_F1="${MIN_F1:-75}"
+CSV_FILE="${VG_PRECISION_CSV_FILE:-}"
 
-cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet
-
-CSV_OUTPUT="$(bash "${REPO_DIR}/tests/run_precision.sh" --all --csv)"
+if [[ -n "${CSV_FILE}" ]]; then
+  if [[ ! -f "${CSV_FILE}" ]]; then
+    echo "FAIL: VG_PRECISION_CSV_FILE does not exist: ${CSV_FILE}" >&2
+    exit 1
+  fi
+  CSV_OUTPUT="$(cat "${CSV_FILE}")"
+elif [[ -n "${VG_PRECISION_CSV:-}" ]]; then
+  CSV_OUTPUT="${VG_PRECISION_CSV}"
+else
+  cargo build --release --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" --quiet
+  CSV_OUTPUT="$(bash "${REPO_DIR}/tests/run_precision.sh" --all --csv)"
+fi
 
 VG_PRECISION_CSV="${CSV_OUTPUT}" python3 - "$MIN_PRECISION" "$MIN_RECALL" "$MIN_F1" <<'PY'
 from __future__ import annotations

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -8,6 +8,8 @@
 #   bash tests/bench_hook_latency.sh              # normal run
 #   bash tests/bench_hook_latency.sh --json       # JSON output for CI
 #   bash tests/bench_hook_latency.sh --fail-on-regression  # exit 1 if a fixture exceeds its budget
+#   bash tests/bench_hook_latency.sh --bench-action-output=/tmp/bench-output.json
+#   bash tests/bench_hook_latency.sh --no-bench-action-output
 #
 # Requires: perl (for hi-res timing) or python3. Codex wrapper fixtures also
 # require a built vibeguard-runtime binary.
@@ -18,6 +20,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HOOKS_DIR="${REPO_DIR}/hooks"
 BENCH_SURFACE="hook_e2e_ms"
 RESULTS_FILE=""
+BENCH_ACTION_FILE="${VIBEGUARD_BENCH_ACTION_OUTPUT:-${REPO_DIR}/bench-output.json}"
 FAIL_ON_REGRESSION=false
 GLOBAL_SLA_MS=""
 DEFAULT_BUDGET_MS=300
@@ -30,6 +33,9 @@ ENVIRONMENT_DISTORTED=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --json) RESULTS_FILE="${REPO_DIR}/data/bench-latency-$(date +%Y%m%d).json"; shift ;;
+    --json-output=*) RESULTS_FILE="${1#--json-output=}"; shift ;;
+    --bench-action-output=*) BENCH_ACTION_FILE="${1#--bench-action-output=}"; shift ;;
+    --no-bench-action-output) BENCH_ACTION_FILE=""; shift ;;
     --fail-on-regression) FAIL_ON_REGRESSION=true; shift ;;
     --sla=*) GLOBAL_SLA_MS="${1#--sla=}"; shift ;;
     --runs=*) RUNS="${1#--runs=}"; shift ;;
@@ -429,7 +435,8 @@ if [[ -n "$RESULTS_FILE" ]]; then
 fi
 
 # --- benchmark-action compatible output (customSmallerIsBetter) ---
-# Always write to bench-output.json for CI consumption
+# Defaults to bench-output.json for CI consumption. Tests and audits can override
+# or disable this to avoid writing repo-root artifacts.
 bench_action_name() {
   case "$1" in
     "pre-edit-guard") printf "pre-edit" ;;
@@ -448,27 +455,31 @@ bench_action_name() {
   esac
 }
 
-BENCH_ACTION_FILE="${REPO_DIR}/bench-output.json"
-_first=true
-{
-  echo "["
-  for r in "${RESULTS[@]}"; do
-    _name=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])" 2>/dev/null || echo "unknown")
-    _display_name=$(bench_action_name "$_name")
-    _p50=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p50'])" 2>/dev/null || echo "0")
-    _p95=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p95'])" 2>/dev/null || echo "0")
-    _p99=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p99'])" 2>/dev/null || echo "0")
-    if [[ "$_first" == "true" ]]; then _first=false; else echo ","; fi
-    printf '  {"name": "e2e %s P50", "unit": "ms", "value": %s}' "$_display_name" "$_p50"
-    echo ","
-    printf '  {"name": "e2e %s P95", "unit": "ms", "value": %s}' "$_display_name" "$_p95"
-    echo ","
-    printf '  {"name": "e2e %s P99", "unit": "ms", "value": %s}' "$_display_name" "$_p99"
-  done
-  echo ""
-  echo "]"
-} > "$BENCH_ACTION_FILE"
-echo "Benchmark Action output: $BENCH_ACTION_FILE"
+if [[ -n "$BENCH_ACTION_FILE" ]]; then
+  mkdir -p "$(dirname "$BENCH_ACTION_FILE")"
+  _first=true
+  {
+    echo "["
+    for r in "${RESULTS[@]}"; do
+      _name=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])" 2>/dev/null || echo "unknown")
+      _display_name=$(bench_action_name "$_name")
+      _p50=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p50'])" 2>/dev/null || echo "0")
+      _p95=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p95'])" 2>/dev/null || echo "0")
+      _p99=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p99'])" 2>/dev/null || echo "0")
+      if [[ "$_first" == "true" ]]; then _first=false; else echo ","; fi
+      printf '  {"name": "e2e %s P50", "unit": "ms", "value": %s}' "$_display_name" "$_p50"
+      echo ","
+      printf '  {"name": "e2e %s P95", "unit": "ms", "value": %s}' "$_display_name" "$_p95"
+      echo ","
+      printf '  {"name": "e2e %s P99", "unit": "ms", "value": %s}' "$_display_name" "$_p99"
+    done
+    echo ""
+    echo "]"
+  } > "$BENCH_ACTION_FILE"
+  echo "Benchmark Action output: $BENCH_ACTION_FILE"
+else
+  echo "Benchmark Action output: disabled"
+fi
 
 echo "======================================"
 

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 VALIDATOR="${REPO_DIR}/scripts/ci/validate-hook-perf.sh"
 BENCH="${REPO_DIR}/tests/bench_hook_latency.sh"
+BENCHMARK="${REPO_DIR}/scripts/benchmark.sh"
 
 PASS=0
 FAIL=0
@@ -123,6 +124,7 @@ write_hook() {
 header "syntax"
 assert_cmd "performance validator syntax" bash -n "${VALIDATOR}"
 assert_cmd "latency benchmark syntax" bash -n "${BENCH}"
+assert_cmd "benchmark syntax" bash -n "${BENCHMARK}"
 assert_file_contains "${BENCH}" "Codex wrapper benchmark requires vibeguard-runtime" "latency benchmark fails fast without runtime for Codex wrapper fixtures"
 
 header "static performance gates"
@@ -140,11 +142,6 @@ DOCUMENTED_HOOKS="${TMP_DIR}/documented-hooks"
 write_hook "${DOCUMENTED_HOOKS}" "documented-hook.sh" '# PERF-OK: fixture intentionally scans its temp project root.
 find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_cmd "PERF-OK documents an intentional scan" env VIBEGUARD_HOOKS_DIR="${DOCUMENTED_HOOKS}" bash "${VALIDATOR}"
-
-SAFE_GIT_HOOKS="${TMP_DIR}/safe-git-hooks"
-write_hook "${SAFE_GIT_HOOKS}" "safe-git-hook.sh" '# This comment mentions git status and must not count.
-git status --short >/dev/null 2>&1 || true'
-assert_cmd "error-suppressed git call passes static validator" env VIBEGUARD_HOOKS_DIR="${SAFE_GIT_HOOKS}" bash "${VALIDATOR}"
 
 TIMEOUT_GIT_HOOKS="${TMP_DIR}/timeout-git-hooks"
 write_hook "${TIMEOUT_GIT_HOOKS}" "timeout-git-hook.sh" 'gtimeout 2 git status --short >/dev/null'
@@ -164,6 +161,12 @@ BAD_GIT_HOOKS="${TMP_DIR}/bad-git-hooks"
 write_hook "${BAD_GIT_HOOKS}" "bad-git-hook.sh" 'git status --short >/dev/null'
 assert_fail_contains "unsafe git call fails static validator" "PERF-03" "${TMP_DIR}/bad-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-git.out" "bad-git-hook.sh" "unsafe git output names the hook"
+
+BAD_SUPPRESSED_GIT_HOOKS="${TMP_DIR}/bad-suppressed-git-hooks"
+write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This comment mentions git status and must not count.
+git status --short >/dev/null 2>&1 || true'
+assert_fail_contains "error-suppressed git still requires timeout or PERF-OK" "PERF-03" "${TMP_DIR}/bad-suppressed-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_SUPPRESSED_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-suppressed-git.out" "bad-suppressed-git-hook.sh" "suppressed git output names the hook"
 
 BAD_LOOP_HOOKS="${TMP_DIR}/bad-loop-hooks"
 write_hook "${BAD_LOOP_HOOKS}" "bad-loop-hook.sh" 'while read -r path; do python3 -c "print(1)" "$path"; done < /dev/null'
@@ -193,6 +196,16 @@ assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "hook
 assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "core_us" "benchmark design documents core microbench surface"
 assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "hook_e2e_ms" "benchmark design documents hook e2e surface"
 assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
+
+header "benchmark score gate"
+BENCHMARK_CSV="${TMP_DIR}/precision-fixture.csv"
+cat > "${BENCHMARK_CSV}" <<'CSV'
+hook,case,type,rule,expect,detected,passed,latency
+pre-bash-guard,tp-case,tp,rule,block,1,1,5
+pre-bash-guard,fp-case,fp,rule,allow,0,1,5
+CSV
+assert_success_contains "fast benchmark reuses precision CSV fixture" "Cases: 2" "${TMP_DIR}/benchmark.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-results" VG_PRECISION_CSV_FILE="${BENCHMARK_CSV}" bash "${BENCHMARK}" --mode=fast
+assert_fail_contains "fast benchmark fails on missing precision CSV" "VG_PRECISION_CSV_FILE does not exist" "${TMP_DIR}/benchmark-missing.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-missing-results" VG_PRECISION_CSV_FILE="${TMP_DIR}/missing-precision.csv" bash "${BENCHMARK}" --mode=fast
 
 echo ""
 echo "======================================"

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -182,6 +182,16 @@ write_hook "${BAD_OUTPUT_SUB_GIT_HOOKS}" "bad-output-sub-git-hook.sh" 'printf "%
 assert_fail_contains "git in output command substitution fails static validator" "PERF-03" "${TMP_DIR}/bad-output-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-output-sub-git.out" "bad-output-sub-git-hook.sh" "output substitution git names the hook"
 
+BAD_OUTPUT_CHAIN_GIT_HOOKS="${TMP_DIR}/bad-output-chain-git-hooks"
+write_hook "${BAD_OUTPUT_CHAIN_GIT_HOOKS}" "bad-output-chain-git-hook.sh" 'printf "%s\n" ok; git status --short >/dev/null'
+assert_fail_contains "git chained after output command fails static validator" "PERF-03" "${TMP_DIR}/bad-output-chain-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_CHAIN_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-output-chain-git.out" "bad-output-chain-git-hook.sh" "output chain git names the hook"
+
+BAD_OUTPUT_PIPE_GIT_HOOKS="${TMP_DIR}/bad-output-pipe-git-hooks"
+write_hook "${BAD_OUTPUT_PIPE_GIT_HOOKS}" "bad-output-pipe-git-hook.sh" 'echo ok | git status --short >/dev/null'
+assert_fail_contains "git piped after output command fails static validator" "PERF-03" "${TMP_DIR}/bad-output-pipe-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_PIPE_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-output-pipe-git.out" "bad-output-pipe-git-hook.sh" "output pipe git names the hook"
+
 BAD_SUPPRESSED_GIT_HOOKS="${TMP_DIR}/bad-suppressed-git-hooks"
 write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This comment mentions git status and must not count.
 git status --short >/dev/null 2>&1 || true'

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -14,11 +14,21 @@ FAIL=0
 TOTAL=0
 TMP_DIR="$(mktemp -d)"
 BENCH_JSON_FILE="${REPO_DIR}/data/bench-latency-$(date +%Y%m%d).json"
+BENCH_JSON_TEMP="${TMP_DIR}/bench-latency.json"
+BENCH_ACTION_TEMP="${TMP_DIR}/bench-output.json"
+ROOT_BENCH_ACTION_FILE="${REPO_DIR}/bench-output.json"
 BENCH_JSON_EXISTED=false
 BENCH_JSON_BACKUP="${TMP_DIR}/bench-latency-existing.json"
 if [[ -e "${BENCH_JSON_FILE}" ]]; then
   BENCH_JSON_EXISTED=true
   cp "${BENCH_JSON_FILE}" "${BENCH_JSON_BACKUP}"
+fi
+ROOT_BENCH_ACTION_EXISTED=false
+ROOT_BENCH_ACTION_BACKUP="${TMP_DIR}/bench-output-existing.json"
+if [[ -e "${ROOT_BENCH_ACTION_FILE}" ]]; then
+  ROOT_BENCH_ACTION_EXISTED=true
+  cp "${ROOT_BENCH_ACTION_FILE}" "${ROOT_BENCH_ACTION_BACKUP}"
+  rm -f "${ROOT_BENCH_ACTION_FILE}"
 fi
 
 cleanup() {
@@ -26,6 +36,11 @@ cleanup() {
     cp "${BENCH_JSON_BACKUP}" "${BENCH_JSON_FILE}" 2>/dev/null || true
   else
     rm -f "${BENCH_JSON_FILE}"
+  fi
+  if [[ "${ROOT_BENCH_ACTION_EXISTED}" == "true" ]]; then
+    cp "${ROOT_BENCH_ACTION_BACKUP}" "${ROOT_BENCH_ACTION_FILE}" 2>/dev/null || true
+  else
+    rm -f "${ROOT_BENCH_ACTION_FILE}"
   fi
   rm -rf "${TMP_DIR}"
 }
@@ -126,10 +141,29 @@ write_hook "${DOCUMENTED_HOOKS}" "documented-hook.sh" '# PERF-OK: fixture intent
 find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_cmd "PERF-OK documents an intentional scan" env VIBEGUARD_HOOKS_DIR="${DOCUMENTED_HOOKS}" bash "${VALIDATOR}"
 
+SAFE_GIT_HOOKS="${TMP_DIR}/safe-git-hooks"
+write_hook "${SAFE_GIT_HOOKS}" "safe-git-hook.sh" '# This comment mentions git status and must not count.
+git status --short >/dev/null 2>&1 || true'
+assert_cmd "error-suppressed git call passes static validator" env VIBEGUARD_HOOKS_DIR="${SAFE_GIT_HOOKS}" bash "${VALIDATOR}"
+
+TIMEOUT_GIT_HOOKS="${TMP_DIR}/timeout-git-hooks"
+write_hook "${TIMEOUT_GIT_HOOKS}" "timeout-git-hook.sh" 'gtimeout 2 git status --short >/dev/null'
+assert_cmd "gtimeout-wrapped git call passes static validator" env VIBEGUARD_HOOKS_DIR="${TIMEOUT_GIT_HOOKS}" bash "${VALIDATOR}"
+
+DOCUMENTED_GIT_HOOKS="${TMP_DIR}/documented-git-hooks"
+write_hook "${DOCUMENTED_GIT_HOOKS}" "documented-git-hook.sh" '# PERF-OK: fixture intentionally exercises unbounded git for the gate.
+git status --short >/dev/null'
+assert_cmd "PERF-OK documents an intentional git call" env VIBEGUARD_HOOKS_DIR="${DOCUMENTED_GIT_HOOKS}" bash "${VALIDATOR}"
+
 BAD_FIND_HOOKS="${TMP_DIR}/bad-find-hooks"
 write_hook "${BAD_FIND_HOOKS}" "bad-find-hook.sh" 'find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_fail_contains "unbounded find fails static validator" "PERF-02" "${TMP_DIR}/bad-find.out" env VIBEGUARD_HOOKS_DIR="${BAD_FIND_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-find.out" "bad-find-hook.sh" "unbounded find output names the hook"
+
+BAD_GIT_HOOKS="${TMP_DIR}/bad-git-hooks"
+write_hook "${BAD_GIT_HOOKS}" "bad-git-hook.sh" 'git status --short >/dev/null'
+assert_fail_contains "unsafe git call fails static validator" "PERF-03" "${TMP_DIR}/bad-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-git.out" "bad-git-hook.sh" "unsafe git output names the hook"
 
 BAD_LOOP_HOOKS="${TMP_DIR}/bad-loop-hooks"
 write_hook "${BAD_LOOP_HOOKS}" "bad-loop-hook.sh" 'while read -r path; do python3 -c "print(1)" "$path"; done < /dev/null'
@@ -137,7 +171,7 @@ assert_fail_contains "subprocess in loop fails static validator" "PERF-04" "${TM
 assert_file_contains "${TMP_DIR}/bad-loop.out" "bad-loop-hook.sh" "loop subprocess output names the hook"
 
 header "dynamic latency gate"
-assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
+assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
 assert_file_contains "${TMP_DIR}/slow.out" "Surface: hook_e2e_ms" "latency gate declares hook e2e surface"
 assert_file_contains "${TMP_DIR}/slow.out" "surface=hook_e2e_ms" "latency rows include hook e2e surface marker"
 assert_file_contains "${TMP_DIR}/slow.out" "exceeded latency budget" "slow hook output explains budget failure"
@@ -145,19 +179,20 @@ assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "sl
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper pre-bash-guard" "latency gate includes Codex PreToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper post-edit-guard (100)" "latency gate includes Codex PostToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "post-build-check (fake cargo)" "latency gate includes post-build fake command fixture"
-assert_success_contains "JSON latency output is written" "Results: ${BENCH_JSON_FILE}" "${TMP_DIR}/json.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --json --sla=100000
-assert_file_contains "${BENCH_JSON_FILE}" '"surface":"hook_e2e_ms"' "JSON latency output declares hook e2e surface"
-assert_file_contains "${REPO_DIR}/bench-output.json" " P50" "benchmark action output includes P50 samples"
-assert_file_contains "${REPO_DIR}/bench-output.json" " P95" "benchmark action output includes P95 samples"
-assert_file_contains "${REPO_DIR}/bench-output.json" " P99" "benchmark action output includes P99 samples"
-assert_file_contains "${REPO_DIR}/bench-output.json" "e2e codex pre-bash P95" "benchmark action output includes compact Codex wrapper samples"
-assert_file_contains "${REPO_DIR}/bench-output.json" "e2e post-build fake P95" "benchmark action output includes compact post-build samples"
+assert_success_contains "JSON latency output is written to override path" "Results: ${BENCH_JSON_TEMP}" "${TMP_DIR}/json.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --json-output="${BENCH_JSON_TEMP}" --bench-action-output="${BENCH_ACTION_TEMP}" --sla=100000
+assert_file_contains "${BENCH_JSON_TEMP}" '"surface":"hook_e2e_ms"' "JSON latency output declares hook e2e surface"
+assert_file_contains "${BENCH_ACTION_TEMP}" " P50" "benchmark action output includes P50 samples"
+assert_file_contains "${BENCH_ACTION_TEMP}" " P95" "benchmark action output includes P95 samples"
+assert_file_contains "${BENCH_ACTION_TEMP}" " P99" "benchmark action output includes P99 samples"
+assert_file_contains "${BENCH_ACTION_TEMP}" "e2e codex pre-bash P95" "benchmark action output includes compact Codex wrapper samples"
+assert_file_contains "${BENCH_ACTION_TEMP}" "e2e post-build fake P95" "benchmark action output includes compact post-build samples"
+assert_cmd "contract test does not require repo-root bench-output.json" test ! -e "${ROOT_BENCH_ACTION_FILE}"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "Codex wrapper hooks" "latency contract documents wrapper coverage"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "core_us" "latency contract documents core microbench surface"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "hook_e2e_ms" "latency contract documents hook e2e surface"
 assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "core_us" "benchmark design documents core microbench surface"
 assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "hook_e2e_ms" "benchmark design documents hook e2e surface"
-assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression
+assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
 
 echo ""
 echo "======================================"

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -182,6 +182,11 @@ write_hook "${BAD_OUTPUT_SUB_GIT_HOOKS}" "bad-output-sub-git-hook.sh" 'printf "%
 assert_fail_contains "git in output command substitution fails static validator" "PERF-03" "${TMP_DIR}/bad-output-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-output-sub-git.out" "bad-output-sub-git-hook.sh" "output substitution git names the hook"
 
+BAD_OUTPUT_PROC_SUB_GIT_HOOKS="${TMP_DIR}/bad-output-proc-sub-git-hooks"
+write_hook "${BAD_OUTPUT_PROC_SUB_GIT_HOOKS}" "bad-output-proc-sub-git-hook.sh" 'printf "%s\n" <(git status --short >/dev/null)'
+assert_fail_contains "git in output process substitution fails static validator" "PERF-03" "${TMP_DIR}/bad-output-proc-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_PROC_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-output-proc-sub-git.out" "bad-output-proc-sub-git-hook.sh" "output process substitution git names the hook"
+
 BAD_OUTPUT_CHAIN_GIT_HOOKS="${TMP_DIR}/bad-output-chain-git-hooks"
 write_hook "${BAD_OUTPUT_CHAIN_GIT_HOOKS}" "bad-output-chain-git-hook.sh" 'printf "%s\n" ok; git status --short >/dev/null'
 assert_fail_contains "git chained after output command fails static validator" "PERF-03" "${TMP_DIR}/bad-output-chain-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_CHAIN_GIT_HOOKS}" bash "${VALIDATOR}"
@@ -191,6 +196,11 @@ BAD_OUTPUT_PIPE_GIT_HOOKS="${TMP_DIR}/bad-output-pipe-git-hooks"
 write_hook "${BAD_OUTPUT_PIPE_GIT_HOOKS}" "bad-output-pipe-git-hook.sh" 'echo ok | git status --short >/dev/null'
 assert_fail_contains "git piped after output command fails static validator" "PERF-03" "${TMP_DIR}/bad-output-pipe-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_PIPE_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-output-pipe-git.out" "bad-output-pipe-git-hook.sh" "output pipe git names the hook"
+
+BAD_TIMEOUT_CHAIN_GIT_HOOKS="${TMP_DIR}/bad-timeout-chain-git-hooks"
+write_hook "${BAD_TIMEOUT_CHAIN_GIT_HOOKS}" "bad-timeout-chain-git-hook.sh" 'timeout 2 git status --short >/dev/null; git status --short >/dev/null'
+assert_fail_contains "unsafe git after bounded git fails static validator" "PERF-03" "${TMP_DIR}/bad-timeout-chain-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_TIMEOUT_CHAIN_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-timeout-chain-git.out" "bad-timeout-chain-git-hook.sh" "timeout chain git names the hook"
 
 BAD_SUPPRESSED_GIT_HOOKS="${TMP_DIR}/bad-suppressed-git-hooks"
 write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This comment mentions git status and must not count.

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -158,6 +158,10 @@ write_hook "${STRING_GIT_HOOKS}" "string-git-hook.sh" 'vg_warn "Copy-paste:
 "'
 assert_cmd "git in multiline warning string does not count" env VIBEGUARD_HOOKS_DIR="${STRING_GIT_HOOKS}" bash "${VALIDATOR}"
 
+OUTPUT_LITERAL_GIT_HOOKS="${TMP_DIR}/output-literal-git-hooks"
+write_hook "${OUTPUT_LITERAL_GIT_HOOKS}" "output-literal-git-hook.sh" 'printf "%s\n" "Copy-paste: git status --short"'
+assert_cmd "git in output literal does not count" env VIBEGUARD_HOOKS_DIR="${OUTPUT_LITERAL_GIT_HOOKS}" bash "${VALIDATOR}"
+
 BAD_FIND_HOOKS="${TMP_DIR}/bad-find-hooks"
 write_hook "${BAD_FIND_HOOKS}" "bad-find-hook.sh" 'find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_fail_contains "unbounded find fails static validator" "PERF-02" "${TMP_DIR}/bad-find.out" env VIBEGUARD_HOOKS_DIR="${BAD_FIND_HOOKS}" bash "${VALIDATOR}"
@@ -167,6 +171,16 @@ BAD_GIT_HOOKS="${TMP_DIR}/bad-git-hooks"
 write_hook "${BAD_GIT_HOOKS}" "bad-git-hook.sh" 'git status --short >/dev/null'
 assert_fail_contains "unsafe git call fails static validator" "PERF-03" "${TMP_DIR}/bad-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-git.out" "bad-git-hook.sh" "unsafe git output names the hook"
+
+BAD_ABSOLUTE_GIT_HOOKS="${TMP_DIR}/bad-absolute-git-hooks"
+write_hook "${BAD_ABSOLUTE_GIT_HOOKS}" "bad-absolute-git-hook.sh" '/usr/bin/git status --short >/dev/null'
+assert_fail_contains "unsafe absolute git call fails static validator" "PERF-03" "${TMP_DIR}/bad-absolute-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_ABSOLUTE_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-absolute-git.out" "bad-absolute-git-hook.sh" "absolute git output names the hook"
+
+BAD_OUTPUT_SUB_GIT_HOOKS="${TMP_DIR}/bad-output-sub-git-hooks"
+write_hook "${BAD_OUTPUT_SUB_GIT_HOOKS}" "bad-output-sub-git-hook.sh" 'printf "%s\n" "$(git status --short >/dev/null)"'
+assert_fail_contains "git in output command substitution fails static validator" "PERF-03" "${TMP_DIR}/bad-output-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_OUTPUT_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-output-sub-git.out" "bad-output-sub-git-hook.sh" "output substitution git names the hook"
 
 BAD_SUPPRESSED_GIT_HOOKS="${TMP_DIR}/bad-suppressed-git-hooks"
 write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This comment mentions git status and must not count.
@@ -178,6 +192,11 @@ BAD_LIB_GIT_HOOKS="${TMP_DIR}/bad-lib-git-hooks"
 write_hook "${BAD_LIB_GIT_HOOKS}/_lib" "bad-lib.sh" 'git status --short >/dev/null 2>&1 || true'
 assert_fail_contains "unsafe helper git call fails static validator" "PERF-03" "${TMP_DIR}/bad-lib-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_LIB_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-lib-git.out" "bad-lib.sh" "helper git output names the file"
+
+BAD_EXEC_GIT_HOOKS="${TMP_DIR}/bad-exec-git-hooks"
+write_hook "${BAD_EXEC_GIT_HOOKS}/git" "pre-push" 'git status --short >/dev/null 2>&1 || true'
+assert_fail_contains "unsafe executable hook git call fails static validator" "PERF-03" "${TMP_DIR}/bad-exec-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_EXEC_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-exec-git.out" "pre-push" "executable hook git output names the file"
 
 BAD_LOOP_HOOKS="${TMP_DIR}/bad-loop-hooks"
 write_hook "${BAD_LOOP_HOOKS}" "bad-loop-hook.sh" 'while read -r path; do python3 -c "print(1)" "$path"; done < /dev/null'

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -202,6 +202,11 @@ write_hook "${BAD_TIMEOUT_CHAIN_GIT_HOOKS}" "bad-timeout-chain-git-hook.sh" 'tim
 assert_fail_contains "unsafe git after bounded git fails static validator" "PERF-03" "${TMP_DIR}/bad-timeout-chain-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_TIMEOUT_CHAIN_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-timeout-chain-git.out" "bad-timeout-chain-git-hook.sh" "timeout chain git names the hook"
 
+BAD_TIMEOUT_SUB_GIT_HOOKS="${TMP_DIR}/bad-timeout-sub-git-hooks"
+write_hook "${BAD_TIMEOUT_SUB_GIT_HOOKS}" "bad-timeout-sub-git-hook.sh" 'timeout 2 git status --short "$(git status --short)" >/dev/null'
+assert_fail_contains "git substitution inside bounded git fails static validator" "PERF-03" "${TMP_DIR}/bad-timeout-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_TIMEOUT_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-timeout-sub-git.out" "bad-timeout-sub-git-hook.sh" "timeout substitution git names the hook"
+
 BAD_SUPPRESSED_GIT_HOOKS="${TMP_DIR}/bad-suppressed-git-hooks"
 write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This comment mentions git status and must not count.
 git status --short >/dev/null 2>&1 || true'

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -152,6 +152,12 @@ write_hook "${DOCUMENTED_GIT_HOOKS}" "documented-git-hook.sh" '# PERF-OK: fixtur
 git status --short >/dev/null'
 assert_cmd "PERF-OK documents an intentional git call" env VIBEGUARD_HOOKS_DIR="${DOCUMENTED_GIT_HOOKS}" bash "${VALIDATOR}"
 
+STRING_GIT_HOOKS="${TMP_DIR}/string-git-hooks"
+write_hook "${STRING_GIT_HOOKS}" "string-git-hook.sh" 'vg_warn "Copy-paste:
+  git status --short
+"'
+assert_cmd "git in multiline warning string does not count" env VIBEGUARD_HOOKS_DIR="${STRING_GIT_HOOKS}" bash "${VALIDATOR}"
+
 BAD_FIND_HOOKS="${TMP_DIR}/bad-find-hooks"
 write_hook "${BAD_FIND_HOOKS}" "bad-find-hook.sh" 'find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_fail_contains "unbounded find fails static validator" "PERF-02" "${TMP_DIR}/bad-find.out" env VIBEGUARD_HOOKS_DIR="${BAD_FIND_HOOKS}" bash "${VALIDATOR}"
@@ -167,6 +173,11 @@ write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This co
 git status --short >/dev/null 2>&1 || true'
 assert_fail_contains "error-suppressed git still requires timeout or PERF-OK" "PERF-03" "${TMP_DIR}/bad-suppressed-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_SUPPRESSED_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-suppressed-git.out" "bad-suppressed-git-hook.sh" "suppressed git output names the hook"
+
+BAD_LIB_GIT_HOOKS="${TMP_DIR}/bad-lib-git-hooks"
+write_hook "${BAD_LIB_GIT_HOOKS}/_lib" "bad-lib.sh" 'git status --short >/dev/null 2>&1 || true'
+assert_fail_contains "unsafe helper git call fails static validator" "PERF-03" "${TMP_DIR}/bad-lib-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_LIB_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-lib-git.out" "bad-lib.sh" "helper git output names the file"
 
 BAD_LOOP_HOOKS="${TMP_DIR}/bad-loop-hooks"
 write_hook "${BAD_LOOP_HOOKS}" "bad-loop-hook.sh" 'while read -r path; do python3 -c "print(1)" "$path"; done < /dev/null'


### PR DESCRIPTION
## Summary

- make `tests/bench_hook_latency.sh` support explicit JSON/action output paths and disabling benchmark-action output, while preserving the CI default `bench-output.json`
- turn PERF-03 from advisory git-call counting into an enforceable recursive static gate for top-level hooks, `hooks/_lib` helpers, and executable hook entrypoints, with fixtures for unsafe, suppressed, helper, executable, absolute-path, output-substitution, process-substitution, output-chained, output-piped, timeout-chain, timeout-substitution, `gtimeout`-wrapped, quoted-warning, output-literal, and `PERF-OK` git calls
- make CI reuse the precision CSV from `tests/run_precision.sh --all --csv` for both threshold validation and the fast benchmark score path

Closes #493.

## Verification

- `bash -n scripts/ci/validate-hook-perf.sh && bash -n tests/bench_hook_latency.sh && bash -n tests/test_hook_perf_contract.sh && bash -n scripts/ci/validate-precision-thresholds.sh && bash -n scripts/benchmark.sh`
- `time bash scripts/ci/validate-hook-perf.sh` (~2.6s locally after timeout substitution scan)
- `bash tests/test_hook_perf_contract.sh` (61/61)
- `bash tests/hooks/test_pre_push_guard.sh` (5/5)
- `bash tests/bench_hook_latency.sh --runs=1 --fail-on-regression --json-output="$tmpdir/latency.json" --bench-action-output="$tmpdir/bench-output.json"`
- `bash tests/run_precision.sh --all --csv > "$tmpcsv" && VG_PRECISION_CSV_FILE="$tmpcsv" bash scripts/ci/validate-precision-thresholds.sh`
- `VIBEGUARD_BENCHMARK_RESULTS_DIR="$tmpdir/results" VG_PRECISION_CSV_FILE="$tmpcsv" bash scripts/benchmark.sh --mode=fast`
- `git diff --check`
