### PR TITLE
ci: harden runtime supply chain provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install cargo-deny
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cargo install cargo-deny --version "${CARGO_DENY_VERSION}" --locked
+
+      - name: Validate Rust dependency policy
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cargo deny --manifest-path vibeguard-runtime/Cargo.toml --locked check -c deny.toml licenses bans sources
+
       - name: Install bash 4+ (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -80,16 +90,6 @@ jobs:
           cargo check --manifest-path vibeguard-runtime/Cargo.toml
           cargo test --manifest-path vibeguard-runtime/Cargo.toml
           cargo bench --manifest-path vibeguard-runtime/Cargo.toml --bench core_us --no-run
-
-      - name: Install cargo-deny
-        if: runner.os == 'Linux'
-        shell: bash
-        run: cargo install cargo-deny --version "${CARGO_DENY_VERSION}" --locked
-
-      - name: Validate Rust dependency policy
-        if: runner.os == 'Linux'
-        shell: bash
-        run: cargo deny --manifest-path vibeguard-runtime/Cargo.toml --locked check -c deny.toml licenses bans sources
 
       # --- Shell-based validation ---
       # Skipped on Windows: these scripts check Unix file-permission bits ([ -x ])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  CARGO_DENY_VERSION: "0.19.9"
+
 jobs:
   validate-and-test:
     name: CI (${{ matrix.os }})
@@ -77,6 +80,16 @@ jobs:
           cargo check --manifest-path vibeguard-runtime/Cargo.toml
           cargo test --manifest-path vibeguard-runtime/Cargo.toml
           cargo bench --manifest-path vibeguard-runtime/Cargo.toml --bench core_us --no-run
+
+      - name: Install cargo-deny
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cargo install cargo-deny --version "${CARGO_DENY_VERSION}" --locked
+
+      - name: Validate Rust dependency policy
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cargo deny --manifest-path vibeguard-runtime/Cargo.toml --locked check -c deny.toml licenses bans sources
 
       # --- Shell-based validation ---
       # Skipped on Windows: these scripts check Unix file-permission bits ([ -x ])

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,11 +164,27 @@ jobs:
       attestations: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_VERSION}" --profile minimal
+          rustup default "${RUST_VERSION}"
+          rustc --version
+
       - name: Download runtime artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
+
+      - name: Generate dependency metadata
+        run: |
+          cargo metadata --locked --manifest-path "${RUNTIME_MANIFEST}" --format-version 1 \
+            > dist/vibeguard-runtime-dependency-metadata.json
 
       - name: Generate checksums
         run: |
@@ -193,4 +209,4 @@ jobs:
           fi
           gh release create "${TAG_NAME}" dist/vibeguard-runtime-* dist/SHA256SUMS \
             --title "${TAG_NAME}" \
-            --notes "VibeGuard runtime binaries for ${TAG_NAME}."
+            --notes "VibeGuard runtime binaries and dependency metadata for ${TAG_NAME}."

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,16 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,7 @@
 allow = [
     "Apache-2.0",
     "MIT",
+    "Unicode-3.0",
 ]
 confidence-threshold = 0.8
 

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -6,7 +6,8 @@ VibeGuard supports Linux via **systemd user units** as the scheduled task mechan
 
 - `gh` or `curl` for the default prebuilt `vibeguard-runtime` download.
   Authenticated `gh` also enables artifact attestation verification; without it,
-  setup reports `checksum-only` after SHA-256 verification.
+  setup reports `checksum-only` after SHA-256 verification. Use
+  `--require-provenance` when checksum-only installs should fail closed.
 - Python 3 is not required for default production install/check/clean on
   supported release targets. It remains used by evals, docs generation,
   developer tools, and optional Python-backed guard tools.
@@ -30,6 +31,18 @@ Rust/Cargo is not required. To force a local build:
 ```bash
 bash setup.sh --yes --build-from-source
 ```
