### PR TITLE
Document plan and repo-local skill policy

### DIFF
--- a/.claude/skills/benchmark-regression-triage/SKILL.md
+++ b/.claude/skills/benchmark-regression-triage/SKILL.md
@@ -7,6 +7,8 @@ description: Use this skill whenever VibeGuard hook latency, benchmark-action ou
 
 ## Overview
 
+This is a repo-local maintainer skill for VibeGuard contributors. It is intentionally stored under `.claude/skills/` so maintainers can use it while working in this repository, but it is not an installable product skill and must not be added to `schemas/install-modules.json` unless it is promoted into `skills/` or `workflows/` with a user-facing support contract.
+
 This skill diagnoses VibeGuard hook latency regressions by comparing GitHub Actions `bench-output` artifacts across PR runs, merge runs, and mainline runs. It is meant for non-obvious cases where the current benchmark is under budget but slower than a previous design, such as a `post-write-guard` path losing its `post-write-fast-check` fast path after a runtime migration.
 
 Treat CI artifacts as the trend source. Local benchmarks are useful for reproduction after a hypothesis exists, but they are not comparable to GitHub runner history because machine load, shell startup, cache state, and `--runs` count can dominate P95.

--- a/docs/directory-map.md
+++ b/docs/directory-map.md
@@ -19,6 +19,7 @@ VibeGuard keeps runtime and installable source directories at the repository roo
 | Path | Role |
 |------|------|
 | `.claude/commands/` | Claude slash command source installed into `~/.claude/commands/`. |
+| `.claude/skills/` | Repo-local maintainer skills for this repository. They are validated by skill-format checks but are not installable product skills unless promoted into `skills/` or `workflows/` and declared in `schemas/install-modules.json`. |
 | `agents/` | Claude agent prompt source installed into `~/.claude/agents/`. |
 | `skills/` | Core reusable skills installed into Claude and Codex skill locations. |
 | `workflows/` | Codex workflow skills and shared workflow references. |
@@ -49,7 +50,7 @@ VibeGuard keeps runtime and installable source directories at the repository roo
 | `docs/assets/` | Demo media and scripts used by public docs. |
 | `site/` | Static landing site deployed by GitHub Pages. |
 | `docs/internal/` | Research notes, historical specs, benchmark designs, and cross-session follow-ups. |
-| `plan/` | Active workflow output directory. Do not move until plan workflow specs change. |
+| `plan/` | Workflow output directory with mixed active, completed, draft, snapshot, and signal files. Read `plan/README.md` before treating any file as backlog; do not move files until plan workflow specs change. |
 
 ## Change Rules
 

--- a/plan/README.md
+++ b/plan/README.md
@@ -2,6 +2,10 @@
 
 `plan/` is the workflow output directory. It contains completed execution records, active plans, draft specs, snapshots, and signal reports. Do not treat every file here as active backlog.
 
+## Current Policy
+
+Keep `plan/` as the workflow output directory. Historical or completed files stay in place until the plan workflow contract changes. Use this index to decide whether a file is actionable before opening work from it.
+
 ## Status Classes
 
 | Class | Meaning | Files |
@@ -11,6 +15,23 @@
 | Historical convergence plan | Older architecture plan; verify current code and newer specs before acting | `2026-04-19_00-15-39-main-architecture-convergence.md` |
 | Draft spec | Candidate work that needs issue and code-state verification before implementation | `spec-test-file-size-decomposition.md`, `full-english-localization-spec.md` |
 | Snapshot or signal report | Evidence artifact for another plan or issue; do not implement directly without an owning spec | `w20-rust-only-production-path-snapshot.md`, `signal-report-legacy-vibeguard-mcp-cleanup.md` |
+
+## File Status Index
+
+| File | Status | Next action |
+|---|---|---|
+| `2026-04-19_00-15-39-main-architecture-convergence.md` | Historical convergence plan | Use as architecture context only after checking current code and newer specs. |
+| `2026-05-01_18-56-41-vibeguard-audit-remediation.md` | Completed record | Use as audit evidence; do not reopen items without a new issue. |
+| `2026-06-05_22-28-rust-only-production-path.md` | Completed record | Use as implementation context for the Rust-only production path. |
+| `full-english-localization-spec.md` | Draft spec | Verify current product priority and open a GitHub issue before implementation. |
+| `signal-report-legacy-vibeguard-mcp-cleanup.md` | Snapshot or signal report | Treat as evidence for another owner; do not implement directly. |
+| `spec-96-prompt-contract-schema.md` | Completed record | Use as prompt-contract history; current schema and tests are authoritative. |
+| `spec-app-server-runtime-policy-gate.md` | Completed record | Use as runtime-policy history; verify against current app-server code before acting. |
+| `spec-codebase-audit-remediation.md` | Completed record | Use as remediation history; create a fresh issue for any remaining work. |
+| `spec-posttool-malformed-input-fail-visible.md` | Completed record | Use as fail-visible behavior context; current tests are authoritative. |
+| `spec-runtime-config-contract-clarity.md` | Completed record | Use as config-contract history; current schema and setup tests are authoritative. |
+| `spec-test-file-size-decomposition.md` | Draft spec | Verify current file-size pressure and open a GitHub issue before implementation. |
+| `w20-rust-only-production-path-snapshot.md` | Snapshot or signal report | Treat as evidence for W-20 runtime drift decisions, not backlog. |
 
 ## Reading Rules
 


### PR DESCRIPTION
## Summary

- Keep `plan/` as the workflow output directory and add a per-file status index instead of moving historical files.
- Document `.claude/skills/` as repo-local maintainer skill space, separate from installable product skills.
- Mark `benchmark-regression-triage` as repo-local and intentionally outside `schemas/install-modules.json` unless promoted later.

Fixes #518
Fixes #519

## Validation

- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-skill-format.sh`
- `bash tests/test_skill_format.sh`
- `python3 scripts/skill_validate.py --format-only --proposed-skill .claude/skills/benchmark-regression-triage/SKILL.md`
- `git diff --check`