### PR TITLE
feat(precision): capture guard hits for triage

### DIFF
--- a/data/triage.example.jsonl
+++ b/data/triage.example.jsonl
@@ -2,12 +2,15 @@
 # Each line is a JSON object with the following fields:
 #   ts        ISO-8601 timestamp
 #   rule      Rule ID, e.g. "RS-03"
-#   verdict   "tp" | "fp" | "acceptable"
+#   verdict   "unclassified" | "tp" | "fp" | "acceptable"
 #   file      Source file path (optional)
 #   context   Short snippet or note (optional)
 #   session   Session ID from VIBEGUARD_SESSION_ID (optional)
 #
 # Record feedback with:
+#   # guard hooks append unclassified candidates automatically when a rule fires
+#   echo '{"ts":"2026-03-24T10:00:00Z","rule":"RS-03","verdict":"unclassified","decision":"warn","file":"src/main.rs","context":"unwrap()"}' >> data/triage.jsonl
+#   # user classification records the tp/fp/acceptable verdict used for precision
 #   echo '{"ts":"2026-03-24T11:00:00Z","rule":"RS-03","verdict":"fp","context":"signal handler"}' >> data/triage.jsonl
 #
 # Then regenerate scorecard:

--- a/docs/specs/GH540/product.md
+++ b/docs/specs/GH540/product.md
@@ -1,0 +1,46 @@
+# Product Spec
+
+## Linked Issue
+
+GH-540
+
+## User Problem
+
+VibeGuard ships a full guard-precision pipeline — `scripts/precision-tracker.py`, `data/rule-scorecard.json`, `data/triage.jsonl`, and the `guard-precision-tracker` skill — but it has never received data. `triage.jsonl` has zero data rows; every scorecard entry is `samples: 0, precision: null`, last updated 2026-03-24. The rule lifecycle (experimental → warn → error → demoted → disabled) cannot run, so no rule has ever been promoted or demoted on evidence. The product claims to track false positives, but operates blind.
+
+## Goals
+
+- Make guard warn/block decisions produce triage records that flow into `data/triage.jsonl`.
+- Have `rule-scorecard.json` accumulate real TP/FP counts so the lifecycle state machine can run.
+- Give the user a low-friction way to mark a guard hit as false positive vs true positive.
+
+## Non-Goals
+
+- Auto-tuning or auto-disabling rules in this change (lifecycle transitions can remain a follow-up once data exists).
+- Changing guard detection logic itself.
+- Building a UI beyond the existing skill/command surface.
+
+## Behavior Invariants
+
+1. When an enforcing or warn guard fires, a triage-eligible record can be appended to `data/triage.jsonl` with rule ID, timestamp, file/context, and decision.
+2. A user (or `/vibeguard:*` command) can classify a recorded hit as `tp` or `fp`, updating the corresponding `rule-scorecard.json` counters.
+3. `precision-tracker.py` computes precision from accumulated counters and reflects it in the scorecard.
+4. Records are append-only; concurrent sessions do not corrupt `triage.jsonl`.
+5. Capture is off the blocking critical path or asynchronous, so it does not add user-visible latency to the guard decision.
+
+## Acceptance Criteria
+
+- [ ] A guard hit produces a triage record (verified by a test that fires a guard and inspects `triage.jsonl`).
+- [ ] Classifying a record as fp/tp updates `rule-scorecard.json` counters and recomputes precision.
+- [ ] `precision-tracker.py` reports non-null precision for a rule with recorded samples.
+- [ ] Concurrent appends do not interleave/corrupt lines.
+
+## Edge Cases
+
+- Guard fires but the session ends before classification (record stays unclassified — must not count as tp or fp).
+- Same rule fires many times in one session (dedup vs count policy documented).
+- Scorecard schema evolution (old entries with `samples:0` must upgrade cleanly).
+
+## Rollout Notes
+
+Backfill is not required; the scorecard simply starts accumulating from adoption. Document that pre-adoption precision is unmeasured. Once data flows for a few weeks, a follow-up can enable evidence-based lifecycle transitions.

--- a/docs/specs/GH540/product.md
+++ b/docs/specs/GH540/product.md
@@ -6,7 +6,7 @@ GH-540
 
 ## User Problem
 
