### PR TITLE
fix(hook): fail closed on Claude policy errors

### DIFF
--- a/docs/specs/GH539/product.md
+++ b/docs/specs/GH539/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-539
+
+## User Problem
+
+Under Claude Code, when the VibeGuard runtime is missing/unsupported (`policy_error`) or `~/.vibeguard/config.json` is malformed (`config_parse_error`), the Claude hook wrapper `hooks/run-hook.sh:71-75` prints a reason to stderr and `exit 1` — it emits no `{"decision":"block"}` and no `exit 2`. Per the Claude Code hook contract, that is a non-blocking error, so the guarded tool call proceeds. Every other guard path fails closed. The Codex wrapper fails closed for the same condition. This means a whole class of failures silently disables all Claude-side guards, and an agent can trigger it deliberately by writing a malformed config file (which no guard blocks).
+
+## Goals
+
+- Make Claude-side policy/runtime/config failures fail **closed** for enforcing PreToolUse/PermissionRequest events, matching the Codex wrapper.
+- Keep the failure reason visible to the user (do not silently block with no explanation).
+- Eliminate the silent divergence between the Claude and Codex wrappers for the same error classes.
+
+## Non-Goals
+
+- Changing PostToolUse/Stop hook behavior (those are advisory and must not block — see GH-related stop-hook work).
+- Redesigning the policy/config parsing itself.
+- Hardening the config file against agent writes (tracked separately; defense-in-depth, not this fix).
+
+## Behavior Invariants
+
+1. When `hooks/run-hook.sh` receives `policy_status` 20 (policy_error) or 30 (config_parse_error) for an enforcing PreToolUse/PermissionRequest event, the wrapper produces a blocking decision (`{"decision":"block"}` + `exit 0`, or `exit 2`) rather than `exit 1`.
+2. The blocking decision carries a human-readable reason (the existing `VG_POLICY_REASON`) so the user can see why the tool call was denied.
+3. The Claude and Codex wrappers produce semantically equivalent outcomes (block/deny) for the same `policy_status` error class.
+4. Non-enforcing events (Stop, SessionStart, advisory PostToolUse) continue to exit 0 and never block, even on the same error class.
+5. A malformed `~/.vibeguard/config.json` results in a visible block, not a silent allow, on the next enforcing Claude event.
+
+## Acceptance Criteria
+
+- [ ] `tests/hooks/test_runtime_policy.sh` asserts the Claude PreToolUse path emits a block decision (not a bare non-zero exit) on `policy_error` and `config_parse_error`.
+- [ ] A test corrupts `~/.vibeguard/config.json` and verifies the next enforcing Claude event is blocked with a visible reason.
+- [ ] Stop/SessionStart hooks still exit 0 under the same failure condition (no regression to the loop-safety invariant).
+- [ ] Behavior documented so any intentional fail-open is explicit, not implicit.
+
+## Edge Cases
+
+- Runtime binary present but wrong version / unsupported subcommand → policy_error path.
+- Config file empty vs partially written vs valid-JSON-but-wrong-schema.
+- Warn-mode events (should remain non-blocking) vs block-mode events.
+- Concurrent sessions all hitting the corrupted config simultaneously.
+
+## Rollout Notes
+
+This flips a currently-permissive failure mode to restrictive. After the change, a genuine config typo hard-blocks all enforcing tools until fixed — that is the intended fail-closed behavior, but the error message must be actionable (point the user at the offending file and how to reset it). Consider a one-line note in the changelog/README so users understand why a broken config now blocks.

