### PR TITLE
docs: add v1.1.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.8] - 2026-06-27
+
+### Added
+- First-class Learn signal inbox support: current-project preview, signal schema/classification, triage state, adoption materialization, verification, and success/failure trajectory capture.
+- Quickstart, team rollout, and troubleshooting docs now give users a clear install-to-proof path with `doctor`, `verify-install`, Codex diagnosis, safe demo, and hook-health checks.
+- False-positive governance now includes a reporting workflow, known-issues documentation, scoped suppression handling, and runtime tests for redaction and matching edge cases.
+- Runtime release publishing now generates and attests a checked `vibeguard-runtime-releases.json` manifest alongside binaries, dependency metadata, and `SHA256SUMS`.
+
+### Fixed
+- Codex pre-edit internal-error handling, stale scheduler target detection, hook-status bounded log reads, post-write duplicate scanning, and post-edit history queries.
+- Scoped suppression matching now handles Codex patch payloads, native hook output, aggregate suppression edge cases, tokenized event ids, and prefixed secret redaction without silently widening matches.
+- Mutable benchmark and triage outputs moved out of tracked `data/` artifacts, keeping tracked data to seed/example files.
+
+### Changed
+- `vibeguard-runtime` is now `1.1.8`.
+- `/vibeguard:learn` is documented as a product-facing signal review loop rather than only a background GC digest.
+- Plan and spec docs now clarify repo-local skill policy, issue-first planning boundaries, and the Learn implementation sequence.
+
 ## [1.1.4] - 2026-06-08
 
 ### Added
@@ -264,7 +282,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `auto-optimize` workflow integrated into VibeGuard
 - `setup.sh` and install scripts for one-command installation
 
-[Unreleased]: https://github.com/majiayu000/vibeguard/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/majiayu000/vibeguard/compare/v1.1.8...HEAD
+[1.1.8]: https://github.com/majiayu000/vibeguard/compare/v1.1.7...v1.1.8
 [1.1.4]: https://github.com/majiayu000/vibeguard/compare/v1.1.2...v1.1.4
 [1.1.3]: https://github.com/majiayu000/vibeguard/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/majiayu000/vibeguard/compare/v1.1.1...v1.1.2

--- a/docs/specs/install-friction-reduction.md
+++ b/docs/specs/install-friction-reduction.md
@@ -59,8 +59,10 @@ Add `.github/workflows/release.yml`, triggered on tag push `v*`:
   | `aarch64-unknown-linux-musl` | `ubuntu-latest` | via `cross` or musl toolchain, static |
 - Each job: `cargo build --release --target <t>`, rename output to
   `vibeguard-runtime-<target>`, compute SHA-256.
-- A final job uploads all binaries + a single `SHA256SUMS` file to the GitHub Release
-  for that tag (`gh release upload` or `softprops/action-gh-release`).
+- A final job uploads all binaries, `SHA256SUMS`,
+  `vibeguard-runtime-releases.json`, and
+  `vibeguard-runtime-dependency-metadata.json` to the GitHub Release for that
+  tag.
 - Reuse the existing toolchain/style from `.github/workflows/ci.yml`; pin Rust to a
   stable version that supports `edition = "2024"` (≥ 1.85).
 
@@ -135,7 +137,8 @@ true `curl | sh` one-liner. Tracked as a follow-up; large and out of scope here.
   and succeeds.
 - AC5: Default install adds **no** launchd/systemd entry; `--with-scheduler` adds it;
   `--clean` removes it.
-- AC6: A tag push publishes 4 platform binaries + `SHA256SUMS` to the Release.
+- AC6: A tag push publishes 4 platform binaries, `SHA256SUMS`, checked runtime
+  release metadata, and locked dependency metadata to the Release.
 - AC7: README install section reflects the no-Rust default path and the prerequisites
   matrix.
 - AC8: A release tag whose `vibeguard-runtime/VERSION` does not match the tag fails


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md` notes for `v1.1.8`
- update the `Unreleased` compare link to start after `v1.1.8`
- align `docs/specs/install-friction-reduction.md` with current release assets: binaries, `SHA256SUMS`, checked runtime release metadata, and locked dependency metadata
- keep the change release-documentation only, no runtime code changes

## Verification
- `bash tests/test_release_workflow.sh` (70 pass, 0 fail)
- `bash scripts/ci/validate-doc-paths.sh` (71 files validated)
- `bash scripts/ci/validate-doc-command-paths.sh` (122 shell command path references validated)
- `git diff --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`

## Release context
`origin/main` already pins `vibeguard-runtime` to `1.1.8`; GitHub latest release is still `v1.1.7`, and `v1.1.8` does not exist yet. This PR closes the release-note/spec gap before tagging `v1.1.8`.
