### PR TITLE
docs: link the Agent Infra Stack across sibling repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,25 @@ Key lessons:
 | [docs/assets/README.md](docs/assets/README.md) | Demo recording script and assets |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor workflow, validation commands, and commit protocol |
 
+## The Agent Infra Stack
+
+This project is one layer of an open-source stack for running coding agents (Claude Code, Codex) as serious infrastructure. Every piece works standalone; together they close the loop:
+
+`vibeguard` is the **Trust** layer at runtime — rules, hooks, and guards while the agent works. Its install-time counterpart is `argus`.
+
+| Layer | Project | What it does |
+|---|---|---|
+| Extend | [claude-skill-registry](https://github.com/majiayu000/claude-skill-registry) | Discover and search community Claude Code skills |
+| Extend | [spellbook](https://github.com/majiayu000/spellbook) | Cross-runtime skills for Claude Code, Codex, and multi-agent workflows |
+| Trust | [argus](https://github.com/majiayu000/argus) | Static install-time scanner for supply-chain attacks (npm / PyPI / crates.io) |
+| Trust | [vibeguard](https://github.com/majiayu000/vibeguard) **◀ you are here** | Rules, hooks, and guards against hallucinated or unverified agent changes |
+| Remember | [remem](https://github.com/majiayu000/remem) | Local-first persistent memory for Claude Code and Codex sessions |
+| Orchestrate | [harness](https://github.com/majiayu000/harness) | Rust agent orchestration platform — rules, skills, GC, observability |
+| Route | [litellm-rs](https://github.com/majiayu000/litellm-rs) | High-performance Rust AI gateway — 100+ LLM APIs via OpenAI format |
+| Keep | [keepline](https://github.com/majiayu000/keepline) | Session command center — monitor, recover, never lose agent work |
+
+---
+
 ## References
 
 - [OpenAI Harness Engineering](https://openai.com/index/harness-engineering/)


### PR DESCRIPTION
Adds a shared **Agent Infra Stack** section cross-linking the 8 sibling repos (extend → trust → remember → orchestrate → route → keep). README-only.