### PR TITLE
feat(learn): materialize adopted signals and trajectories

### DIFF
--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -343,6 +343,53 @@ python3 scripts/skill_validate.py --check-repo-format --repo-root . --json
 }
 ```
 
+Adopt mode records the full materialization contract:
+
+```json
+{
+  "command": "learn",
+  "mode": "adopt",
+  "schema_version": 1,
+  "signal_id": "lrn_a31f7c9d",
+  "action": {
+    "type": "fix_runtime",
+    "rationale": "Runtime truncation should tune the metrics pipeline."
+  },
+  "state_transition": {
+    "from": "new",
+    "to": "adopted",
+    "reason": "fix runtime"
+  },
+  "verification": {
+    "status": "pending",
+    "commands": ["bash tests/test_gc_scheduled.sh"],
+    "notes": "truncation recurrence falls in the next window"
+  },
+  "adoption": {
+    "schema_version": 1,
+    "ts": "2026-06-25T00:00:00Z",
+    "signal_id": "lrn_a31f7c9d",
+    "classification": "runtime_health",
+    "selected_action": {
+      "type": "fix_runtime",
+      "rationale": "Runtime truncation should tune the metrics pipeline."
+    },
+    "files_or_artifacts": ["hooks/learn-evaluator.sh"],
+    "original_evidence": [{"summary": "metrics input truncated"}],
+    "verification_commands": ["bash tests/test_gc_scheduled.sh"],
+    "regression_checks": ["bash tests/test_gc_scheduled.sh"],
+    "baseline": "18 truncated sessions",
+    "expected_later_observation": "truncation recurrence falls",
+    "rollback_path": "revert runtime pipeline change",
+    "state_transition": {
+      "from": "new",
+      "to": "adopted",
+      "reason": "fix runtime"
+    }
+  }
+}
+```
+
 ## learn signal Schema
 
 ```json

