### PR TITLE
fix(learn): add explicit triage state

### DIFF
--- a/docs/how/learning-skill-generation.md
+++ b/docs/how/learning-skill-generation.md
@@ -163,16 +163,18 @@ preview via `--code-scan`; keep `--no-code-scan` for the lightweight default.
 Hot-file signals are attributed to the current project root; external edit paths
 are reported as diagnostic noise instead of current-project hot files.
 
-**Anti-repetitive learning (water mark mechanism):**
+**Anti-repetitive learning (triage state):**
 
-`~/.vibeguard/.learn-watermark` stores the latest timestamp of the last consumption. skills-loader only reads new entries after the watermark, and updates the watermark after confirming adoption/skipping. The same signal is only recommended once.
+`~/.vibeguard/learn-state.jsonl` stores explicit append-only transitions keyed
+by `signal_id`. `skills-loader.sh` previews pending signals from
+`learn-digest.jsonl` and never advances a watermark or changes triage state.
+Signals are hidden only after an explicit `adopt`, `skip`, or `snooze`
+transition.
 
 ```
-learn-digest.jsonl:  ts=T1, ts=T2, ts=T3, ts=T4
-                                    ↑
-.learn-watermark: T3 (processed here)
-                                         ↑
-Watch only next time: T4 (new data)
+learn-digest.jsonl:  signal A, signal B, signal C
+learn-state.jsonl:   signal A -> adopted
+Next display:        signal B, signal C remain pending
 ```
 
 **Benchmarking against Harness GC Agent:**
