### PR TITLE
docs: clarify agent context and spec plan status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Follow `workflows/references/routing-contract.md` for non-trivial work.
 | Ambiguous behavior, missing done-when, or conflicting specs | `clarify_first` |
 | Generated surface or high-context file rewrite | `plan_first` |
 
-Handoffs must carry `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` when those fields are relevant.
+`plan_first` handoffs must always carry `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map`; use `None` or a minimal value when a field does not otherwise apply.
 
 ## Repository Map
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,92 @@
-# AGENTS.md instructions for VibeGuard
+# Agent Instructions
 
-VibeGuard is an anti-hallucination rules, hooks, and workflow repository. There is no ORM, no front-end framework, and no microservices layer in this project.
+## Scope
 
-## Project Rules
+This file applies to the whole repository unless a nested `AGENTS.md` overrides it.
 
-- Search first before adding files, functions, rules, hooks, workflows, or tests.
-- Keep names snake_case unless an external API boundary requires camelCase.
+VibeGuard is an anti-hallucination rules, hooks, runtime, installer, and workflow repository. There is no ORM, front-end framework, or microservices layer in this project.
+
+## Start Here
+
+1. Check the worktree with `git status --short --branch`.
+2. Search before adding files, functions, rules, hooks, workflows, or tests.
+3. Read `docs/directory-map.md` before moving files or changing public paths.
+4. Read `docs/specs/README.md` before treating a spec as pending work.
+5. Read `plan/README.md` before treating files under `plan/` as active backlog.
+6. For runtime, hook, setup, or workflow changes, read the closest scoped `CLAUDE.md` in that subtree.
+
+## Core Rules
+
+- Keep names `snake_case` unless an external API boundary requires `camelCase`.
 - Do not swallow errors silently. User-visible missing data or wrong output must fail loudly.
 - Do only the requested scope; avoid opportunistic refactors.
-- Follow `workflows/references/routing-contract.md`: set `readiness` to `execute_direct`, `plan_first`, or `clarify_first`; handoffs carry `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map`.
-- High-context files such as `AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, setup scripts, and hooks must not be modified by generated output without explicit intent.
+- Preserve VibeGuard's core enforcement model: rules, hooks, setup scripts, and `vibeguard-runtime/` are the source implementation.
+- Treat plugin, pack, docs, and workflow changes as distribution layers unless a spec explicitly changes runtime behavior.
+- High-context files such as `AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, setup scripts, hooks, and workflow contracts must not be modified by generated output without explicit intent.
+- Never add AI-generated markers or hidden attribution text to commits, docs, or generated artifacts.
+
+## Routing
+
+Follow `workflows/references/routing-contract.md` for non-trivial work.
+
+| Change | Default readiness |
+|---|---|
+| Focused docs or test-only cleanup | `execute_direct` |
+| Small bug with clear reproduction and local test | `execute_direct` |
+| Runtime, hook, setup, policy, schema, or installer change | `plan_first` |
+| Ambiguous behavior, missing done-when, or conflicting specs | `clarify_first` |
+| Generated surface or high-context file rewrite | `plan_first` |
+
+Handoffs must carry `mode`, `artifacts`, `runtime_pinning_snapshot`, `verification_owner`, `stop_conditions`, and `lane_map` when those fields are relevant.
+
+## Repository Map
+
+- `rules/claude-rules/`: canonical native rule source.
+- `hooks/`: installed hook scripts and adapters.
+- `guards/`: universal and language-specific guard scripts.
+- `vibeguard-runtime/`: Rust runtime for hook-side JSON, metrics, package rewrite logic, and Codex app-server wrapper.
+- `scripts/setup/` and `setup.sh`: public setup entrypoints.
+- `scripts/ci/`: CI contract validators.
+- `tests/`: shell and Rust regression coverage for hooks, setup, workflows, and contracts.
+- `skills/`, `workflows/`, `agents/`, `.claude/commands/`: shipped agent workflow surfaces.
+- `plugins/vibeguard/`: Codex App plugin wrapper and observability commands.
+- `docs/specs/`: maintainer specs with status index.
+- `plan/`: workflow output and historical execution plans; not all files are active backlog.
+
+## Spec And Plan Gate
+
+| Situation | Required context |
+|---|---|
+| New user-facing behavior or policy semantics | Add or update a spec under `docs/specs/` or `plan/` first |
+| Work on existing spec | Check `docs/specs/README.md` for status and linked issue state |
+| Work on existing plan | Check `plan/README.md` for active, draft, historical, or snapshot status |
+| Rust-only production path | Start with `docs/specs/rust-only-production-path.md` and `plan/2026-06-05_22-28-rust-only-production-path.md` |
+| Codex plugin or dashboard | Start with `docs/specs/codex-app-observability-plugin.md` and `plugins/vibeguard/README.md` |
+| Install friction, release binaries, scheduler defaults | Start with `docs/specs/install-friction-reduction.md` |
+
+If code and an older spec disagree, verify the current implementation before changing either. Update the spec index when a draft becomes implemented or obsolete.
+
+## High-Risk Areas
+
+- Runtime policy and fail-closed behavior in `vibeguard-runtime/` and `hooks/_lib/`.
+- Setup writes to user high-context files under Claude, Codex, Git hooks, or VibeGuard config.
+- Manifest and schema contracts under `schemas/`, `hooks/manifest.json`, and workflow references.
+- Generated rule documentation and canonical rule language.
+- Shared local setup state touched by `tests/test_setup.sh`.
+- Plugin manifests, marketplace metadata, and install-surface assets.
 
 ## Validation
 