--- a/docs/specs/GH539/tasks.md
+++ b/docs/specs/GH539/tasks.md
@@ -1,0 +1,31 @@
+# Task Plan
+
+## Linked Issue
+
+GH-539
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP539-T1` Owner: agent — Extract a shared block-emit/reason helper in `hooks/_lib/policy.sh` used by both wrappers. Done when: a single function formats the policy block reason and both `run-hook.sh` and `run-hook-codex.sh` call it. Verify: `bash -n hooks/_lib/policy.sh` and existing policy tests still pass.
+- [ ] `SP539-T2` Owner: agent — In `hooks/run-hook.sh`, replace the `exit 1` at :71-75 with an event-class branch: enforcing PreToolUse/PermissionRequest emits a block decision + exit 0; non-enforcing events keep exit 0 without blocking. Done when: policy_error/config_parse_error produce a block for enforcing events only. Verify: `tests/hooks/test_runtime_policy.sh` passes with updated assertions.
+- [ ] `SP539-T3` Owner: agent — Update `tests/hooks/test_runtime_policy.sh` to assert Claude fail-closed (block decision, visible reason) and add a corrupt-config end-to-end case. Done when: tests assert block+reason, not bare non-zero. Verify: `bash tests/hooks/test_runtime_policy.sh`.
+- [ ] `SP539-T4` Owner: agent — Add a Stop-hook regression asserting exit 0 under missing-runtime/broken-config. Done when: Stop path proven non-blocking under the failure. Verify: run the Stop regression test green.
+- [ ] `SP539-T5` Owner: human — Security review of the fail-closed change (SEC-11 guard-enforcement path) and confirm the error message is actionable. Done when: reviewer approves. Verify: PR review approval recorded.
+
+## Parallelization
+
+T1 must land before T2 (T2 consumes the helper). T3 and T4 (tests) can be written in parallel with T2 but share `tests/hooks/` — single owner to avoid write conflicts. T5 gates merge.
+
+## Verification
+
+- Run `bash tests/hooks/test_runtime_policy.sh`; green with fail-closed assertions.
+- Manual: corrupt config, then an enforcing Edit is blocked visibly; Stop still exits 0.
+
+## Handoff Notes
+
+The core insight: `exit 1` is non-blocking under Claude's PreToolUse contract, so it must become a decision-JSON block. Do not apply the block to Stop/SessionStart — that reintroduces the infinite-loop hazard `stop-guard.sh` documents (issues #3573/#10205). Mirror the Codex path exactly; the shared helper is what prevents future drift.

--- a/docs/specs/GH539/tech.md
+++ b/docs/specs/GH539/tech.md
@@ -1,0 +1,64 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-539
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Claude wrapper | `hooks/run-hook.sh:71-75` | `policy_error`/`config_parse_error` → stderr + `exit 1` (non-blocking) | The defect site |
+| Codex wrapper | `hooks/run-hook-codex.sh`, `hooks/_lib/policy.sh` (`vg_policy_codex_gate`, `vg_policy_codex_error_output`) | Same error class → `permissionDecision:deny` | The fail-closed reference to mirror |
+| Enforcement contract | `docs/internal/benchmarks/benchmark-design.md:63,394` | "exit 2 = Block"; block guaranteed only via exit 2 / decision JSON | Defines what "blocking" means |
+| Tests | `tests/hooks/test_runtime_policy.sh:307-334` | Asserts Claude "exits non-zero, no deny JSON"; Codex emits deny | Must be updated to assert fail-closed |
+| Event classing | `hooks/run-hook.sh` (wrapper), `hooks/stop-guard.sh`, `hooks/log.sh` | Stop/SessionStart must never block | Must exclude non-enforcing events from the new block path |
+
+## Proposed Design
+
+In `hooks/run-hook.sh`, on `policy_status` 20/30, branch on event class:
+
+- Enforcing PreToolUse / PermissionRequest → emit the same blocking output the guards use (`printf '{"decision":"block","reason":"..."}'` to stdout + `exit 0`, or `exit 2`), reusing `VG_POLICY_REASON`. Prefer reusing the existing helper that guards call so the JSON shape stays consistent.
+- Non-enforcing events (Stop, SessionStart, advisory PostToolUse) → keep current visible-but-allow (`exit 0`), never block.
+
+Factor the block-emit into a shared `_lib/policy.sh` helper if one does not already exist, so the Claude and Codex wrappers call the same reason-formatting logic and cannot drift again.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 block on policy/config error | `run-hook.sh` policy branch | `test_runtime_policy.sh` asserts block decision, not bare exit 1 |
+| P2 visible reason | reuse `VG_POLICY_REASON` | test asserts reason string present in output |
+| P3 Claude/Codex parity | shared `_lib/policy.sh` helper | differential test comparing both wrappers on same input |
+| P4 Stop never blocks | event-class guard in wrapper | test fires Stop with broken runtime, asserts exit 0 |
+| P5 corrupt config blocks | end-to-end | test writes `{` to config, asserts next enforcing event blocked |
+
+## Data Flow
+
+stdin tool event → `run-hook.sh` resolves policy via runtime → `policy_status` → (new) event-class branch → block decision JSON on stdout / exit code. Reads `~/.vibeguard/config.json` (via runtime). No new persistence.
+
+## Alternatives Considered
+
+- Keep fail-open on Claude and document it: rejected — contradicts the product's core promise and the Codex path.
+- `exit 2` instead of decision JSON: acceptable, but decision JSON carries a user-visible reason and matches how every other guard blocks; prefer decision JSON for PreToolUse.
+
+## Risks
+
+- Security: positive — closes a global bypass.
+- Compatibility: a broken config now blocks all enforcing tools until fixed; mitigate with an actionable error message.
+- Performance: negligible (same code path, different terminal output).
+- Maintenance: reduces drift by sharing the reason-formatting helper across wrappers.
+
+## Test Plan
+
+- [ ] Unit tests: `test_runtime_policy.sh` updated for Claude fail-closed on policy_error + config_parse_error.
+- [ ] Integration tests: corrupt-config end-to-end block; Stop-hook exit-0-under-failure regression.
+- [ ] Manual verification: `echo '{' > ~/.vibeguard/config.json`, run an Edit, confirm visible block; restore config, confirm normal operation.
+
+## Rollback Plan
+
+Revert the `run-hook.sh` policy branch to the prior `exit 1`. Change is confined to the wrapper plus test assertions; no data migration.

--- a/docs/specs/GH539/tech.md
+++ b/docs/specs/GH539/tech.md
@@ -25,7 +25,7 @@ In `hooks/run-hook.sh`, on `policy_status` 20/30, branch on event class:
 - Enforcing PreToolUse / PermissionRequest → emit the same blocking output the guards use (`printf '{"decision":"block","reason":"..."}'` to stdout + `exit 0`, or `exit 2`), reusing `VG_POLICY_REASON`. Prefer reusing the existing helper that guards call so the JSON shape stays consistent.
 - Non-enforcing events (Stop, SessionStart, advisory PostToolUse) → keep current visible-but-allow (`exit 0`), never block.
 
-Factor the block-emit into a shared `_lib/policy.sh` helper if one does not already exist, so the Claude and Codex wrappers call the same reason-formatting logic and cannot drift again.
+Factor the block-emit into a shared `hooks/_lib/policy.sh` helper if one does not already exist, so the Claude and Codex wrappers call the same reason-formatting logic and cannot drift again.
 
 ## Product-to-Test Mapping
 
@@ -33,7 +33,7 @@ Factor the block-emit into a shared `_lib/policy.sh` helper if one does not alre
 | --- | --- | --- |
 | P1 block on policy/config error | `run-hook.sh` policy branch | `test_runtime_policy.sh` asserts block decision, not bare exit 1 |
 | P2 visible reason | reuse `VG_POLICY_REASON` | test asserts reason string present in output |
-| P3 Claude/Codex parity | shared `_lib/policy.sh` helper | differential test comparing both wrappers on same input |
+| P3 Claude/Codex parity | shared `hooks/_lib/policy.sh` helper | differential test comparing both wrappers on same input |
 | P4 Stop never blocks | event-class guard in wrapper | test fires Stop with broken runtime, asserts exit 0 |
 | P5 corrupt config blocks | end-to-end | test writes `{` to config, asserts next enforcing event blocked |
 

--- a/hooks/_lib/policy.sh
+++ b/hooks/_lib/policy.sh
@@ -111,6 +111,68 @@ vg_policy_json_field() {
   fi
 }
 
+vg_policy_json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '%s' "${value}"
+}
+
+vg_policy_claude_event_name() {
+  local hook_name="$1" payload_ref="${2:-}" runtime_path="${VG_POLICY_RUNTIME_PATH:-}" event_name=""
+  if [[ -n "${payload_ref}" && -n "${runtime_path}" ]]; then
+    if [[ -f "${payload_ref}" ]]; then
+      event_name="$("${runtime_path}" json-field hook_event_name < "${payload_ref}" 2>/dev/null || true)"
+    else
+      event_name="$(printf '%s' "${payload_ref}" | "${runtime_path}" json-field hook_event_name 2>/dev/null || true)"
+    fi
+    if [[ -n "${event_name}" && "${event_name}" != "null" && "${event_name}" != \{* && "${event_name}" != \[* ]]; then
+      printf '%s\n' "${event_name}"
+      return 0
+    fi
+  fi
+
+  case "${hook_name}" in
+    pre-*|vibeguard-pre-*)
+      printf '%s\n' "PreToolUse"
+      ;;
+    post-*|vibeguard-post-*|analysis-paralysis-guard.sh)
+      printf '%s\n' "PostToolUse"
+      ;;
+    stop-guard.sh|vibeguard-stop-guard.sh|learn-evaluator.sh|vibeguard-learn-evaluator.sh)
+      printf '%s\n' "Stop"
+      ;;
+    count_active_constraints.sh|skills-loader.sh)
+      printf '%s\n' "SessionStart"
+      ;;
+    *)
+      printf '%s\n' "unknown"
+      ;;
+  esac
+}
+
+vg_policy_claude_event_enforces() {
+  case "${1:-}" in
+    PreToolUse|PermissionRequest) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+vg_policy_error_reason() {
+  local reason="${1:-}"
+  printf '%s' "${reason:-VibeGuard policy error: runtime policy check failed.}"
+}
+
+vg_policy_claude_error_output() {
+  local reason escaped_reason
+  reason="$(vg_policy_error_reason "${1:-}")"
+  escaped_reason="$(vg_policy_json_escape "${reason}")"
+  printf '{"decision":"block","reason":"%s"}\n' "${escaped_reason}"
+}
+
 vg_policy_payload_cwd() {
   local payload_ref="$1" runtime_path="$2" field value
   [[ -n "${payload_ref}" ]] || return 1
@@ -310,7 +372,8 @@ vg_policy_diag() {
 }
 
 vg_policy_codex_error_output() {
-  local event_name="$1" reason="$2" runtime_path
+  local event_name="$1" reason runtime_path
+  reason="$(vg_policy_error_reason "${2:-}")"
   runtime_path="${VG_POLICY_RUNTIME_PATH:-}"
   if [[ -z "${runtime_path}" ]] && ! runtime_path="$(vg_policy_runtime_path)"; then
     vg_policy_codex_error_fallback "${event_name}"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -107,9 +107,14 @@ if [[ ${policy_status} -eq 10 ]]; then
   vg_policy_diag "${HOOK_NAME}" "Claude" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
   exit 0
 elif [[ ${policy_status} -ne 0 ]]; then
-  vg_policy_diag "${HOOK_NAME}" "Claude" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
+  CLAUDE_EVENT_NAME="$(vg_policy_claude_event_name "${HOOK_NAME}" "${_VG_HOOK_STDIN_FILE:-}")"
+  vg_policy_diag "${HOOK_NAME}" "${CLAUDE_EVENT_NAME}" "${VG_POLICY_KIND}" "${VG_POLICY_REASON}"
+  if vg_policy_claude_event_enforces "${CLAUDE_EVENT_NAME}"; then
+    vg_policy_claude_error_output "${VG_POLICY_REASON}"
+    exit 0
+  fi
   printf '%s\n' "${VG_POLICY_REASON}" >&2
-  exit 1
+  exit 0
 fi
 
 # Ensure Python writes UTF-8 regardless of the terminal's default encoding (fixes Windows CP-1252)

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -262,13 +262,14 @@ bad_project_claude_out="$(run_claude_wrapper "${bad_project_home}" "${bad_projec
 bad_project_claude_status=$?
 set -e
 TOTAL=$((TOTAL + 1))
-if [[ "${bad_project_claude_status}" -ne 0 ]]; then
-  green "Claude wrapper fails loudly on invalid .vibeguard.json"
+if [[ "${bad_project_claude_status}" -eq 0 ]]; then
+  green "Claude wrapper exits cleanly after invalid .vibeguard.json block"
   PASS=$((PASS + 1))
 else
-  red "Claude wrapper fails loudly on invalid .vibeguard.json"
+  red "Claude wrapper exits cleanly after invalid .vibeguard.json block"
   FAIL=$((FAIL + 1))
 fi
+assert_contains "${bad_project_claude_out}" '"decision":"block"' "Claude wrapper blocks invalid .vibeguard.json"
 assert_contains "${bad_project_claude_out}" "VibeGuard project config invalid" "Claude wrapper explains invalid .vibeguard.json"
 
 set +e
@@ -289,9 +290,9 @@ assert_contains "${bad_project_codex_out}" "VibeGuard project config invalid" "C
 header "runtime policy — malformed user runtime config"
 bad_user_home="${WORK_DIR}/home-bad-user"
 bad_user_project="${WORK_DIR}/project-bad-user"
-bad_user_config="${WORK_DIR}/bad-config.json"
 make_home "${bad_user_home}"
 make_project "${bad_user_project}" '{}'
+bad_user_config="${bad_user_home}/.vibeguard/config.json"
 printf '{"write_mode":' > "${bad_user_config}"
 
 set +e
@@ -299,27 +300,66 @@ bad_user_claude_out="$(
   cd "${bad_user_project}" && printf '%s' "${pretool_block_input}" \
     | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
       VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
-      VIBEGUARD_CONFIG_FILE="${bad_user_config}" \
       bash "${REPO_DIR}/hooks/run-hook.sh" pre-bash-guard.sh 2>&1
 )"
 bad_user_claude_status=$?
 set -e
 TOTAL=$((TOTAL + 1))
-if [[ "${bad_user_claude_status}" -ne 0 ]]; then
-  green "Claude wrapper fails loudly on malformed runtime config"
+if [[ "${bad_user_claude_status}" -eq 0 ]]; then
+  green "Claude wrapper exits cleanly after malformed runtime config block"
   PASS=$((PASS + 1))
 else
-  red "Claude wrapper fails loudly on malformed runtime config"
+  red "Claude wrapper exits cleanly after malformed runtime config block"
   FAIL=$((FAIL + 1))
 fi
+assert_contains "${bad_user_claude_out}" '"decision":"block"' "Claude wrapper blocks malformed runtime config"
 assert_contains "${bad_user_claude_out}" "VibeGuard runtime config invalid JSON" "Claude wrapper explains malformed runtime config"
+
+set +e
+bad_user_stop_out="$(
+  cd "${bad_user_project}" && printf '{"hook_event_name":"Stop"}' \
+    | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
+      bash "${REPO_DIR}/hooks/run-hook.sh" stop-guard.sh 2>&1
+)"
+bad_user_stop_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${bad_user_stop_status}" -eq 0 ]]; then
+  green "Claude Stop hook exits cleanly on malformed runtime config"
+  PASS=$((PASS + 1))
+else
+  red "Claude Stop hook exits cleanly on malformed runtime config"
+  FAIL=$((FAIL + 1))
+fi
+assert_not_contains "${bad_user_stop_out}" '"decision":"block"' "Claude Stop hook does not block on malformed runtime config"
+assert_contains "${bad_user_stop_out}" "VibeGuard runtime config invalid JSON" "Claude Stop hook keeps malformed runtime config visible"
+
+set +e
+bad_user_session_out="$(
+  cd "${bad_user_project}" && printf '{"hook_event_name":"SessionStart"}' \
+    | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
+      VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
+      bash "${REPO_DIR}/hooks/run-hook.sh" count_active_constraints.sh 2>&1
+)"
+bad_user_session_status=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${bad_user_session_status}" -eq 0 ]]; then
+  green "Claude SessionStart hook exits cleanly on malformed runtime config"
+  PASS=$((PASS + 1))
+else
+  red "Claude SessionStart hook exits cleanly on malformed runtime config"
+  FAIL=$((FAIL + 1))
+fi
+assert_not_contains "${bad_user_session_out}" '"decision":"block"' "Claude SessionStart hook does not block on malformed runtime config"
+assert_contains "${bad_user_session_out}" "VibeGuard runtime config invalid JSON" "Claude SessionStart hook keeps malformed runtime config visible"
 
 set +e
 bad_user_codex_out="$(
   cd "${bad_user_project}" && printf '%s' "${codex_pretool_input}" \
     | HOME="${bad_user_home}" VIBEGUARD_LOG_DIR="${bad_user_home}/.vibeguard" \
       VIBEGUARD_POLICY_RUNTIME="${RUNTIME_BIN}" \
-      VIBEGUARD_CONFIG_FILE="${bad_user_config}" \
       bash "${REPO_DIR}/hooks/run-hook-codex.sh" vibeguard-pre-bash-guard.sh 2>&1
 )"
 bad_user_codex_status=$?


### PR DESCRIPTION
Implements GH539 on top of the spec packet in `docs/specs/GH539/`.

Summary:
- Adds shared policy error reason/block helpers in `hooks/_lib/policy.sh`.
- Makes Claude enforcing policy/config failures emit `{"decision":"block"}` with exit 0 instead of bare `exit 1`.
- Keeps Stop and SessionStart non-blocking under the same policy/config failure.
- Updates runtime policy tests for invalid project config and malformed `~/.vibeguard/config.json`.

Verification:
- `bash -n hooks/_lib/policy.sh && bash -n hooks/run-hook.sh && bash -n tests/hooks/test_runtime_policy.sh`
- `bash tests/hooks/test_runtime_policy.sh` (44/44)
- `bash tests/hooks/test_runtime_policy_json.sh` (8/8)
- `git diff --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`

Human gate:
- SEC-11 human security review required before merge because this changes guard enforcement behavior.

Refs #539