+
+For stricter supply-chain environments, require GitHub artifact attestation
+verification in addition to the checksum:
+
+```bash
+bash setup.sh --yes --require-provenance
+```
+
+This mode fails instead of falling back to `checksum-only` when `gh`,
+`gh attestation verify`, or GitHub authentication is unavailable. It also rejects
+`--build-from-source`, because release provenance only exists for published
+release assets.
 
 Scheduled GC is opt-in. To install and enable the systemd timer:
 

--- a/docs/specs/install-friction-reduction.md
+++ b/docs/specs/install-friction-reduction.md
@@ -73,8 +73,11 @@ Replace the unconditional `cargo build` block (`install.sh:184-212`) with:
 3. If target is supported and not `--build-from-source`:
    - Download `vibeguard-runtime-<target>` and `SHA256SUMS` from the release
      (`gh release download` if `gh` present, else `curl -fsSL`).
-   - **Verify SHA-256** against `SHA256SUMS`; on mismatch → abort (do not silently
-     fall back to an unverified binary).
+  - **Verify SHA-256** against `SHA256SUMS`; on mismatch → abort (do not silently
+    fall back to an unverified binary).
+  - When `--require-provenance` is set, also require GitHub artifact attestation
+    verification. If the verifier, authentication, or attestation is unavailable,
+    abort instead of accepting the default `checksum-only` mode.
    - On verify success: `install -m 0755` into `~/.vibeguard/installed/bin/vibeguard-runtime`.
 4. If download fails (offline / 404 / unsupported target) **or** `--build-from-source`:
    - Fall back to the current `cargo build --release` path unchanged.
@@ -82,7 +85,9 @@ Replace the unconditional `cargo build` block (`install.sh:184-212`) with:
      the unsupported target and the `--build-from-source` requirement.
 
 Flags: `--build-from-source` (force compile), `--runtime-version <tag>` (override, for
-testing). The atomic snapshot swap (`install.sh:213-228`) is unchanged.
+testing), and `--require-provenance` (fail closed unless release attestation verifies).
+`--require-provenance` rejects `--build-from-source`, because source builds do not have
+release-asset provenance. The atomic snapshot swap (`install.sh:213-228`) is unchanged.
 
 ### 3.3 Scheduled GC → opt-in
 
@@ -113,7 +118,9 @@ true `curl | sh` one-liner. Tracked as a follow-up; large and out of scope here.
 - Binary integrity: SHA-256 verification against the release `SHA256SUMS` is mandatory;
   a mismatch aborts (never silently uses an unverified binary). Aligns with the project's
   own supply-chain stance (SEC-12 / SEC-13).
-- Provenance (stretch): add build provenance / cosign attestation in a later iteration.
+- Provenance: release assets carry GitHub artifact attestations when the release workflow
+  runs. Default setup reports `checksum-only` if local verification is unavailable after
+  SHA-256 verification. Strict installs use `--require-provenance` to fail closed instead.
 - The download path must not pipe remote content into a shell; only fetch the binary +
   checksum file and verify before executing.
 
@@ -134,6 +141,8 @@ true `curl | sh` one-liner. Tracked as a follow-up; large and out of scope here.
 - AC8: A release tag whose `vibeguard-runtime/VERSION` does not match the tag fails
   before any release asset is published.
 - AC9: The binary download path succeeds when `gh` is absent but `curl` is present.