--- a/docs/how/learning-skill-generation.md
+++ b/docs/how/learning-skill-generation.md
@@ -177,6 +177,61 @@ learn-state.jsonl:   signal A -> adopted
 Next display:        signal B, signal C remain pending
 ```
 
+**Adoption compiler and verification:**
+
+Adopting a signal materializes a constrained action record instead of asking the
+model to invent the next step. The deterministic compiler records the selected
+action, changed files or artifacts, original evidence, verification commands,
+regression checks, baseline, expected later observation, and rollback path.
+
+```bash
+python3 "$VIBEGUARD_REPO_DIR/scripts/learn/adoption.py" \
+  --state-file "$HOME/.vibeguard/learn-state.jsonl" \
+  --adoptions-file "$HOME/.vibeguard/learn-adoptions.jsonl" \
+  adopt \
+  --signal signal.json \
+  --action fix_runtime \
+  --artifact hooks/learn-evaluator.sh \
+  --verification-command "bash tests/test_gc_scheduled.sh" \
+  --regression-command "bash tests/test_gc_scheduled.sh" \
+  --baseline "18 truncated sessions" \
+  --expected-observation "truncation recurrence falls in the next window" \
+  --rollback "revert runtime pipeline change" \
+  --reason "adopt runtime fix"
+```
+
+Verification must use fresh evidence newer than the adoption record:
+
+```bash
+python3 "$VIBEGUARD_REPO_DIR/scripts/learn/adoption.py" \
+  --state-file "$HOME/.vibeguard/learn-state.jsonl" \
+  --adoptions-file "$HOME/.vibeguard/learn-adoptions.jsonl" \
+  verify \
+  --signal-id lrn_a31f7c9d \
+  --evidence fresh-evidence.json \
+  --reason "later observation improved"
+```
+
+**W-37 success trajectory learning:**
+
+Learn records successful low-friction trajectories separately from failure and
+friction lessons. Planning retrieval should show both when they exist for the
+same task class; success-only retrieval is rejected if failure lessons exist.
+
+```bash
+python3 "$VIBEGUARD_REPO_DIR/scripts/learn/trajectory.py" \
+  record \
+  --task-class rust-hook-fix \
+  --outcome success \
+  --low-friction \
+  --evidence "focused hook test and setup test passed without churn" \
+  --verification-command "bash tests/test_setup.sh"
+
+python3 "$VIBEGUARD_REPO_DIR/scripts/learn/trajectory.py" \
+  preview \
+  --task-class rust-hook-fix
+```
+
 **Benchmarking against Harness GC Agent:**
 
 | Harness GC Agent | VibeGuard GC Learning |

--- a/docs/specs/learn-first-class-signal-inbox.md
+++ b/docs/specs/learn-first-class-signal-inbox.md
@@ -16,6 +16,17 @@
 - Adoption compiler and verification: https://github.com/majiayu000/vibeguard/issues/530
 - Success trajectory learning: https://github.com/majiayu000/vibeguard/issues/531
 
+## Implementation notes
+
+- `scripts/learn/adoption.py` materializes adopted signals into append-only
+  records with verification commands, baseline, expected later observation, and
+  rollback path.
+- `scripts/learn/adoption.py verify` requires fresh evidence newer than the
+  adoption record before marking a signal `verified` or `regressed`.
+- `scripts/learn/trajectory.py` records W-37 success and failure trajectories
+  separately and rejects success-only retrieval when failure lessons exist for
+  the same task class.
+
 ## 1. Problem
 
 The public learning story says VibeGuard should turn repeated mistakes into

--- a/schemas/command-learn-output.schema.json
+++ b/schemas/command-learn-output.schema.json
@@ -51,6 +51,9 @@
     "verification": {
       "$ref": "#/$defs/verification_result"
     },
+    "adoption": {
+      "$ref": "#/$defs/adoption_record"
+    },
     "skill": {
       "$ref": "#/$defs/skill_result"
     }
@@ -73,7 +76,7 @@
       }
     },
     {
-      "required": ["schema_version", "signal_id", "action", "state_transition", "verification"],
+      "required": ["schema_version", "signal_id", "action", "state_transition", "verification", "adoption"],
       "additionalProperties": false,
       "properties": {
         "command": {},
@@ -84,7 +87,8 @@
         "signal_id": {},
         "action": {},
         "state_transition": {},
-        "verification": {}
+        "verification": {},
+        "adoption": {}
       }
     },
     {
@@ -242,6 +246,111 @@
         },
         "notes": {
           "type": ["string", "null"]
+        },
+        "evidence_observed_at": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "adoption_record": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "ts",
+        "signal_id",
+        "classification",
+        "selected_action",
+        "files_or_artifacts",
+        "original_evidence",
+        "verification_commands",
+        "regression_checks",
+        "baseline",
+        "expected_later_observation",
+        "rollback_path",
+        "state_transition"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "schema_version": {
+          "const": 1
+        },
+        "ts": {
+          "type": "string",
+          "minLength": 1
+        },
+        "signal_id": {
+          "type": "string",
+          "pattern": "^(learn:|lrn_)[A-Za-z0-9_-]{8,}$"
+        },
+        "observation_id": {
+          "type": "string"
+        },
+        "classification": {
+          "enum": [
+            "runtime_health",
+            "defense_gap",
+            "defense_friction",
+            "project_quality",
+            "workflow_friction",
+            "skill_candidate",
+            "noise"
+          ]
+        },
+        "selected_action": {
+          "$ref": "#/$defs/recommended_action"
+        },
+        "files_or_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "original_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["summary"],
+            "additionalProperties": true,
+            "properties": {
+              "summary": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "verification_commands": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "regression_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "baseline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_later_observation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rollback_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state_transition": {
+          "$ref": "#/$defs/state_transition"
         }
       }
     },

--- a/scripts/learn/adoption.py
+++ b/scripts/learn/adoption.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Materialize and verify adopted VibeGuard Learn signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from triage_state import append_transition, default_state_file, read_latest_states, utc_now
+
+
+ACTION_SPACES: dict[str, set[str]] = {
+    "runtime_health": {"fix_runtime", "tune_config", "collect_more_evidence"},
+    "defense_gap": {"enhance_guard", "add_hook", "add_rule"},
+    "defense_friction": {"add_scoped_suppression", "enhance_guard", "tune_config"},
+    "project_quality": {"change_project_code", "collect_more_evidence"},
+    "workflow_friction": {"create_or_update_skill", "tune_config", "collect_more_evidence"},
+    "skill_candidate": {"create_or_update_skill"},
+    "noise": {"no_action", "collect_more_evidence"},
+}
+
+DEFAULT_ADOPTIONS_FILE = Path.home() / ".vibeguard" / "learn-adoptions.jsonl"
+
+
+class LearnAdoptionError(ValueError):
+    """Raised when a Learn adoption or verification record is invalid."""
+
+
+def default_adoptions_file() -> Path:
+    return Path(os.environ.get("VIBEGUARD_LEARN_ADOPTIONS_FILE", DEFAULT_ADOPTIONS_FILE))
+
+
+def load_learn_json_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise LearnAdoptionError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise LearnAdoptionError(f"invalid JSON in {path}: {exc.msg}") from exc
+    if not isinstance(data, dict):
+        raise LearnAdoptionError(f"{path} must contain a JSON object")
+    return data
+
+
+def append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def iter_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(item, dict):
+                records.append(item)
+    return records
+
+
+def parse_utc(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise LearnAdoptionError(f"{field} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise LearnAdoptionError(f"{field} must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def iso_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def require_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise LearnAdoptionError(f"{key} is required")
+    return value.strip()
+
+
+def recommended_actions(signal: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = signal.get("recommended_actions")
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def select_action(signal: dict[str, Any], requested_type: str | None) -> dict[str, Any]:
+    classification = require_string(signal, "classification")
+    allowed = ACTION_SPACES.get(classification)
+    if allowed is None:
+        raise LearnAdoptionError(f"unsupported classification: {classification}")
+
+    candidates = recommended_actions(signal)
+    if requested_type:
+        action_type = requested_type.strip()
+        selected = next((item for item in candidates if item.get("type") == action_type), None)
+        action = dict(selected or {"type": action_type, "rationale": f"selected {action_type}"})
+    else:
+        selected = next((item for item in candidates if item.get("type") in allowed), None)
+        if selected is None:
+            raise LearnAdoptionError(f"signal has no allowed action for {classification}")
+        action = dict(selected)
+
+    action_type = action.get("type")
+    if action_type not in allowed:
+        allowed_text = ", ".join(sorted(allowed))
+        raise LearnAdoptionError(f"{classification} cannot use action {action_type}; allowed: {allowed_text}")
+    if not isinstance(action.get("rationale"), str) or not action["rationale"].strip():
+        action["rationale"] = f"selected {action_type}"
+    return action
+
+
+def governance_for_action(action: dict[str, Any]) -> dict[str, Any] | None:
+    action_type = action.get("type")
+    if action_type == "add_scoped_suppression":
+        return {
+            "config_key": "scoped_suppressions",
+            "artifact": ".vibeguard.json",
+            "review_focus": "narrow hook/rule/path false-positive governance",
+        }
+    if action_type == "no_action":
+        return {
+            "config_key": None,
+            "artifact": None,
+            "review_focus": "noise path, no project or guard mutation",
+        }
+    return None
+
+
+def state_transition(
+    state_file: Path,
+    signal_id: str,
+    to_state: str,
+    reason: str,
+    now: datetime,
+) -> dict[str, Any]:
+    latest = read_latest_states(state_file)
+    record = {
+        "schema_version": 1,
+        "signal_id": signal_id,
+        "from": latest.get(signal_id, "new"),
+        "to": to_state,
+        "reason": reason,
+        "ts": iso_z(now),
+    }
+    append_transition(state_file, record)
+    return record
+
+
+def evidence_samples(signal: dict[str, Any]) -> list[dict[str, Any]]:
+    samples = signal.get("evidence_samples")
+    if isinstance(samples, list) and samples:
+        return [item for item in samples if isinstance(item, dict)]
+    summary = signal.get("reason") or signal.get("file") or signal.get("type") or "learn signal"
+    return [{"summary": str(summary)}]
+
+
+def build_adoption_record(args: argparse.Namespace, signal: dict[str, Any], now: datetime) -> dict[str, Any]:
+    action = select_action(signal, args.action)
+    signal_id = require_string(signal, "signal_id")
+    observation_id = str(signal.get("observation_id") or "")
+    artifact_values = [item for item in args.artifact if item.strip()]
+    if not artifact_values and action.get("target"):
+        artifact_values = [str(action["target"])]
+
+    to_state = "skipped" if action["type"] == "no_action" else "adopted"
+    transition = state_transition(args.state_file, signal_id, to_state, args.reason, now)
+    verification_commands = [args.verification_command]
+    regression_checks = [args.regression_command]
+
+    record: dict[str, Any] = {
+        "schema_version": 1,
+        "ts": iso_z(now),
+        "signal_id": signal_id,
+        "observation_id": observation_id,
+        "classification": require_string(signal, "classification"),
+        "selected_action": action,
+        "files_or_artifacts": artifact_values,
+        "original_evidence": evidence_samples(signal),
+        "verification_commands": verification_commands,
+        "regression_checks": regression_checks,
+        "baseline": args.baseline,
+        "expected_later_observation": args.expected_observation,
+        "rollback_path": args.rollback,
+        "state_transition": transition,
+    }
+    governance = governance_for_action(action)
+    if governance is not None:
+        record["governance"] = governance
+    append_jsonl(args.adoptions_file, record)
+    return record
+
+
+def latest_adoption(path: Path, signal_id: str) -> dict[str, Any]:
+    matches = [record for record in iter_jsonl(path) if record.get("signal_id") == signal_id]
+    if not matches:
+        raise LearnAdoptionError(f"no adoption record found for {signal_id}")
+    return matches[-1]
+
+
+def verification_status(evidence: dict[str, Any], requested_status: str | None) -> str:
+    regression_signals = evidence.get("regression_signals", [])
+    has_regression = bool(regression_signals)
+    recurrence_delta = evidence.get("recurrence_delta")
+    recurrence_regressed = isinstance(recurrence_delta, (int, float)) and recurrence_delta > 0
+    inferred = "regressed" if has_regression or recurrence_regressed else "verified"
+    if requested_status and requested_status != inferred:
+        raise LearnAdoptionError(
+            f"requested status {requested_status} conflicts with fresh evidence status {inferred}"
+        )
+    return requested_status or inferred
+
+
+def build_verify_record(args: argparse.Namespace, now: datetime) -> dict[str, Any]:
+    adoption = latest_adoption(args.adoptions_file, args.signal_id)
+    evidence = load_learn_json_object(args.evidence)
+    evidence_signal_id = evidence.get("signal_id")
+    if evidence_signal_id != args.signal_id:
+        raise LearnAdoptionError("fresh evidence signal_id must match --signal-id")
+    observed_at = require_string(evidence, "observed_at")
+    observed_time = parse_utc(observed_at, "observed_at")
+    adoption_time = parse_utc(require_string(adoption, "ts"), "adoption ts")
+    if observed_time <= adoption_time:
+        raise LearnAdoptionError("fresh evidence must be newer than the adoption record")
+
+    status = verification_status(evidence, args.status)
+    command = args.verification_command or "; ".join(adoption.get("verification_commands", []))
+    if not command:
+        raise LearnAdoptionError("verification command is required")
+    transition = state_transition(args.state_file, args.signal_id, status, args.reason, now)
+    record = {
+        "schema_version": 1,
+        "ts": iso_z(now),
+        "signal_id": args.signal_id,
+        "verification": {
+            "status": status,
+            "commands": [command],
+            "evidence_observed_at": iso_z(observed_time),
+            "notes": args.reason,
+        },
+        "state_transition": transition,
+        "fresh_evidence": evidence,
+    }
+    append_jsonl(args.adoptions_file, record)
+    return record
+
+
+def output_for_adoption(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "command": "learn",
+        "mode": "adopt",
+        "schema_version": 1,
+        "signal_id": record["signal_id"],
+        "action": record["selected_action"],
+        "state_transition": {
+            "from": record["state_transition"]["from"],
+            "to": record["state_transition"]["to"],
+            "reason": record["state_transition"]["reason"],
+        },
+        "verification": {
+            "status": "pending",
+            "commands": record["verification_commands"] + record["regression_checks"],
+            "notes": record["expected_later_observation"],
+        },
+        "adoption": record,
+    }
+
+
+def output_for_verification(record: dict[str, Any]) -> dict[str, Any]:
+    verification = dict(record["verification"])
+    return {
+        "command": "learn",
+        "mode": "verify",
+        "schema_version": 1,
+        "signal_id": record["signal_id"],
+        "verification": verification,
+    }
+
+
+def build_adoption_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Materialize or verify adopted Learn signals.")
+    parser.add_argument("--state-file", type=Path, default=default_state_file())
+    parser.add_argument("--adoptions-file", type=Path, default=default_adoptions_file())
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    adopt = sub.add_parser("adopt")
+    adopt.add_argument("--signal", type=Path, required=True)
+    adopt.add_argument("--action")
+    adopt.add_argument("--artifact", action="append", default=[])
+    adopt.add_argument("--verification-command", required=True)
+    adopt.add_argument("--regression-command", required=True)
+    adopt.add_argument("--baseline", required=True)
+    adopt.add_argument("--expected-observation", required=True)
+    adopt.add_argument("--rollback", required=True)
+    adopt.add_argument("--reason", required=True)
+
+    verify = sub.add_parser("verify")
+    verify.add_argument("--signal-id", required=True)
+    verify.add_argument("--evidence", type=Path, required=True)
+    verify.add_argument("--status", choices=["verified", "regressed"])
+    verify.add_argument("--verification-command")
+    verify.add_argument("--reason", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_adoption_parser().parse_args(argv)
+    try:
+        now = utc_now()
+        if args.command == "adopt":
+            record = build_adoption_record(args, load_learn_json_object(args.signal), now)
+            output = output_for_adoption(record)
+        else:
+            record = build_verify_record(args, now)
+            output = output_for_verification(record)
+    except LearnAdoptionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/learn/trajectory.py
+++ b/scripts/learn/trajectory.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Record and preview W-37 success/failure Learn trajectories."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from triage_state import utc_now
+
+
+DEFAULT_TRAJECTORY_STORE = Path.home() / ".vibeguard" / "learn-trajectories.jsonl"
+
+
+class LearnTrajectoryError(ValueError):
+    """Raised when Learn trajectory data would violate W-37."""
+
+
+def default_trajectory_store() -> Path:
+    return Path(os.environ.get("VIBEGUARD_LEARN_TRAJECTORY_FILE", DEFAULT_TRAJECTORY_STORE))
+
+
+def learn_trajectory_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return "traj:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+
+
+def append_trajectory_record(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def read_trajectory_records(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(item, dict):
+                records.append(item)
+    return records
+
+
+def iso_now() -> str:
+    return utc_now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_record(args: argparse.Namespace) -> dict[str, Any]:
+    if args.outcome == "success" and not args.low_friction:
+        raise LearnTrajectoryError("successful trajectories must set --low-friction")
+    base = {
+        "schema_version": 1,
+        "task_class": args.task_class,
+        "outcome": args.outcome,
+        "evidence": args.evidence,
+        "signal_id": args.signal_id,
+    }
+    record = {
+        **base,
+        "trajectory_id": learn_trajectory_hash(base),
+        "ts": iso_now(),
+        "outcome_flags": {
+            "success": args.outcome == "success",
+            "failure": args.outcome == "failure",
+            "low_friction": bool(args.low_friction),
+        },
+        "verification_commands": args.verification_command,
+        "failure_lesson": args.failure_lesson,
+    }
+    return record
+
+
+def records_for_task(records: list[dict[str, Any]], task_class: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    matching = [record for record in records if record.get("task_class") == task_class]
+    successes = [record for record in matching if record.get("outcome") == "success"]
+    failures = [record for record in matching if record.get("outcome") == "failure"]
+    return successes, failures
+
+
+def preview_task(path: Path, task_class: str, success_only: bool) -> dict[str, Any]:
+    successes, failures = records_for_task(read_trajectory_records(path), task_class)
+    if success_only and failures:
+        raise LearnTrajectoryError(
+            "success-only retrieval is rejected because failure lessons exist for this task class"
+        )
+    return {
+        "command": "learn",
+        "mode": "trajectory_preview",
+        "schema_version": 1,
+        "task_class": task_class,
+        "success_trajectories": successes,
+        "failure_trajectories": [] if success_only else failures,
+        "combined_evidence_available": bool(successes and failures and not success_only),
+    }
+
+
+def build_trajectory_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Record or preview W-37 Learn trajectories.")
+    parser.add_argument("--store", type=Path, default=default_trajectory_store())
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    record = sub.add_parser("record")
+    record.add_argument("--task-class", required=True)
+    record.add_argument("--outcome", choices=["success", "failure"], required=True)
+    record.add_argument("--evidence", required=True)
+    record.add_argument("--signal-id")
+    record.add_argument("--verification-command", action="append", default=[])
+    record.add_argument("--failure-lesson")
+    record.add_argument("--low-friction", action="store_true")
+
+    preview = sub.add_parser("preview")
+    preview.add_argument("--task-class", required=True)
+    preview.add_argument("--success-only", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_trajectory_parser().parse_args(argv)
+    try:
+        if args.command == "record":
+            output = build_record(args)
+            append_trajectory_record(args.store, output)
+        else:
+            output = preview_task(args.store, args.task_class, args.success_only)
+    except LearnTrajectoryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gc_scheduled.sh
+++ b/tests/test_gc_scheduled.sh
@@ -52,6 +52,8 @@ assert_cmd "scheduled GC Python helpers compile" python3 -m py_compile \
   scripts/gc/session_metrics_cleanup.py \
   scripts/gc/learn_digest.py \
   scripts/learn/analyze.py \
+  scripts/learn/adoption.py \
+  scripts/learn/trajectory.py \
   scripts/gc/reflection_digest.py
 
 header "gc-scheduled.sh orchestrates helpers"
@@ -538,6 +540,10 @@ VIBEGUARD_LOG_DIR="$log_dir" VIBEGUARD_PROJECT_CONFIG="$cfg" VIBEGUARD_GC_LOG_TH
 assert_cmd "failed scheduled GC records an attempt" test -f "${log_dir}/gc-last-attempt"
 assert_contains "$(cat "${log_dir}/gc-last-success")" "123" "failed scheduled GC does not update last-success"
 assert_contains "$(cat "${log_dir}/gc-cron.log")" "GC completed with errors" "failed scheduled GC is visible in cron log"
+
+header "learn adoption and trajectory regressions"
+assert_cmd "learn adoption regression suite passes" bash tests/test_learn_adoption.sh
+assert_cmd "learn trajectory regression suite passes" bash tests/test_learn_trajectory.sh
 
 printf '\n==============================\n'
 printf 'Total: %s  Pass: \033[32m%s\033[0m  Fail: \033[31m%s\033[0m\n' "$TOTAL" "$PASS" "$FAIL"

--- a/tests/test_learn_adoption.sh
+++ b/tests/test_learn_adoption.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# VibeGuard Learn adoption compiler and verification tests.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+PASS=0
+FAIL=0
+TOTAL=0
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fails() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    red "$desc (expected failure)"; FAIL=$((FAIL + 1))
+  else
+    green "$desc"; PASS=$((PASS + 1))
+  fi
+}
+
+state_file="${TMP_DIR}/learn-state.jsonl"
+adoptions_file="${TMP_DIR}/learn-adoptions.jsonl"
+
+header "learn adoption compiler"
+assert_cmd "learn adoption helper compiles" python3 -m py_compile scripts/learn/adoption.py
+
+runtime_signal="${TMP_DIR}/runtime-signal.json"
+cat > "$runtime_signal" <<'JSON'
+{
+  "schema_version": 1,
+  "signal_id": "lrn_runtime_001",
+  "observation_id": "obs_runtime_001",
+  "classification": "runtime_health",
+  "type": "metrics_truncation",
+  "evidence_samples": [{"summary": "learn metrics input was truncated"}],
+  "recommended_actions": [
+    {"type": "fix_runtime", "rationale": "runtime pipeline issue", "target": "hooks/learn-evaluator.sh"},
+    {"type": "add_rule", "rationale": "wrong action"}
+  ]
+}
+JSON
+
+runtime_out="${TMP_DIR}/runtime-adopt.json"
+_VIBEGUARD_TEST_NOW="2026-06-25T00:00:00Z" python3 scripts/learn/adoption.py \
+  --state-file "$state_file" \
+  --adoptions-file "$adoptions_file" \
+  adopt \
+  --signal "$runtime_signal" \
+  --action fix_runtime \
+  --artifact hooks/learn-evaluator.sh \
+  --verification-command "bash tests/test_gc_scheduled.sh" \
+  --regression-command "bash tests/test_gc_scheduled.sh" \
+  --baseline "18 truncated sessions" \
+  --expected-observation "truncation recurrence falls in next window" \
+  --rollback "revert runtime pipeline change" \
+  --reason "adopt runtime fix" > "$runtime_out"
+
+assert_cmd "runtime-health adoption records full verification bundle" python3 - "$runtime_out" "$adoptions_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = [json.loads(line) for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()]
+record = records[-1]
+assert payload["mode"] == "adopt", payload
+assert payload["action"]["type"] == "fix_runtime", payload
+assert payload["verification"]["status"] == "pending", payload
+assert record["verification_commands"] == ["bash tests/test_gc_scheduled.sh"], record
+assert record["regression_checks"] == ["bash tests/test_gc_scheduled.sh"], record
+assert record["baseline"] == "18 truncated sessions", record
+assert record["expected_later_observation"], record
+assert record["rollback_path"], record
+assert record["state_transition"]["to"] == "adopted", record
+PY
+
+assert_fails "runtime-health cannot adopt guard/rule action" python3 scripts/learn/adoption.py \
+  --state-file "$state_file" \
+  --adoptions-file "$adoptions_file" \
+  adopt \
+  --signal "$runtime_signal" \
+  --action add_rule \
+  --verification-command "bash tests/test_gc_scheduled.sh" \
+  --regression-command "bash tests/test_gc_scheduled.sh" \
+  --baseline "baseline" \
+  --expected-observation "later" \
+  --rollback "rollback" \
+  --reason "bad action"
+
+friction_signal="${TMP_DIR}/friction-signal.json"
+cat > "$friction_signal" <<'JSON'
+{
+  "schema_version": 1,
+  "signal_id": "lrn_friction_001",
+  "observation_id": "obs_friction_001",
+  "classification": "defense_friction",
+  "type": "repeated_warn",
+  "evidence_samples": [{"summary": "docs examples repeatedly trigger RS-03"}],
+  "recommended_actions": [
+    {"type": "add_scoped_suppression", "rationale": "known false positive", "target": ".vibeguard.json"}
+  ]
+}
+JSON
+
+friction_out="${TMP_DIR}/friction-adopt.json"
+_VIBEGUARD_TEST_NOW="2026-06-25T00:00:00Z" python3 scripts/learn/adoption.py \
+  --state-file "$state_file" \
+  --adoptions-file "$adoptions_file" \
+  adopt \
+  --signal "$friction_signal" \
+  --action add_scoped_suppression \
+  --artifact .vibeguard.json \
+  --verification-command "cargo test --manifest-path vibeguard-runtime/Cargo.toml scoped_suppression" \
+  --regression-command "bash tests/hooks/test_post_edit_suppression.sh" \
+  --baseline "docs examples trigger RS-03" \
+  --expected-observation "same docs examples no longer warn while nonmatching paths still warn" \
+  --rollback "remove scoped_suppressions entry" \
+  --reason "adopt scoped suppression" > "$friction_out"
+
+assert_cmd "defense-friction adoption uses scoped_suppressions governance" python3 - "$friction_out" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+governance = payload["adoption"]["governance"]
+assert governance["config_key"] == "scoped_suppressions", governance
+assert governance["artifact"] == ".vibeguard.json", governance
+PY
+
+noise_signal="${TMP_DIR}/noise-signal.json"
+cat > "$noise_signal" <<'JSON'
+{
+  "schema_version": 1,
+  "signal_id": "lrn_noise_001",
+  "observation_id": "obs_noise_001",
+  "classification": "noise",
+  "type": "edit_path",
+  "evidence_samples": [{"summary": "external temp path"}],
+  "recommended_actions": [
+    {"type": "no_action", "rationale": "external path is not project evidence"}
+  ]
+}
+JSON
+
+noise_out="${TMP_DIR}/noise-adopt.json"
+_VIBEGUARD_TEST_NOW="2026-06-25T00:00:00Z" python3 scripts/learn/adoption.py \
+  --state-file "$state_file" \
+  --adoptions-file "$adoptions_file" \
+  adopt \
+  --signal "$noise_signal" \
+  --action no_action \
+  --verification-command "python3 scripts/learn/analyze.py --scope current --dry-run --no-code-scan" \
+  --regression-command "python3 scripts/learn/analyze.py --scope current --dry-run --no-code-scan" \
+  --baseline "external temp path diagnostic" \
+  --expected-observation "external path remains diagnostic noise only" \
+  --rollback "none" \
+  --reason "ignore noise" > "$noise_out"
+
+assert_cmd "noise no-action transition is skipped not adopted" python3 - "$noise_out" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["action"]["type"] == "no_action", payload
+assert payload["state_transition"]["to"] == "skipped", payload
+PY
+
+fresh_evidence="${TMP_DIR}/fresh-evidence.json"
+cat > "$fresh_evidence" <<'JSON'
+{
+  "signal_id": "lrn_runtime_001",
+  "observed_at": "2026-06-26T00:00:00Z",
+  "recurrence_delta": -12,
+  "regression_signals": []
+}
+JSON
+verify_out="${TMP_DIR}/verify.json"
+_VIBEGUARD_TEST_NOW="2026-06-26T00:00:01Z" python3 scripts/learn/adoption.py \
+  --state-file "$state_file" \
+  --adoptions-file "$adoptions_file" \
+  verify \
+  --signal-id lrn_runtime_001 \
+  --evidence "$fresh_evidence" \
+  --reason "fresh window improved" > "$verify_out"
+
+assert_cmd "fresh evidence can verify an adopted signal" python3 - "$verify_out" "$state_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+states = [json.loads(line) for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()]
+assert payload["verification"]["status"] == "verified", payload
+assert payload["verification"]["evidence_observed_at"] == "2026-06-26T00:00:00Z", payload
+assert states[-1]["to"] == "verified", states[-1]
+PY
+
+stale_evidence="${TMP_DIR}/stale-evidence.json"
+cat > "$stale_evidence" <<'JSON'
+{
+  "signal_id": "lrn_runtime_001",
+  "observed_at": "2026-06-24T00:00:00Z",
+  "recurrence_delta": -12,
+  "regression_signals": []
+}
+JSON
+assert_fails "verification rejects stale pre-adoption evidence" python3 scripts/learn/adoption.py \
+  --state-file "$state_file" \
+  --adoptions-file "$adoptions_file" \
+  verify \
+  --signal-id lrn_runtime_001 \
+  --evidence "$stale_evidence" \
+  --reason "stale"
+
+printf "\n==============================\n"
+printf "Total: %d  Pass: %d  Fail: %d\n" "$TOTAL" "$PASS" "$FAIL"
+printf "==============================\n"
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi

--- a/tests/test_learn_trajectory.sh
+++ b/tests/test_learn_trajectory.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# VibeGuard Learn W-37 success/failure trajectory tests.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+PASS=0
+FAIL=0
+TOTAL=0
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fails() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    red "$desc (expected failure)"; FAIL=$((FAIL + 1))
+  else
+    green "$desc"; PASS=$((PASS + 1))
+  fi
+}
+
+store="${TMP_DIR}/learn-trajectories.jsonl"
+
+header "learn W-37 trajectories"
+assert_cmd "learn trajectory helper compiles" python3 -m py_compile scripts/learn/trajectory.py
+
+assert_fails "successful trajectory requires explicit low-friction flag" python3 scripts/learn/trajectory.py \
+  --store "$store" \
+  record \
+  --task-class rust-hook-fix \
+  --outcome success \
+  --evidence "passed in one local verification"
+
+python3 scripts/learn/trajectory.py \
+  --store "$store" \
+  record \
+  --task-class rust-hook-fix \
+  --outcome failure \
+  --evidence "previous attempt missed failing setup test" \
+  --failure-lesson "run tests/test_setup.sh after hook state changes" \
+  --signal-id lrn_failure_001 \
+  --verification-command "bash tests/test_setup.sh" >/dev/null
+
+python3 scripts/learn/trajectory.py \
+  --store "$store" \
+  record \
+  --task-class rust-hook-fix \
+  --outcome success \
+  --low-friction \
+  --evidence "later attempt passed focused hook test and setup test without churn" \
+  --verification-command "bash tests/hooks/test_post_edit_guard_basic.sh" \
+  --verification-command "bash tests/test_setup.sh" >/dev/null
+
+preview="${TMP_DIR}/trajectory-preview.json"
+python3 scripts/learn/trajectory.py \
+  --store "$store" \
+  preview \
+  --task-class rust-hook-fix > "$preview"
+
+assert_cmd "trajectory preview shows success and failure evidence together" python3 - "$preview" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert data["combined_evidence_available"] is True, data
+assert len(data["success_trajectories"]) == 1, data
+assert len(data["failure_trajectories"]) == 1, data
+success = data["success_trajectories"][0]
+failure = data["failure_trajectories"][0]
+assert success["outcome_flags"]["success"] is True, success
+assert success["outcome_flags"]["low_friction"] is True, success
+assert failure["outcome_flags"]["failure"] is True, failure
+assert failure["failure_lesson"], failure
+PY
+
+assert_fails "success-only retrieval is rejected when failure lessons exist" python3 scripts/learn/trajectory.py \
+  --store "$store" \
+  preview \
+  --task-class rust-hook-fix \
+  --success-only
+
+assert_cmd "success record does not overwrite failure record" bash -c "test \"\$(wc -l < '$store' | tr -d ' ')\" = 2"
+
+printf "\n==============================\n"
+printf "Total: %d  Pass: %d  Fail: %d\n" "$TOTAL" "$PASS" "$FAIL"
+printf "==============================\n"
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -441,7 +441,28 @@ spec.loader.exec_module(module)
 schema = json.loads((repo / "schemas/command-learn-output.schema.json").read_text(encoding="utf-8"))
 signal_id = "lrn_a31f7c9d"
 action = {"type": "fix_runtime", "rationale": "runtime pipeline issue"}
-verification = {"status": "passed", "commands": ["bash tests/test_gc_scheduled.sh"], "notes": None}
+verification = {
+    "status": "passed",
+    "commands": ["bash tests/test_gc_scheduled.sh"],
+    "notes": None,
+    "evidence_observed_at": "2026-06-26T00:00:00Z",
+}
+adoption = {
+    "schema_version": 1,
+    "ts": "2026-06-25T00:00:00Z",
+    "signal_id": signal_id,
+    "observation_id": "obs_2026w26_77bc",
+    "classification": "runtime_health",
+    "selected_action": action,
+    "files_or_artifacts": ["hooks/learn-evaluator.sh"],
+    "original_evidence": [{"summary": "metrics input truncated"}],
+    "verification_commands": ["bash tests/test_gc_scheduled.sh"],
+    "regression_checks": ["bash tests/test_gc_scheduled.sh"],
+    "baseline": "18 truncated sessions",
+    "expected_later_observation": "truncation recurrence falls",
+    "rollback_path": "revert runtime pipeline change",
+    "state_transition": {"from": "new", "to": "adopted", "reason": "fix runtime"},
+}
 payloads = [
     {
         "command": "learn",
@@ -468,6 +489,7 @@ payloads = [
         "action": action,
         "state_transition": {"from": "new", "to": "adopted", "reason": "fix runtime"},
         "verification": verification,
+        "adoption": adoption,
     },
     {"command": "learn", "mode": "verify", "schema_version": 1, "signal_id": signal_id, "verification": verification},
     {


### PR DESCRIPTION
## Summary

Replacement for #535 after #534 merged and its stacked base branch was deleted.

- Supersedes #535
- Closes #530
- Closes #531
- Part of #526

Adds deterministic Learn adoption and W-37 trajectory helpers:

- `scripts/learn/adoption.py` materializes an adopted signal into an append-only adoption record with selected action, artifacts, original evidence, verification commands, regression checks, baseline, expected later observation, rollback path, and triage transition.
- `scripts/learn/adoption.py verify` requires fresh evidence newer than the adoption record before marking a signal `verified` or `regressed`.
- `scripts/learn/trajectory.py` records successful low-friction and failed trajectories separately, previews both for the same task class, and rejects success-only retrieval when failure lessons exist.
- Updates `/vibeguard:learn` schema/docs/tests for the adoption record and evidence timestamp.

## Verification

Passed locally on the replacement branch:

- `python3 -m py_compile scripts/learn/adoption.py scripts/learn/trajectory.py scripts/learn/analyze.py scripts/gc/learn_digest.py`
- `bash tests/test_learn_adoption.sh` — 7/7
- `bash tests/test_learn_trajectory.sh` — 5/5
- `bash tests/test_workflow_contracts.sh` — 21/21

Earlier full local and CI validation on #535 also passed:

- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-no-personal-paths.sh`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash tests/hooks/test_skills_loader.sh` — 13/13
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`
- GitHub CI for #535: Ubuntu, macOS, Windows, Self-Application CI, Benchmark Report all passed.
