### PR TITLE
feat(learn): introduce signal schema and classifications

### DIFF
--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -319,22 +319,63 @@ python3 scripts/skill_validate.py --check-repo-format --repo-root . --json
 ```json
 {
   "command": "learn",
-  "error": "Error description",
-  "rootCause": {
-    "surface": "surface reason",
-    "direct": "direct cause",
-    "root": "root cause"
-  },
-  "improvements": [
+  "mode": "preview",
+  "schema_version": 1,
+  "generated_at": "2026-06-25T00:00:00Z",
+  "partial": false,
+  "truncated_reason": null,
+  "signals": [
     {
-      "type": "enhance_guard",
-      "target": "target file path",
-      "description": "Improve description"
+      "signal_id": "lrn_a31f7c9d",
+      "observation_id": "obs_2026w26_77bc",
+      "classification": "runtime_health",
+      "path_relation": "unknown",
+      "affected_sessions": 3,
+      "recommended_actions": [
+        {
+          "type": "fix_runtime",
+          "rationale": "Metrics input truncation is a runtime pipeline issue."
+        }
+      ]
     }
   ],
-  "verification": {
-    "newGuardPassed": true,
-    "noRegression": true
-  }
+  "diagnostics": []
+}
+```
+
+## learn signal Schema
+
+```json
+{
+  "schema_version": 1,
+  "signal_id": "lrn_a31f7c9d",
+  "observation_id": "obs_2026w26_77bc",
+  "project_hash": "dc1db069",
+  "project_root": "/Users/me/code/app",
+  "type": "metrics_truncation",
+  "classification": "runtime_health",
+  "normalized_key": "source:learn-evaluator:metrics_truncation",
+  "path": null,
+  "path_relation": "unknown",
+  "source_hook": "learn-evaluator",
+  "source_tool": null,
+  "affected_sessions": 3,
+  "occurrences": 18,
+  "event_rate": 0.12,
+  "first_seen": "2026-06-24T00:00:00Z",
+  "last_seen": "2026-06-24T12:00:00Z",
+  "evidence_samples": [
+    {
+      "summary": "metrics input truncated before analysis"
+    }
+  ],
+  "recommended_actions": [
+    {
+      "type": "fix_runtime",
+      "rationale": "Runtime truncation should tune the metrics pipeline, not create a guard.",
+      "target": "hooks/learn-evaluator.sh",
+      "verification_command": "bash tests/test_gc_scheduled.sh"
+    }
+  ]
 }
 ```

--- a/schemas/command-learn-output.schema.json
+++ b/schemas/command-learn-output.schema.json
@@ -58,34 +58,60 @@
   "oneOf": [
     {
       "required": ["schema_version", "generated_at", "partial", "signals", "diagnostics"],
+      "additionalProperties": false,
       "properties": {
+        "command": {},
         "mode": {
           "const": "preview"
-        }
+        },
+        "schema_version": {},
+        "generated_at": {},
+        "partial": {},
+        "truncated_reason": {},
+        "signals": {},
+        "diagnostics": {}
       }
     },
     {
       "required": ["schema_version", "signal_id", "action", "state_transition", "verification"],
+      "additionalProperties": false,
       "properties": {
+        "command": {},
         "mode": {
           "const": "adopt"
-        }
+        },
+        "schema_version": {},
+        "signal_id": {},
+        "action": {},
+        "state_transition": {},
+        "verification": {}
       }
     },
     {
       "required": ["schema_version", "signal_id", "verification"],
+      "additionalProperties": false,
       "properties": {
+        "command": {},
         "mode": {
           "const": "verify"
-        }
+        },
+        "schema_version": {},
+        "signal_id": {},
+        "verification": {}
       }
     },
     {
       "required": ["schema_version", "signal_id", "skill", "verification"],
+      "additionalProperties": false,
       "properties": {
+        "command": {},
         "mode": {
           "const": "extract_skill"
-        }
+        },
+        "schema_version": {},
+        "signal_id": {},
+        "skill": {},
+        "verification": {}
       }
     }
   ],

--- a/schemas/command-learn-output.schema.json
+++ b/schemas/command-learn-output.schema.json
@@ -2,68 +2,242 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://vibeguard.local/schemas/command-learn-output.schema.json",
   "title": "VibeGuard Learn Command Output",
