### PR TITLE
perf: consolidate post-edit history queries

### DIFF
--- a/hooks/_lib/post_edit_history.sh
+++ b/hooks/_lib/post_edit_history.sh
@@ -231,6 +231,10 @@ ESCAPE: set VIBEGUARD_SUPPRESS_W15=1 to suppress (e.g. for long-document writing
 }
 
 vg_post_edit_warn_count_for_file() {
+  if [[ "${1:-}" == "--fresh" ]]; then
+    vg_post_edit_history_numeric_query 500 warn-count "$VIBEGUARD_SESSION_ID" "$FILE_PATH"
+    return 0
+  fi
   vg_post_edit_history_summary
   vg_post_edit_history_numeric_field "WARN_COUNT"
 }

--- a/hooks/_lib/post_edit_history.sh
+++ b/hooks/_lib/post_edit_history.sh
@@ -51,16 +51,62 @@ vg_post_edit_history_numeric_query() {
   fi
 }
 
-vg_post_edit_count_build_failures() {
-  local project_root
+_VG_POST_EDIT_HISTORY_SUMMARY_LOADED=0
+_VG_POST_EDIT_HISTORY_SUMMARY=""
+
+vg_post_edit_history_reset() {
+  _VG_POST_EDIT_HISTORY_SUMMARY_LOADED=0
+  _VG_POST_EDIT_HISTORY_SUMMARY=""
+}
+
+vg_post_edit_history_project_root() {
   # PERF-OK: build-failure history is repo-scoped; outside git uses an empty root.
-  project_root=$(vg_post_edit_history_with_timeout git rev-parse --show-toplevel 2>/dev/null || echo "")
-  vg_post_edit_history_numeric_query 200 build-fails "$VIBEGUARD_SESSION_ID" "$project_root"
+  vg_post_edit_history_with_timeout git rev-parse --show-toplevel 2>/dev/null || echo ""
+}
+
+vg_post_edit_history_summary() {
+  if [[ "${_VG_POST_EDIT_HISTORY_SUMMARY_LOADED:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  local project_root
+  project_root="$(vg_post_edit_history_project_root)"
+  _VG_POST_EDIT_HISTORY_SUMMARY="$(
+    vg_post_edit_history_query 500 post-edit-history \
+      "$VIBEGUARD_SESSION_ID" \
+      "$FILE_PATH" \
+      "${VIBEGUARD_AGENT_TYPE:-}" \
+      "$project_root" \
+      2>/dev/null || true
+  )"
+  _VG_POST_EDIT_HISTORY_SUMMARY_LOADED=1
+}
+
+vg_post_edit_history_field() {
+  local key="$1"
+  vg_post_edit_history_summary
+  awk -v key="$key" 'index($0, key "\t") == 1 { print substr($0, length(key) + 2); exit }' \
+    <<< "${_VG_POST_EDIT_HISTORY_SUMMARY}"
+}
+
+vg_post_edit_history_numeric_field() {
+  local value
+  value="$(vg_post_edit_history_field "$1" | tr -d '[:space:]')"
+  if [[ "${value}" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "${value}"
+  else
+    printf '0\n'
+  fi
+}
+
+vg_post_edit_count_build_failures() {
+  vg_post_edit_history_numeric_field "BUILD_FAILS"
 }
 
 vg_post_edit_detect_churn() {
   local churn_count build_fail_count
-  churn_count="$(vg_post_edit_history_numeric_query 500 churn-count "$VIBEGUARD_SESSION_ID" "$FILE_PATH")"
+  vg_post_edit_history_summary
+  churn_count="$(vg_post_edit_history_numeric_field "CHURN")"
   build_fail_count="0"
 
   if [[ "$churn_count" -ge 20 ]]; then
@@ -92,8 +138,8 @@ DO NOT: Take any action — this is informational only"
 
 vg_post_edit_detect_w14_overlap() {
   local recent_conflict other_session other_agent other_hook other_tool
-  recent_conflict=$(vg_post_edit_history_query 500 post-edit-history "$VIBEGUARD_SESSION_ID" "$FILE_PATH" "${VIBEGUARD_AGENT_TYPE:-}" \
-    2>/dev/null | awk -F '\t' '$1 == "W14" { print $2 "|" $3 "|" $4 "|" $5 }' | tail -1 | tr -d '\r' || true)
+  vg_post_edit_history_summary
+  recent_conflict="$(vg_post_edit_history_field "W14" | tr '\t' '|' | tail -1 | tr -d '\r' || true)"
 
   [[ -n "$recent_conflict" ]] || return 0
   IFS='|' read -r other_session other_agent other_hook other_tool <<< "$recent_conflict"
@@ -146,14 +192,12 @@ vg_post_edit_detect_w15_loop() {
     esac
   fi
 
-  local current_delta past_consecutive past_deltas raw
+  local current_delta past_consecutive past_deltas
   current_delta="${VG_W15_CURRENT_DELTA:-0}"
 
-  raw=$(vg_post_edit_history_query 200 post-edit-w15 "$VIBEGUARD_SESSION_ID" "$FILE_PATH" \
-    2>/dev/null || printf "0\n\n")
-
-  past_consecutive=$(printf '%s\n' "$raw" | sed -n '1p' | tr -d '[:space:]')
-  past_deltas=$(printf '%s\n' "$raw" | sed -n '2p')
+  vg_post_edit_history_summary
+  past_consecutive="$(vg_post_edit_history_numeric_field "W15")"
+  past_deltas="$(vg_post_edit_history_field "W15_DELTAS")"
   past_consecutive="${past_consecutive:-0}"
 
   [[ "$past_consecutive" -ge 2 ]] || return 0
@@ -187,5 +231,6 @@ ESCAPE: set VIBEGUARD_SUPPRESS_W15=1 to suppress (e.g. for long-document writing
 }
 
 vg_post_edit_warn_count_for_file() {
-  vg_post_edit_history_numeric_query 500 warn-count "$VIBEGUARD_SESSION_ID" "$FILE_PATH"
+  vg_post_edit_history_summary
+  vg_post_edit_history_numeric_field "WARN_COUNT"
 }

--- a/hooks/post-edit-guard.sh
+++ b/hooks/post-edit-guard.sh
@@ -118,7 +118,7 @@ fi
 # --- Escalation detection ---
 # The same file is warned more than 3 times in the current log → upgrade to escalate
 DECISION="warn"
-WARN_COUNT_FOR_FILE=$(vg_post_edit_warn_count_for_file)
+WARN_COUNT_FOR_FILE=$(vg_post_edit_warn_count_for_file --fresh)
 WARN_COUNT_FOR_FILE="${WARN_COUNT_FOR_FILE:-0}"
 
 if [[ "$WARN_COUNT_FOR_FILE" -ge 3 ]]; then

--- a/tests/hooks/test_post_edit_churn.sh
+++ b/tests/hooks/test_post_edit_churn.sh
@@ -21,6 +21,7 @@ touch "$FILE_PATH"
 
 append_event() {
   local hook="$1" tool="$2" decision="$3" reason="$4" detail="$5"
+  vg_post_edit_history_reset
   printf '{"ts":"%s","session":"%s","hook":"%s","tool":"%s","decision":"%s","reason":"%s","detail":"%s"}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "$VIBEGUARD_SESSION_ID" "$hook" "$tool" "$decision" "$reason" "$detail" >> "$VIBEGUARD_LOG_FILE"
@@ -74,6 +75,54 @@ VIBEGUARD_POST_EDIT_HISTORY_TIMEOUT=bad
 assert_exit_zero "invalid post-edit history timeout falls back below aggregate hook budget" test "$(vg_post_edit_history_timeout_seconds)" = "2"
 unset VIBEGUARD_POST_EDIT_HISTORY_TIMEOUT
 
+summary_runtime="$WORK_DIR/summary-runtime.sh"
+summary_calls="$WORK_DIR/summary-runtime-calls.log"
+cat > "$summary_runtime" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "${1:-}" >> "$VG_STUB_RUNTIME_CALLS"
+cat >/dev/null || true
+
+case "${1:-}" in
+  post-edit-history)
+    printf 'CHURN\t20\n'
+    printf 'W15\t2\n'
+    printf 'W15_DELTAS\t100,200\n'
+    printf 'WARN_COUNT\t1\n'
+    printf 'BUILD_FAILS\t5\n'
+    ;;
+  *)
+    printf '0\n'
+    ;;
+esac
+STUB
+chmod +x "$summary_runtime"
+
+old_runtime="$_VIBEGUARD_RUNTIME"
+_VIBEGUARD_RUNTIME="$summary_runtime"
+export VG_STUB_RUNTIME_CALLS="$summary_calls"
+VG_W15_CURRENT_DELTA=50
+EDIT_DETAIL="$FILE_PATH||delta=50"
+vg_post_edit_history_reset
+WARNINGS=""
+vg_post_edit_detect_churn
+warn_count="$(vg_post_edit_warn_count_for_file)"
+vg_post_edit_detect_w15_loop
+assert_contains "$WARNINGS" "[CHURN CRITICAL]" "combined post-edit history keeps churn critical semantics"
+assert_contains "$WARNINGS" "[W-15]" "combined post-edit history keeps W-15 semantics"
+assert_exit_zero "combined post-edit history keeps warn-count semantics" test "$warn_count" = "1"
+assert_exit_zero "post-edit history summary uses one history query across detectors" \
+  test "$(grep -c '^post-edit-history$' "$summary_calls" | tr -d '[:space:]')" = "1"
+assert_contains "$(cat "$summary_calls")" "post-edit-history" "combined summary calls post-edit-history"
+assert_not_contains "$(cat "$summary_calls")" "churn-count" "combined summary avoids legacy churn-count call"
+assert_not_contains "$(cat "$summary_calls")" "build-fails" "combined summary avoids legacy build-fails call"
+assert_not_contains "$(cat "$summary_calls")" "warn-count" "combined summary avoids legacy warn-count call"
+_VIBEGUARD_RUNTIME="$old_runtime"
+unset VG_STUB_RUNTIME_CALLS
+unset VG_W15_CURRENT_DELTA
+unset EDIT_DETAIL
+
 slow_runtime="$WORK_DIR/slow-runtime.sh"
 cat > "$slow_runtime" <<'STUB'
 #!/usr/bin/env bash
@@ -92,7 +141,6 @@ esac
 STUB
 chmod +x "$slow_runtime"
 
-old_runtime="$_VIBEGUARD_RUNTIME"
 _VIBEGUARD_RUNTIME="$slow_runtime"
 export VIBEGUARD_POST_EDIT_HISTORY_TIMEOUT=1
 seed_edits 20

--- a/tests/hooks/test_post_edit_churn.sh
+++ b/tests/hooks/test_post_edit_churn.sh
@@ -92,6 +92,9 @@ case "${1:-}" in
     printf 'WARN_COUNT\t1\n'
     printf 'BUILD_FAILS\t5\n'
     ;;
+  warn-count)
+    printf '3\n'
+    ;;
   *)
     printf '0\n'
     ;;
@@ -107,17 +110,20 @@ EDIT_DETAIL="$FILE_PATH||delta=50"
 vg_post_edit_history_reset
 WARNINGS=""
 vg_post_edit_detect_churn
-warn_count="$(vg_post_edit_warn_count_for_file)"
+cached_warn_count="$(vg_post_edit_warn_count_for_file)"
+fresh_warn_count="$(vg_post_edit_warn_count_for_file --fresh)"
 vg_post_edit_detect_w15_loop
 assert_contains "$WARNINGS" "[CHURN CRITICAL]" "combined post-edit history keeps churn critical semantics"
 assert_contains "$WARNINGS" "[W-15]" "combined post-edit history keeps W-15 semantics"
-assert_exit_zero "combined post-edit history keeps warn-count semantics" test "$warn_count" = "1"
+assert_exit_zero "combined post-edit history keeps cached warn-count semantics" test "$cached_warn_count" = "1"
+assert_exit_zero "final escalation path refreshes warn-count semantics" test "$fresh_warn_count" = "3"
 assert_exit_zero "post-edit history summary uses one history query across detectors" \
   test "$(grep -c '^post-edit-history$' "$summary_calls" | tr -d '[:space:]')" = "1"
+assert_exit_zero "fresh warn-count uses one bounded refresh query" \
+  test "$(grep -c '^warn-count$' "$summary_calls" | tr -d '[:space:]')" = "1"
 assert_contains "$(cat "$summary_calls")" "post-edit-history" "combined summary calls post-edit-history"
 assert_not_contains "$(cat "$summary_calls")" "churn-count" "combined summary avoids legacy churn-count call"
 assert_not_contains "$(cat "$summary_calls")" "build-fails" "combined summary avoids legacy build-fails call"
-assert_not_contains "$(cat "$summary_calls")" "warn-count" "combined summary avoids legacy warn-count call"
 _VIBEGUARD_RUNTIME="$old_runtime"
 unset VG_STUB_RUNTIME_CALLS
 unset VG_W15_CURRENT_DELTA

--- a/vibeguard-runtime/src/log_query.rs
+++ b/vibeguard-runtime/src/log_query.rs
@@ -11,6 +11,11 @@ use crate::time_utils::{now_unix_secs, parse_iso_ts};
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 const PARALYSIS_WINDOW_SECS: u64 = 30 * 60;
 
+struct PositionedEvent {
+    line_index: usize,
+    value: Value,
+}
+
 fn read_events(session: &str) -> Vec<Value> {
     read_all_events()
         .into_iter()
@@ -19,15 +24,24 @@ fn read_events(session: &str) -> Vec<Value> {
 }
 
 fn read_all_events() -> Vec<Value> {
+    read_positioned_events()
+        .0
+        .into_iter()
+        .map(|event| event.value)
+        .collect()
+}
+
+fn read_positioned_events() -> (Vec<PositionedEvent>, usize) {
     let stdin = io::stdin();
     let mut reader = io::BufReader::new(stdin.lock());
     let mut events = Vec::new();
     let mut buf = Vec::new();
+    let mut line_count = 0usize;
     loop {
         buf.clear();
         match reader.read_until(b'\n', &mut buf) {
             Ok(0) => break,
-            Ok(_) => {}
+            Ok(_) => line_count += 1,
             Err(_) => break,
         }
         // Use lossy decoding so malformed UTF-8 bytes become U+FFFD rather than
@@ -38,10 +52,13 @@ fn read_all_events() -> Vec<Value> {
             continue;
         }
         if let Ok(v) = serde_json::from_str::<Value>(line) {
-            events.push(v);
+            events.push(PositionedEvent {
+                line_index: line_count - 1,
+                value: v,
+            });
         }
     }
-    events
+    (events, line_count)
 }
 
 fn event_within_time_window(e: &Value, cutoff_secs: u64) -> bool {
@@ -227,10 +244,13 @@ fn recent_overlap(
     last
 }
 
-pub(crate) fn count_build_fail_events(events: &[Value], project: &str) -> u32 {
+fn count_build_fail_events_from_newest<'a>(
+    events: impl IntoIterator<Item = &'a Value>,
+    project: &str,
+) -> u32 {
     let project_prefix = format!("{}/", project.trim_end_matches('/'));
     let mut count = 0u32;
-    for e in events.iter().rev() {
+    for e in events {
         if e.get(field::HOOK).and_then(Value::as_str) != Some(hook::POST_BUILD_CHECK) {
             continue;
         }
@@ -245,6 +265,31 @@ pub(crate) fn count_build_fail_events(events: &[Value], project: &str) -> u32 {
         }
     }
     count
+}
+
+pub(crate) fn count_build_fail_events(events: &[Value], project: &str) -> u32 {
+    count_build_fail_events_from_newest(events.iter().rev(), project)
+}
+
+fn count_build_fail_events_in_recent_lines(
+    events: &[PositionedEvent],
+    total_lines: usize,
+    tail_lines: usize,
+    session: &str,
+    project: &str,
+) -> u32 {
+    let first_line = total_lines.saturating_sub(tail_lines);
+    count_build_fail_events_from_newest(
+        events
+            .iter()
+            .rev()
+            .take_while(|event| event.line_index >= first_line)
+            .filter(|event| {
+                event.value.get(field::SESSION).and_then(Value::as_str) == Some(session)
+            })
+            .map(|event| &event.value),
+        project,
+    )
 }
 
 fn count_paralysis_events(events: &[Value], now_secs: u64) -> u32 {
@@ -330,7 +375,11 @@ pub fn post_edit_history(args: &[String]) -> Result {
     let file_path = &args[1];
     let agent = args.get(2).map(String::as_str).unwrap_or("");
     let project = args.get(3).map(String::as_str).unwrap_or("");
-    let events = read_all_events();
+    let (positioned_events, total_lines) = read_positioned_events();
+    let events = positioned_events
+        .iter()
+        .map(|event| event.value.clone())
+        .collect::<Vec<_>>();
     let session_events = events
         .iter()
         .filter(|e| e.get(field::SESSION).and_then(Value::as_str) == Some(session))
@@ -358,7 +407,13 @@ pub fn post_edit_history(args: &[String]) -> Result {
     );
     println!(
         "BUILD_FAILS\t{}",
-        count_build_fail_events(&session_events, project)
+        count_build_fail_events_in_recent_lines(
+            &positioned_events,
+            total_lines,
+            200,
+            session,
+            project
+        )
     );
     if let Some((session_id, agent_name, hook_name, tool_name)) =
         recent_overlap(&events, session, agent, file_path, now_unix_secs())
@@ -529,6 +584,30 @@ mod tests {
             vec![10, 20]
         );
         assert_eq!(count_build_fail_events(&session_events, "/repo"), 2);
+    }
+
+    #[test]
+    fn combined_history_build_fails_uses_recent_200_raw_lines() {
+        let mut events = Vec::new();
+        for index in 0..5 {
+            events.push(PositionedEvent {
+                line_index: index,
+                value: json!({"session": "s", "hook": "post-build-check", "decision": "warn", "detail": "/repo/src/old.rs"}),
+            });
+        }
+        events.push(PositionedEvent {
+            line_index: 450,
+            value: json!({"session": "s", "hook": "post-build-check", "decision": "warn", "detail": "/repo/src/recent.rs"}),
+        });
+        events.push(PositionedEvent {
+            line_index: 451,
+            value: json!({"session": "other", "hook": "post-build-check", "decision": "warn", "detail": "/repo/src/other.rs"}),
+        });
+
+        assert_eq!(
+            count_build_fail_events_in_recent_lines(&events, 500, 200, "s", "/repo"),
+            1
+        );
     }
 
     #[test]

--- a/vibeguard-runtime/src/log_query.rs
+++ b/vibeguard-runtime/src/log_query.rs
@@ -318,23 +318,25 @@ pub fn reason_count(args: &[String]) -> Result {
     Ok(())
 }
 
-/// Combined post-edit history query. Replaces multiple tail+Python/helper calls.
-/// Usage: tail -500 log | vibeguard-runtime post-edit-history <session> <file_path> [agent]
+/// Combined post-edit history query. Replaces multiple tail+runtime helper calls.
+/// Usage: tail -500 log | vibeguard-runtime post-edit-history <session> <file_path> [agent] [project_root]
 pub fn post_edit_history(args: &[String]) -> Result {
     if args.len() < 2 {
         return Err(
-            "Usage: tail -N log | vibeguard-runtime post-edit-history <session> <file_path> [agent]".into(),
+            "Usage: tail -N log | vibeguard-runtime post-edit-history <session> <file_path> [agent] [project_root]".into(),
         );
     }
     let session = &args[0];
     let file_path = &args[1];
     let agent = args.get(2).map(String::as_str).unwrap_or("");
+    let project = args.get(3).map(String::as_str).unwrap_or("");
     let events = read_all_events();
     let session_events = events
         .iter()
         .filter(|e| e.get(field::SESSION).and_then(Value::as_str) == Some(session))
         .cloned()
         .collect::<Vec<_>>();
+    let w15_trail = same_file_edit_delta_trail(&events, session, file_path);
 
     println!("CHURN\t{}", count_churn_events(&session_events, file_path));
     println!(
@@ -342,8 +344,21 @@ pub fn post_edit_history(args: &[String]) -> Result {
         consecutive_same_file_edits(&events, session, file_path)
     );
     println!(
+        "W15_DELTAS\t{}",
+        w15_trail
+            .iter()
+            .take(2)
+            .map(|delta| delta.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    println!(
         "WARN_COUNT\t{}",
         count_warn_events(&session_events, file_path)
+    );
+    println!(
+        "BUILD_FAILS\t{}",
+        count_build_fail_events(&session_events, project)
     );
     if let Some((session_id, agent_name, hook_name, tool_name)) =
         recent_overlap(&events, session, agent, file_path, now_unix_secs())
@@ -490,6 +505,30 @@ mod tests {
 
         assert_eq!(count_build_fail_events(&events, "/repo"), 2);
         assert_eq!(count_build_fail_events(&events, "/other"), 1);
+    }
+
+    #[test]
+    fn combined_history_can_compute_build_fails_from_shared_events() {
+        let events = vec![
+            json!({"session": "s", "hook": "post-edit-guard", "tool": "Edit", "decision": "pass", "detail": "src/a.rs||delta=20"}),
+            json!({"session": "s", "hook": "post-edit-guard", "tool": "Edit", "decision": "warn", "reason": "[RS-03] unwrap", "detail": "src/a.rs||delta=10"}),
+            json!({"session": "s", "hook": "post-build-check", "decision": "warn", "detail": "/repo/src/a.rs"}),
+            json!({"session": "s", "hook": "post-build-check", "decision": "escalate", "detail": "/repo/src/b.rs"}),
+            json!({"session": "other", "hook": "post-build-check", "decision": "warn", "detail": "/repo/src/c.rs"}),
+        ];
+        let session_events = events
+            .iter()
+            .filter(|e| e.get(field::SESSION).and_then(Value::as_str) == Some("s"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(count_churn_events(&session_events, "src/a.rs"), 2);
+        assert_eq!(count_warn_events(&session_events, "src/a.rs"), 1);
+        assert_eq!(
+            same_file_edit_delta_trail(&events, "s", "src/a.rs"),
+            vec![10, 20]
+        );
+        assert_eq!(count_build_fail_events(&session_events, "/repo"), 2);
     }
 
     #[test]

--- a/vibeguard-runtime/src/log_query.rs
+++ b/vibeguard-runtime/src/log_query.rs
@@ -292,6 +292,19 @@ fn count_build_fail_events_in_recent_lines(
     )
 }
 
+fn events_in_recent_lines(
+    events: &[PositionedEvent],
+    total_lines: usize,
+    tail_lines: usize,
+) -> Vec<Value> {
+    let first_line = total_lines.saturating_sub(tail_lines);
+    events
+        .iter()
+        .filter(|event| event.line_index >= first_line)
+        .map(|event| event.value.clone())
+        .collect()
+}
+
 fn count_paralysis_events(events: &[Value], now_secs: u64) -> u32 {
     let cutoff_secs = now_secs.saturating_sub(PARALYSIS_WINDOW_SECS);
     let mut consecutive = 0u32;
@@ -385,12 +398,13 @@ pub fn post_edit_history(args: &[String]) -> Result {
         .filter(|e| e.get(field::SESSION).and_then(Value::as_str) == Some(session))
         .cloned()
         .collect::<Vec<_>>();
-    let w15_trail = same_file_edit_delta_trail(&events, session, file_path);
+    let w15_events = events_in_recent_lines(&positioned_events, total_lines, 200);
+    let w15_trail = same_file_edit_delta_trail(&w15_events, session, file_path);
 
     println!("CHURN\t{}", count_churn_events(&session_events, file_path));
     println!(
         "W15\t{}",
-        consecutive_same_file_edits(&events, session, file_path)
+        consecutive_same_file_edits(&w15_events, session, file_path)
     );
     println!(
         "W15_DELTAS\t{}",
@@ -607,6 +621,43 @@ mod tests {
         assert_eq!(
             count_build_fail_events_in_recent_lines(&events, 500, 200, "s", "/repo"),
             1
+        );
+    }
+
+    #[test]
+    fn combined_history_w15_uses_recent_200_raw_lines() {
+        let events = vec![
+            PositionedEvent {
+                line_index: 10,
+                value: json!({"session": "s", "hook": "post-edit-guard", "tool": "Edit", "detail": "src/a.rs||delta=200"}),
+            },
+            PositionedEvent {
+                line_index: 20,
+                value: json!({"session": "s", "hook": "post-edit-guard", "tool": "Edit", "detail": "src/a.rs||delta=100"}),
+            },
+            PositionedEvent {
+                line_index: 450,
+                value: json!({"session": "s", "hook": "pre-bash-guard", "tool": "Bash", "detail": "cargo test"}),
+            },
+        ];
+        let all_events = events
+            .iter()
+            .map(|event| event.value.clone())
+            .collect::<Vec<_>>();
+        let recent_events = events_in_recent_lines(&events, 500, 200);
+
+        assert_eq!(consecutive_same_file_edits(&all_events, "s", "src/a.rs"), 2);
+        assert_eq!(
+            same_file_edit_delta_trail(&all_events, "s", "src/a.rs"),
+            vec![100, 200]
+        );
+        assert_eq!(
+            consecutive_same_file_edits(&recent_events, "s", "src/a.rs"),
+            0
+        );
+        assert_eq!(
+            same_file_edit_delta_trail(&recent_events, "s", "src/a.rs"),
+            Vec::<i64>::new()
         );
     }
 


### PR DESCRIPTION
## Summary
- extend `post-edit-history` to emit churn, warn count, W14, W15 deltas, and build-failure counts from one log-tail parse
- cache the combined summary in the shell fallback so one hook invocation avoids legacy `churn-count`, `build-fails`, `warn-count`, and `post-edit-w15` queries
- add fixture-backed coverage for combined semantics and one history query across detectors

Closes #490

## Verification
- `bash -n hooks/_lib/post_edit_history.sh tests/hooks/test_post_edit_churn.sh`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml log_query`
- `bash tests/hooks/test_post_edit_churn.sh`
- `bash tests/hooks/test_post_edit_w14.sh`
- `bash tests/hooks/test_post_edit_w15.sh`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_hooks.sh`
- `git diff --check`
- `bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression` (rerun passed; first run had unrelated transient pre-bash p95 312ms/300ms while post-edit passed)