@@ -311,9 +313,9 @@ If you need to manually hook into `PreToolUse(Read)`, it will trigger two things
 ```
 New Session → First Read
   │
-  ├─ [Learning Recommendation] Read learn-digest.jsonl (new signal after the water mark)
+  ├─ [Learning Recommendation] Read pending signals from learn-digest.jsonl
   │ ├─ There is a new signal → Output recommendations and prompt to run /vibeguard:learn
-  │ └─ Update the watermark (~/.vibeguard/.learn-watermark) and do not repeat it next time
+  │ └─ Display is read-only; only explicit triage commands append learn-state.jsonl
   │
   ├─ [Skill Match] Scan ~/.claude/skills/ and .claude/skills/
   │ ├─ Read the frontmatter (name + description) of each SKILL.md

--- a/hooks/skills-loader.sh
+++ b/hooks/skills-loader.sh
@@ -123,29 +123,69 @@ for score, name, desc in matches[:5]:
     print(f'{name}: {desc}')
 " 2>/dev/null || true)
 
-# ── Learning signal recommendation (consume learn-digest.jsonl, water level deduplication) ──
+# ── Learning signal recommendation (read-only signal inbox preview) ──
 DIGEST_FILE="${HOME}/.vibeguard/learn-digest.jsonl"
-WATERMARK_FILE="${HOME}/.vibeguard/.learn-watermark"
+LEARN_STATE_FILE="${HOME}/.vibeguard/learn-state.jsonl"
 
-LEARN_HINTS=$(python3 -c "
-import json, os, sys
+LEARN_HINTS=$(DIGEST_FILE="$DIGEST_FILE" LEARN_STATE_FILE="$LEARN_STATE_FILE" python3 <<'PY'
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
 
-digest = '${DIGEST_FILE}'
-watermark = '${WATERMARK_FILE}'
-
+digest = os.environ["DIGEST_FILE"]
+state_file = os.environ["LEARN_STATE_FILE"]
 if not os.path.exists(digest):
     sys.exit(0)
 
-# Read water level
-last_ts = ''
-if os.path.exists(watermark):
-    with open(watermark) as f:
-        last_ts = f.read().strip()
+now = datetime.now(timezone.utc)
+states = {}
+if os.path.exists(state_file):
+    with open(state_file, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            signal_id = record.get("signal_id")
+            to_state = record.get("to")
+            if not isinstance(signal_id, str) or not isinstance(to_state, str):
+                continue
+            states[signal_id] = record
 
-# Read the new signal after the water mark
-new_signals = []
-latest_ts = last_ts
-with open(digest) as f:
+def fallback_signal_id(project, sig):
+    key = json.dumps(
+        {
+            "project": project,
+            "type": sig.get("type", ""),
+            "reason": sig.get("reason", ""),
+            "file": sig.get("file", ""),
+            "guard": sig.get("guard", ""),
+        },
+        sort_keys=True,
+    )
+    return "legacy:" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+def is_pending(signal_id):
+    record = states.get(signal_id)
+    if not record:
+        return True
+    state = record.get("to")
+    if state in {"adopted", "skipped", "verified", "stale"}:
+        return False
+    if state == "snoozed":
+        until = record.get("until")
+        if not isinstance(until, str):
+            return True
+        try:
+            return datetime.fromisoformat(until.replace("Z", "+00:00")) <= now
+        except ValueError:
+            return True
+    return True
+
+pending_signals = []
+with open(digest, encoding="utf-8", errors="replace") as f:
     for line in f:
         line = line.strip()
         if not line:
@@ -155,18 +195,23 @@ with open(digest) as f:
         except json.JSONDecodeError:
             continue
         ts = entry.get('ts', '')
-        if ts <= last_ts:
-            continue
-        if ts > latest_ts:
-            latest_ts = ts
+        project = entry.get('project', '')
         for sig in entry.get('signals', []):
-            sig['project'] = entry.get('project', '')
-            new_signals.append(sig)
+            if not isinstance(sig, dict):
+                continue
+            sig = dict(sig)
+            sig['project'] = project
+            sig['ts'] = ts
+            signal_id = sig.get('signal_id') or fallback_signal_id(project, sig)
+            sig['signal_id'] = signal_id
+            if is_pending(signal_id):
+                pending_signals.append(sig)
 
-if not new_signals:
+if not pending_signals:
     sys.exit(0)
 
-# Summarize by type, output up to 5 items
+# Summarize by type, output up to 5 items. Display is read-only; triage state
+# changes only through scripts/learn/triage_state.py.
 type_labels = {
     'repeated_warn': 'High frequency warning',
     'chronic_block': 'Repeated interception',
@@ -176,7 +221,7 @@ type_labels = {
     'linter_violations': 'Code violations',
 }
 output = []
-for sig in new_signals[:5]:
+for sig in pending_signals[:5]:
     t = type_labels.get(sig['type'], sig['type'])
     src = '[scan]' if sig.get('source') == 'code_scan' else '[log]'
     if sig['type'] == 'linter_violations':
@@ -189,13 +234,10 @@ for sig in new_signals[:5]:
         detail = '...' + detail[-52:]
     output.append(f'{src} {t}: {detail} ({count} times)')
 
-# Update water level
-with open(watermark, 'w') as f:
-    f.write(latest_ts)
-
 for line in output:
     print(line)
-" 2>/dev/null || true)
+PY
+) || LEARN_HINTS=""
 
 # output
 HAS_OUTPUT=false

--- a/scripts/learn/triage_state.py
+++ b/scripts/learn/triage_state.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Append explicit Learn signal triage transitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+STATES = {"new", "adopted", "skipped", "stale", "snoozed", "verified", "regressed"}
+
+
+def default_state_file() -> Path:
+    return Path(os.environ.get("VIBEGUARD_LEARN_STATE_FILE", Path.home() / ".vibeguard" / "learn-state.jsonl"))
+
+
+def utc_now() -> datetime:
+    fixed = os.environ.get("_VIBEGUARD_TEST_NOW")
+    if fixed:
+        return datetime.fromisoformat(fixed.replace("Z", "+00:00")).astimezone(timezone.utc)
+    return datetime.now(timezone.utc)
+
+
+def read_latest_states(path: Path) -> dict[str, str]:
+    states: dict[str, str] = {}
+    if not path.exists():
+        return states
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            signal_id = record.get("signal_id")
+            to_state = record.get("to")
+            if isinstance(signal_id, str) and to_state in STATES:
+                states[signal_id] = to_state
+    return states
+
+
+def append_transition(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def build_triage_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Append a Learn triage state transition.")
+    parser.add_argument("--state-file", type=Path, default=default_state_file())
+    sub = parser.add_subparsers(dest="command", required=True)
+    for command, to_state in (("adopt", "adopted"), ("skip", "skipped"), ("snooze", "snoozed")):
+        item = sub.add_parser(command)
+        item.set_defaults(to_state=to_state)
+        item.add_argument("signal_id")
+        item.add_argument("--reason", required=True)
+        if command == "snooze":
+            item.add_argument("--days", type=int, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_triage_parser().parse_args(argv)
+    if args.command == "snooze" and args.days <= 0:
+        print("--days must be > 0", file=sys.stderr)
+        return 2
+
+    now = utc_now()
+    latest = read_latest_states(args.state_file)
+    record: dict[str, Any] = {
+        "schema_version": 1,
+        "signal_id": args.signal_id,
+        "from": latest.get(args.signal_id, "new"),
+        "to": args.to_state,
+        "reason": args.reason,
+        "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if args.command == "snooze":
+        record["until"] = (now + timedelta(days=args.days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    append_transition(args.state_file, record)
+    sys.stdout.write(json.dumps(record, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hooks/test_skills_loader.sh
+++ b/tests/hooks/test_skills_loader.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
+hook_test_init
+
+header "skills-loader — learn display is read-only"
+
+loader_home="$(mktemp -d)"
+loader_project="$(mktemp -d)"
+mkdir -p "${loader_home}/.claude/skills/demo" "${loader_home}/.vibeguard"
+hook_test_install_runtime_stub "$loader_home"
+cat > "${loader_home}/.claude/skills/demo/SKILL.md" <<'SKILL'
+---
+name: demo
+description: Rust demo skill
+---
+SKILL
+
+python3 - "${loader_home}/.vibeguard/learn-digest.jsonl" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open("w", encoding="utf-8") as handle:
+    signals = []
+    for index in range(1, 7):
+        signals.append({
+            "type": "repeated_warn",
+            "source": "events",
+            "reason": f"pending-signal-{index}",
+            "count": index + 10,
+            "signal_id": f"lrn_pending_{index:02d}",
+        })
+    handle.write(json.dumps({"ts": "2026-06-24T00:00:00Z", "project": "abc12345", "signals": signals}) + "\n")
+PY
+
+first_out="$(
+  cd "$loader_project"
+  touch Cargo.toml
+  HOME="$loader_home" VIBEGUARD_SESSION_ID="skills-loader-1" bash "$REPO_DIR/hooks/skills-loader.sh"
+)"
+second_out="$(
+  cd "$loader_project"
+  HOME="$loader_home" VIBEGUARD_SESSION_ID="skills-loader-2" bash "$REPO_DIR/hooks/skills-loader.sh"
+)"
+
+assert_contains "$first_out" "pending-signal-1" "loader displays first pending signal"
+assert_contains "$first_out" "pending-signal-5" "loader displays fifth pending signal"
+assert_not_contains "$first_out" "pending-signal-6" "loader display remains bounded to five signals"
+assert_contains "$second_out" "pending-signal-1" "repeated display is stable without state transition"
+assert_exit_nonzero "loader display does not create learn watermark" test -e "${loader_home}/.vibeguard/.learn-watermark"
+assert_exit_nonzero "loader display does not create triage state" test -e "${loader_home}/.vibeguard/learn-state.jsonl"
+
+for index in 1 2 3 4 5; do
+  case "$index" in
+    1|2)
+      HOME="$loader_home" python3 "$REPO_DIR/scripts/learn/triage_state.py" adopt "lrn_pending_0${index}" --reason "accepted" >/dev/null
+      ;;
+    3|4)
+      HOME="$loader_home" python3 "$REPO_DIR/scripts/learn/triage_state.py" skip "lrn_pending_0${index}" --reason "not useful" >/dev/null
+      ;;
+    5)
+      HOME="$loader_home" _VIBEGUARD_TEST_NOW="2026-06-24T00:00:00Z" \
+        python3 "$REPO_DIR/scripts/learn/triage_state.py" snooze "lrn_pending_05" --days 14 --reason "later" >/dev/null
+      ;;
+  esac
+done
+
+state_lines="$(wc -l < "${loader_home}/.vibeguard/learn-state.jsonl" | tr -d ' ')"
+assert_exit_zero "triage transitions are append-only records" test "$state_lines" = "5"
+third_out="$(
+  cd "$loader_project"
+  HOME="$loader_home" VIBEGUARD_SESSION_ID="skills-loader-3" bash "$REPO_DIR/hooks/skills-loader.sh"
+)"
+assert_contains "$third_out" "pending-signal-6" "undisplayed signal remains pending after visible signals are triaged"
+assert_not_contains "$third_out" "pending-signal-1" "adopted signal is hidden from loader"
+assert_not_contains "$third_out" "pending-signal-3" "skipped signal is hidden from loader"
+assert_not_contains "$third_out" "pending-signal-5" "snoozed signal is hidden from loader"
+
+cat >> "${loader_home}/.vibeguard/learn-state.jsonl" <<'JSON'
+{"schema_version":1,"signal_id":"lrn_pending_01","from":"adopted","to":"regressed","reason":"recurred","ts":"2026-06-24T00:00:01Z"}
+{"schema_version":1,"signal_id":"lrn_pending_06","from":"new","to":"snoozed","reason":"missing until","ts":"2026-06-24T00:00:02Z"}
+JSON
+fourth_out="$(
+  cd "$loader_project"
+  HOME="$loader_home" VIBEGUARD_SESSION_ID="skills-loader-4" bash "$REPO_DIR/hooks/skills-loader.sh"
+)"
+assert_contains "$fourth_out" "pending-signal-1" "regressed signal returns to loader"
+assert_contains "$fourth_out" "pending-signal-6" "malformed snooze does not hide pending signal"
+
+rm -rf "$loader_home" "$loader_project"
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi
+
+printf "\n==============================\n"
+printf "Total: %d  Pass: %d  Fail: %d\n" "$TOTAL" "$PASS" "$FAIL"
+printf "==============================\n"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -33,6 +33,7 @@ shards=(
   "tests/hooks/test_log_session.sh"
   "tests/hooks/test_post_edit_suppression.sh"
   "tests/hooks/test_log_timer.sh"
+  "tests/hooks/test_skills_loader.sh"
   "tests/hooks/test_post_edit_w14.sh"
   "tests/hooks/test_post_edit_w15.sh"
   "tests/hooks/test_runtime_config.sh"


### PR DESCRIPTION
## Summary
- make skills-loader learning recommendations read-only by removing watermark consumption
- add append-only Learn triage transitions for adopt/skip/snooze
- add loader regression coverage for >5 pending signals, state transitions, regressed signals, and malformed snoozes

Closes #529

## Tests
- python3 -m py_compile scripts/learn/triage_state.py scripts/learn/analyze.py scripts/gc/learn_digest.py
- bash -n hooks/skills-loader.sh tests/hooks/test_skills_loader.sh tests/test_hooks.sh
- bash tests/hooks/test_skills_loader.sh
- bash scripts/ci/validate-doc-command-paths.sh
- bash scripts/ci/validate-doc-paths.sh
- git diff --check
- bash tests/test_hooks.sh
- bash tests/test_setup.sh