-  "description": "Structured output contract for /vibeguard:learn.",
+  "description": "Envelope contract for /vibeguard:learn preview, triage, verification, and skill extraction modes.",
   "type": "object",
-  "required": ["command", "error", "rootCause", "improvements", "verification"],
+  "required": ["command", "mode"],
   "additionalProperties": false,
   "properties": {
     "command": {
       "const": "learn"
     },
-    "error": {
+    "mode": {
+      "enum": ["preview", "adopt", "verify", "extract_skill"]
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "generated_at": {
       "type": "string",
       "minLength": 1
     },
-    "rootCause": {
-      "type": "object",
-      "required": ["surface", "direct", "root"],
-      "additionalProperties": false,
+    "partial": {
+      "type": "boolean"
+    },
+    "truncated_reason": {
+      "type": ["string", "null"]
+    },
+    "signals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/signal_summary"
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "signal_id": {
+      "type": "string",
+      "pattern": "^(learn:|lrn_)[A-Za-z0-9_-]{8,}$"
+    },
+    "action": {
+      "$ref": "#/$defs/recommended_action"
+    },
+    "state_transition": {
+      "$ref": "#/$defs/state_transition"
+    },
+    "verification": {
+      "$ref": "#/$defs/verification_result"
+    },
+    "skill": {
+      "$ref": "#/$defs/skill_result"
+    }
+  },
+  "oneOf": [
+    {
+      "required": ["schema_version", "generated_at", "partial", "signals", "diagnostics"],
       "properties": {
-        "surface": {
-          "type": "string",
-          "minLength": 1
-        },
-        "direct": {
-          "type": "string",
-          "minLength": 1
-        },
-        "root": {
-          "type": "string",
-          "minLength": 1
+        "mode": {
+          "const": "preview"
         }
       }
     },
-    "improvements": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["type", "target", "description"],
-        "additionalProperties": false,
-        "properties": {
-          "type": {
-            "enum": ["new_guard", "enhance_guard", "new_hook", "new_rule", "claude_md"]
-          },
-          "target": {
-            "type": "string",
-            "minLength": 1
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1
+    {
+      "required": ["schema_version", "signal_id", "action", "state_transition", "verification"],
+      "properties": {
+        "mode": {
+          "const": "adopt"
+        }
+      }
+    },
+    {
+      "required": ["schema_version", "signal_id", "verification"],
+      "properties": {
+        "mode": {
+          "const": "verify"
+        }
+      }
+    },
+    {
+      "required": ["schema_version", "signal_id", "skill", "verification"],
+      "properties": {
+        "mode": {
+          "const": "extract_skill"
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "signal_summary": {
+      "type": "object",
+      "required": [
+        "signal_id",
+        "observation_id",
+        "classification",
+        "path_relation",
+        "affected_sessions",
+        "recommended_actions"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "signal_id": {
+          "type": "string",
+          "pattern": "^(learn:|lrn_)[A-Za-z0-9_-]{8,}$"
+        },
+        "observation_id": {
+          "type": "string",
+          "pattern": "^obs_[A-Za-z0-9_-]{8,}$"
+        },
+        "classification": {
+          "enum": [
+            "runtime_health",
+            "defense_gap",
+            "defense_friction",
+            "project_quality",
+            "workflow_friction",
+            "skill_candidate",
+            "noise"
+          ]
+        },
+        "path_relation": {
+          "enum": ["in_project", "external", "unknown"]
+        },
+        "affected_sessions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "recommended_actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/recommended_action"
           }
         }
       }
     },
-    "verification": {
+    "diagnostic": {
       "type": "object",
-      "required": ["newGuardPassed", "noRegression"],
+      "required": ["type", "classification"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "classification": {
+          "enum": ["runtime_health", "noise", "truncated"]
+        }
+      }
+    },
+    "recommended_action": {
+      "type": "object",
+      "required": ["type", "rationale"],
       "additionalProperties": false,
       "properties": {
-        "newGuardPassed": {
-          "type": "boolean"
+        "type": {
+          "enum": [
+            "fix_runtime",
+            "tune_config",
+            "enhance_guard",
+            "add_hook",
+            "add_rule",
+            "add_scoped_suppression",
+            "change_project_code",
+            "create_or_update_skill",
+            "collect_more_evidence",
+            "no_action"
+          ]
         },
-        "noRegression": {
-          "type": "boolean"
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": ["string", "null"]
+        },
+        "verification_command": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "state_transition": {
+      "type": "object",
+      "required": ["from", "to", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "enum": ["new", "adopted", "skipped", "stale", "snoozed", "verified", "regressed"]
+        },
+        "to": {
+          "enum": ["new", "adopted", "skipped", "stale", "snoozed", "verified", "regressed"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "verification_result": {
+      "type": "object",
+      "required": ["status", "commands"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "enum": ["pending", "passed", "failed", "verified", "regressed"]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "skill_result": {
+      "type": "object",
+      "required": ["name", "source_signal_ids"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": ["string", "null"]
+        },
+        "source_signal_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^(learn:|lrn_)[A-Za-z0-9_-]{8,}$"
+          }
         }
       }
     }

--- a/schemas/learn-signal.schema.json
+++ b/schemas/learn-signal.schema.json
@@ -122,6 +122,9 @@
         "classification": {
           "const": "runtime_health"
         },
+        "path_relation": {
+          "enum": ["in_project", "unknown"]
+        },
         "recommended_actions": {
           "$ref": "#/$defs/runtime_health_actions"
         }
@@ -131,6 +134,12 @@
       "properties": {
         "classification": {
           "const": "defense_gap"
+        },
+        "type": {
+          "enum": ["repeated_warn", "chronic_block", "linter_violations", "warn_escalation", "workflow_retry"]
+        },
+        "path_relation": {
+          "enum": ["in_project", "unknown"]
         },
         "recommended_actions": {
           "$ref": "#/$defs/defense_gap_actions"
@@ -142,6 +151,12 @@
         "classification": {
           "const": "defense_friction"
         },
+        "type": {
+          "enum": ["repeated_warn", "chronic_block", "linter_violations", "warn_escalation", "workflow_retry"]
+        },
+        "path_relation": {
+          "enum": ["in_project", "unknown"]
+        },
         "recommended_actions": {
           "$ref": "#/$defs/defense_friction_actions"
         }
@@ -151,6 +166,9 @@
       "properties": {
         "classification": {
           "const": "project_quality"
+        },
+        "type": {
+          "enum": ["repeated_warn", "chronic_block", "hot_files", "slow_sessions", "warn_escalation", "linter_violations"]
         },
         "path_relation": {
           "const": "in_project"
@@ -165,6 +183,12 @@
         "classification": {
           "const": "workflow_friction"
         },
+        "type": {
+          "enum": ["repeated_warn", "chronic_block", "slow_sessions", "warn_escalation", "workflow_retry"]
+        },
+        "path_relation": {
+          "enum": ["in_project", "unknown"]
+        },
         "recommended_actions": {
           "$ref": "#/$defs/workflow_friction_actions"
         }
@@ -175,6 +199,12 @@
         "classification": {
           "const": "skill_candidate"
         },
+        "type": {
+          "const": "skill_candidate"
+        },
+        "path_relation": {
+          "enum": ["in_project", "unknown"]
+        },
         "recommended_actions": {
           "$ref": "#/$defs/skill_candidate_actions"
         }
@@ -184,6 +214,19 @@
       "properties": {
         "classification": {
           "const": "noise"
+        },
+        "type": {
+          "enum": [
+            "repeated_warn",
+            "chronic_block",
+            "hot_files",
+            "slow_sessions",
+            "warn_escalation",
+            "linter_violations",
+            "edit_path",
+            "workflow_retry",
+            "skill_candidate"
+          ]
         },
         "recommended_actions": {
           "$ref": "#/$defs/noise_actions"

--- a/schemas/learn-signal.schema.json
+++ b/schemas/learn-signal.schema.json
@@ -1,0 +1,419 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibeguard.local/schemas/learn-signal.schema.json",
+  "title": "VibeGuard Learn Signal",
+  "description": "Stable Learn signal protocol with classification-bound action constraints.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "signal_id",
+    "observation_id",
+    "project_hash",
+    "project_root",
+    "type",
+    "classification",
+    "normalized_key",
+    "path_relation",
+    "affected_sessions",
+    "occurrences",
+    "first_seen",
+    "last_seen",
+    "evidence_samples",
+    "recommended_actions"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "signal_id": {
+      "type": "string",
+      "pattern": "^(learn:|lrn_)[A-Za-z0-9_-]{8,}$"
+    },
+    "observation_id": {
+      "type": "string",
+      "pattern": "^obs_[A-Za-z0-9_-]{8,}$"
+    },
+    "project_hash": {
+      "type": "string",
+      "minLength": 1
+    },
+    "project_root": {
+      "type": ["string", "null"]
+    },
+    "type": {
+      "enum": [
+        "repeated_warn",
+        "chronic_block",
+        "hot_files",
+        "slow_sessions",
+        "warn_escalation",
+        "linter_violations",
+        "metrics_truncation",
+        "edit_path",
+        "workflow_retry",
+        "skill_candidate"
+      ]
+    },
+    "classification": {
+      "enum": [
+        "runtime_health",
+        "defense_gap",
+        "defense_friction",
+        "project_quality",
+        "workflow_friction",
+        "skill_candidate",
+        "noise"
+      ]
+    },
+    "normalized_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "path": {
+      "type": ["string", "null"]
+    },
+    "path_relation": {
+      "enum": ["in_project", "external", "unknown"]
+    },
+    "source_hook": {
+      "type": ["string", "null"]
+    },
+    "source_tool": {
+      "type": ["string", "null"]
+    },
+    "affected_sessions": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "occurrences": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "event_rate": {
+      "type": "number",
+      "minimum": 0
+    },
+    "first_seen": {
+      "type": "string",
+      "minLength": 1
+    },
+    "last_seen": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence_samples": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/evidence_sample"
+      }
+    },
+    "recommended_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/recommended_action"
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "classification": {
+          "const": "runtime_health"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/runtime_health_actions"
+        }
+      }
+    },
+    {
+      "properties": {
+        "classification": {
+          "const": "defense_gap"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/defense_gap_actions"
+        }
+      }
+    },
+    {
+      "properties": {
+        "classification": {
+          "const": "defense_friction"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/defense_friction_actions"
+        }
+      }
+    },
+    {
+      "properties": {
+        "classification": {
+          "const": "project_quality"
+        },
+        "path_relation": {
+          "const": "in_project"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/project_quality_actions"
+        }
+      }
+    },
+    {
+      "properties": {
+        "classification": {
+          "const": "workflow_friction"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/workflow_friction_actions"
+        }
+      }
+    },
+    {
+      "properties": {
+        "classification": {
+          "const": "skill_candidate"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/skill_candidate_actions"
+        }
+      }
+    },
+    {
+      "properties": {
+        "classification": {
+          "const": "noise"
+        },
+        "recommended_actions": {
+          "$ref": "#/$defs/noise_actions"
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "evidence_sample": {
+      "type": "object",
+      "required": ["summary"],
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": ["string", "null"]
+        },
+        "ts": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "recommended_action": {
+      "type": "object",
+      "required": ["type", "rationale"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": [
+            "fix_runtime",
+            "tune_config",
+            "enhance_guard",
+            "add_hook",
+            "add_rule",
+            "add_scoped_suppression",
+            "change_project_code",
+            "create_or_update_skill",
+            "collect_more_evidence",
+            "no_action"
+          ]
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": ["string", "null"]
+        },
+        "verification_command": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/recommended_action"
+      }
+    },
+    "runtime_health_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["fix_runtime", "tune_config", "collect_more_evidence"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "defense_gap_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["enhance_guard", "add_hook", "add_rule", "collect_more_evidence"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "defense_friction_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["add_scoped_suppression", "enhance_guard", "tune_config", "collect_more_evidence"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "project_quality_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["change_project_code", "collect_more_evidence"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "workflow_friction_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["create_or_update_skill", "tune_config", "collect_more_evidence"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "skill_candidate_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["create_or_update_skill"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "noise_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "rationale"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["no_action", "collect_more_evidence"]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": ["string", "null"]
+          },
+          "verification_command": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/workflow-contract-consumers.json
+++ b/schemas/workflow-contract-consumers.json
@@ -3,6 +3,7 @@
   "schema_files": {
     "check_output": "command-check-output.schema.json",
     "learn_output": "command-learn-output.schema.json",
+    "learn_signal": "learn-signal.schema.json",
     "live_truth_output": "command-live-truth-output.schema.json",
     "preflight_output": "command-preflight-output.schema.json",
     "review_output": "command-review-output.schema.json",
@@ -73,6 +74,11 @@
       "path": "docs/command-schemas.md",
       "heading": "learn output Schema",
       "schema": "learn_output"
+    },
+    {
+      "path": "docs/command-schemas.md",
+      "heading": "learn signal Schema",
+      "schema": "learn_signal"
     }
   ],
   "consumers": [

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -345,6 +345,133 @@ else
 fi
 TOTAL=$((TOTAL + 1))
 if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/learn-signal.schema.json").read_text(encoding="utf-8"))
+signal = {
+    "schema_version": 1,
+    "signal_id": "lrn_a31f7c9d",
+    "observation_id": "obs_2026w26_77bc",
+    "project_hash": "dc1db069",
+    "project_root": "/repo",
+    "type": "metrics_truncation",
+    "classification": "runtime_health",
+    "normalized_key": "source:learn-evaluator:metrics_truncation",
+    "path": None,
+    "path_relation": "unknown",
+    "source_hook": "learn-evaluator",
+    "source_tool": None,
+    "affected_sessions": 3,
+    "occurrences": 18,
+    "event_rate": 0.12,
+    "first_seen": "2026-06-24T00:00:00Z",
+    "last_seen": "2026-06-24T12:00:00Z",
+    "evidence_samples": [{"summary": "metrics input truncated"}],
+    "recommended_actions": [{"type": "fix_runtime", "rationale": "runtime pipeline issue"}],
+}
+errors = module.validate_instance(signal, schema)
+if errors:
+    raise SystemExit("\n".join(errors))
+
+bad_runtime = deepcopy(signal)
+bad_runtime["recommended_actions"] = [{"type": "add_rule", "rationale": "wrong action space"}]
+if not module.validate_instance(bad_runtime, schema):
+    raise SystemExit("expected runtime_health add_rule to fail")
+
+bad_external = deepcopy(signal)
+bad_external.update({
+    "type": "hot_files",
+    "classification": "project_quality",
+    "path": "/tmp/external.rs",
+    "path_relation": "external",
+    "recommended_actions": [{"type": "change_project_code", "rationale": "wrong attribution"}],
+})
+if not module.validate_instance(bad_external, schema):
+    raise SystemExit("expected external project_quality to fail")
+PY
+  green "learn signal schema enforces classification action space"
+  PASS=$((PASS + 1))
+else
+  red "learn signal schema enforces classification action space"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("workflow_contracts", repo / "scripts/lib/workflow_contracts.py")
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+schema = json.loads((repo / "schemas/command-learn-output.schema.json").read_text(encoding="utf-8"))
+signal_id = "lrn_a31f7c9d"
+action = {"type": "fix_runtime", "rationale": "runtime pipeline issue"}
+verification = {"status": "passed", "commands": ["bash tests/test_gc_scheduled.sh"], "notes": None}
+payloads = [
+    {
+        "command": "learn",
+        "mode": "preview",
+        "schema_version": 1,
+        "generated_at": "2026-06-25T00:00:00Z",
+        "partial": False,
+        "truncated_reason": None,
+        "signals": [{
+            "signal_id": signal_id,
+            "observation_id": "obs_2026w26_77bc",
+            "classification": "runtime_health",
+            "path_relation": "unknown",
+            "affected_sessions": 3,
+            "recommended_actions": [action],
+        }],
+        "diagnostics": [],
+    },
+    {
+        "command": "learn",
+        "mode": "adopt",
+        "schema_version": 1,
+        "signal_id": signal_id,
+        "action": action,
+        "state_transition": {"from": "new", "to": "adopted", "reason": "fix runtime"},
+        "verification": verification,
+    },
+    {"command": "learn", "mode": "verify", "schema_version": 1, "signal_id": signal_id, "verification": verification},
+    {
+        "command": "learn",
+        "mode": "extract_skill",
+        "schema_version": 1,
+        "signal_id": signal_id,
+        "skill": {"name": "debug-runtime-metrics", "path": "skills/debug-runtime-metrics/SKILL.md", "source_signal_ids": [signal_id]},
+        "verification": verification,
+    },
+]
+for payload in payloads:
+    errors = module.validate_instance(payload, schema)
+    if errors:
+        raise SystemExit(f"{payload['mode']}: " + "\n".join(errors))
+PY
+  green "learn command schema accepts preview adopt verify and skill modes"
+  PASS=$((PASS + 1))
+else
+  red "learn command schema accepts preview adopt verify and skill modes"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
 import json
 import sys
 from pathlib import Path
@@ -393,6 +520,7 @@ expected_examples = {
     ("skill_validate format output Schema", "skill_validate_output"),
     ("review output Schema", "review_output"),
     ("learn output Schema", "learn_output"),
+    ("learn signal Schema", "learn_signal"),
 }
 missing_examples = expected_examples - examples
 if missing_examples:

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -388,6 +388,14 @@ bad_runtime["recommended_actions"] = [{"type": "add_rule", "rationale": "wrong a
 if not module.validate_instance(bad_runtime, schema):
     raise SystemExit("expected runtime_health add_rule to fail")
 
+bad_truncation = deepcopy(signal)
+bad_truncation.update({
+    "classification": "defense_gap",
+    "recommended_actions": [{"type": "add_rule", "rationale": "wrong action space"}],
+})
+if not module.validate_instance(bad_truncation, schema):
+    raise SystemExit("expected metrics_truncation defense_gap to fail")
+
 bad_external = deepcopy(signal)
 bad_external.update({
     "type": "hot_files",
@@ -398,6 +406,17 @@ bad_external.update({
 })
 if not module.validate_instance(bad_external, schema):
     raise SystemExit("expected external project_quality to fail")
+
+bad_external_gap = deepcopy(signal)
+bad_external_gap.update({
+    "type": "hot_files",
+    "classification": "defense_gap",
+    "path": "/tmp/external.rs",
+    "path_relation": "external",
+    "recommended_actions": [{"type": "add_rule", "rationale": "wrong attribution"}],
+})
+if not module.validate_instance(bad_external_gap, schema):
+    raise SystemExit("expected external hot_files defense_gap to fail")
 PY
   green "learn signal schema enforces classification action space"
   PASS=$((PASS + 1))
@@ -410,6 +429,7 @@ if python3 - "${REPO_DIR}" >/dev/null <<'PY'; then
 import importlib.util
 import json
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 repo = Path(sys.argv[1])
@@ -463,6 +483,16 @@ for payload in payloads:
     errors = module.validate_instance(payload, schema)
     if errors:
         raise SystemExit(f"{payload['mode']}: " + "\n".join(errors))
+
+mixed_preview = deepcopy(payloads[0])
+mixed_preview.update({
+    "signal_id": signal_id,
+    "action": action,
+    "state_transition": {"from": "new", "to": "adopted", "reason": "wrong mode"},
+    "verification": verification,
+})
+if not module.validate_instance(mixed_preview, schema):
+    raise SystemExit("expected preview mixed with adopt fields to fail")
 PY
   green "learn command schema accepts preview adopt verify and skill modes"
   PASS=$((PASS + 1))


### PR DESCRIPTION
Fixes #528

## Summary
- add `learn-signal.schema.json` for stable signal IDs, observation IDs, classifications, path ownership, evidence samples, and recommended actions
- convert `command-learn-output.schema.json` into a mode envelope for preview, adopt, verify, and extract_skill
- document the Learn envelope and signal examples, and register the new schema with workflow contract validation

## Verification
- `python3 -m json.tool schemas/learn-signal.schema.json >/dev/null && python3 -m json.tool schemas/command-learn-output.schema.json >/dev/null && python3 -m json.tool schemas/workflow-contract-consumers.json >/dev/null`
- `python3 -m py_compile scripts/lib/workflow_contracts.py`
- `bash tests/test_workflow_contracts.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`