### PR TITLE
docs: split README into onboarding paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![VibeGuard project card](docs/assets/readme-card.png)
 
-[Chinese Docs](docs/README_CN.md) · [Rule Reference](docs/rule-reference.md) · [Contributing](CONTRIBUTING.md)
+[Chinese Docs](docs/README_CN.md) · [Quickstart](docs/how/quickstart.md) · [Team Rollout](docs/how/team-rollout.md) · [Troubleshooting](docs/how/troubleshooting.md) · [Rule Reference](docs/rule-reference.md) · [Contributing](CONTRIBUTING.md)
 
 VibeGuard adds **native rules + real-time hooks + static guards** to catch what AI coding agents get wrong — **before it reaches your codebase**:
 
@@ -20,11 +20,20 @@ VibeGuard adds **native rules + real-time hooks + static guards** to catch what 
 
 Works with **Claude Code** and **Codex CLI**.
 
-## Install in 30 seconds
+## Start Here
+
+| Path | Use it when | Start with |
+|------|-------------|------------|
+| **Quickstart** | You want one local install, one health check, and one real intercepted demo | [docs/how/quickstart.md](docs/how/quickstart.md) |
+| **Team rollout** | You need profiles, CI policy, rollout expectations, or project bootstrap guidance | [docs/how/team-rollout.md](docs/how/team-rollout.md) |
+| **Troubleshooting** | Setup/check/status output is stale, degraded, broken, or confusing | [docs/how/troubleshooting.md](docs/how/troubleshooting.md) |
+
+Fastest local proof:
 
 ```bash
 git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard
 bash ~/vibeguard/setup.sh --yes
+bash ~/vibeguard/setup.sh verify-install
 ```
 
 On supported macOS/Linux targets, the production install/check/clean path is
@@ -36,11 +45,11 @@ is not required by default.
 Python still supports evals, docs generation, developer tools, and optional
 language-specific guard packs.
 
-Open a new Claude Code or Codex session. Run `bash ~/vibeguard/setup.sh doctor` for an interactive report, or `bash ~/vibeguard/setup.sh verify-install` for CI/post-install verification.
+Open a new Claude Code or Codex session after install. Use `bash ~/vibeguard/setup.sh doctor` for an interactive report, or `bash ~/vibeguard/setup.sh verify-install` for CI/post-install verification.
 
 ### First 5 minutes
 