-Before completion, run the focused test or check that covers the changed surface.
+Before completion, run the focused command that proves the changed surface. Before submission, run the relevant gate from this table.
 
-Before submission:
+| Changed surface | Commands |
+|---|---|
+| Rust runtime | `cargo check --manifest-path vibeguard-runtime/Cargo.toml` and `cargo test --manifest-path vibeguard-runtime/Cargo.toml` |
+| Hooks or guard behavior | `bash scripts/ci/validate-hooks.sh`, `bash scripts/ci/validate-hooks-manifest.sh`, and the focused test under `tests/hooks/` or `tests/codex_runtime/` |
+| Setup or installed hook state | `bash tests/test_setup.sh` and the focused setup test |
+| Manifest, schema, routing, or workflow contracts | `bash tests/test_manifest_contract.sh` and `bash tests/test_workflow_contracts.sh` |
+| Skills or workflows | `bash scripts/ci/validate-skill-format.sh` and `bash scripts/ci/validate-workflow-contracts.sh` |
+| Documentation paths or commands | `bash scripts/ci/validate-doc-paths.sh` and `bash scripts/ci/validate-doc-command-paths.sh` |
+| Rule docs or rule IDs | `bash scripts/ci/validate-rules.sh`, `bash scripts/ci/validate-generated-rule-docs.sh`, and `bash scripts/verify/doc-freshness-check.sh --strict` |
 
