### PR TITLE
Validate project config schema drift

### DIFF
--- a/schemas/install-modules.json
+++ b/schemas/install-modules.json
@@ -61,7 +61,7 @@
       "paths": ["rules/claude-rules/typescript/quality.md"],
       "target": "~/.claude/rules/vibeguard/typescript/",
       "defaultInstall": true,
-      "languages": ["typescript"],
+      "languages": ["typescript", "javascript"],
       "cost": "light",
       "stability": "stable"
     },
@@ -251,7 +251,7 @@
       "description": "TypeScript guard scripts (any abuse, console residual, duplication)",
       "paths": ["guards/typescript/"],
       "defaultInstall": true,
-      "languages": ["typescript"],
+      "languages": ["typescript", "javascript"],
       "cost": "light",
       "stability": "stable"
     },

--- a/schemas/vibeguard-project.schema.json
+++ b/schemas/vibeguard-project.schema.json
@@ -67,7 +67,9 @@
           "check_dead_shims",
           "check_declaration_execution_gap",
           "check_defer_in_loop",
+          "check_dependency_changes",
           "check_dependency_layers",
+          "check_doc_overload",
           "check_duplicate_constants",
           "check_duplicate_types",
           "check_duplicates",
@@ -75,10 +77,13 @@
           "check_goroutine_leak",
           "check_naming_convention",
           "check_nested_locks",
+          "check_runtime_drift",
+          "check_sec13_mcp_config_risks",
           "check_semantic_effect",
           "check_single_source_of_truth",
           "check_taste_invariants",
           "check_test_integrity",
+          "check_test_weakening",
           "check_unwrap_in_prod",
           "check_workspace_consistency"
         ]
@@ -126,6 +131,12 @@
           "minimum": 1,
           "default": 1024,
           "description": "Trim gc-cron.log when it exceeds this size in KB. Env override: VIBEGUARD_GC_LOG_MAX_KB."
+        },
+        "catchup_interval_hours": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 168,
+          "description": "Maximum age in hours for scheduled GC catch-up runs. Env override: VIBEGUARD_GC_CATCHUP_INTERVAL_HOURS."
         }
       }
     }