+- AC10: `bash setup.sh --require-provenance` fails closed when attestation verification
+  is unavailable, and succeeds only when release attestation verification passes.
 
 ## 6. Work breakdown (→ issues)
 

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -426,6 +426,10 @@ prepare_runtime_binary() {
     if [[ "${RUNTIME_VERSION_OVERRIDE_SET}" == "1" ]]; then
       exit 2
     fi
+    if [[ "${REQUIRE_PROVENANCE}" == "1" ]]; then
+      red "  ERROR: --require-provenance requires a downloaded runtime that matches the repo runtime VERSION."
+      exit 2
+    fi
     rm -f "${_INSTALL_TMP}/bin/vibeguard-runtime"
     prepare_runtime_from_source "downloaded runtime does not match repo runtime VERSION"
     return

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # bash setup.sh --yes # Apply high-context diffs non-interactively
 # bash setup.sh --build-from-source # Build vibeguard-runtime with cargo instead of downloading a release binary
 # bash setup.sh --runtime-version v1.2.3 # Download a specific vibeguard-runtime release tag
+# bash setup.sh --require-provenance # Require GitHub artifact attestation verification for release binaries
 # bash setup.sh --with-scheduler # Opt in to launchd/systemd scheduled GC
 # bash setup.sh --force-overwrite # Replace user-customized managed files/commands
 # bash setup.sh --dev-linked # Opt in to live-repo execution for local development
@@ -43,6 +44,7 @@ VIBEGUARD_SETUP_AUTO="${VIBEGUARD_SETUP_AUTO:-0}"
 VIBEGUARD_SETUP_FORCE_OVERWRITE="${VIBEGUARD_SETUP_FORCE_OVERWRITE:-0}"
 WITH_SCHEDULER="${VIBEGUARD_SETUP_WITH_SCHEDULER:-0}"
 BUILD_FROM_SOURCE="${VIBEGUARD_SETUP_BUILD_FROM_SOURCE:-0}"
+REQUIRE_PROVENANCE="${VIBEGUARD_SETUP_REQUIRE_PROVENANCE:-0}"
 DEV_LINKED="${VIBEGUARD_SETUP_DEV_LINKED:-0}"
 VIBEGUARD_HOME="${HOME}/.vibeguard"
 _INSTALL_TMP=""
@@ -72,6 +74,8 @@ while [[ $# -gt 0 ]]; do
       RUNTIME_VERSION_OVERRIDE="$2"; RUNTIME_VERSION_OVERRIDE_SET=1; shift 2 ;;
     --runtime-version=*)
       RUNTIME_VERSION_OVERRIDE="${1#*=}"; RUNTIME_VERSION_OVERRIDE_SET=1; shift ;;
+    --require-provenance)
+      REQUIRE_PROVENANCE=1; shift ;;
     --with-scheduler)
       WITH_SCHEDULER=1; shift ;;
     --force-overwrite)