-- Rust: `cargo check` and `cargo test`
-- Shell/setup changes: `bash tests/test_setup.sh`
-- Manifest/routing changes: `bash tests/test_manifest_contract.sh`
-- Documentation path changes: `bash scripts/ci/validate-doc-paths.sh` and `bash scripts/ci/validate-doc-command-paths.sh`
-
-If a validation command cannot run, report the exact blocker instead of claiming completion.
+Run `bash scripts/local-contract-check.sh --quick` for a broad local contract pass when the change crosses multiple surfaces. If a validation command cannot run, report the exact blocker instead of claiming completion.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,34 @@
+# VibeGuard Specs Index
+
+This directory holds maintainer-facing specs. Most files here are implementation evidence or scoped design contracts, not a raw backlog. Before opening new work, check the status below and verify linked issues or PRs.
+
+## Current Specs
+
+| Spec | Status | Use it for |
+|---|---|---|
+| `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
+| `install-friction-reduction.md` | Draft reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
+| `rust-only-production-path.md` | Implemented reference | Python-free production path, Rust runtime boundaries, and remaining validation expectations |
+
+## Reading Rules
+
+- Treat `Status: Implemented` as current implementation context, not pending scope.
+- Treat `Draft` as a design contract that still needs live code and issue verification before implementation.
+- Keep linked issues and PRs in the spec when they are part of the execution contract.
+- Do not move a spec into `docs/internal/` while active issues or public docs still point to it.
+- Update this index when a spec is implemented, superseded, or split.
+
+## Adjacent Planning Material
+
+Execution plans and older draft specs live under `plan/`. Read `plan/README.md` before using those files as backlog. Some `plan/` files are completed records, snapshots, or signal reports rather than current work.
+
+## Validation For Spec Edits
+
+Run these checks for documentation-only spec edits:
+
+```bash
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+```
+
+When a spec edit also changes workflows, manifests, runtime behavior, or setup behavior, run the corresponding commands from the top-level `AGENTS.md` validation table.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,7 +7,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | Spec | Status | Use it for |
 |---|---|---|
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
-| `install-friction-reduction.md` | Draft reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
+| `install-friction-reduction.md` | Implemented reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
 | `rust-only-production-path.md` | Implemented reference | Python-free production path, Rust runtime boundaries, and remaining validation expectations |
 
 ## Reading Rules

--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,41 @@
+# VibeGuard Plan Index
+
+`plan/` is the workflow output directory. It contains completed execution records, active plans, draft specs, snapshots, and signal reports. Do not treat every file here as active backlog.
+
+## Status Classes
+
+| Class | Meaning | Files |
+|---|---|---|
+| Active execution plan | Current multi-step work where remaining steps may still be actionable after checking linked issues and main branch | `2026-06-05_22-28-rust-only-production-path.md` |
+| Completed record | Historical execution evidence; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `spec-codebase-audit-remediation.md` |
+| Historical convergence plan | Older architecture plan; verify current code and newer specs before acting | `2026-04-19_00-15-39-main-architecture-convergence.md` |
+| Draft spec | Candidate work that needs issue and code-state verification before implementation | `spec-app-server-runtime-policy-gate.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md`, `spec-test-file-size-decomposition.md`, `spec-96-prompt-contract-schema.md`, `full-english-localization-spec.md` |
+| Snapshot or signal report | Evidence artifact for another plan or issue; do not implement directly without an owning spec | `w20-rust-only-production-path-snapshot.md`, `signal-report-legacy-vibeguard-mcp-cleanup.md` |
+
+## Reading Rules
+
+- Start with `docs/specs/README.md` for specs that have moved into the maintained specs directory.
+- Verify linked GitHub issues before acting on any draft or active plan.
+- For completed records, prefer current code, tests, and merged PRs over old wording.
+- Do not move `plan/` files unless the plan workflow contract changes.
+- Keep new plan files focused on one execution lane and include explicit stop conditions and validation commands.
+
+## When To Add A New Plan
+
+Add a plan when work is multi-step, crosses runtime/setup/workflow boundaries, or changes fail-closed semantics. Small documentation edits, focused test fixes, and narrow bug fixes can execute directly when the root cause and validation command are clear.
+
+## Validation For Plan Edits
+
+Run these checks for documentation-only plan edits:
+
+```bash
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+```
+
+If the plan edit changes workflow routing, also run:
+
+```bash
+bash scripts/ci/validate-workflow-contracts.sh
+bash tests/test_workflow_contracts.sh
+```

--- a/plan/README.md
+++ b/plan/README.md
@@ -6,8 +6,8 @@
 
 | Class | Meaning | Files |
 |---|---|---|
-| Active execution plan | Current multi-step work where remaining steps may still be actionable after checking linked issues and main branch | `2026-06-05_22-28-rust-only-production-path.md` |
-| Completed record | Historical execution evidence; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `spec-codebase-audit-remediation.md` |
+| Active execution plan | Current multi-step work where remaining steps may still be actionable after checking linked issues and main branch | None currently |
+| Completed record | Historical execution evidence or implemented plan record; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `2026-06-05_22-28-rust-only-production-path.md`, `spec-codebase-audit-remediation.md` |
 | Historical convergence plan | Older architecture plan; verify current code and newer specs before acting | `2026-04-19_00-15-39-main-architecture-convergence.md` |
 | Draft spec | Candidate work that needs issue and code-state verification before implementation | `spec-app-server-runtime-policy-gate.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md`, `spec-test-file-size-decomposition.md`, `spec-96-prompt-contract-schema.md`, `full-english-localization-spec.md` |
 | Snapshot or signal report | Evidence artifact for another plan or issue; do not implement directly without an owning spec | `w20-rust-only-production-path-snapshot.md`, `signal-report-legacy-vibeguard-mcp-cleanup.md` |

--- a/plan/README.md
+++ b/plan/README.md
@@ -7,9 +7,9 @@
 | Class | Meaning | Files |
 |---|---|---|
 | Active execution plan | Current multi-step work where remaining steps may still be actionable after checking linked issues and main branch | None currently |
-| Completed record | Historical execution evidence or implemented plan record; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `2026-06-05_22-28-rust-only-production-path.md`, `spec-codebase-audit-remediation.md` |
+| Completed record | Historical execution evidence or implemented plan record; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `2026-06-05_22-28-rust-only-production-path.md`, `spec-96-prompt-contract-schema.md`, `spec-app-server-runtime-policy-gate.md`, `spec-codebase-audit-remediation.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md` |
 | Historical convergence plan | Older architecture plan; verify current code and newer specs before acting | `2026-04-19_00-15-39-main-architecture-convergence.md` |
-| Draft spec | Candidate work that needs issue and code-state verification before implementation | `spec-app-server-runtime-policy-gate.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md`, `spec-test-file-size-decomposition.md`, `spec-96-prompt-contract-schema.md`, `full-english-localization-spec.md` |
+| Draft spec | Candidate work that needs issue and code-state verification before implementation | `spec-test-file-size-decomposition.md`, `full-english-localization-spec.md` |
 | Snapshot or signal report | Evidence artifact for another plan or issue; do not implement directly without an owning spec | `w20-rust-only-production-path-snapshot.md`, `signal-report-legacy-vibeguard-mcp-cleanup.md` |
 
 ## Reading Rules


### PR DESCRIPTION
## Summary

- Expand `AGENTS.md` from a short rule list into a repository router with start-here steps, routing gates, high-risk areas, and validation mapping.
- Add `docs/specs/README.md` to classify current specs as draft or implemented reference.
- Add `plan/README.md` to distinguish active plans, completed records, drafts, snapshots, and signal reports.

Closes #512

## Validation

- `python3 /Users/lifcc/.codex/skills/repo-agent-context-audit/scripts/scan_repo_context.py .`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash scripts/ci/validate-no-personal-paths.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`

## Not tested

- `bash tests/test_setup.sh` was not run because this PR does not touch setup, install, or shared hook state.