--- a/scripts/lib/project_schema_contract.py
+++ b/scripts/lib/project_schema_contract.py
@@ -1,0 +1,169 @@
+"""Project-config schema drift checks for VibeGuard install contracts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+GC_CONFIG_RE = re.compile(r"\bvg_config_positive_int\s+\S+\s+gc\.([A-Za-z0-9_]+)\b")
+
+
+def _normalize_language(value: str) -> str:
+    language = value.strip().lower()
+    if language == "golang":
+        return "go"
+    return language
+
+
+def manifest_languages(manifest: dict[str, Any]) -> list[str]:
+    languages: set[str] = set()
+    modules = manifest.get("modules", [])
+    if not isinstance(modules, list):
+        raise ValueError("manifest modules must be a list")
+    for module in modules:
+        if not isinstance(module, dict):
+            raise ValueError("manifest module entry is not an object")
+        module_id = str(module.get("id", "<unknown>"))
+        languages.update(_module_languages(module, module_id))
+    return sorted(languages)
+
+
+def gc_config_keys(root: Path) -> list[str]:
+    keys: set[str] = set()
+    for file in sorted((root / "scripts" / "gc").glob("*.sh")):
+        text = file.read_text(encoding="utf-8")
+        keys.update(GC_CONFIG_RE.findall(text))
+    return sorted(keys)
+
+
+def project_schema_contract_errors(
+    project_schema: dict[str, Any],
+    *,
+    manifest_profiles: list[str],
+    manifest_languages: list[str],
+    disabled_hooks: list[str],
+    disabled_guards: list[str],
+    gc_keys: list[str],
+) -> list[str]:
+    errors: list[str] = []
+
+    profile_enum, enum_error = _project_schema_enum(project_schema, "profile")
+    if enum_error:
+        errors.append(enum_error)
+        profile_enum = []
+    if profile_enum != manifest_profiles:
+        errors.append(
+            "project schema profile enum drift: "
+            f"manifest={manifest_profiles} schema={profile_enum}"
+        )
+
+    enforcement_enum, enum_error = _project_schema_enum(project_schema, "enforcement")
+    if enum_error:
+        errors.append(enum_error)
+    elif not enforcement_enum:
+        errors.append("project schema enforcement enum must not be empty")
+
+    language_enum, enum_error = _project_schema_enum(
+        project_schema,
+        "languages",
+        array_items=True,
+    )
+    if enum_error:
+        errors.append(enum_error)
+        language_enum = []
+    if language_enum != manifest_languages:
+        errors.append(
+            "project schema languages enum drift: "
+            f"manifest={manifest_languages} schema={language_enum}"
+        )
+
+    disabled_hook_enum, enum_error = _project_schema_enum(
+        project_schema,
+        "disabled_hooks",
+        array_items=True,
+    )
+    if enum_error:
+        errors.append(enum_error)
+        disabled_hook_enum = []
+    if disabled_hook_enum != disabled_hooks:
+        errors.append(
+            "project schema disabled_hooks enum drift: "
+            f"manifest={disabled_hooks} schema={disabled_hook_enum}"
+        )
+
+    disabled_guard_enum, enum_error = _project_schema_enum(
+        project_schema,
+        "disabled_guards",
+        array_items=True,
+    )
+    if enum_error:
+        errors.append(enum_error)
+        disabled_guard_enum = []
+    if disabled_guard_enum != disabled_guards:
+        errors.append(
+            "project schema disabled_guards enum drift: "
+            f"guards={disabled_guards} schema={disabled_guard_enum}"
+        )
+
+    schema_gc_keys, gc_error = _project_schema_gc_keys(project_schema)
+    if gc_error:
+        errors.append(gc_error)
+        schema_gc_keys = []
+    if schema_gc_keys != gc_keys:
+        errors.append(
+            "project schema gc key drift: "
+            f"scripts={gc_keys} schema={schema_gc_keys}"
+        )
+
+    return errors
+
+
+def _module_languages(module: dict[str, Any], module_id: str) -> set[str]:
+    languages = module.get("languages", [])
+    if not isinstance(languages, list):
+        raise ValueError(f"module {module_id}: languages must be a list")
+    normalized: set[str] = set()
+    for item in languages:
+        if not isinstance(item, str):
+            raise ValueError(f"module {module_id}: non-string language entry")
+        language = _normalize_language(item)
+        if language:
+            normalized.add(language)
+    return normalized
+
+
+def _project_schema_enum(
+    project_schema: dict[str, Any],
+    field: str,
+    *,
+    array_items: bool = False,
+) -> tuple[list[str], str | None]:
+    properties = project_schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return [], "project schema properties must be an object"
+    node = properties.get(field)
+    if not isinstance(node, dict):
+        return [], f"project schema {field} property missing"
+    if array_items:
+        node = node.get("items", {})
+        if not isinstance(node, dict):
+            return [], f"project schema {field}.items must be an object"
+    values = node.get("enum", [])
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        return [], f"project schema {field} enum must be a string array"
+    return sorted(values), None
+
+
+def _project_schema_gc_keys(project_schema: dict[str, Any]) -> tuple[list[str], str | None]:
+    properties = project_schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return [], "project schema properties must be an object"
+    gc_node = properties.get("gc", {})
+    if not isinstance(gc_node, dict):
+        return [], "project schema gc property missing"
+    gc_properties = gc_node.get("properties", {})
+    if not isinstance(gc_properties, dict):
+        return [], "project schema gc.properties must be an object"
+    return sorted(gc_properties.keys()), None

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -11,6 +11,11 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
 from hooks_manifest import disableable_hook_names, load_manifest as load_hooks_manifest
+from project_schema_contract import (
+    gc_config_keys,
+    manifest_languages,
+    project_schema_contract_errors,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -356,27 +361,19 @@ def _validate_project_schema(
     project_schema: dict[str, Any],
     hooks_manifest: dict[str, Any],
 ) -> list[str]:
-    errors: list[str] = []
-    manifest_profiles = sorted(profile_names(manifest))
-    properties = project_schema.get("properties", {})
-    project_profile = properties.get("profile", {}).get("enum", [])
-    if sorted(project_profile) != manifest_profiles:
-        errors.append(
-            "project schema profile enum drift: "
-            f"manifest={manifest_profiles} schema={project_profile}"
-        )
-    disabled_hook_enum = (
-        properties.get("disabled_hooks", {})
-        .get("items", {})
-        .get("enum", [])
+    try:
+        expected_languages = manifest_languages(manifest)
+    except ValueError as exc:
+        return [str(exc)]
+
+    return project_schema_contract_errors(
+        project_schema,
+        manifest_profiles=sorted(profile_names(manifest)),
+        manifest_languages=expected_languages,
+        disabled_hooks=disableable_hook_names(hooks_manifest),
+        disabled_guards=guard_names(),
+        gc_keys=gc_config_keys(ROOT),
     )
-    expected_disabled_hooks = disableable_hook_names(hooks_manifest)
-    if sorted(disabled_hook_enum) != expected_disabled_hooks:
-        errors.append(
-            "project schema disabled_hooks enum drift: "
-            f"manifest={expected_disabled_hooks} schema={disabled_hook_enum}"
-        )
-    return errors
 
 
 def _hook_modules(manifest: dict[str, Any]) -> tuple[dict[str, set[str]], list[str]]:

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -139,6 +139,24 @@ assert_contains "${rust_rule_links_out}" $'rules/claude-rules/rust/quality.md\tr
 assert_not_contains "${rust_rule_links_out}" "rules/claude-rules/python/quality.md" "manifest rule-links omit unselected Python rules"
 go_rule_links_out="$(python3 "${MANIFEST_HELPER}" rule-links --languages golang)"
 assert_contains "${go_rule_links_out}" $'rules/claude-rules/golang/quality.md\tgolang/quality.md\tgolang' "manifest rule-links normalize golang language filters"
+javascript_rule_links_out="$(python3 "${MANIFEST_HELPER}" rule-links --languages javascript)"
+assert_contains "${javascript_rule_links_out}" $'rules/claude-rules/typescript/quality.md\ttypescript/quality.md\ttypescript' "manifest rule-links map JavaScript to TypeScript rules"
+assert_not_contains "${javascript_rule_links_out}" "rules/claude-rules/rust/quality.md" "manifest JavaScript rule-links omit unselected Rust rules"
+assert_not_contains "${javascript_rule_links_out}" "rules/claude-rules/python/quality.md" "manifest JavaScript rule-links omit unselected Python rules"
+assert_not_contains "${javascript_rule_links_out}" "rules/claude-rules/golang/quality.md" "manifest JavaScript rule-links omit unselected Go rules"
+javascript_guard_languages_out="$(python3 - "${REPO_DIR}/schemas/install-modules.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for module in manifest["modules"]:
+    if module.get("id") == "guards-typescript":
+        print("\n".join(module["languages"]))
+        break
+PY
+)"
+assert_contains "${javascript_guard_languages_out}" "javascript" "guards-typescript applies to JavaScript projects"
 rust_rule_labels_out="$(python3 "${MANIFEST_HELPER}" rule-labels --languages rust)"
 assert_contains "${rust_rule_labels_out}" "common" "manifest rule-labels include common"
 assert_contains "${rust_rule_labels_out}" "rust" "manifest rule-labels include selected Rust label"

--- a/tests/test_manifest_contract.sh
+++ b/tests/test_manifest_contract.sh
@@ -203,6 +203,56 @@ bad_project_schema_out="$(python3 "${MANIFEST_HELPER}" validate --project-schema
 assert_contains "${bad_project_schema_out}" "project schema disabled_hooks enum drift" "manifest validation detects disabled_hooks schema drift"
 assert_not_contains "${bad_project_schema_out}" "Traceback" "disabled_hooks schema drift reports without traceback"
 
+BAD_LANGUAGE_SCHEMA="${TMP_DIR}/bad-language-vibeguard-project.schema.json"
+python3 - "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${BAD_LANGUAGE_SCHEMA}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+enum = data["properties"]["languages"]["items"]["enum"]
+enum.remove("javascript")
+target.write_text(json.dumps(data), encoding="utf-8")
+PY
+bad_language_schema_out="$(python3 "${MANIFEST_HELPER}" validate --project-schema "${BAD_LANGUAGE_SCHEMA}" 2>&1 || true)"
+assert_contains "${bad_language_schema_out}" "project schema languages enum drift" "manifest validation detects language schema drift"
+assert_not_contains "${bad_language_schema_out}" "Traceback" "language schema drift reports without traceback"
+
+BAD_GUARD_SCHEMA="${TMP_DIR}/bad-guard-vibeguard-project.schema.json"
+python3 - "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${BAD_GUARD_SCHEMA}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+enum = data["properties"]["disabled_guards"]["items"]["enum"]
+enum.remove("check_runtime_drift")
+target.write_text(json.dumps(data), encoding="utf-8")
+PY
+bad_guard_schema_out="$(python3 "${MANIFEST_HELPER}" validate --project-schema "${BAD_GUARD_SCHEMA}" 2>&1 || true)"
+assert_contains "${bad_guard_schema_out}" "project schema disabled_guards enum drift" "manifest validation detects disabled_guards schema drift"
+assert_not_contains "${bad_guard_schema_out}" "Traceback" "disabled_guards schema drift reports without traceback"
+
+BAD_GC_SCHEMA="${TMP_DIR}/bad-gc-vibeguard-project.schema.json"
+python3 - "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${BAD_GC_SCHEMA}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+data["properties"]["gc"]["properties"].pop("catchup_interval_hours")
+target.write_text(json.dumps(data), encoding="utf-8")
+PY
+bad_gc_schema_out="$(python3 "${MANIFEST_HELPER}" validate --project-schema "${BAD_GC_SCHEMA}" 2>&1 || true)"
+assert_contains "${bad_gc_schema_out}" "project schema gc key drift" "manifest validation detects gc schema drift"
+assert_not_contains "${bad_gc_schema_out}" "Traceback" "gc schema drift reports without traceback"
+
 BAD_HOOKS_MANIFEST="${TMP_DIR}/bad-hooks-manifest.json"
 python3 - "${REPO_DIR}/hooks/manifest.json" "${BAD_HOOKS_MANIFEST}" <<'PY'
 import json

--- a/vibeguard-runtime/src/project_config.rs
+++ b/vibeguard-runtime/src/project_config.rs
@@ -19,7 +19,9 @@ const DISABLED_GUARD_VALUES: &[&str] = &[
     "check_dead_shims",
     "check_declaration_execution_gap",
     "check_defer_in_loop",
+    "check_dependency_changes",
     "check_dependency_layers",
+    "check_doc_overload",
     "check_duplicate_constants",
     "check_duplicate_types",
     "check_duplicates",
@@ -27,10 +29,13 @@ const DISABLED_GUARD_VALUES: &[&str] = &[
     "check_goroutine_leak",
     "check_naming_convention",
     "check_nested_locks",
+    "check_runtime_drift",
+    "check_sec13_mcp_config_risks",
     "check_semantic_effect",
     "check_single_source_of_truth",
     "check_taste_invariants",
     "check_test_integrity",
+    "check_test_weakening",
     "check_unwrap_in_prod",
     "check_workspace_consistency",
 ];
@@ -41,6 +46,7 @@ const GC_KEYS: &[&str] = &[
     "session_metrics_retain_days",
     "learning_window_days",
     "gc_log_max_kb",
+    "catchup_interval_hours",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -470,6 +476,80 @@ mod tests {
     use serde_json::json;
 
     const PROJECT_SCHEMA_JSON: &str = include_str!("../../schemas/vibeguard-project.schema.json");
+
+    fn sorted_values(values: &[&str]) -> Vec<String> {
+        let mut values = values
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>();
+        values.sort();
+        values
+    }
+
+    fn schema_string_enum(field: &str) -> Vec<String> {
+        let schema = serde_json::from_str::<Value>(PROJECT_SCHEMA_JSON)
+            .expect("project schema should be valid JSON");
+        let mut values = schema["properties"][field]["enum"]
+            .as_array()
+            .unwrap_or_else(|| panic!("schema {field} enum should be an array"))
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .unwrap_or_else(|| panic!("schema {field} enum entries should be strings"))
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        values.sort();
+        values
+    }
+
+    fn schema_array_enum(field: &str) -> Vec<String> {
+        let schema = serde_json::from_str::<Value>(PROJECT_SCHEMA_JSON)
+            .expect("project schema should be valid JSON");
+        let mut values = schema["properties"][field]["items"]["enum"]
+            .as_array()
+            .unwrap_or_else(|| panic!("schema {field} items enum should be an array"))
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .unwrap_or_else(|| panic!("schema {field} enum entries should be strings"))
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        values.sort();
+        values
+    }
+
+    fn schema_gc_keys() -> Vec<String> {
+        let schema = serde_json::from_str::<Value>(PROJECT_SCHEMA_JSON)
+            .expect("project schema should be valid JSON");
+        let mut values = schema["properties"]["gc"]["properties"]
+            .as_object()
+            .expect("schema gc properties should be an object")
+            .keys()
+            .map(|key| key.to_string())
+            .collect::<Vec<_>>();
+        values.sort();
+        values
+    }
+
+    #[test]
+    fn project_config_allowlists_match_schema() {
+        assert_eq!(schema_string_enum("profile"), sorted_values(PROFILE_VALUES));
+        assert_eq!(
+            schema_string_enum("enforcement"),
+            sorted_values(ENFORCEMENT_VALUES)
+        );
+        assert_eq!(
+            schema_array_enum("languages"),
+            sorted_values(LANGUAGE_VALUES)
+        );
+        assert_eq!(
+            schema_array_enum("disabled_guards"),
+            sorted_values(DISABLED_GUARD_VALUES)
+        );
+        assert_eq!(schema_gc_keys(), sorted_values(GC_KEYS));
+    }
 
     #[test]
     fn validation_reports_runtime_config_key_hints() {

--- a/vibeguard-runtime/tests/project_config_cli.rs
+++ b/vibeguard-runtime/tests/project_config_cli.rs
@@ -68,6 +68,33 @@ fn project_config_value_reads_valid_values_and_defaults_missing_values() {
 }
 
 #[test]
+fn project_config_validate_accepts_schema_backed_values() {
+    let dir = unique_temp_dir("project_config_schema_values");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let config = dir.join(".vibeguard.json");
+    fs::write(
+        &config,
+        r#"{
+          "languages": ["javascript"],
+          "disabled_guards": ["check_dependency_changes"],
+          "gc": {
+            "catchup_interval_hours": 24
+          }
+        }"#,
+    )
+    .expect("project config should be written");
+
+    let output = bin()
+        .arg("project-config-validate")
+        .arg(&config)
+        .output()
+        .expect("project config validate should run");
+
+    assert_eq!(output.status.code(), Some(0));
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn project_config_value_fails_visibly_before_reading_invalid_config() {
     let dir = unique_temp_dir("project_config_invalid_value");
     fs::create_dir_all(&dir).expect("temp dir should be created");


### PR DESCRIPTION
## Summary
- extend project schema and Rust validator coverage for current guard and GC keys
- add project schema contract checks for languages, disabled guards, and GC keys
- map JavaScript projects to TypeScript rules/guards in install modules

## Verification
- python3 -m py_compile scripts/lib/vibeguard_manifest.py scripts/lib/project_schema_contract.py && python3 scripts/lib/vibeguard_manifest.py validate
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml project_config
- bash tests/test_manifest_contract.sh
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/test_gc_config.sh
- git diff --check HEAD

Closes #505