-Use this path to prove the install is active before changing another project:
+The complete first-run flow lives in [Quickstart](docs/how/quickstart.md). These commands prove the install is active before changing another project:
 
 ```bash
 bash ~/vibeguard/setup.sh doctor
@@ -66,9 +75,9 @@ The current mainline is install-verified on macOS and CI-verified on Ubuntu, mac
 - Interactive health report: `bash setup.sh doctor` (compatibility alias: `bash setup.sh --check`)
 - CI/post-install health gate: `bash setup.sh verify-install`
 - Expected verdict after a healthy install: `HEALTHY`
-- Claude Code: native rules, skills, commands, hooks, and git hooks are installed by `setup.sh`; scheduled GC is opt-in with `--with-scheduler`
-- Codex CLI: `~/.codex/AGENTS.md`, copied skills, native Bash/apply_patch/PermissionRequest/PostToolUse/Stop hooks, and `~/.vibeguard/run-hook-codex.sh` are installed by `setup.sh`
-- Known Codex boundary: Read/Glob/Grep native hooks are not currently available through Codex, so read-only exploration gates remain Claude Code or app-server-wrapper only
+- Claude Code and Codex install details: [Quickstart](docs/how/quickstart.md)
+- Profiles, CI rollout, and scheduler expectations: [Team Rollout](docs/how/team-rollout.md)
+- Stale install/runtime/hook diagnosis: [Troubleshooting](docs/how/troubleshooting.md)
 
 Benchmark gate: hook latency is tracked through CI's `Hook Latency (P95)` report and checked against per-hook budgets. The previous-commit ratio is useful for spotting changes, but single-run noise can move it; merge decisions should use the budget gate plus recent-main trend, not one baseline sample alone.
 
@@ -519,6 +528,9 @@ Key lessons:
 | Doc | Purpose |
 |-----|---------|
 | [docs/README_CN.md](docs/README_CN.md) | Chinese overview and setup guide |
+| [docs/how/quickstart.md](docs/how/quickstart.md) | Minimal install, verification, project bootstrap, and intercepted demo path |
+| [docs/how/team-rollout.md](docs/how/team-rollout.md) | Profiles, CI policy, scheduler rollout, and team verification expectations |
+| [docs/how/troubleshooting.md](docs/how/troubleshooting.md) | Install, runtime, Codex hook, and hook-status diagnosis |
 | [docs/rule-reference.md](docs/rule-reference.md) | Rule layers, guard coverage, and language-specific checks |
 | [docs/CLAUDE.md.example](docs/CLAUDE.md.example) | Project-level CLAUDE template without installing hooks |
 | [docs/linux-setup.md](docs/linux-setup.md) | Linux-specific setup notes |

--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart
+
+Use this path to prove VibeGuard is installed, healthy, and intercepting a real
+agent action before you rely on it in another repository.
+
+## 1. Install
+
+```bash
+git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard
+bash ~/vibeguard/setup.sh --yes
+```
+
+On supported macOS/Linux targets, setup downloads a prebuilt
+`vibeguard-runtime` release binary and verifies its checksum. Source builds are
+only needed for unsupported targets, offline installs, or explicit
+`--build-from-source` runs.
+
+## 2. Verify
+
+```bash
+bash ~/vibeguard/setup.sh doctor
+bash ~/vibeguard/setup.sh verify-install
+```
+
+Expected result on a healthy machine:
+
+- `doctor` prints a human-readable `HEALTHY` report.
+- `verify-install` exits 0 and is suitable for CI or post-install checks.
+- Broken required install state is reported as non-zero instead of silently
+  passing.
+
+For Codex-specific hook state, run:
+
+```bash
+bash ~/vibeguard/scripts/doctors/codex-doctor.sh
+```
+
+## 3. Bootstrap a Project
+
+```bash
+cd /path/to/project
+bash ~/vibeguard/scripts/project-init.sh "$PWD"
+```
+
+This installs project guidance and the shared pre-commit wrapper for that
+repository. Open a new Claude Code or Codex session after bootstrapping so the
+agent loads the updated instructions and hooks.
+
+## 4. Run One Intercepted Demo
+
+Start with the side-effect-free demo:
+
+```bash
+bash ~/vibeguard/setup.sh demo safe-bash
+```
+
+Then try one live agent action in a disposable branch or scratch project:
+
+```text
+Ask the agent to create a new source file that duplicates an existing module name without searching first.
+```
+
+Expected behavior: VibeGuard emits a search-first warning or block with a fix
+instruction. If no hook output appears, use [Troubleshooting](troubleshooting.md)
+before assuming protection is active.
+
+## 5. Inspect Recent Hook Status
+
+```bash
+bash ~/vibeguard/scripts/hook-health.sh 24
+~/.vibeguard/installed/bin/vibeguard-runtime hook-status --mode focused
+```
+
+`hook-health.sh` summarizes recent local hook events. `hook-status` shows the
+project-scoped hook log for the current git repository; see
+[Codex Hook Status](../reference/codex-hook-status.md) for JSON and global-scope
+diagnostics.

--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -49,6 +49,12 @@ guidance file before relying on agent-visible instructions. Open a new Claude
 Code or Codex session after saving that guidance so the agent loads the updated
 instructions and hooks.
 
+`project-init.sh` only bootstraps repositories where it detects a known
+language marker such as `Cargo.toml`, `tsconfig.json`, `package.json`,
+`go.mod`, `pyproject.toml`, or `requirements.txt`. Shell-only, docs-only, and
+other unrecognized repositories print `No known language detected, skipping.`
+and do not get git hooks from this command.
+
 ## 4. Run One Intercepted Demo
 
 Start with the side-effect-free demo:

--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -42,9 +42,12 @@ cd /path/to/project
 bash ~/vibeguard/scripts/project-init.sh "$PWD"
 ```
 