@@ -90,11 +94,12 @@ while [[ $# -gt 0 ]]; do
       LANGUAGES="${1#*=}"; shift ;;
     *)
       red "ERROR: unknown argument: $1"
-      red "Usage: bash setup.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--with-scheduler] [--force-overwrite] [--dev-linked] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean"
+      red "Usage: bash setup.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--require-provenance] [--with-scheduler] [--force-overwrite] [--dev-linked] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean"
       exit 1 ;;
   esac
 done
 export VIBEGUARD_SETUP_DRY_RUN VIBEGUARD_SETUP_AUTO VIBEGUARD_SETUP_FORCE_OVERWRITE
+export VIBEGUARD_SETUP_REQUIRE_PROVENANCE="${REQUIRE_PROVENANCE}"
 export VIBEGUARD_SETUP_DEV_LINKED="${DEV_LINKED}"
 
 if [[ "${RUNTIME_VERSION_OVERRIDE_SET}" == "1" && -z "${RUNTIME_VERSION_OVERRIDE}" ]]; then
@@ -103,6 +108,14 @@ if [[ "${RUNTIME_VERSION_OVERRIDE_SET}" == "1" && -z "${RUNTIME_VERSION_OVERRIDE
 fi
 if [[ "${RUNTIME_VERSION_OVERRIDE_SET}" == "1" ]]; then
   export VIBEGUARD_SETUP_RUNTIME_VERSION="${RUNTIME_VERSION_OVERRIDE}"
+fi
+case "${REQUIRE_PROVENANCE}" in
+  0|1) ;;
+  *) red "ERROR: VIBEGUARD_SETUP_REQUIRE_PROVENANCE must be 0 or 1"; exit 1 ;;
+esac
+if [[ "${REQUIRE_PROVENANCE}" == "1" && "${BUILD_FROM_SOURCE}" == "1" ]]; then
+  red "ERROR: --require-provenance cannot be combined with --build-from-source; release provenance is only available for downloaded release binaries."
+  exit 1
 fi
 
 case "${PROFILE}" in
@@ -260,6 +273,12 @@ download_prebuilt_runtime() {
       provenance_note="provenance=verified-provenance"
       ;;
     2)
+      if [[ "${REQUIRE_PROVENANCE}" == "1" ]]; then
+        red "  ERROR: vibeguard-runtime provenance verification is required but unavailable for ${asset}."
+        red "  ${SETUP_RUNTIME_PROVENANCE_REASON:-verifier unavailable}"
+        rm -rf "${download_dir}"
+        return 10
+      fi
       provenance_status="checksum-only"
       provenance_note="provenance=checksum-only (${SETUP_RUNTIME_PROVENANCE_REASON:-verifier unavailable})"
       yellow "  Runtime provenance is checksum-only: ${SETUP_RUNTIME_PROVENANCE_REASON:-verifier unavailable}."
@@ -381,10 +400,18 @@ prepare_runtime_binary() {
   fi
 
   if ! target="$(runtime_release_target)"; then
+    if [[ "${REQUIRE_PROVENANCE}" == "1" ]]; then
+      red "  ERROR: --require-provenance requires a supported release target; unsupported platform $(uname -s)/$(uname -m)."
+      exit 2
+    fi
     prepare_runtime_from_source "unsupported platform $(uname -s)/$(uname -m)"
     return
   fi
   if ! tag="$(runtime_release_tag)"; then
+    if [[ "${REQUIRE_PROVENANCE}" == "1" ]]; then
+      red "  ERROR: --require-provenance requires a resolvable runtime release tag."
+      exit 2
+    fi
     prepare_runtime_from_source "runtime VERSION could not be resolved"
     return
   fi
@@ -407,6 +434,10 @@ prepare_runtime_binary() {
     exit 2
   fi
   fallback_reason="${RUNTIME_PREBUILT_REASON:-download failed}"
+  if [[ "${REQUIRE_PROVENANCE}" == "1" ]]; then
+    red "  ERROR: --require-provenance requires a downloaded runtime with verified provenance (${fallback_reason})."
+    exit 2
+  fi
   prepare_runtime_from_source "${fallback_reason}"
 }
 
@@ -487,6 +518,9 @@ if [[ "${VIBEGUARD_SETUP_FORCE_OVERWRITE}" == "1" ]]; then
 fi
 if [[ "${BUILD_FROM_SOURCE}" == "1" ]]; then
   echo "Mode: build-from-source (vibeguard-runtime will be built with cargo)"
+fi
+if [[ "${REQUIRE_PROVENANCE}" == "1" ]]; then
+  echo "Mode: require-provenance (release attestation must verify)"
 fi
 if [[ -n "${RUNTIME_VERSION_OVERRIDE}" ]]; then
   echo "Runtime version override: ${RUNTIME_VERSION_OVERRIDE}"

--- a/setup.sh
+++ b/setup.sh
@@ -33,6 +33,7 @@ Install options:
   --dry-run
   --build-from-source
   --runtime-version vX.Y.Z
+  --require-provenance
   --with-scheduler
   --force-overwrite
   --profile minimal|core|full|strict

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -170,6 +170,26 @@ assert_contains "${checksum_fail_out}" "vibeguard-runtime checksum verification 
 assert_not_contains "${checksum_fail_out}" "Falling back to source build" "tampered prebuilt checksum does not fall back to source"
 assert_not_contains "${checksum_fail_out}" "Setup complete! All components installed." "tampered prebuilt checksum does not report setup complete"
 
+require_provenance_fail_home="${TMP_HOME}/require-provenance-fail-home"
+mkdir -p "${require_provenance_fail_home}"
+set +e
+require_provenance_fail_out="$(HOME="${require_provenance_fail_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --require-provenance 2>&1)"
+require_provenance_fail_rc=$?
+set -e
+assert_cmd "--require-provenance exits nonzero when attestation verifier is unavailable" test "${require_provenance_fail_rc}" -ne 0
+assert_contains "${require_provenance_fail_out}" "Mode: require-provenance" "--require-provenance reports strict mode"
+assert_contains "${require_provenance_fail_out}" "provenance verification is required but unavailable" "--require-provenance fails closed on checksum-only provenance"
+assert_contains "${require_provenance_fail_out}" "gh attestation verify unavailable" "--require-provenance reports missing attestation verifier"
+assert_not_contains "${require_provenance_fail_out}" "Setup complete! All components installed." "--require-provenance unavailable verifier does not report setup complete"
+
+require_provenance_ok_home="${TMP_HOME}/require-provenance-ok-home"
+mkdir -p "${require_provenance_ok_home}"
+require_provenance_ok_out="$(HOME="${require_provenance_ok_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 VIBEGUARD_TEST_ATTESTATION_AVAILABLE=1 VIBEGUARD_TEST_GH_AUTH_OK=1 VIBEGUARD_TEST_ATTESTATION_OK=1 bash "${REPO_DIR}/setup.sh" --yes --require-provenance)"
+assert_contains "${require_provenance_ok_out}" "Mode: require-provenance" "--require-provenance success reports strict mode"
+assert_contains "${require_provenance_ok_out}" "provenance=verified-provenance" "--require-provenance requires verified provenance"
+assert_contains "${require_provenance_ok_out}" "runtime provenance status: verified-provenance" "--require-provenance records verified provenance status"
+assert_contains "${require_provenance_ok_out}" "Setup complete! All components installed." "--require-provenance install succeeds with verified attestation"
+
 empty_version_home="${TMP_HOME}/empty-version-home"
 mkdir -p "${empty_version_home}"
 set +e

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -190,6 +190,18 @@ assert_contains "${require_provenance_ok_out}" "provenance=verified-provenance" 
 assert_contains "${require_provenance_ok_out}" "runtime provenance status: verified-provenance" "--require-provenance records verified provenance status"
 assert_contains "${require_provenance_ok_out}" "Setup complete! All components installed." "--require-provenance install succeeds with verified attestation"
 
+require_provenance_mismatch_home="${TMP_HOME}/require-provenance-mismatch-home"
+mkdir -p "${require_provenance_mismatch_home}"
+set +e
+require_provenance_mismatch_out="$(HOME="${require_provenance_mismatch_home}" VIBEGUARD_TEST_RUNTIME_VERSION=0.0.0 VIBEGUARD_TEST_ATTESTATION_AVAILABLE=1 VIBEGUARD_TEST_GH_AUTH_OK=1 VIBEGUARD_TEST_ATTESTATION_OK=1 bash "${REPO_DIR}/setup.sh" --yes --require-provenance 2>&1)"
+require_provenance_mismatch_rc=$?
+set -e
+assert_cmd "--require-provenance exits nonzero when verified runtime version mismatches" test "${require_provenance_mismatch_rc}" -ne 0
+assert_contains "${require_provenance_mismatch_out}" "prepared vibeguard-runtime is incompatible" "--require-provenance mismatch reports incompatible runtime"
+assert_contains "${require_provenance_mismatch_out}" "--require-provenance requires a downloaded runtime that matches the repo runtime VERSION" "--require-provenance mismatch fails before source fallback"
+assert_not_contains "${require_provenance_mismatch_out}" "Falling back to source build" "--require-provenance mismatch does not fall back to source"
+assert_not_contains "${require_provenance_mismatch_out}" "Setup complete! All components installed." "--require-provenance mismatch does not report setup complete"
+
 empty_version_home="${TMP_HOME}/empty-version-home"
 mkdir -p "${empty_version_home}"
 set +e

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -143,6 +143,7 @@ assert_contains "$deny_text" 'unknown-git = "deny"' "deny.toml denies unknown gi
 assert_contains "$deny_text" 'multiple-versions = "deny"' "deny.toml denies duplicate dependency versions"
 assert_contains "$deny_text" '"MIT"' "deny.toml allows MIT license"
 assert_contains "$deny_text" '"Apache-2.0"' "deny.toml allows Apache-2.0 license"
+assert_contains "$deny_text" '"Unicode-3.0"' "deny.toml allows unicode-ident license"
 assert_regex "$workflow_text" 'uses: actions/checkout@[0-9a-f]{40}[[:space:]]*# v6\.0\.2' "checkout action is pinned to a full commit SHA"
 assert_regex "$workflow_text" 'uses: actions/upload-artifact@[0-9a-f]{40}[[:space:]]*# v7\.0\.1' "upload-artifact action is pinned to a full commit SHA"
 assert_regex "$workflow_text" 'uses: actions/download-artifact@[0-9a-f]{40}[[:space:]]*# v8\.0\.1' "download-artifact action is pinned to a full commit SHA"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -72,6 +72,21 @@ assert_regex() {
   fi
 }
 
+assert_before() {
+  local text="$1" first="$2" second="$3" desc="$4"
+  local first_line second_line
+  TOTAL=$((TOTAL + 1))
+  first_line="$(grep -nF -- "$first" <<< "$text" | head -n 1 | cut -d: -f1 || true)"
+  second_line="$(grep -nF -- "$second" <<< "$text" | head -n 1 | cut -d: -f1 || true)"
+  if [[ -n "${first_line}" && -n "${second_line}" && "${first_line}" -lt "${second_line}" ]]; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected '$first' before '$second')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 ensure_runtime_tag_available() {
   local tag="$1"
   if git -C "${REPO_DIR}" rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
@@ -122,6 +137,7 @@ assert_not_contains "$workflow_text" 'RUST_VERSION: "stable"' "release workflow 
 assert_contains "$ci_text" 'CARGO_DENY_VERSION: "0.19.9"' "CI pins cargo-deny version"
 assert_contains "$ci_text" "cargo install cargo-deny --version" "CI installs cargo-deny explicitly"
 assert_contains "$ci_text" "cargo deny --manifest-path vibeguard-runtime/Cargo.toml --locked check -c deny.toml licenses bans sources" "CI enforces Rust dependency policy"
+assert_before "$ci_text" "Validate Rust dependency policy" "Rust runtime checks" "CI validates dependency policy before runtime Cargo builds"
 assert_contains "$deny_text" 'unknown-registry = "deny"' "deny.toml denies unknown registries"
 assert_contains "$deny_text" 'unknown-git = "deny"' "deny.toml denies unknown git sources"
 assert_contains "$deny_text" 'multiple-versions = "deny"' "deny.toml denies duplicate dependency versions"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -5,11 +5,15 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="${REPO_DIR}/.github/workflows/release.yml"
+CI_WORKFLOW="${REPO_DIR}/.github/workflows/ci.yml"
 VERSION_FILE="${REPO_DIR}/vibeguard-runtime/VERSION"
 CARGO_TOML="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 RUST_TOOLCHAIN="${REPO_DIR}/rust-toolchain.toml"
 INSTALL_SH="${REPO_DIR}/scripts/setup/install.sh"
 SETUP_LIB="${REPO_DIR}/scripts/setup/lib.sh"
+DENY_TOML="${REPO_DIR}/deny.toml"
+LINUX_SETUP="${REPO_DIR}/docs/linux-setup.md"
+INSTALL_SPEC="${REPO_DIR}/docs/specs/install-friction-reduction.md"
 
 PASS=0
 FAIL=0
@@ -80,9 +84,13 @@ ensure_runtime_tag_available() {
 }
 
 workflow_text="$(<"${WORKFLOW}")"
+ci_text="$(<"${CI_WORKFLOW}")"
 toolchain_text="$(<"${RUST_TOOLCHAIN}")"
 install_text="$(<"${INSTALL_SH}")"
 setup_lib_text="$(<"${SETUP_LIB}")"
+deny_text="$(<"${DENY_TOML}")"
+linux_setup_text="$(<"${LINUX_SETUP}")"
+install_spec_text="$(<"${INSTALL_SPEC}")"
 runtime_version="$(tr -d '[:space:]' < "${VERSION_FILE}")"
 cargo_version="$(
   python3 - "${CARGO_TOML}" <<'PY'
@@ -111,6 +119,14 @@ assert_contains "$workflow_text" "release tag \${TAG_NAME} does not match" "tag/
 assert_contains "$workflow_text" 'RUST_VERSION: "1.95.0"' "release workflow pins Rust release toolchain"
 assert_contains "$toolchain_text" 'channel = "1.95.0"' "repo rust-toolchain pins the same release toolchain"
 assert_not_contains "$workflow_text" 'RUST_VERSION: "stable"' "release workflow does not use moving stable Rust"
+assert_contains "$ci_text" 'CARGO_DENY_VERSION: "0.19.9"' "CI pins cargo-deny version"
+assert_contains "$ci_text" "cargo install cargo-deny --version" "CI installs cargo-deny explicitly"
+assert_contains "$ci_text" "cargo deny --manifest-path vibeguard-runtime/Cargo.toml --locked check -c deny.toml licenses bans sources" "CI enforces Rust dependency policy"
+assert_contains "$deny_text" 'unknown-registry = "deny"' "deny.toml denies unknown registries"
+assert_contains "$deny_text" 'unknown-git = "deny"' "deny.toml denies unknown git sources"
+assert_contains "$deny_text" 'multiple-versions = "deny"' "deny.toml denies duplicate dependency versions"
+assert_contains "$deny_text" '"MIT"' "deny.toml allows MIT license"
+assert_contains "$deny_text" '"Apache-2.0"' "deny.toml allows Apache-2.0 license"
 assert_regex "$workflow_text" 'uses: actions/checkout@[0-9a-f]{40}[[:space:]]*# v6\.0\.2' "checkout action is pinned to a full commit SHA"
 assert_regex "$workflow_text" 'uses: actions/upload-artifact@[0-9a-f]{40}[[:space:]]*# v7\.0\.1' "upload-artifact action is pinned to a full commit SHA"
 assert_regex "$workflow_text" 'uses: actions/download-artifact@[0-9a-f]{40}[[:space:]]*# v8\.0\.1' "download-artifact action is pinned to a full commit SHA"
@@ -122,13 +138,23 @@ assert_contains "$workflow_text" "subject-path: dist/\${{ matrix.target }}/vibeg
 assert_contains "$workflow_text" "sha256sum vibeguard-runtime-* | sort -k2 > SHA256SUMS" "checksums use deterministic sorted layout"
 assert_contains "$workflow_text" "Attest checksum manifest" "release workflow attests checksum manifest"
 assert_contains "$workflow_text" "subject-path: dist/SHA256SUMS" "release workflow attests SHA256SUMS"
+assert_contains "$workflow_text" "Generate dependency metadata" "release workflow generates dependency metadata"
+assert_contains "$workflow_text" "cargo metadata --locked --manifest-path" "dependency metadata comes from locked Cargo graph"
+assert_contains "$workflow_text" "vibeguard-runtime-dependency-metadata.json" "release publishes dependency metadata asset"
 assert_contains "$workflow_text" 'GH_REPO: ${{ github.repository }}' "publish job pins gh target repository"
 assert_contains "$setup_lib_text" "gh attestation verify" "setup verifies runtime release attestations when verifier is available"
 assert_contains "$setup_lib_text" "--signer-workflow" "setup pins provenance signer workflow"
 assert_contains "$setup_lib_text" '--source-ref "refs/tags/${tag}"' "setup pins provenance to the release tag"
 assert_contains "$install_text" "provenance=verified-provenance" "install output reports verified provenance"
 assert_contains "$install_text" "provenance=checksum-only" "install output reports checksum-only fallback explicitly"
+assert_contains "$install_text" "--require-provenance" "install supports provenance-required mode"
+assert_contains "$install_text" "provenance verification is required but unavailable" "install fails closed when strict provenance cannot verify"
+assert_contains "$install_text" "cannot be combined with --build-from-source" "strict provenance rejects source-build mode"
 assert_contains "$install_text" "runtime-provenance" "install snapshot records runtime provenance status"
+assert_contains "$linux_setup_text" "--require-provenance" "Linux setup docs document strict provenance mode"
+assert_contains "$linux_setup_text" "checksum-only" "Linux setup docs distinguish checksum-only mode"
+assert_contains "$install_spec_text" "--require-provenance" "install spec documents strict provenance mode"
+assert_contains "$install_spec_text" "release attestation verification passes" "install spec captures strict provenance acceptance criteria"
 
 for target in \
   aarch64-apple-darwin \

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -432,6 +432,18 @@ cat > "${TMP_HOME}/bin/gh" <<'SH'
 if [[ "${VIBEGUARD_TEST_DOWNLOAD_FAIL:-0}" == "1" || "${VIBEGUARD_TEST_GH_FAIL:-0}" == "1" ]]; then
   exit 1
 fi
+if [[ "${1:-}" == "attestation" && "${2:-}" == "verify" ]]; then
+  if [[ "${3:-}" == "--help" ]]; then
+    [[ "${VIBEGUARD_TEST_ATTESTATION_AVAILABLE:-0}" == "1" ]]
+    exit $?
+  fi
+  [[ "${VIBEGUARD_TEST_ATTESTATION_OK:-0}" == "1" ]]
+  exit $?
+fi
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  [[ "${VIBEGUARD_TEST_GH_AUTH_OK:-0}" == "1" ]]
+  exit $?
+fi
 if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
   shift 2
   tag="${1:-}"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -525,6 +525,10 @@ cat > "${asset}" <<SH
 #!/usr/bin/env bash
 set -euo pipefail
 REAL_RUNTIME="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+if [[ "\${1:-}" == "version" && -n "\${VIBEGUARD_TEST_RUNTIME_VERSION:-}" ]]; then
+  printf '%s\n' "\${VIBEGUARD_TEST_RUNTIME_VERSION#v}"
+  exit 0
+fi
 if [[ "\${1:-}" == "version" && -n "\${VIBEGUARD_SETUP_RUNTIME_VERSION:-}" ]]; then
   printf '%s\n' "\${VIBEGUARD_SETUP_RUNTIME_VERSION#v}"
   exit 0

--- a/vibeguard-runtime/Cargo.toml
+++ b/vibeguard-runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "vibeguard-runtime"
 version = "1.1.8"
 edition = "2024"
 description = "VibeGuard runtime — fast JSON/JSONL ops, hook metrics, and Codex app-server guards"
+license = "MIT"
 
 [dependencies]
 serde_json = "1"


### PR DESCRIPTION
Closes #504.

## Summary
- Add locked Rust dependency policy enforcement through `deny.toml` and CI `cargo deny` checks.
- Publish runtime dependency metadata from the locked Cargo graph with release assets.
- Add `--require-provenance` installer mode that fails closed when attestation verification is unavailable or cannot verify.

## Validation
- `cargo deny --manifest-path vibeguard-runtime/Cargo.toml --locked check -c deny.toml licenses bans sources`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_release_workflow.sh`
- `bash tests/test_setup.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check HEAD`