-VibeGuard ships a full guard-precision pipeline — `scripts/precision-tracker.py`, `data/rule-scorecard.json`, `data/triage.jsonl`, and the `guard-precision-tracker` skill — but it has never received data. `triage.jsonl` has zero data rows; every scorecard entry is `samples: 0, precision: null`, last updated 2026-03-24. The rule lifecycle (experimental → warn → error → demoted → disabled) cannot run, so no rule has ever been promoted or demoted on evidence. The product claims to track false positives, but operates blind.
+VibeGuard ships a full guard-precision pipeline — `scripts/precision-tracker.py`, the tracked seed `data/rule-scorecard.seed.json` (from which the runtime writes the generated, gitignored `rule-scorecard.json`), the tracked `data/triage.example.jsonl` example, and the `guard-precision-tracker` skill — but it has never received data. The runtime triage log has zero data rows; every scorecard entry is `samples: 0, precision: null`, last updated 2026-03-24. The rule lifecycle (experimental → warn → error → demoted → disabled) cannot run, so no rule has ever been promoted or demoted on evidence. The product claims to track false positives, but operates blind.
 
 ## Goals
 

--- a/docs/specs/GH540/tasks.md
+++ b/docs/specs/GH540/tasks.md
@@ -13,7 +13,7 @@ GH-540
 
 - [ ] `SP540-T1` Owner: agent — Add a triage projection at the guard-output path that appends a normalized row (rule ID, ts, context, decision) to `data/triage.jsonl`, reusing `hooks/_lib/log_write.sh` locking and `log_redact.sh` redaction. Done when: a guard warn/block appends one triage row. Verify: fire a guard in a test, assert a new row in `triage.jsonl`.
 - [ ] `SP540-T2` Owner: agent — Add a classification entry point (extend a `/vibeguard:*` command or small script) that lists unclassified rows and records tp/fp. Done when: classifying updates the row and calls into scorecard update. Verify: run classify on a seeded row, assert row marked.
-- [ ] `SP540-T3` Owner: agent — Wire classification into `scripts/precision-tracker.py` so tp/fp counters and precision update in `data/rule-scorecard.json`. Done when: a classified fp increments fp and recomputes precision. Verify: `python3 scripts/precision-tracker.py` shows non-null precision for the rule.
+- [ ] `SP540-T3` Owner: agent — Wire classification into `scripts/precision-tracker.py` so tp/fp counters and precision update in the runtime scorecard generated from `data/rule-scorecard.seed.json`. Done when: a classified fp increments fp and recomputes precision. Verify: `python3 scripts/precision-tracker.py` shows non-null precision for the rule.
 - [ ] `SP540-T4` Owner: agent — Add concurrent-append safety test and scorecard schema upgrade for legacy `samples:0` entries. Done when: parallel appends do not corrupt; old entries upgrade in place. Verify: run the concurrency test green.
 - [ ] `SP540-T5` Owner: human — Confirm redaction covers triage context and that capture stays off the blocking latency path. Done when: reviewer approves. Verify: PR review approval recorded.
 

