### PR TITLE
test: expand performance gate contracts

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -64,16 +64,25 @@ L1_CSV="$(load_layer1_csv)"
 L1_RESULT=$(echo "$L1_CSV" | python3 -c "
 import sys, json
 
-lines = [l.strip() for l in sys.stdin if l.strip() and not l.startswith('hook,')]
+lines = [
+    (lineno, line.strip())
+    for lineno, line in enumerate(sys.stdin, start=1)
+    if line.strip() and not line.startswith('hook,')
+]
 tp = fp = fn = tn = 0
 by_hook = {}
 
-for line in lines:
+for lineno, line in lines:
     parts = line.split(',')
     if len(parts) < 8:
-        continue
+        print(f'FAIL: malformed precision CSV line {lineno}: {line}', file=sys.stderr)
+        raise SystemExit(1)
     hook, case, case_type, rule, expect, detected, passed, latency = parts
-    detected = int(detected)
+    try:
+        detected = int(detected)
+    except ValueError:
+        print(f'FAIL: invalid detected value {detected!r} on precision CSV line {lineno}', file=sys.stderr)
+        raise SystemExit(1)
 
     by_hook.setdefault(hook, {'tp': 0, 'fp': 0, 'fn': 0, 'tn': 0})
 
@@ -87,6 +96,10 @@ for line in lines:
             fp += 1; by_hook[hook]['fp'] += 1
         else:
             tn += 1; by_hook[hook]['tn'] += 1
+
+if not by_hook:
+    print('FAIL: zero precision rows parsed from CSV output', file=sys.stderr)
+    raise SystemExit(1)
 
 precision = tp / (tp + fp) if (tp + fp) > 0 else 0
 recall = tp / (tp + fn) if (tp + fn) > 0 else 0

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -155,10 +155,28 @@ hook_script_files() {
   find "$HOOKS_DIR" -type f \( -name '*.sh' -o -perm -111 \) | sort
 }
 
+hook_perf_scan_files() {
+  local file base
+  while IFS= read -r file; do
+    base="${file##*/}"
+    case "$base" in
+      log.sh|circuit-breaker.sh)
+        continue ;;
+    esac
+    printf '%s\n' "$file"
+  done < <(hook_script_files)
+}
+
 line_has_git_command() {
   local line="$1"
   local git_re='(^|[[:space:];|&({])(/?[[:alnum:]_.-]+/)*git[[:space:]]'
   [[ "$line" =~ $git_re ]]
+}
+
+line_has_git_in_substitution() {
+  local line="$1"
+  local git_sub_re='(\$\(|<\(|>\()[^)]*(/?[[:alnum:]_.-]+/)*git[[:space:]]|`[^`]*(/?[[:alnum:]_.-]+/)*git[[:space:]]'
+  [[ "$line" =~ $git_sub_re ]]
 }
 
 find_command_has_maxdepth() {
@@ -180,11 +198,16 @@ find_command_has_maxdepth() {
 git_command_is_safe() {
   local line="$1"
   local timeout_git_re='(^|[[:space:];|&({])(gtimeout|timeout)[[:space:]][^;&|]*[[:space:]](/?[[:alnum:]_.-]+/)*git[[:space:]]'
-  local remaining
+  local remaining timeout_match
 
   # timeout-wrapped git calls have a bounded wall-clock budget.
   if [[ "$line" =~ $timeout_git_re ]]; then
-    remaining="${line#*"${BASH_REMATCH[0]}"}"
+    timeout_match="${BASH_REMATCH[0]}"
+    # Command substitutions inside timeout arguments run before timeout starts.
+    if line_has_git_in_substitution "$line"; then
+      return 1
+    fi
+    remaining="${line#*"${timeout_match}"}"
     ! line_has_git_command "$remaining"
     return
   fi
@@ -225,17 +248,18 @@ while IFS= read -r file; do
     if ! line_is_comment "$line" && ! perf_ok_nearby "$file" "$line_no"; then
       OPEN_VIOLATION=true
     fi
-  done < <(grep -n 'with open(log_file)' "$file" 2>/dev/null || true)
+  done < <(
+    grep -nE 'with[[:space:]]+open\([[:space:]]*log_file|open\([[:space:]]*os\.environ' "$file" 2>/dev/null \
+      | grep -E 'log_file|LOG_FILE|with[[:space:]]+open\([[:space:]]*log_file' \
+      || true
+  )
   if [[ "$OPEN_VIOLATION" == "true" ]]; then
     red "${file##*/}: Python opens log_file directly — use 'tail -N \$LOG | python3' instead"
-    VIOLATIONS=$((VIOLATIONS + 1))
-  elif grep -n "open(os.environ" "$file" 2>/dev/null | grep -q 'LOG_FILE\|log_file'; then
-    red "${file##*/}: Python opens log file via env var — use 'tail -N | python3' instead"
     VIOLATIONS=$((VIOLATIONS + 1))
   else
     green "${file##*/}: no unbounded JSONL read"
   fi
-done < <(find "$HOOKS_DIR" -name '*.sh' -not -name 'log.sh' -not -name 'circuit-breaker.sh' -not -path '*/_lib/*' | sort)
+done < <(hook_perf_scan_files)
 echo ""
 
 # --- Rule 2: find without -maxdepth ---
@@ -261,7 +285,7 @@ while IFS= read -r file; do
       fi
     done <<< "$UNBOUNDED_FINDS"
   fi
-done < <(find "$HOOKS_DIR" -name '*.sh' | sort)
+done < <(hook_script_files)
 echo ""
 
 # --- Rule 3: Git commands that could hang (no timeout context) ---
@@ -339,7 +363,7 @@ while IFS= read -r file; do
   if [[ "$LOOP_SUBPROCESS" == "false" ]]; then
     green "${file##*/}: no subprocess-in-loop"
   fi
-done < <(find "$HOOKS_DIR" -name '*.sh' -not -name 'log.sh' -not -name 'circuit-breaker.sh' | sort)
+done < <(hook_perf_scan_files)
 echo ""
 
 # --- Summary ---

--- a/scripts/ci/validate-hook-perf.sh
+++ b/scripts/ci/validate-hook-perf.sh
@@ -152,7 +152,7 @@ line_has_odd_quote() {
 }
 
 hook_script_files() {
-  find "$HOOKS_DIR" -type f \( -name '*.sh' -o -perm -111 \) | sort
+  find "$HOOKS_DIR" -type f \( -name '*.sh' -o -perm -100 -o -perm -010 -o -perm -001 \) | sort
 }
 
 hook_perf_scan_files() {

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -9,6 +9,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 VALIDATOR="${REPO_DIR}/scripts/ci/validate-hook-perf.sh"
 BENCH="${REPO_DIR}/tests/bench_hook_latency.sh"
 BENCHMARK="${REPO_DIR}/scripts/benchmark.sh"
+THRESHOLD_VALIDATOR="${REPO_DIR}/scripts/ci/validate-precision-thresholds.sh"
 
 PASS=0
 FAIL=0
@@ -125,6 +126,7 @@ header "syntax"
 assert_cmd "performance validator syntax" bash -n "${VALIDATOR}"
 assert_cmd "latency benchmark syntax" bash -n "${BENCH}"
 assert_cmd "benchmark syntax" bash -n "${BENCHMARK}"
+assert_cmd "precision threshold validator syntax" bash -n "${THRESHOLD_VALIDATOR}"
 assert_file_contains "${BENCH}" "Codex wrapper benchmark requires vibeguard-runtime" "latency benchmark fails fast without runtime for Codex wrapper fixtures"
 
 header "static performance gates"
@@ -142,6 +144,15 @@ DOCUMENTED_HOOKS="${TMP_DIR}/documented-hooks"
 write_hook "${DOCUMENTED_HOOKS}" "documented-hook.sh" '# PERF-OK: fixture intentionally scans its temp project root.
 find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_cmd "PERF-OK documents an intentional scan" env VIBEGUARD_HOOKS_DIR="${DOCUMENTED_HOOKS}" bash "${VALIDATOR}"
+
+DOCUMENTED_JSONL_OPEN_HOOKS="${TMP_DIR}/documented-jsonl-open-hooks"
+write_hook "${DOCUMENTED_JSONL_OPEN_HOOKS}" "documented-jsonl-open-hook.sh" 'python3 - <<PY
+import os
+# PERF-OK: fixture intentionally reads the full log.
+with open(os.environ["VIBEGUARD_LOG_FILE"], encoding="utf-8") as handle:
+    print(handle.readline())
+PY'
+assert_cmd "PERF-OK documents an intentional full JSONL read" env VIBEGUARD_HOOKS_DIR="${DOCUMENTED_JSONL_OPEN_HOOKS}" bash "${VALIDATOR}"
 
 TIMEOUT_GIT_HOOKS="${TMP_DIR}/timeout-git-hooks"
 write_hook "${TIMEOUT_GIT_HOOKS}" "timeout-git-hook.sh" 'gtimeout 2 git status --short >/dev/null'
@@ -166,6 +177,29 @@ BAD_FIND_HOOKS="${TMP_DIR}/bad-find-hooks"
 write_hook "${BAD_FIND_HOOKS}" "bad-find-hook.sh" 'find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
 assert_fail_contains "unbounded find fails static validator" "PERF-02" "${TMP_DIR}/bad-find.out" env VIBEGUARD_HOOKS_DIR="${BAD_FIND_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-find.out" "bad-find-hook.sh" "unbounded find output names the hook"
+
+BAD_EXEC_FIND_HOOKS="${TMP_DIR}/bad-exec-find-hooks"
+write_hook "${BAD_EXEC_FIND_HOOKS}/git" "pre-push" 'find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
+assert_fail_contains "unbounded find in executable hook fails static validator" "PERF-02" "${TMP_DIR}/bad-exec-find.out" env VIBEGUARD_HOOKS_DIR="${BAD_EXEC_FIND_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-exec-find.out" "pre-push" "executable find output names the hook"
+
+BAD_JSONL_OPEN_HOOKS="${TMP_DIR}/bad-jsonl-open-hooks"
+write_hook "${BAD_JSONL_OPEN_HOOKS}" "bad-jsonl-open-hook.sh" 'python3 - <<PY
+log_file = "${VIBEGUARD_LOG_FILE:-events.jsonl}"
+with open(log_file, encoding="utf-8") as handle:
+    print(handle.readline())
+PY'
+assert_fail_contains "direct log_file open fails static validator" "PERF-01" "${TMP_DIR}/bad-jsonl-open.out" env VIBEGUARD_HOOKS_DIR="${BAD_JSONL_OPEN_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-jsonl-open.out" "bad-jsonl-open-hook.sh" "direct log_file open output names the hook"
+
+BAD_LIB_JSONL_OPEN_HOOKS="${TMP_DIR}/bad-lib-jsonl-open-hooks"
+write_hook "${BAD_LIB_JSONL_OPEN_HOOKS}/_lib" "bad-lib.sh" 'python3 - <<PY
+import os
+with open(os.environ["VIBEGUARD_LOG_FILE"], encoding="utf-8") as handle:
+    print(handle.readline())
+PY'
+assert_fail_contains "helper log env open fails static validator" "PERF-01" "${TMP_DIR}/bad-lib-jsonl-open.out" env VIBEGUARD_HOOKS_DIR="${BAD_LIB_JSONL_OPEN_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-lib-jsonl-open.out" "bad-lib.sh" "helper log env open output names the file"
 
 BAD_GIT_HOOKS="${TMP_DIR}/bad-git-hooks"
 write_hook "${BAD_GIT_HOOKS}" "bad-git-hook.sh" 'git status --short >/dev/null'
@@ -207,6 +241,11 @@ write_hook "${BAD_TIMEOUT_SUB_GIT_HOOKS}" "bad-timeout-sub-git-hook.sh" 'timeout
 assert_fail_contains "git substitution inside bounded git fails static validator" "PERF-03" "${TMP_DIR}/bad-timeout-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_TIMEOUT_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-timeout-sub-git.out" "bad-timeout-sub-git-hook.sh" "timeout substitution git names the hook"
 
+BAD_TIMEOUT_PREFIX_SUB_GIT_HOOKS="${TMP_DIR}/bad-timeout-prefix-sub-git-hooks"
+write_hook "${BAD_TIMEOUT_PREFIX_SUB_GIT_HOOKS}" "bad-timeout-prefix-sub-git-hook.sh" 'timeout "$(git config hooks.timeout)" git status --short >/dev/null'
+assert_fail_contains "git substitution in timeout argument fails static validator" "PERF-03" "${TMP_DIR}/bad-timeout-prefix-sub-git.out" env VIBEGUARD_HOOKS_DIR="${BAD_TIMEOUT_PREFIX_SUB_GIT_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-timeout-prefix-sub-git.out" "bad-timeout-prefix-sub-git-hook.sh" "timeout argument substitution git names the hook"
+
 BAD_SUPPRESSED_GIT_HOOKS="${TMP_DIR}/bad-suppressed-git-hooks"
 write_hook "${BAD_SUPPRESSED_GIT_HOOKS}" "bad-suppressed-git-hook.sh" '# This comment mentions git status and must not count.
 git status --short >/dev/null 2>&1 || true'
@@ -228,6 +267,11 @@ write_hook "${BAD_LOOP_HOOKS}" "bad-loop-hook.sh" 'while read -r path; do python
 assert_fail_contains "subprocess in loop fails static validator" "PERF-04" "${TMP_DIR}/bad-loop.out" env VIBEGUARD_HOOKS_DIR="${BAD_LOOP_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-loop.out" "bad-loop-hook.sh" "loop subprocess output names the hook"
 
+BAD_EXEC_LOOP_HOOKS="${TMP_DIR}/bad-exec-loop-hooks"
+write_hook "${BAD_EXEC_LOOP_HOOKS}/git" "pre-commit" 'while read -r path; do python3 -c "print(1)" "$path"; done < /dev/null'
+assert_fail_contains "subprocess loop in executable hook fails static validator" "PERF-04" "${TMP_DIR}/bad-exec-loop.out" env VIBEGUARD_HOOKS_DIR="${BAD_EXEC_LOOP_HOOKS}" bash "${VALIDATOR}"
+assert_file_contains "${TMP_DIR}/bad-exec-loop.out" "pre-commit" "executable loop output names the hook"
+
 header "dynamic latency gate"
 assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
 assert_file_contains "${TMP_DIR}/slow.out" "Surface: hook_e2e_ms" "latency gate declares hook e2e surface"
@@ -244,12 +288,23 @@ assert_file_contains "${BENCH_ACTION_TEMP}" " P95" "benchmark action output incl
 assert_file_contains "${BENCH_ACTION_TEMP}" " P99" "benchmark action output includes P99 samples"
 assert_file_contains "${BENCH_ACTION_TEMP}" "e2e codex pre-bash P95" "benchmark action output includes compact Codex wrapper samples"
 assert_file_contains "${BENCH_ACTION_TEMP}" "e2e post-build fake P95" "benchmark action output includes compact post-build samples"
+assert_cmd "benchmark action output parses as JSON" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert isinstance(data, list) and data
+for row in data:
+    assert set(["name", "unit", "value"]) <= set(row)
+    assert row["unit"] == "ms"
+    assert isinstance(row["value"], (int, float))
+' "${BENCH_ACTION_TEMP}"
 assert_cmd "contract test does not require repo-root bench-output.json" test ! -e "${ROOT_BENCH_ACTION_FILE}"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "Codex wrapper hooks" "latency contract documents wrapper coverage"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "core_us" "latency contract documents core microbench surface"
 assert_file_contains "${REPO_DIR}/docs/reference/hook-latency-contract.md" "hook_e2e_ms" "latency contract documents hook e2e surface"
 assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "core_us" "benchmark design documents core microbench surface"
 assert_file_contains "${REPO_DIR}/docs/internal/benchmarks/benchmark-design.md" "hook_e2e_ms" "benchmark design documents hook e2e surface"
+assert_file_contains "${REPO_DIR}/vibeguard-runtime/benches/core_us.rs" 'benchmark_group("core_us")' "core_us benchmark group stays registered"
+assert_file_contains "${REPO_DIR}/vibeguard-runtime/benches/core_us.rs" 'bash_destructive_restore' "core_us benchmark keeps bash classifier sample"
+assert_file_contains "${REPO_DIR}/vibeguard-runtime/benches/core_us.rs" 'write_clean_rust_fast_path' "core_us benchmark keeps write classifier sample"
 assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
 
 header "benchmark score gate"
@@ -261,6 +316,29 @@ pre-bash-guard,fp-case,fp,rule,allow,0,1,5
 CSV
 assert_success_contains "fast benchmark reuses precision CSV fixture" "Cases: 2" "${TMP_DIR}/benchmark.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-results" VG_PRECISION_CSV_FILE="${BENCHMARK_CSV}" bash "${BENCHMARK}" --mode=fast
 assert_fail_contains "fast benchmark fails on missing precision CSV" "VG_PRECISION_CSV_FILE does not exist" "${TMP_DIR}/benchmark-missing.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-missing-results" VG_PRECISION_CSV_FILE="${TMP_DIR}/missing-precision.csv" bash "${BENCHMARK}" --mode=fast
+assert_success_contains "precision threshold validator accepts CSV fixture" "F1:" "${TMP_DIR}/threshold.out" env VG_PRECISION_CSV_FILE="${BENCHMARK_CSV}" bash "${THRESHOLD_VALIDATOR}"
+
+EMPTY_BENCHMARK_CSV="${TMP_DIR}/precision-empty.csv"
+cat > "${EMPTY_BENCHMARK_CSV}" <<'CSV'
+hook,case,type,rule,expect,detected,passed,latency
+CSV
+assert_fail_contains "fast benchmark fails on empty precision CSV" "zero precision rows parsed" "${TMP_DIR}/benchmark-empty.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-empty-results" VG_PRECISION_CSV_FILE="${EMPTY_BENCHMARK_CSV}" bash "${BENCHMARK}" --mode=fast
+assert_fail_contains "precision threshold validator fails on empty CSV" "zero precision rows parsed" "${TMP_DIR}/threshold-empty.out" env VG_PRECISION_CSV_FILE="${EMPTY_BENCHMARK_CSV}" bash "${THRESHOLD_VALIDATOR}"
+
+MALFORMED_BENCHMARK_CSV="${TMP_DIR}/precision-malformed.csv"
+cat > "${MALFORMED_BENCHMARK_CSV}" <<'CSV'
+hook,case,type,rule,expect,detected,passed,latency
+pre-bash-guard,tp-case,tp
+CSV
+assert_fail_contains "fast benchmark fails on malformed precision CSV" "malformed precision CSV line" "${TMP_DIR}/benchmark-malformed.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-malformed-results" VG_PRECISION_CSV_FILE="${MALFORMED_BENCHMARK_CSV}" bash "${BENCHMARK}" --mode=fast
+
+BAD_DETECTED_BENCHMARK_CSV="${TMP_DIR}/precision-bad-detected.csv"
+cat > "${BAD_DETECTED_BENCHMARK_CSV}" <<'CSV'
+hook,case,type,rule,expect,detected,passed,latency
+pre-bash-guard,tp-case,tp,rule,block,maybe,1,5
+CSV
+assert_fail_contains "fast benchmark fails on invalid detected value" "invalid detected value" "${TMP_DIR}/benchmark-bad-detected.out" env VIBEGUARD_BENCHMARK_RESULTS_DIR="${TMP_DIR}/benchmark-bad-detected-results" VG_PRECISION_CSV_FILE="${BAD_DETECTED_BENCHMARK_CSV}" bash "${BENCHMARK}" --mode=fast
+assert_fail_contains "precision threshold validator fails on invalid detected value" "invalid detected value" "${TMP_DIR}/threshold-bad-detected.out" env VG_PRECISION_CSV_FILE="${BAD_DETECTED_BENCHMARK_CSV}" bash "${THRESHOLD_VALIDATOR}"
 
 echo ""
 echo "======================================"

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -180,6 +180,7 @@ assert_file_contains "${TMP_DIR}/bad-find.out" "bad-find-hook.sh" "unbounded fin
 
 BAD_EXEC_FIND_HOOKS="${TMP_DIR}/bad-exec-find-hooks"
 write_hook "${BAD_EXEC_FIND_HOOKS}/git" "pre-push" 'find "$PROJECT_DIR" -type f >/dev/null 2>&1 || true'
+chmod 700 "${BAD_EXEC_FIND_HOOKS}/git/pre-push"
 assert_fail_contains "unbounded find in executable hook fails static validator" "PERF-02" "${TMP_DIR}/bad-exec-find.out" env VIBEGUARD_HOOKS_DIR="${BAD_EXEC_FIND_HOOKS}" bash "${VALIDATOR}"
 assert_file_contains "${TMP_DIR}/bad-exec-find.out" "pre-push" "executable find output names the hook"
 

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -405,6 +405,38 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "ci performance gate wiring"
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}/.github/workflows/ci.yml" >/dev/null <<'PY'; then
+from pathlib import Path
+import sys
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+required_steps = {
+    "Hook performance static analysis": "bash scripts/ci/validate-hook-perf.sh",
+    "Hook performance contract regression tests": "bash tests/test_hook_perf_contract.sh",
+    "Hook latency benchmark": "bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression",
+}
+
+for name, command in required_steps.items():
+    marker = f"- name: {name}"
+    start = workflow.find(marker)
+    if start < 0:
+        raise SystemExit(f"missing CI performance step: {name}")
+    next_step = workflow.find("\n      - name:", start + len(marker))
+    block = workflow[start:] if next_step < 0 else workflow[start:next_step]
+    if command not in block:
+        raise SystemExit(f"{name} does not run required command: {command}")
+    if "continue-on-error" in block:
+        raise SystemExit(f"{name} must not use continue-on-error")
+PY
+  green "CI performance gates stay blocking"
+  PASS=$((PASS + 1))
+else
+  red "CI performance gates stay blocking"
+  FAIL=$((FAIL + 1))
+fi
+
 header "consumer drift failures"
 HANDOFF_FIXTURE="${TMP_DIR}/handoff"
 copy_schemas "${HANDOFF_FIXTURE}"


### PR DESCRIPTION
## Summary
- expand hook performance contract coverage for PERF-01, extensionless executable hooks, timeout-argument git substitutions, benchmark JSON output, and core_us benchmark registration
- make scripts/benchmark.sh fail loudly on empty, malformed, or invalid precision CSV input
- add a workflow contract that keeps the CI performance gates blocking and wired to the expected commands

## Verification
- bash scripts/ci/validate-hook-perf.sh
- bash tests/test_hook_perf_contract.sh
- bash tests/test_workflow_contracts.sh
- git diff --check