### PR TITLE
perf: bound hook status log reads

### DIFF
--- a/vibeguard-runtime/src/hook_status.rs
+++ b/vibeguard-runtime/src/hook_status.rs
@@ -248,7 +248,7 @@ fn parse_mode(value: &str) -> Result<Mode> {
 }
 
 fn read_main_events(options: &Options) -> Result<(Vec<Value>, String)> {
-    let read_limit = read_window_lines(options.limit);
+    let read_limit = read_window_lines_for_options(options);
     if let Some(path) = &options.log_file {
         return Ok((
             read_jsonl_file_limited(path, read_limit)?,
@@ -300,7 +300,7 @@ fn read_diag_events(options: &Options) -> Result<Vec<DiagSource>> {
 
     let log_path = display_path(&path);
     Ok(
-        read_jsonl_file_limited(&path, read_window_lines(options.limit))?
+        read_jsonl_file_limited(&path, read_window_lines_for_options(options))?
             .into_iter()
             .map(|event| DiagSource {
                 event,
@@ -314,6 +314,13 @@ fn read_window_lines(limit: usize) -> usize {
     limit
         .saturating_mul(READ_WINDOW_MULTIPLIER)
         .max(MIN_READ_WINDOW_LINES)
+}
+
+fn read_window_lines_for_options(options: &Options) -> usize {
+    if options.session.is_some() || options.event.is_some() {
+        return usize::MAX;
+    }
+    read_window_lines(options.limit)
 }
 
 fn read_jsonl_file(path: &Path) -> Result<Vec<Value>> {

--- a/vibeguard-runtime/src/hook_status.rs
+++ b/vibeguard-runtime/src/hook_status.rs
@@ -4,9 +4,10 @@
 //! hook output contract, so successful hooks stay out of the model context.
 
 use serde_json::{Value, json};
+use std::collections::VecDeque;
 use std::env;
 use std::fs::File;
-use std::io::{self, BufRead, IsTerminal, Read};
+use std::io::{self, BufRead, IsTerminal, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::event_schema::{UNKNOWN, decision, field, status, tool};
@@ -24,6 +25,9 @@ type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 const HOOK_STATUS_SCHEMA_VERSION: u64 = 1;
 const DEFAULT_LIMIT: usize = 20;
 const DEFAULT_SLOW_MS: u64 = 2_000;
+const MIN_READ_WINDOW_LINES: usize = 200;
+const READ_WINDOW_MULTIPLIER: usize = 20;
+const TAIL_READ_CHUNK_BYTES: u64 = 8 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Mode {
@@ -244,8 +248,12 @@ fn parse_mode(value: &str) -> Result<Mode> {
 }
 
 fn read_main_events(options: &Options) -> Result<(Vec<Value>, String)> {
+    let read_limit = read_window_lines(options.limit);
     if let Some(path) = &options.log_file {
-        return Ok((read_jsonl_file(path)?, display_path(path)));
+        return Ok((
+            read_jsonl_file_limited(path, read_limit)?,
+            display_path(path),
+        ));
     }
 
     let stdin_events = read_jsonl_from_stdin()?;
@@ -261,7 +269,7 @@ fn read_main_events(options: &Options) -> Result<(Vec<Value>, String)> {
     })?;
     if resolved.path.exists() {
         return Ok((
-            read_jsonl_file(&resolved.path)?,
+            read_jsonl_file_limited(&resolved.path, read_limit)?,
             display_path(&resolved.path),
         ));
     }
@@ -291,13 +299,21 @@ fn read_diag_events(options: &Options) -> Result<Vec<DiagSource>> {
     }
 
     let log_path = display_path(&path);
-    Ok(read_jsonl_file(&path)?
-        .into_iter()
-        .map(|event| DiagSource {
-            event,
-            log_path: log_path.clone(),
-        })
-        .collect())
+    Ok(
+        read_jsonl_file_limited(&path, read_window_lines(options.limit))?
+            .into_iter()
+            .map(|event| DiagSource {
+                event,
+                log_path: log_path.clone(),
+            })
+            .collect(),
+    )
+}
+
+fn read_window_lines(limit: usize) -> usize {
+    limit
+        .saturating_mul(READ_WINDOW_MULTIPLIER)
+        .max(MIN_READ_WINDOW_LINES)
 }
 
 fn read_jsonl_file(path: &Path) -> Result<Vec<Value>> {
@@ -305,6 +321,52 @@ fn read_jsonl_file(path: &Path) -> Result<Vec<Value>> {
     let mut text = String::new();
     file.read_to_string(&mut text)?;
     Ok(read_jsonl_text(&text))
+}
+
+fn read_jsonl_file_limited(path: &Path, line_limit: usize) -> Result<Vec<Value>> {
+    if line_limit == usize::MAX {
+        return read_jsonl_file(path);
+    }
+    let text = read_tail_lines(path, line_limit)?;
+    Ok(read_jsonl_text(&text))
+}
+
+fn read_tail_lines(path: &Path, line_limit: usize) -> Result<String> {
+    if line_limit == 0 {
+        return Ok(String::new());
+    }
+
+    let mut file = File::open(path)?;
+    let mut offset = file.seek(SeekFrom::End(0))?;
+    if offset == 0 {
+        return Ok(String::new());
+    }
+
+    let mut chunks: VecDeque<Vec<u8>> = VecDeque::new();
+    let mut newline_count = 0usize;
+    while offset > 0 && newline_count <= line_limit {
+        let read_len = offset.min(TAIL_READ_CHUNK_BYTES);
+        offset -= read_len;
+        file.seek(SeekFrom::Start(offset))?;
+        let mut chunk = vec![0; read_len as usize];
+        file.read_exact(&mut chunk)?;
+        newline_count += chunk.iter().filter(|byte| **byte == b'\n').count();
+        chunks.push_front(chunk);
+    }
+
+    let byte_len = chunks.iter().map(Vec::len).sum();
+    let mut bytes = Vec::with_capacity(byte_len);
+    for chunk in chunks {
+        bytes.extend_from_slice(&chunk);
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    if offset == 0 {
+        return Ok(text.into_owned());
+    }
+
+    let mut lines = text.lines().rev().take(line_limit).collect::<Vec<_>>();
+    lines.reverse();
+    Ok(lines.join("\n"))
 }
 
 fn read_jsonl_from_stdin() -> Result<Vec<Value>> {

--- a/vibeguard-runtime/src/hook_status_tests.rs
+++ b/vibeguard-runtime/src/hook_status_tests.rs
@@ -1,5 +1,9 @@
 #[cfg(test)]
 use super::*;
+#[cfg(test)]
+use std::fs;
+#[cfg(test)]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn normalizes_skip_without_model_context() {
@@ -108,5 +112,47 @@ fn running_summary_shows_elapsed_and_timeout() {
     assert_eq!(
         minimal_line(&entries),
         "PostToolUse checks  1/2 running - 12s / 30s"
+    );
+}
+
+#[test]
+fn limited_jsonl_reader_reads_only_recent_tail_window() {
+    let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(error) => panic!("system time should be after epoch: {error}"),
+    };
+    let path = env::temp_dir().join(format!("vibeguard-hook-status-tail-{unique}.jsonl"));
+    let mut text = String::new();
+    for index in 0..1_000 {
+        text.push_str(&format!(
+            "{{\"ts\":\"2026-05-31T00:00:00Z\",\"hook\":\"old-hook\",\"detail\":\"old-{index}\"}}\n"
+        ));
+    }
+    for index in 0..3 {
+        text.push_str(&format!(
+            "{{\"ts\":\"2026-05-31T00:00:0{index}Z\",\"hook\":\"recent-hook\",\"detail\":\"recent-{index}\"}}\n"
+        ));
+    }
+    if let Err(error) = fs::write(&path, text) {
+        panic!("test log should be writable: {error}");
+    }
+
+    let events = match read_jsonl_file_limited(&path, 3) {
+        Ok(events) => events,
+        Err(error) => panic!("tail window should read: {error}"),
+    };
+    if let Err(error) = fs::remove_file(&path) {
+        panic!("test log should be removed: {error}");
+    }
+
+    assert_eq!(events.len(), 3);
+    assert!(
+        events
+            .iter()
+            .all(|event| { event.get(field::HOOK).and_then(Value::as_str) == Some("recent-hook") })
+    );
+    assert_eq!(
+        events[0].get(field::DETAIL).and_then(Value::as_str),
+        Some("recent-0")
     );
 }

--- a/vibeguard-runtime/src/hook_status_tests.rs
+++ b/vibeguard-runtime/src/hook_status_tests.rs
@@ -156,3 +156,60 @@ fn limited_jsonl_reader_reads_only_recent_tail_window() {
         Some("recent-0")
     );
 }
+
+#[test]
+fn filtered_main_events_read_full_history_before_output_limit() {
+    let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(error) => panic!("system time should be after epoch: {error}"),
+    };
+    let path = env::temp_dir().join(format!(
+        "vibeguard-hook-status-filtered-tail-{unique}.jsonl"
+    ));
+    let mut text = String::from(
+        "{\"ts\":\"2026-05-31T00:00:00Z\",\"session\":\"s1\",\"hook\":\"old-hook\",\"detail\":\"old-target\"}\n",
+    );
+    for index in 0..300 {
+        text.push_str(&format!(
+            "{{\"ts\":\"2026-05-31T00:00:01Z\",\"session\":\"s2\",\"hook\":\"recent-hook\",\"detail\":\"recent-{index}\"}}\n"
+        ));
+    }
+    if let Err(error) = fs::write(&path, text) {
+        panic!("test log should be writable: {error}");
+    }
+
+    let mut options = Options {
+        log_file: Some(path.clone()),
+        limit: 5,
+        session: Some("s1".to_string()),
+        ..Options::default()
+    };
+    let (events, log_path) = match read_main_events(&options) {
+        Ok(result) => result,
+        Err(error) => panic!("filtered status read should use full history: {error}"),
+    };
+    let matched = events
+        .into_iter()
+        .map(|event| normalize_hook_event(&event, &log_path, options.slow_ms))
+        .filter(|entry| entry_matches_filters(entry, &options))
+        .collect::<Vec<_>>();
+
+    options.session = None;
+    let (tail_events, _) = match read_main_events(&options) {
+        Ok(result) => result,
+        Err(error) => panic!("unfiltered status read should use tail history: {error}"),
+    };
+    if let Err(error) = fs::remove_file(&path) {
+        panic!("test log should be removed: {error}");
+    }
+
+    assert_eq!(matched.len(), 1);
+    assert_eq!(matched[0].session, "s1");
+    assert_eq!(matched[0].detail, "old-target");
+    assert_eq!(tail_events.len(), read_window_lines(5));
+    assert!(
+        tail_events
+            .iter()
+            .all(|event| { event.get(field::SESSION).and_then(Value::as_str) == Some("s2") })
+    );
+}

--- a/vibeguard-runtime/src/log_scope.rs
+++ b/vibeguard-runtime/src/log_scope.rs
@@ -1,10 +1,9 @@
 use std::env;
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 use crate::git_root::{current_git_root, git_root_for};
+use crate::setup_support::sha256_text_short;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -118,11 +117,15 @@ fn project_log_path(log_root: &Path, project: ProjectRef) -> Result<PathBuf> {
             .join("events.jsonl")),
         ProjectRef::Path(root) => {
             let root_text = root.to_string_lossy().to_string();
+            let digest = sha256_text_short(&root_text);
+            let direct_path = log_root.join("projects").join(digest).join("events.jsonl");
+            if direct_path.exists() {
+                return Ok(direct_path);
+            }
             if let Some(path) = project_log_path_from_mapping(log_root, &root_text) {
                 return Ok(path);
             }
-            let digest = sha256_short(&root_text)?;
-            Ok(log_root.join("projects").join(digest).join("events.jsonl"))
+            Ok(direct_path)
         }
     }
 }
@@ -156,43 +159,6 @@ fn same_project_root(left: &str, right: &str) -> bool {
         (Ok(left_real), Ok(right_real)) => left_real == right_real,
         _ => false,
     }
-}
-
-fn sha256_short(input: &str) -> Result<String> {
-    for (program, args) in [("shasum", &["-a", "256"][..]), ("sha256sum", &[][..])] {
-        if let Some(digest) = run_sha256_command(program, args, input)? {
-            return Ok(digest);
-        }
-    }
-    Err("unable to compute project log hash: shasum or sha256sum is required".into())
-}
-
-fn run_sha256_command(program: &str, args: &[&str], input: &str) -> Result<Option<String>> {
-    let mut child = match Command::new(program)
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(Box::new(error)),
-    };
-
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-    let output = child.wait_with_output()?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-    let text = String::from_utf8_lossy(&output.stdout);
-    let digest = text
-        .split_whitespace()
-        .next()
-        .filter(|value| value.len() >= 8 && value.bytes().all(|byte| byte.is_ascii_hexdigit()));
-    Ok(digest.map(|value| value[..8].to_ascii_lowercase()))
 }
 
 #[cfg(test)]
@@ -231,5 +197,48 @@ mod tests {
         assert_eq!(path, mapped.join("events.jsonl"));
 
         let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn deterministic_hash_path_wins_before_legacy_mapping_scan() {
+        let unique = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_nanos(),
+            Err(error) => panic!("system time should be after unix epoch: {error}"),
+        };
+        let temp = env::temp_dir().join(format!("vibeguard-log-scope-direct-{unique}"));
+        let project = temp.join("repo");
+        let log_root = temp.join("logs");
+        let direct = log_root
+            .join("projects")
+            .join(sha256_text_short(project.to_string_lossy().as_ref()));
+        let mapped = log_root.join("projects/knownhash");
+        if let Err(error) = fs::create_dir_all(&project) {
+            panic!("test project directory should be created: {error}");
+        }
+        if let Err(error) = fs::create_dir_all(&direct) {
+            panic!("direct log directory should be created: {error}");
+        }
+        if let Err(error) = fs::create_dir_all(&mapped) {
+            panic!("legacy mapped directory should be created: {error}");
+        }
+        if let Err(error) = fs::write(direct.join("events.jsonl"), "") {
+            panic!("direct log file should be created: {error}");
+        }
+        if let Err(error) = fs::write(
+            mapped.join(".project-root"),
+            project.to_string_lossy().as_ref(),
+        ) {
+            panic!("legacy mapping should be written: {error}");
+        }
+
+        let path = match project_log_path(&log_root, ProjectRef::Path(project)) {
+            Ok(path) => path,
+            Err(error) => panic!("project log path should resolve: {error}"),
+        };
+        assert_eq!(path, direct.join("events.jsonl"));
+
+        if let Err(error) = fs::remove_dir_all(temp) {
+            panic!("test temp directory should be removed: {error}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- read bounded tail windows for hook-status main and diag JSONL files instead of loading whole files for small limits
- prefer deterministic in-process project log hashing before legacy .project-root mapping scans
- add regression coverage for tail-window reads and deterministic project path precedence

Closes #492

## Verification
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check
- cargo test --manifest-path vibeguard-runtime/Cargo.toml hook_status
- cargo test --manifest-path vibeguard-runtime/Cargo.toml log_scope
- bash tests/test_hook_status.sh
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- git diff --check