--- a/docs/specs/GH540/tasks.md
+++ b/docs/specs/GH540/tasks.md
@@ -1,0 +1,31 @@
+# Task Plan
+
+## Linked Issue
+
+GH-540
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP540-T1` Owner: agent — Add a triage projection at the guard-output path that appends a normalized row (rule ID, ts, context, decision) to `data/triage.jsonl`, reusing `hooks/_lib/log_write.sh` locking and `log_redact.sh` redaction. Done when: a guard warn/block appends one triage row. Verify: fire a guard in a test, assert a new row in `triage.jsonl`.
+- [ ] `SP540-T2` Owner: agent — Add a classification entry point (extend a `/vibeguard:*` command or small script) that lists unclassified rows and records tp/fp. Done when: classifying updates the row and calls into scorecard update. Verify: run classify on a seeded row, assert row marked.
+- [ ] `SP540-T3` Owner: agent — Wire classification into `scripts/precision-tracker.py` so tp/fp counters and precision update in `data/rule-scorecard.json`. Done when: a classified fp increments fp and recomputes precision. Verify: `python3 scripts/precision-tracker.py` shows non-null precision for the rule.
+- [ ] `SP540-T4` Owner: agent — Add concurrent-append safety test and scorecard schema upgrade for legacy `samples:0` entries. Done when: parallel appends do not corrupt; old entries upgrade in place. Verify: run the concurrency test green.
+- [ ] `SP540-T5` Owner: human — Confirm redaction covers triage context and that capture stays off the blocking latency path. Done when: reviewer approves. Verify: PR review approval recorded.
+
+## Parallelization
+
+T1 is the foundation; T2 and T3 depend on the row shape from T1. T4 can be written alongside once the shape is fixed. All touch `data/` + `scripts/precision-tracker.py` + hook libs — single owner to keep file ownership disjoint per W-14.
+
+## Verification
+
+- Run `python3 scripts/precision-tracker.py` and confirm a rule with recorded samples reports non-null precision.
+- Manual: fire a known guard, classify the hit as fp, re-run tracker, confirm counters moved.
+
+## Handoff Notes
+
+Do not auto-label fp/tp — precision is only meaningful with human classification. Reuse the existing log locking/redaction rather than inventing a second write path. Lifecycle auto-transitions are intentionally out of scope until real data accumulates.

--- a/docs/specs/GH540/tech.md
+++ b/docs/specs/GH540/tech.md
@@ -1,0 +1,59 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-540
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Precision tracker | `scripts/precision-tracker.py` (613 lines) | Computes precision from scorecard; never fed | Consumer of the data we must produce |
+| Scorecard | `data/rule-scorecard.json` | All entries `samples:0, precision:null`, stale 2026-03-24 | The store to populate |
+| Triage log | `data/triage.jsonl` | Header/comments only, no rows | The capture sink |
+| Skill | `guard-precision-tracker` skill | Documents the workflow, no live wiring | Entry point to align |
+| Guard output | `hooks/*guard*.sh`, `hooks/_lib/log_write.sh` | Emits warn/block + logs events to `events.jsonl` | Natural hook to also emit triage records |
+
+## Proposed Design
+
+Reuse the existing event-log path. Guard hits already write to `events.jsonl` via `vg_log`; add a triage projection: when a guard emits a warn/block with a rule ID, append a normalized triage-candidate line to `data/triage.jsonl` (append-only, same locking discipline as `log_write.sh`). Provide a classification entry point (extend an existing `/vibeguard:*` command or add a small script) that reads unclassified triage rows and lets the user mark tp/fp, updating `rule-scorecard.json` via `precision-tracker.py`. Keep capture asynchronous/append-only so the guard decision latency is unchanged.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 triage record on hit | guard → triage projection | test fires guard, asserts row in triage.jsonl |
+| P2 tp/fp classification | classification command + precision-tracker | test classifies, asserts scorecard counters change |
+| P3 precision computed | `precision-tracker.py` | test asserts non-null precision after samples |
+| P4 append-only safety | reuse `log_write.sh` lock | concurrent-append test, no corruption |
+| P5 no added latency | capture off critical path | timing assertion or code review |
+
+## Data Flow
+
+Guard decision → (new) triage projection appends JSONL row → user/command classifies → `precision-tracker.py` updates `rule-scorecard.json`. Persistence: `data/triage.jsonl` (append-only), `data/rule-scorecard.json` (rewrite). No external calls.
+
+## Alternatives Considered
+
+- Fully automatic fp inference: rejected — fp/tp is a human judgment; auto-labeling would poison precision.
+- Separate new log file instead of reusing `log_write.sh` discipline: rejected — duplicates locking/redaction logic.
+
+## Risks
+
+- Security: triage rows may contain file paths/snippets — reuse `log_redact.sh` redaction.
+- Compatibility: scorecard schema must upgrade `samples:0` entries in place.
+- Performance: capture must stay append-only/async to avoid hot-path cost.
+- Maintenance: keep a single projection point so guards do not each reimplement triage emission.
+
+## Test Plan
+
+- [ ] Unit tests: triage projection emits a well-formed row; classification updates counters.
+- [ ] Integration tests: end-to-end guard-hit → classify → precision recomputed.
+- [ ] Manual verification: fire a known guard, run the classify command, inspect scorecard.
+
+## Rollback Plan
+
+Disable the triage projection (feature flag or revert the guard hook addition); `triage.jsonl`/scorecard remain readable. No migration to undo.

--- a/docs/specs/GH540/tech.md
+++ b/docs/specs/GH540/tech.md
@@ -13,8 +13,8 @@ See `product.md`.
 | Area | Files | Current behavior | Why relevant |
 | --- | --- | --- | --- |
 | Precision tracker | `scripts/precision-tracker.py` (613 lines) | Computes precision from scorecard; never fed | Consumer of the data we must produce |
-| Scorecard | `data/rule-scorecard.json` | All entries `samples:0, precision:null`, stale 2026-03-24 | The store to populate |
-| Triage log | `data/triage.jsonl` | Header/comments only, no rows | The capture sink |
+| Scorecard | `data/rule-scorecard.seed.json` (tracked seed; runtime writes generated `rule-scorecard.json`) | All entries `samples:0, precision:null`, stale 2026-03-24 | The store to populate |
+| Triage log | `data/triage.example.jsonl` (tracked example; runtime writes `triage.jsonl`) | Header/comments only, no rows | The capture sink |
 | Skill | `guard-precision-tracker` skill | Documents the workflow, no live wiring | Entry point to align |
 | Guard output | `hooks/*guard*.sh`, `hooks/_lib/log_write.sh` | Emits warn/block + logs events to `events.jsonl` | Natural hook to also emit triage records |
 
@@ -34,7 +34,7 @@ Reuse the existing event-log path. Guard hits already write to `events.jsonl` vi
 
 ## Data Flow
 
-Guard decision → (new) triage projection appends JSONL row → user/command classifies → `precision-tracker.py` updates `rule-scorecard.json`. Persistence: `data/triage.jsonl` (append-only), `data/rule-scorecard.json` (rewrite). No external calls.
+Guard decision → (new) triage projection appends JSONL row → user/command classifies → `precision-tracker.py` updates the runtime scorecard (generated from `data/rule-scorecard.seed.json`). Persistence: runtime `triage.jsonl` (append-only) and runtime `rule-scorecard.json` (rewrite); both are generated from the tracked seed/example. No external calls.
 
 ## Alternatives Considered
 

--- a/hooks/_lib/log_write.sh
+++ b/hooks/_lib/log_write.sh
@@ -186,6 +186,60 @@ vg_log_append_string_field() {
   printf '%s, "%s": "%s"' "$json" "$field" "$(vg_log_json_escape "$value")"
 }
 
+vg_log_triage_rule_id() {
+  local text="$1"
+  if [[ "${text}" =~ ([A-Z]+[A-Z0-9]*-[0-9]+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ "${text}" =~ (^|[^A-Z0-9_-])(DEBUG|STUB|CHURN|LARGE-EDIT)([^A-Z0-9_-]|$) ]]; then
+    printf '%s' "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
+vg_log_triage_file() {
+  if [[ -n "${VIBEGUARD_TRIAGE_FILE:-}" ]]; then
+    printf '%s' "${VIBEGUARD_TRIAGE_FILE}"
+  elif [[ -n "${VIBEGUARD_REPO_DIR:-}" ]]; then
+    printf '%s/data/triage.jsonl' "${VIBEGUARD_REPO_DIR}"
+  else
+    printf '%s/triage.jsonl' "${VIBEGUARD_LOG_DIR}"
+  fi
+}
+
+vg_log_triage_projection() {
+  local ts="$1" hook="$2" tool="$3" decision="$4" reason="$5" detail="$6"
+  local rule_id triage_file triage_json triage_dir
+  case "${decision}" in
+    warn|block|gate|escalate) ;;
+    *) return 0 ;;
+  esac
+  rule_id="$(vg_log_triage_rule_id "${reason} ${detail}")" || return 0
+  triage_file="$(vg_log_triage_file)"
+  triage_dir="$(dirname "${triage_file}")"
+  mkdir -p "${triage_dir}" 2>/dev/null || {
+    printf 'VIBEGUARD ERROR: failed to create triage log directory: %s\n' "${triage_dir}" >&2
+    return 0
+  }
+
+  triage_json="{\"schema_version\": 1, \"ts\": \"${ts}\", \"rule\": \"$(vg_log_json_escape "${rule_id}")\", \"verdict\": \"unclassified\""
+  triage_json="$(vg_log_append_string_field "${triage_json}" "decision" "${decision}")"
+  triage_json="$(vg_log_append_string_field "${triage_json}" "hook" "${hook}")"
+  triage_json="$(vg_log_append_string_field "${triage_json}" "tool" "${tool}")"
+  triage_json="$(vg_log_append_string_field "${triage_json}" "file" "${detail}")"
+  triage_json="$(vg_log_append_string_field "${triage_json}" "context" "${reason}")"
+  triage_json="$(vg_log_append_string_field "${triage_json}" "session" "${VIBEGUARD_SESSION_ID:-}")"
+  triage_json="${triage_json}}"
+
+  vg_private_log_file "${triage_file}"
+  if ! vg_append_log_line "${triage_file}" "${triage_json}"; then
+    printf 'VIBEGUARD ERROR: triage log write failed: %s\n' "${triage_file}" >&2
+  fi
+  vg_private_log_file "${triage_file}"
+}
+
 vg_log() {
   local hook="$1"
   local tool="$2"
@@ -268,4 +322,5 @@ vg_log() {
   fi
   vg_private_log_file "$VIBEGUARD_LOG_FILE"
   vg_private_log_file "$global_log"
+  vg_log_triage_projection "${ts}" "${hook}" "${tool}" "${decision}" "${reason}" "${detail}"
 }

--- a/scripts/precision-tracker.py
+++ b/scripts/precision-tracker.py
@@ -56,7 +56,8 @@ WARN_TO_ERROR_NO_FP_DAYS = 30
 DEMOTION_PRECISION = 0.80
 DEMOTION_MIN_SAMPLES = 20
 
-VALID_VERDICTS = {"tp", "fp", "acceptable"}
+CLASSIFIED_VERDICTS = {"tp", "fp", "acceptable"}
+VALID_VERDICTS = CLASSIFIED_VERDICTS | {"unclassified"}
 
 # Severity × Confidence → stage mapping
 # Used only as documentation; actual graduation is data-driven.
@@ -263,6 +264,8 @@ def compute_rule_stats(
                     pass  # ts already validated; should not reach here
         elif verdict == "acceptable":
             stats[rule]["acceptable"] += 1
+        elif verdict == "unclassified":
+            continue
 
     return stats
 
@@ -544,7 +547,7 @@ def main(argv: list[str] | None = None) -> int:
     # --record verdict rule
     if args.record:
         verdict, rule = args.record
-        if verdict not in VALID_VERDICTS:
+        if verdict not in CLASSIFIED_VERDICTS:
             print(f"[ERROR] verdict must be tp, fp, or acceptable; got: {verdict}", file=sys.stderr)
             return 1
         ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/hooks/test_log_injection.sh
+++ b/tests/hooks/test_log_injection.sh
@@ -289,6 +289,81 @@ assert_contains "$stale_mirror_result" "global=1" "Stale runtime mirror fallback
 assert_not_contains "$(cat "$stale_mirror_runtime_stderr")" "runtime mirrored JSONL append failed" "Stale runtime mirror fallback does not report runtime mirror failure"
 rm -rf "$stale_mirror_runtime_test_dir"
 
+header "log.sh — triage projection"
+
+TRIAGE_RUNTIME="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
+
+triage_test_dir="$(mktemp -d)"
+triage_file="${triage_test_dir}/triage.jsonl"
+triage_result=$(
+  export HOME="${triage_test_dir}/home"
+  export VIBEGUARD_LOG_DIR="${triage_test_dir}/logs"
+  export VIBEGUARD_PROJECT_LOG_DIR="${triage_test_dir}/project"
+  export VIBEGUARD_LOG_FILE="${VIBEGUARD_PROJECT_LOG_DIR}/events.jsonl"
+  export VIBEGUARD_TRIAGE_FILE="${triage_file}"
+  export VIBEGUARD_SESSION_ID="triage-projection-test"
+  export VIBEGUARD_RUNTIME="${TRIAGE_RUNTIME}"
+  source hooks/log.sh
+  vg_log "post-edit-guard" "Edit" "warn" "[RS-03] unwrap Authorization: Bearer sk-triage-secret" "src/main.rs --token triage-token"
+  vg_log "post-edit-guard" "Edit" "pass" "[RS-03] pass should not project" "src/pass.rs"
+  python3 - "$triage_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    rows = [json.loads(line) for line in fh if line.strip()]
+assert len(rows) == 1, rows
+row = rows[0]
+assert row["rule"] == "RS-03", row
+assert row["verdict"] == "unclassified", row
+assert row["decision"] == "warn", row
+assert row["file"] == "src/main.rs --token ***REDACTED***", row
+assert row["session"] == "triage-projection-test", row
+print("triage-ok")
+PY
+)
+assert_contains "$triage_result" "triage-ok" "Warn/block guard hit projects one unclassified triage row"
+assert_not_contains "$(cat "$triage_file")" "sk-triage-secret" "Triage projection redacts bearer secrets"
+assert_not_contains "$(cat "$triage_file")" "triage-token" "Triage projection redacts token flags"
+rm -rf "$triage_test_dir"
+
+triage_concurrent_dir="$(mktemp -d)"
+triage_concurrent_file="${triage_concurrent_dir}/triage.jsonl"
+pids=()
+for i in $(seq 1 12); do
+  (
+    export HOME="${triage_concurrent_dir}/home-${i}"
+    export VIBEGUARD_LOG_DIR="${triage_concurrent_dir}/logs"
+    export VIBEGUARD_PROJECT_LOG_DIR="${triage_concurrent_dir}/project-${i}"
+    export VIBEGUARD_LOG_FILE="${VIBEGUARD_PROJECT_LOG_DIR}/events.jsonl"
+    export VIBEGUARD_TRIAGE_FILE="${triage_concurrent_file}"
+    export VIBEGUARD_SESSION_ID="triage-concurrent-${i}"
+    export VIBEGUARD_RUNTIME="${TRIAGE_RUNTIME}"
+    source hooks/log.sh
+    vg_log "pre-write-guard" "Write" "block" "[U-16] concurrent candidate ${i}" "src/file_${i}.rs"
+  ) &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+triage_concurrent_result=$(python3 - "$triage_concurrent_file" <<'PY'
+import json
+import sys
+
+rows = []
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        rows.append(json.loads(line))
+assert len(rows) == 12, len(rows)
+assert {row["rule"] for row in rows} == {"U-16"}, rows
+print(f"lines={len(rows)}")
+PY
+)
+assert_contains "$triage_concurrent_result" "lines=12" "Concurrent triage appends stay parseable and complete"
+rm -rf "$triage_concurrent_dir"
+
 # =========================================================
 
 hook_test_finish

--- a/tests/test_precision_tracker.sh
+++ b/tests/test_precision_tracker.sh
@@ -127,6 +127,17 @@ python3 "$TRACKER" \
 assert_contains "$(cat "$TRIAGE_FILE")" '"verdict": "fp"' "--record fp write triage.jsonl"
 assert_contains "$(cat "$TRIAGE_FILE")" "false alarm in tests" "--context write triage.jsonl"
 
+record_unclassified_stderr="${TMPDIR_TEST}/record-unclassified.err"
+if python3 "$TRACKER" \
+  --triage-file "$TRIAGE_FILE" \
+  --scorecard-file "$SCORECARD_FILE" \
+  --record unclassified RS-03 > /dev/null 2>"$record_unclassified_stderr"; then
+  FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1))
+  red "--record rejects unclassified verdicts"
+else
+  assert_contains "$(cat "$record_unclassified_stderr")" "verdict must be tp, fp, or acceptable" "--record rejects unclassified verdicts"
+fi
+
 header "Precision calculation correctness"
 # 1 tp + 1 fp → precision = 50%
 updated_scorecard=$(cat "$SCORECARD_FILE")
@@ -145,6 +156,30 @@ print('OK')
 } || {
   FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1))
   red "Accuracy calculation error (expected 50%)"
+}
+
+printf '%s\n' '{"ts":"2026-03-01T00:00:00Z","rule":"RS-03","verdict":"unclassified","decision":"warn","context":"candidate only"}' >> "$TRIAGE_FILE"
+python3 "$TRACKER" \
+  --triage-file "$TRIAGE_FILE" \
+  --scorecard-file "$SCORECARD_FILE" \
+  --update-scorecard >/dev/null
+python3 - "$SCORECARD_FILE" <<'PY' >/dev/null && {
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    scorecard = json.load(fh)
+rs03 = scorecard["rules"]["RS-03"]
+assert rs03["samples"] == 2, rs03
+assert rs03["tp"] == 1, rs03
+assert rs03["fp"] == 1, rs03
+assert abs(rs03["precision"] - 0.5) < 0.001, rs03
+PY
+  PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1))
+  green "Unclassified triage candidates do not affect precision counters"
+} || {
+  FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1))
+  red "Unclassified triage candidates should not affect precision counters"
 }
 
 header "lifecycle promotion — experimental → warn"


### PR DESCRIPTION
Implements GH540 on top of the spec packet in `docs/specs/GH540/`.

Summary:
- Projects warn/block/gate/escalate guard events with stable rule IDs into triage JSONL as `verdict: "unclassified"`.
- Reuses existing log redaction and JSONL append locking; write failures are visible but do not block the guard decision.
- Keeps unclassified candidates out of precision counters; `--record tp|fp|acceptable` remains the manual classification path.
- Adds tests for projection redaction, concurrent append safety, unclassified counter behavior, and manual-record validation.

Verification:
- `bash -n hooks/_lib/log_write.sh && bash -n tests/hooks/test_log_injection.sh && python3 -m py_compile scripts/precision-tracker.py`
- `bash tests/test_precision_tracker.sh` (42/42)
- `bash tests/hooks/test_log_injection.sh` (51/51)
- `git diff --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`

Human gate:
- SP540-T5 reviewer confirmation required for triage redaction coverage and hot-path latency.

Refs #540