-This installs project guidance and the shared pre-commit wrapper for that
-repository. Open a new Claude Code or Codex session after bootstrapping so the
-agent loads the updated instructions and hooks.
+This prints a `Suggested project CLAUDE.md snippet` and installs the shared
+pre-commit/pre-push wrappers when they are available. Save the suggested
+snippet into the repository's `CLAUDE.md`, `AGENTS.md`, or equivalent project
+guidance file before relying on agent-visible instructions. Open a new Claude
+Code or Codex session after saving that guidance so the agent loads the updated
+instructions and hooks.
 
 ## 4. Run One Intercepted Demo
 

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -68,9 +68,12 @@ For manifest or routing changes, use the focused contract checks listed in
 bash ~/vibeguard/scripts/project-init.sh /path/to/project
 ```
 
-`project-init.sh` installs project guidance and attaches the shared pre-commit
-wrapper. Keep repository-specific facts in that repository's `AGENTS.md` or
-`CLAUDE.md`; do not put local machine facts in shared VibeGuard docs.
+`project-init.sh` prints project guidance and attaches the shared
+pre-commit/pre-push wrappers when they are available. When it prints a
+`Suggested project CLAUDE.md snippet`, save that snippet into the repository's
+`CLAUDE.md`, `AGENTS.md`, or equivalent project guidance file as a manual
+rollout step. Keep repository-specific facts in that repository's guidance
+file; do not put local machine facts in shared VibeGuard docs.
 
 ## Codex and Claude Boundaries
 

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -7,7 +7,8 @@ not just a local experiment.
 
 1. Install locally and complete the [Quickstart](quickstart.md).
 2. Bootstrap one low-risk repository with `scripts/project-init.sh`.
-3. Run VibeGuard in `minimal` or `core` profile until warnings are understood.
+3. Set a repository `.vibeguard.json` profile and run VibeGuard in `minimal`
+   or `core` until warnings are understood.
 4. Add `verify-install` and repository contract checks to CI.
 5. Move selected repositories to `full` or `strict` only after the team accepts
    the hook behavior and false-positive handling path.
@@ -30,6 +31,21 @@ bash ~/vibeguard/setup.sh --profile strict
 | `core` | Default local development profile |
 | `full` | Adds stop/build/learning feedback for teams ready to review more signals |
 | `strict` | Maximum enforcement, including stricter Claude Code constraint budget checks |
+
+The setup commands configure the local install profile. For per-repository
+runtime policy, add `.vibeguard.json` to the target repository:
+
+```json
+{
+  "profile": "core",
+  "enforcement": "block"
+}
+```
+
+Use `minimal` for early pilots and move to `core`, `full`, or `strict` after
+the team has accepted the hook surface. Without a repository config, native
+Codex hooks still exist at the installed hook surface and no repository-scoped
+profile narrowing is applied.
 
 Use language selection when a repository should only receive relevant rules and
 guards:

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -1,0 +1,108 @@
+# Team Rollout
+
+Use this path when VibeGuard needs to become a shared project or team policy,
+not just a local experiment.
+
+## Rollout Order
+
+1. Install locally and complete the [Quickstart](quickstart.md).
+2. Bootstrap one low-risk repository with `scripts/project-init.sh`.
+3. Run VibeGuard in `minimal` or `core` profile until warnings are understood.
+4. Add `verify-install` and repository contract checks to CI.
+5. Move selected repositories to `full` or `strict` only after the team accepts
+   the hook behavior and false-positive handling path.
+
+Do not automate scheduled cleanup or strict blocking until the manual path has
+been validated on real team work.
+
+## Profiles
+
+```bash
+bash ~/vibeguard/setup.sh --profile minimal
+bash ~/vibeguard/setup.sh --profile core
+bash ~/vibeguard/setup.sh --profile full
+bash ~/vibeguard/setup.sh --profile strict
+```
+
+| Profile | Use Case |
+|---------|----------|
+| `minimal` | Critical pre-action interception with the smallest hook surface |
+| `core` | Default local development profile |
+| `full` | Adds stop/build/learning feedback for teams ready to review more signals |
+| `strict` | Maximum enforcement, including stricter Claude Code constraint budget checks |
+
+Use language selection when a repository should only receive relevant rules and
+guards:
+
+```bash
+bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
+```
+
+## CI and Verification
+
+Use `verify-install` for install health:
+
+```bash
+bash ~/vibeguard/setup.sh verify-install
+```
+
+Use the repository contract gate before pushing changes to VibeGuard itself:
+
+```bash
+bash scripts/local-contract-check.sh
+```
+
+For documentation-only changes in this repository, keep path references green:
+
+```bash
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+```
+
+For manifest or routing changes, use the focused contract checks listed in
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Repository Bootstrap
+
+```bash
+bash ~/vibeguard/scripts/project-init.sh /path/to/project
+```
+
+`project-init.sh` installs project guidance and attaches the shared pre-commit
+wrapper. Keep repository-specific facts in that repository's `AGENTS.md` or
+`CLAUDE.md`; do not put local machine facts in shared VibeGuard docs.
+
+## Codex and Claude Boundaries
+
+Claude Code receives native rules, skills, commands, hooks, and git hooks.
+Codex receives `~/.codex/AGENTS.md`, copied skills, native
+Bash/apply_patch/PermissionRequest/PostToolUse/Stop hooks, and
+`~/.vibeguard/run-hook-codex.sh`.
+
+Current Codex boundary: native Read/Glob/Grep hooks are not available through
+Codex, so read-only exploration gates remain Claude Code or optional
+app-server-wrapper only.
+
+## Scheduler
+
+Scheduled GC is opt-in:
+
+```bash
+bash ~/vibeguard/setup.sh --with-scheduler
+```
+
+Treat scheduler rollout as a later stage. The manual cleanup/check path should
+be stable first, and the owner should know how to disable or inspect scheduled
+state before enabling it across a team.
+
+## Observability
+
+```bash
+bash ~/vibeguard/scripts/stats.sh
+bash ~/vibeguard/scripts/hook-health.sh 24
+~/.vibeguard/installed/bin/vibeguard-runtime hook-status --mode focused
+```
+
+Use [Observability Harness Contract](../reference/observability-harness.md) for
+metric semantics and [Hook Latency Contract](../reference/hook-latency-contract.md)
+for per-hook latency budgets.

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -47,12 +47,17 @@ the team has accepted the hook surface. Without a repository config, native
 Codex hooks still exist at the installed hook surface and no repository-scoped
 profile narrowing is applied.
 
-Use language selection when a repository should only receive relevant rules and
-guards:
+Use language selection only when a developer wants to filter the local Claude
+native rule install for their machine:
 
 ```bash
 bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
 ```
+
+This is a global local-install setting, not a repository policy. It updates the
+rules linked under `~/.claude/rules/vibeguard` and does not narrow the installed
+guard script tree. Prefer `.vibeguard.json` for repository-scoped profile and
+enforcement policy.
 
 ## CI and Verification
 

--- a/docs/how/troubleshooting.md
+++ b/docs/how/troubleshooting.md
@@ -1,0 +1,97 @@
+# Troubleshooting
+
+Use this path when VibeGuard is installed but the visible behavior does not
+match the expected hook, rule, or runtime state.
+
+## Start with Install Health
+
+```bash
+bash ~/vibeguard/setup.sh doctor
+bash ~/vibeguard/setup.sh verify-install
+```
+
+Read the final verdict first:
+
+| Verdict | Meaning | Next Action |
+|---------|---------|-------------|
+| `HEALTHY` | Required install state is present | Inspect recent hook events if behavior still looks wrong |
+| `DEGRADED` | Optional or recoverable state is missing | Read the warning row and rerun the suggested setup command |
+| `BROKEN` | Required state is missing or inconsistent | Fix the broken row before relying on hooks |
+
+`doctor` is meant for humans and stays friendly. `verify-install` is the
+post-install/CI gate and returns non-zero for broken required state.
+
+## Codex Hook State
+
+```bash
+bash ~/vibeguard/scripts/doctors/codex-doctor.sh
+```
+
+Check these fields separately:
+
+- `~/.codex/AGENTS.md` contains the managed VibeGuard block.
+- `~/.codex/hooks.json` has managed hooks with timeout fields.
+- `~/.vibeguard/run-hook-codex.sh` exists and points at the installed runtime.
+- Codex native hooks are limited to Bash/apply_patch/PermissionRequest/PostToolUse/Stop.
+
+Read-only exploration hooks such as Read/Glob/Grep are not available on the
+native Codex path. Use Claude Code or the optional app-server-wrapper when that
+coverage is required.
+
+## Runtime and Provenance
+
+```bash
+~/.vibeguard/installed/bin/vibeguard-runtime --version
+bash ~/vibeguard/setup.sh verify-install
+```
+
+Expected state:
+
+- Supported macOS/Linux installs use a downloaded release binary by default.
+- Setup verifies `SHA256SUMS`.
+- Authenticated `gh` attestation verification reports `verified-provenance`.
+- If attestation verification is unavailable, setup reports `checksum-only`
+  rather than claiming provenance was verified.
+
+Checksum mismatch or a missing checksum entry is fatal and should not be
+treated as a source-build fallback.
+
+## Recent Hook Events
+
+Inside the repository where you expected a hook to run:
+
+```bash
+bash ~/vibeguard/scripts/hook-health.sh 24
+~/.vibeguard/installed/bin/vibeguard-runtime hook-status --mode focused
+```
+
+For global logs:
+
+```bash
+~/.vibeguard/installed/bin/vibeguard-runtime hook-status --scope global --mode focused
+```
+
+If hook status reports no data, check whether the command is running inside the
+intended git repository and whether the session was opened after setup.
+
+## Common States
+
+| Symptom | Likely Cause | Check |
+|---------|--------------|-------|
+| No hook output in a new session | Session was opened before setup or hooks are not enabled | Rerun `setup.sh doctor`, restart the agent session |
+| Codex has rules but no hook events | `hooks.json` missing, hooks feature disabled, or no write/bash action occurred | Run `scripts/doctors/codex-doctor.sh` |
+| `verify-install` fails but `doctor` looks readable | Human report is not the CI gate | Use the failing `verify-install` row as source of truth |
+| Hook status shows only old events | Wrong project scope or stale session | Run `hook-status --scope global --mode focused`, then retry inside the target repo |
+| Setup reports `checksum-only` | Attestation verification was unavailable | Install is checksum-verified, not provenance-verified |
+
+## Linux Notes
+
+Use [Linux Setup](../linux-setup.md) when shell, package manager, or service
+manager differences are involved.
+
+## Deeper References
+
+- [Codex Hook Status](../reference/codex-hook-status.md)
+- [Observability Harness Contract](../reference/observability-harness.md)
+- [Claude Code Known Issues](../reference/claude-code-known-issues.md)
+- [Known False Positives](../known-issues/false-positives.md)

--- a/docs/how/troubleshooting.md
+++ b/docs/how/troubleshooting.md
@@ -41,7 +41,7 @@ coverage is required.
 ## Runtime and Provenance
 
 ```bash
-~/.vibeguard/installed/bin/vibeguard-runtime --version
+~/.vibeguard/installed/bin/vibeguard-runtime version
 bash ~/vibeguard/setup.sh verify-install
 ```
 


### PR DESCRIPTION
## Summary
- Add README first-screen paths for Quickstart, Team rollout, and Troubleshooting
- Add docs/how quickstart, team-rollout, and troubleshooting guides
- Link the new path docs from the documentation index

Closes #503

## Validation
- bash scripts/ci/validate-doc-paths.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/verify/doc-freshness-check.sh
- bash setup.sh demo safe-bash