### PR TITLE
[codex] add checked runtime release manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,10 +192,26 @@ jobs:
           sha256sum vibeguard-runtime-* | sort -k2 > SHA256SUMS
           cat SHA256SUMS
 
+      - name: Generate runtime release manifest
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          python3 scripts/ci/generate_runtime_release_manifest.py \
+            "${TAG_NAME#v}" \
+            dist \
+            dist/vibeguard-runtime-releases.json \
+            "${GH_REPO}"
+
       - name: Attest checksum manifest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/SHA256SUMS
+
+      - name: Attest runtime release manifest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/vibeguard-runtime-releases.json
 
       - name: Publish GitHub Release
         env:
@@ -209,4 +225,4 @@ jobs:
           fi
           gh release create "${TAG_NAME}" dist/vibeguard-runtime-* dist/SHA256SUMS \
             --title "${TAG_NAME}" \
-            --notes "VibeGuard runtime binaries and dependency metadata for ${TAG_NAME}."
+            --notes "VibeGuard runtime binaries, release manifest, and dependency metadata for ${TAG_NAME}."

--- a/scripts/ci/generate_runtime_release_manifest.py
+++ b/scripts/ci/generate_runtime_release_manifest.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Generate the checked vibeguard-runtime release manifest."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+EXPECTED_TARGETS = (
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+)
+ALLOWED_EXTRA_RUNTIME_ASSETS = {
+    "vibeguard-runtime-dependency-metadata.json",
+}
+CHECKSUM_LINE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+\*?([^ \t\r\n]+)$")
+
+
+def die(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_sha256sums(path: Path) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = CHECKSUM_LINE.match(line)
+        if not match:
+            die(f"{path} line {line_number} is not a valid SHA256SUMS entry")
+        checksum, filename = match.groups()
+        filename = Path(filename).name
+        if filename in checksums:
+            die(f"{path} has duplicate checksum entry for {filename}")
+        checksums[filename] = checksum.lower()
+    return checksums
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) not in {4, 5}:
+        print(
+            "Usage: generate_runtime_release_manifest.py <version> <artifacts-dir> <output-json> [release-repo]",
+            file=sys.stderr,
+        )
+        return 2
+
+    version = argv[1].strip()
+    artifacts_dir = Path(argv[2])
+    output_path = Path(argv[3])
+    release_repo = argv[4].strip() if len(argv) == 5 else os.environ.get("GITHUB_REPOSITORY", "majiayu000/vibeguard")
+
+    if not version or version.startswith("v"):
+        die("version must be a bare runtime version such as 1.2.3")
+    if "/" not in release_repo or release_repo.startswith("/") or release_repo.endswith("/"):
+        die("release repo must be owner/repo")
+    if not artifacts_dir.is_dir():
+        die(f"artifacts directory not found: {artifacts_dir}")
+
+    checksum_path = artifacts_dir / "SHA256SUMS"
+    if not checksum_path.is_file():
+        die(f"checksum manifest not found: {checksum_path}")
+
+    checksums = parse_sha256sums(checksum_path)
+    assets: dict[str, dict[str, int | str]] = {}
+    expected_filenames = {f"vibeguard-runtime-{target}" for target in EXPECTED_TARGETS}
+
+    for filename in checksums:
+        if (
+            filename.startswith("vibeguard-runtime-")
+            and filename not in expected_filenames
+            and filename not in ALLOWED_EXTRA_RUNTIME_ASSETS
+        ):
+            die(f"unexpected runtime release asset in SHA256SUMS: {filename}")
+
+    for target in EXPECTED_TARGETS:
+        filename = f"vibeguard-runtime-{target}"
+        asset_path = artifacts_dir / filename
+        if filename not in checksums:
+            die(f"SHA256SUMS missing entry for {filename}")
+        if not asset_path.is_file():
+            die(f"runtime artifact not found: {asset_path}")
+        assets[target] = {
+            "name": filename,
+            "sha256": checksums[filename],
+            "size": asset_path.stat().st_size,
+        }
+
+    manifest = {
+        "assets": assets,
+        "package": "vibeguard-runtime",
+        "release_repo": release_repo,
+        "schema_version": 1,
+        "tag": f"v{version}",
+        "version": version,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -197,6 +197,7 @@ download_prebuilt_runtime() {
   local asset="vibeguard-runtime-${target}"
   local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
   local download_dir downloaded reason expected actual
+  local manifest_expected
   local provenance_rc provenance_status provenance_note
   local -a errors=()
 
@@ -211,6 +212,10 @@ download_prebuilt_runtime() {
       --pattern "SHA256SUMS" \
       --dir "${download_dir}" >/dev/null 2>&1; then
       downloaded=1
+      gh release download "${tag}" \
+        --repo "${release_repo}" \
+        --pattern "${SETUP_RUNTIME_RELEASE_MANIFEST}" \
+        --dir "${download_dir}" >/dev/null 2>&1 || true
     else
       errors+=("gh release download failed")
     fi
@@ -224,6 +229,8 @@ download_prebuilt_runtime() {
       if curl -fsSL -o "${download_dir}/${asset}" "${base_url}/${asset}" >/dev/null 2>&1 \
         && curl -fsSL -o "${download_dir}/SHA256SUMS" "${base_url}/SHA256SUMS" >/dev/null 2>&1; then
         downloaded=1
+        curl -fsSL -o "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" \
+          "${base_url}/${SETUP_RUNTIME_RELEASE_MANIFEST}" >/dev/null 2>&1 || true
       else
         errors+=("curl release download failed")
       fi
@@ -264,6 +271,25 @@ download_prebuilt_runtime() {
     red "  Expected ${expected}, got ${actual}."
     rm -rf "${download_dir}"
     return 10
+  fi
+  if [[ -f "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" ]]; then
+    if ! manifest_expected="$(setup_runtime_release_manifest_sha256 \
+      "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" \
+      "${tag}" \
+      "${release_repo}" \
+      "${target}" \
+      "${asset}")"; then
+      red "  ERROR: runtime release manifest verification failed for ${asset}."
+      red "  ${SETUP_RUNTIME_RELEASE_MANIFEST} must match repo, tag, version, target, filename, size, and SHA256 format."
+      rm -rf "${download_dir}"
+      return 10
+    fi
+    if [[ "${manifest_expected}" != "${expected}" ]]; then
+      red "  ERROR: runtime release manifest checksum mismatch for ${asset}."
+      red "  SHA256SUMS has ${expected}, ${SETUP_RUNTIME_RELEASE_MANIFEST} has ${manifest_expected}."
+      rm -rf "${download_dir}"
+      return 10
+    fi
   fi
   provenance_rc=0
   setup_runtime_verify_release_provenance "${download_dir}/${asset}" "${release_repo}" "${tag}" || provenance_rc=$?

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -196,8 +196,8 @@ download_prebuilt_runtime() {
   local target="$1" tag="$2" dest="$3"
   local asset="vibeguard-runtime-${target}"
   local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
-  local download_dir downloaded reason expected actual
-  local manifest_expected
+  local download_dir downloaded reason expected actual actual_size
+  local manifest_metadata manifest_expected manifest_size
   local provenance_rc provenance_status provenance_note
   local -a errors=()
 
@@ -273,7 +273,12 @@ download_prebuilt_runtime() {
     return 10
   fi
   if [[ -f "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" ]]; then
-    if ! manifest_expected="$(setup_runtime_release_manifest_sha256 \
+    if ! actual_size="$(setup_runtime_file_size "${download_dir}/${asset}")"; then
+      red "  ERROR: could not determine downloaded size for ${asset}."
+      rm -rf "${download_dir}"
+      return 10
+    fi
+    if ! manifest_metadata="$(setup_runtime_release_manifest_sha256 \
       "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" \
       "${tag}" \
       "${release_repo}" \
@@ -284,9 +289,16 @@ download_prebuilt_runtime() {
       rm -rf "${download_dir}"
       return 10
     fi
+    read -r manifest_expected manifest_size <<< "${manifest_metadata}"
     if [[ "${manifest_expected}" != "${expected}" ]]; then
       red "  ERROR: runtime release manifest checksum mismatch for ${asset}."
       red "  SHA256SUMS has ${expected}, ${SETUP_RUNTIME_RELEASE_MANIFEST} has ${manifest_expected}."
+      rm -rf "${download_dir}"
+      return 10
+    fi
+    if [[ "${manifest_size}" != "${actual_size}" ]]; then
+      red "  ERROR: runtime release manifest size mismatch for ${asset}."
+      red "  Downloaded ${actual_size} bytes, ${SETUP_RUNTIME_RELEASE_MANIFEST} has ${manifest_size}."
       rm -rf "${download_dir}"
       return 10
     fi

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -14,6 +14,7 @@ SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
 VIBEGUARD_SETUP_DRY_RUN="${VIBEGUARD_SETUP_DRY_RUN:-0}"
 VIBEGUARD_SETUP_AUTO="${VIBEGUARD_SETUP_AUTO:-0}"
 VIBEGUARD_SETUP_FORCE_OVERWRITE="${VIBEGUARD_SETUP_FORCE_OVERWRITE:-0}"
+SETUP_RUNTIME_RELEASE_MANIFEST="vibeguard-runtime-releases.json"
 
 green() { printf '\033[32m%s\033[0m\n' "$1"; }
 yellow() { printf '\033[33m%s\033[0m\n' "$1"; }
@@ -150,6 +151,61 @@ setup_runtime_sha256_file() {
   fi
 }
 
+setup_runtime_release_manifest_sha256() {
+  local manifest_path="$1" tag="$2" release_repo="$3" target="$4" asset="$5"
+  local version="${tag#v}"
+  [[ -f "${manifest_path}" && -n "${version}" && "${tag}" == v* ]] || return 1
+  awk -v tag="${tag}" \
+    -v version="${version}" \
+    -v release_repo="${release_repo}" \
+    -v target="${target}" \
+    -v asset="${asset}" '
+    function string_value(line, value) {
+      value = line
+      sub(/^[^:]*:[[:space:]]*"/, "", value)
+      sub(/",[[:space:]]*$/, "", value)
+      sub(/"[[:space:]]*$/, "", value)
+      return value
+    }
+    function number_value(line, value) {
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/,[[:space:]]*$/, "", value)
+      return value
+    }
+    $0 ~ /"schema_version"[[:space:]]*:[[:space:]]*1[[:space:],]*$/ { schema_ok = 1 }
+    $0 ~ /"package"[[:space:]]*:/ { package_ok = (string_value($0) == "vibeguard-runtime") }
+    $0 ~ /"release_repo"[[:space:]]*:/ { repo_ok = (string_value($0) == release_repo) }
+    $0 ~ /"tag"[[:space:]]*:/ { tag_ok = (string_value($0) == tag) }
+    $0 ~ /"version"[[:space:]]*:/ { version_ok = (string_value($0) == version) }
+    index($0, "\"" target "\"") && $0 ~ /:[[:space:]]*\{[[:space:]]*$/ {
+      in_target = 1
+      target_name = ""
+      target_sha = ""
+      target_size_ok = 0
+      next
+    }
+    in_target && $0 ~ /"name"[[:space:]]*:/ { target_name = string_value($0) }
+    in_target && $0 ~ /"sha256"[[:space:]]*:/ { target_sha = string_value($0) }
+    in_target && $0 ~ /"size"[[:space:]]*:/ {
+      target_size = number_value($0)
+      target_size_ok = (target_size ~ /^[1-9][0-9]*$/)
+    }
+    in_target && $0 ~ /^[[:space:]]*}[,]?[[:space:]]*$/ {
+      found_target = 1
+      in_target = 0
+    }
+    END {
+      manifest_ok = schema_ok && package_ok && repo_ok && tag_ok && version_ok && found_target && target_name == asset && target_size_ok && target_sha ~ /^[0-9a-f]{64}$/
+      if (manifest_ok) {
+        print target_sha
+        exit 0
+      }
+      exit 1
+    }
+  ' "${manifest_path}"
+}
+
 setup_runtime_verify_release_provenance() {
   local asset_path="$1" release_repo="$2" tag="$3"
   SETUP_RUNTIME_PROVENANCE_STATUS="checksum-only"
@@ -185,7 +241,7 @@ setup_download_prebuilt_runtime_quiet() {
   local target="$1" tag="$2" dest="$3"
   local asset="vibeguard-runtime-${target}"
   local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
-  local download_dir downloaded expected actual provenance_rc
+  local download_dir downloaded expected actual provenance_rc manifest_expected
 
   download_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-runtime-download_XXXXXX")"
   downloaded=0
@@ -197,6 +253,10 @@ setup_download_prebuilt_runtime_quiet() {
       --pattern "SHA256SUMS" \
       --dir "${download_dir}" >/dev/null 2>&1; then
       downloaded=1
+      gh release download "${tag}" \
+        --repo "${release_repo}" \
+        --pattern "${SETUP_RUNTIME_RELEASE_MANIFEST}" \
+        --dir "${download_dir}" >/dev/null 2>&1 || true
     fi
   fi
 
@@ -205,6 +265,8 @@ setup_download_prebuilt_runtime_quiet() {
     if curl -fsSL -o "${download_dir}/${asset}" "${base_url}/${asset}" >/dev/null 2>&1 \
       && curl -fsSL -o "${download_dir}/SHA256SUMS" "${base_url}/SHA256SUMS" >/dev/null 2>&1; then
       downloaded=1
+      curl -fsSL -o "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" \
+        "${base_url}/${SETUP_RUNTIME_RELEASE_MANIFEST}" >/dev/null 2>&1 || true
     fi
   fi
 
@@ -221,6 +283,17 @@ setup_download_prebuilt_runtime_quiet() {
   if ! actual="$(setup_runtime_sha256_file "${download_dir}/${asset}")" || [[ "${actual}" != "${expected}" ]]; then
     rm -rf "${download_dir}"
     return 1
+  fi
+  if [[ -f "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" ]]; then
+    if ! manifest_expected="$(setup_runtime_release_manifest_sha256 \
+      "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" \
+      "${tag}" \
+      "${release_repo}" \
+      "${target}" \
+      "${asset}")" || [[ "${manifest_expected}" != "${expected}" ]]; then
+      rm -rf "${download_dir}"
+      return 1
+    fi
   fi
   provenance_rc=0
   setup_runtime_verify_release_provenance "${download_dir}/${asset}" "${release_repo}" "${tag}" || provenance_rc=$?

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -151,6 +151,13 @@ setup_runtime_sha256_file() {
   fi
 }
 
+setup_runtime_file_size() {
+  local path="$1" size
+  size="$(wc -c < "${path}" | tr -d '[:space:]')" || return 1
+  [[ "${size}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "${size}"
+}
+
 setup_runtime_release_manifest_sha256() {
   local manifest_path="$1" tag="$2" release_repo="$3" target="$4" asset="$5"
   local version="${tag#v}"
@@ -198,7 +205,7 @@ setup_runtime_release_manifest_sha256() {
     END {
       manifest_ok = schema_ok && package_ok && repo_ok && tag_ok && version_ok && found_target && target_name == asset && target_size_ok && target_sha ~ /^[0-9a-f]{64}$/
       if (manifest_ok) {
-        print target_sha
+        print target_sha " " target_size
         exit 0
       }
       exit 1
@@ -241,7 +248,8 @@ setup_download_prebuilt_runtime_quiet() {
   local target="$1" tag="$2" dest="$3"
   local asset="vibeguard-runtime-${target}"
   local release_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
-  local download_dir downloaded expected actual provenance_rc manifest_expected
+  local download_dir downloaded expected actual actual_size provenance_rc
+  local manifest_metadata manifest_expected manifest_size
 
   download_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-runtime-download_XXXXXX")"
   downloaded=0
@@ -285,12 +293,21 @@ setup_download_prebuilt_runtime_quiet() {
     return 1
   fi
   if [[ -f "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" ]]; then
-    if ! manifest_expected="$(setup_runtime_release_manifest_sha256 \
+    if ! actual_size="$(setup_runtime_file_size "${download_dir}/${asset}")"; then
+      rm -rf "${download_dir}"
+      return 1
+    fi
+    if ! manifest_metadata="$(setup_runtime_release_manifest_sha256 \
       "${download_dir}/${SETUP_RUNTIME_RELEASE_MANIFEST}" \
       "${tag}" \
       "${release_repo}" \
       "${target}" \
-      "${asset}")" || [[ "${manifest_expected}" != "${expected}" ]]; then
+      "${asset}")"; then
+      rm -rf "${download_dir}"
+      return 1
+    fi
+    read -r manifest_expected manifest_size <<< "${manifest_metadata}"
+    if [[ "${manifest_expected}" != "${expected}" || "${manifest_size}" != "${actual_size}" ]]; then
       rm -rf "${download_dir}"
       return 1
     fi

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -181,6 +181,17 @@ assert_contains "${manifest_fail_out}" "runtime release manifest checksum mismat
 assert_not_contains "${manifest_fail_out}" "Falling back to source build" "tampered runtime release manifest does not fall back to source"
 assert_not_contains "${manifest_fail_out}" "Setup complete! All components installed." "tampered runtime release manifest does not report setup complete"
 
+manifest_size_fail_home="${TMP_HOME}/manifest-size-fail-home"
+mkdir -p "${manifest_size_fail_home}"
+set +e
+manifest_size_fail_out="$(HOME="${manifest_size_fail_home}" VIBEGUARD_TEST_BAD_MANIFEST_SIZE=1 VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes 2>&1)"
+manifest_size_fail_rc=$?
+set -e
+assert_cmd "tampered runtime release manifest size exits nonzero" test "${manifest_size_fail_rc}" -ne 0
+assert_contains "${manifest_size_fail_out}" "runtime release manifest size mismatch" "tampered runtime release manifest reports size mismatch"
+assert_not_contains "${manifest_size_fail_out}" "Falling back to source build" "tampered runtime release manifest size does not fall back to source"
+assert_not_contains "${manifest_size_fail_out}" "Setup complete! All components installed." "tampered runtime release manifest size does not report setup complete"
+
 require_provenance_fail_home="${TMP_HOME}/require-provenance-fail-home"
 mkdir -p "${require_provenance_fail_home}"
 set +e

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -170,6 +170,17 @@ assert_contains "${checksum_fail_out}" "vibeguard-runtime checksum verification 
 assert_not_contains "${checksum_fail_out}" "Falling back to source build" "tampered prebuilt checksum does not fall back to source"
 assert_not_contains "${checksum_fail_out}" "Setup complete! All components installed." "tampered prebuilt checksum does not report setup complete"
 
+manifest_fail_home="${TMP_HOME}/manifest-fail-home"
+mkdir -p "${manifest_fail_home}"
+set +e
+manifest_fail_out="$(HOME="${manifest_fail_home}" VIBEGUARD_TEST_BAD_MANIFEST=1 VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes 2>&1)"
+manifest_fail_rc=$?
+set -e
+assert_cmd "tampered runtime release manifest exits nonzero" test "${manifest_fail_rc}" -ne 0
+assert_contains "${manifest_fail_out}" "runtime release manifest checksum mismatch" "tampered runtime release manifest reports checksum mismatch"
+assert_not_contains "${manifest_fail_out}" "Falling back to source build" "tampered runtime release manifest does not fall back to source"
+assert_not_contains "${manifest_fail_out}" "Setup complete! All components installed." "tampered runtime release manifest does not report setup complete"
+
 require_provenance_fail_home="${TMP_HOME}/require-provenance-fail-home"
 mkdir -p "${require_provenance_fail_home}"
 set +e
@@ -220,6 +231,7 @@ version_override_out="$(HOME="${version_override_home}" VIBEGUARD_TEST_CARGO_UNA
 assert_contains "${version_override_out}" "Runtime version override: v9.9.9" "--runtime-version reports selected release tag"
 assert_contains "${version_override_out}" "vibeguard-runtime downloaded and verified (v9.9.9," "--runtime-version downloads selected release tag"
 assert_cmd "--runtime-version passes selected tag to release download" grep -qF "tag=v9.9.9" "${version_override_log}"
+assert_cmd "--runtime-version tries runtime release manifest download" grep -qF "vibeguard-runtime-releases.json" "${version_override_log}"
 
 curl_download_home="${TMP_HOME}/curl-download-home"
 mkdir -p "${curl_download_home}"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -221,12 +221,13 @@ assert_cmd "runtime release manifest generator emits checked target metadata" ba
   metadata_checksum="$(sha256_file "${tmp}/vibeguard-runtime-dependency-metadata.json")"
   printf "%s  vibeguard-runtime-dependency-metadata.json\n" "${metadata_checksum}" >> "${tmp}/SHA256SUMS"
   python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard"
-  python3 - "${tmp}/vibeguard-runtime-releases.json" <<'"'"'PY'"'"'
+  python3 - "${tmp}/vibeguard-runtime-releases.json" "${tmp}" <<'"'"'PY'"'"'
 import json
 import sys
 from pathlib import Path
 
 manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+artifacts_dir = Path(sys.argv[2])
 expected_targets = {
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
@@ -243,8 +244,28 @@ for target, asset in manifest["assets"].items():
     assert asset["name"] == f"vibeguard-runtime-{target}"
     assert len(asset["sha256"]) == 64
     int(asset["sha256"], 16)
-    assert asset["size"] > 0
+    assert asset["size"] == (artifacts_dir / asset["name"]).stat().st_size
 PY
+' _ "${RELEASE_MANIFEST_SCRIPT}"
+assert_cmd "runtime release manifest generator rejects malformed SHA256SUMS rows" bash -c '
+  set -euo pipefail
+  script="$1"
+  tmp="$(mktemp -d)"
+  trap "rm -rf \"${tmp}\"" EXIT
+  printf "not-a-valid-sha-row\n" > "${tmp}/SHA256SUMS"
+  ! python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard" 2>"${tmp}/err"
+  grep -q "not a valid SHA256SUMS entry" "${tmp}/err"
+' _ "${RELEASE_MANIFEST_SCRIPT}"
+assert_cmd "runtime release manifest generator rejects unexpected runtime assets" bash -c '
+  set -euo pipefail
+  script="$1"
+  tmp="$(mktemp -d)"
+  trap "rm -rf \"${tmp}\"" EXIT
+  checksum="0000000000000000000000000000000000000000000000000000000000000000"
+  printf "%s  vibeguard-runtime-surprise-target\n" "${checksum}" > "${tmp}/SHA256SUMS"
+  printf "unexpected runtime\n" > "${tmp}/vibeguard-runtime-surprise-target"
+  ! python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard" 2>"${tmp}/err"
+  grep -q "unexpected runtime release asset" "${tmp}/err"
 ' _ "${RELEASE_MANIFEST_SCRIPT}"
 assert_cmd "runtime release manifest generator rejects missing targets" bash -c '
   set -euo pipefail

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -198,6 +198,13 @@ assert_cmd "runtime release manifest generator emits checked target metadata" ba
   script="$1"
   tmp="$(mktemp -d)"
   trap "rm -rf \"${tmp}\"" EXIT
+  sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$1" | awk "{print \$1}"
+    else
+      shasum -a 256 "$1" | awk "{print \$1}"
+    fi
+  }
   : > "${tmp}/SHA256SUMS"
   for target in \
     aarch64-apple-darwin \
@@ -207,11 +214,11 @@ assert_cmd "runtime release manifest generator emits checked target metadata" ba
   do
     asset="${tmp}/vibeguard-runtime-${target}"
     printf "runtime asset %s\n" "${target}" > "${asset}"
-    checksum="$(shasum -a 256 "${asset}" | awk "{print \$1}")"
+    checksum="$(sha256_file "${asset}")"
     printf "%s  %s\n" "${checksum}" "vibeguard-runtime-${target}" >> "${tmp}/SHA256SUMS"
   done
   printf "{}\n" > "${tmp}/vibeguard-runtime-dependency-metadata.json"
-  metadata_checksum="$(shasum -a 256 "${tmp}/vibeguard-runtime-dependency-metadata.json" | awk "{print \$1}")"
+  metadata_checksum="$(sha256_file "${tmp}/vibeguard-runtime-dependency-metadata.json")"
   printf "%s  vibeguard-runtime-dependency-metadata.json\n" "${metadata_checksum}" >> "${tmp}/SHA256SUMS"
   python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard"
   python3 - "${tmp}/vibeguard-runtime-releases.json" <<'"'"'PY'"'"'
@@ -244,9 +251,16 @@ assert_cmd "runtime release manifest generator rejects missing targets" bash -c 
   script="$1"
   tmp="$(mktemp -d)"
   trap "rm -rf \"${tmp}\"" EXIT
+  sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$1" | awk "{print \$1}"
+    else
+      shasum -a 256 "$1" | awk "{print \$1}"
+    fi
+  }
   asset="${tmp}/vibeguard-runtime-aarch64-apple-darwin"
   printf "runtime asset\n" > "${asset}"
-  checksum="$(shasum -a 256 "${asset}" | awk "{print \$1}")"
+  checksum="$(sha256_file "${asset}")"
   printf "%s  vibeguard-runtime-aarch64-apple-darwin\n" "${checksum}" > "${tmp}/SHA256SUMS"
   ! python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard"
 ' _ "${RELEASE_MANIFEST_SCRIPT}"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -11,6 +11,7 @@ CARGO_TOML="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 RUST_TOOLCHAIN="${REPO_DIR}/rust-toolchain.toml"
 INSTALL_SH="${REPO_DIR}/scripts/setup/install.sh"
 SETUP_LIB="${REPO_DIR}/scripts/setup/lib.sh"
+RELEASE_MANIFEST_SCRIPT="${REPO_DIR}/scripts/ci/generate_runtime_release_manifest.py"
 DENY_TOML="${REPO_DIR}/deny.toml"
 LINUX_SETUP="${REPO_DIR}/docs/linux-setup.md"
 INSTALL_SPEC="${REPO_DIR}/docs/specs/install-friction-reduction.md"
@@ -155,6 +156,11 @@ assert_contains "$workflow_text" "subject-path: dist/\${{ matrix.target }}/vibeg
 assert_contains "$workflow_text" "sha256sum vibeguard-runtime-* | sort -k2 > SHA256SUMS" "checksums use deterministic sorted layout"
 assert_contains "$workflow_text" "Attest checksum manifest" "release workflow attests checksum manifest"
 assert_contains "$workflow_text" "subject-path: dist/SHA256SUMS" "release workflow attests SHA256SUMS"
+assert_contains "$workflow_text" "Generate runtime release manifest" "release workflow generates runtime release manifest"
+assert_contains "$workflow_text" "generate_runtime_release_manifest.py" "release workflow uses manifest generator"
+assert_contains "$workflow_text" "dist/vibeguard-runtime-releases.json" "release workflow writes runtime release manifest asset"
+assert_contains "$workflow_text" "Attest runtime release manifest" "release workflow attests runtime release manifest"
+assert_contains "$workflow_text" "subject-path: dist/vibeguard-runtime-releases.json" "release workflow attests manifest path"
 assert_contains "$workflow_text" "Generate dependency metadata" "release workflow generates dependency metadata"
 assert_contains "$workflow_text" "cargo metadata --locked --manifest-path" "dependency metadata comes from locked Cargo graph"
 assert_contains "$workflow_text" "vibeguard-runtime-dependency-metadata.json" "release publishes dependency metadata asset"
@@ -168,6 +174,9 @@ assert_contains "$install_text" "--require-provenance" "install supports provena
 assert_contains "$install_text" "provenance verification is required but unavailable" "install fails closed when strict provenance cannot verify"
 assert_contains "$install_text" "cannot be combined with --build-from-source" "strict provenance rejects source-build mode"
 assert_contains "$install_text" "runtime-provenance" "install snapshot records runtime provenance status"
+assert_contains "$setup_lib_text" "vibeguard-runtime-releases.json" "setup knows runtime release manifest filename"
+assert_contains "$install_text" "runtime release manifest checksum mismatch" "install fails closed on manifest checksum mismatch"
+assert_contains "$install_text" "runtime release manifest verification failed" "install fails closed on malformed runtime release manifest"
 assert_contains "$linux_setup_text" "--require-provenance" "Linux setup docs document strict provenance mode"
 assert_contains "$linux_setup_text" "checksum-only" "Linux setup docs distinguish checksum-only mode"
 assert_contains "$install_spec_text" "--require-provenance" "install spec documents strict provenance mode"
@@ -181,6 +190,66 @@ for target in \
 do
   assert_contains "$workflow_text" "target: ${target}" "release matrix includes ${target}"
 done
+
+header "runtime release manifest contract"
+assert_cmd "runtime release manifest generator syntax is correct" python3 -m py_compile "${RELEASE_MANIFEST_SCRIPT}"
+assert_cmd "runtime release manifest generator emits checked target metadata" bash -c '
+  set -euo pipefail
+  script="$1"
+  tmp="$(mktemp -d)"
+  trap "rm -rf \"${tmp}\"" EXIT
+  : > "${tmp}/SHA256SUMS"
+  for target in \
+    aarch64-apple-darwin \
+    x86_64-apple-darwin \
+    x86_64-unknown-linux-musl \
+    aarch64-unknown-linux-musl
+  do
+    asset="${tmp}/vibeguard-runtime-${target}"
+    printf "runtime asset %s\n" "${target}" > "${asset}"
+    checksum="$(shasum -a 256 "${asset}" | awk "{print \$1}")"
+    printf "%s  %s\n" "${checksum}" "vibeguard-runtime-${target}" >> "${tmp}/SHA256SUMS"
+  done
+  printf "{}\n" > "${tmp}/vibeguard-runtime-dependency-metadata.json"
+  metadata_checksum="$(shasum -a 256 "${tmp}/vibeguard-runtime-dependency-metadata.json" | awk "{print \$1}")"
+  printf "%s  vibeguard-runtime-dependency-metadata.json\n" "${metadata_checksum}" >> "${tmp}/SHA256SUMS"
+  python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard"
+  python3 - "${tmp}/vibeguard-runtime-releases.json" <<'"'"'PY'"'"'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected_targets = {
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+}
+assert manifest["schema_version"] == 1
+assert manifest["package"] == "vibeguard-runtime"
+assert manifest["release_repo"] == "majiayu000/vibeguard"
+assert manifest["version"] == "9.9.9"
+assert manifest["tag"] == "v9.9.9"
+assert set(manifest["assets"]) == expected_targets
+for target, asset in manifest["assets"].items():
+    assert asset["name"] == f"vibeguard-runtime-{target}"
+    assert len(asset["sha256"]) == 64
+    int(asset["sha256"], 16)
+    assert asset["size"] > 0
+PY
+' _ "${RELEASE_MANIFEST_SCRIPT}"
+assert_cmd "runtime release manifest generator rejects missing targets" bash -c '
+  set -euo pipefail
+  script="$1"
+  tmp="$(mktemp -d)"
+  trap "rm -rf \"${tmp}\"" EXIT
+  asset="${tmp}/vibeguard-runtime-aarch64-apple-darwin"
+  printf "runtime asset\n" > "${asset}"
+  checksum="$(shasum -a 256 "${asset}" | awk "{print \$1}")"
+  printf "%s  vibeguard-runtime-aarch64-apple-darwin\n" "${checksum}" > "${tmp}/SHA256SUMS"
+  ! python3 "${script}" "9.9.9" "${tmp}" "${tmp}/vibeguard-runtime-releases.json" "majiayu000/vibeguard"
+' _ "${RELEASE_MANIFEST_SCRIPT}"
 
 header "runtime version contract"
 assert_cmd "runtime VERSION is non-empty" test -n "${runtime_version}"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -470,6 +470,10 @@ if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
   for pattern in "${patterns[@]}"; do
     if [[ "${pattern}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; then
       cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${dir}/SHA256SUMS"
+    elif [[ "${pattern}" == "vibeguard-runtime-releases.json" && "${VIBEGUARD_TEST_BAD_MANIFEST:-0}" == "1" ]]; then
+      cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json" "${dir}/vibeguard-runtime-releases.json"
+    elif [[ "${pattern}" == "vibeguard-runtime-releases.json" && -f "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.${tag}.json" ]]; then
+      cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.${tag}.json" "${dir}/vibeguard-runtime-releases.json"
     else
       cp "${VIBEGUARD_TEST_RELEASE_DIR}/${pattern}" "${dir}/${pattern}"
     fi
@@ -504,6 +508,8 @@ fi
 mkdir -p "$(dirname "${out}")"
 if [[ "${asset}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; then
   cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${out}"
+elif [[ "${asset}" == "vibeguard-runtime-releases.json" && "${VIBEGUARD_TEST_BAD_MANIFEST:-0}" == "1" ]]; then
+  cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json" "${out}"
 else
   cp "${VIBEGUARD_TEST_RELEASE_DIR}/${asset}" "${out}"
 fi
@@ -597,6 +603,28 @@ for line in lines:
     bad_lines.append("0" * len(digest) + "  " + asset)
 lines = bad_lines
 dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+python3 "${REPO_DIR}/scripts/ci/generate_runtime_release_manifest.py" \
+  "$(tr -d '[:space:]' < "${REPO_DIR}/vibeguard-runtime/VERSION")" \
+  "${TEST_RELEASE_DIR}" \
+  "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.json" \
+  "majiayu000/vibeguard"
+python3 "${REPO_DIR}/scripts/ci/generate_runtime_release_manifest.py" \
+  "9.9.9" \
+  "${TEST_RELEASE_DIR}" \
+  "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.v9.9.9.json" \
+  "majiayu000/vibeguard"
+python3 - <<'PY' "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.json" "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json"
+import json
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+dest = Path(sys.argv[2])
+manifest = json.loads(src.read_text(encoding="utf-8"))
+for asset in manifest["assets"].values():
+    asset["sha256"] = "1" * 64
+dest.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
 export VIBEGUARD_TEST_RELEASE_DIR="${TEST_RELEASE_DIR}"
 

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -472,6 +472,8 @@ if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
       cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${dir}/SHA256SUMS"
     elif [[ "${pattern}" == "vibeguard-runtime-releases.json" && "${VIBEGUARD_TEST_BAD_MANIFEST:-0}" == "1" ]]; then
       cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json" "${dir}/vibeguard-runtime-releases.json"
+    elif [[ "${pattern}" == "vibeguard-runtime-releases.json" && "${VIBEGUARD_TEST_BAD_MANIFEST_SIZE:-0}" == "1" ]]; then
+      cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad-size.json" "${dir}/vibeguard-runtime-releases.json"
     elif [[ "${pattern}" == "vibeguard-runtime-releases.json" && -f "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.${tag}.json" ]]; then
       cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.${tag}.json" "${dir}/vibeguard-runtime-releases.json"
     else
@@ -510,6 +512,8 @@ if [[ "${asset}" == "SHA256SUMS" && "${VIBEGUARD_TEST_BAD_SHA:-0}" == "1" ]]; th
   cp "${VIBEGUARD_TEST_RELEASE_DIR}/SHA256SUMS.bad" "${out}"
 elif [[ "${asset}" == "vibeguard-runtime-releases.json" && "${VIBEGUARD_TEST_BAD_MANIFEST:-0}" == "1" ]]; then
   cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json" "${out}"
+elif [[ "${asset}" == "vibeguard-runtime-releases.json" && "${VIBEGUARD_TEST_BAD_MANIFEST_SIZE:-0}" == "1" ]]; then
+  cp "${VIBEGUARD_TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad-size.json" "${out}"
 else
   cp "${VIBEGUARD_TEST_RELEASE_DIR}/${asset}" "${out}"
 fi
@@ -614,19 +618,41 @@ python3 "${REPO_DIR}/scripts/ci/generate_runtime_release_manifest.py" \
   "${TEST_RELEASE_DIR}" \
   "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.v9.9.9.json" \
   "majiayu000/vibeguard"
-python3 - <<'PY' "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.json" "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json"
+python3 - <<'PY' "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.json" "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad.json" "${TEST_RELEASE_DIR}/vibeguard-runtime-releases.bad-size.json"
 import json
 import sys
 from pathlib import Path
 
 src = Path(sys.argv[1])
-dest = Path(sys.argv[2])
+checksum_dest = Path(sys.argv[2])
+size_dest = Path(sys.argv[3])
 manifest = json.loads(src.read_text(encoding="utf-8"))
-for asset in manifest["assets"].values():
+bad_checksum_manifest = json.loads(json.dumps(manifest))
+for asset in bad_checksum_manifest["assets"].values():
     asset["sha256"] = "1" * 64
-dest.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+checksum_dest.write_text(json.dumps(bad_checksum_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+bad_size_manifest = json.loads(json.dumps(manifest))
+for asset in bad_size_manifest["assets"].values():
+    asset["size"] += 1
+size_dest.write_text(json.dumps(bad_size_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
 export VIBEGUARD_TEST_RELEASE_DIR="${TEST_RELEASE_DIR}"
+
+assert_cmd "quiet runtime download rejects manifest size mismatch" bash -c '
+  set -euo pipefail
+  repo_dir="$1"
+  tmp_home="$2"
+  mkdir -p "${tmp_home}/quiet-size-mismatch-home"
+  export HOME="${tmp_home}/quiet-size-mismatch-home"
+  export VIBEGUARD_REPO_DIR="${repo_dir}"
+  export VIBEGUARD_TEST_BAD_MANIFEST_SIZE=1
+  source "${repo_dir}/scripts/setup/lib.sh"
+  target="$(setup_runtime_release_target)"
+  tag="$(setup_runtime_release_tag)"
+  dest="${tmp_home}/quiet-size-mismatch-runtime"
+  ! setup_download_prebuilt_runtime_quiet "${target}" "${tag}" "${dest}"
+  test ! -e "${dest}"
+' _ "${REPO_DIR}" "${TMP_HOME}"
 
 
 for setup_test in \


### PR DESCRIPTION
Fixes #521.

## Summary
- generate a checked vibeguard-runtime release manifest from SHA256SUMS during tagged releases
- publish and attest vibeguard-runtime-releases.json with the existing release assets
- validate manifest repo/tag/version/target/name/size/SHA when setup downloads release binaries, while preserving legacy fallback when the manifest is absent
- cover manifest generation, tampered manifest failures, gh/curl paths, --runtime-version, and no-Python setup

## Validation
- bash tests/test_release_workflow.sh (68/68)
- PATH with shasum masked: bash tests/test_release_workflow.sh (68/68)
- bash tests/test_setup.sh (401/401)
- bash tests/test_setup_check.sh (169/169)
- bash tests/test_manifest_contract.sh (95/95)
- cargo check --manifest-path vibeguard-runtime/Cargo.toml --locked
- cargo test --manifest-path vibeguard-runtime/Cargo.toml --locked
- git diff --check
- python3 -m py_compile scripts/ci/generate_runtime_release_manifest.py
- bash -n scripts/setup/lib.sh scripts/setup/install.sh tests/test_setup.sh tests/setup/install_flow_tests.sh