### PR TITLE
docs(spec): GH541 stop injecting full rule set into Claude sessions (U-32)

### DIFF
--- a/docs/specs/GH541/product.md
+++ b/docs/specs/GH541/product.md
@@ -1,0 +1,46 @@
+# Product Spec
+
+## Linked Issue
+
+GH-541
+
+## User Problem
+
+VibeGuard defines rule U-32: more than 15 effective constraints degrade agent performance, and more than 30 must block. Yet for Claude Code it injects the full ~126-rule set (full text of `rules/claude-rules/**`) into every session — about 4× its own block threshold. The compact Codex path (~82-line L1-L7 + 16-row table) stays in budget; only the Claude path over-injects. The product's flagship anti-bloat rule is broken by its own rule-delivery mechanism, and it even ships a hook (`count_active_constraints.sh`) that would fire on this default payload.
+
+## Goals
+
+- Bring the default Claude-session constraint payload within (or near) U-32's budget.
+- Keep always-on critical constraints (security, verification, core workflow) present by default.
+- Load lower-frequency, language- or path-specific rules on demand rather than all at once.
+
+## Non-Goals
+
+- Deleting rules or reducing the total rule set.
+- Changing the Codex compact path (already in budget).
+- Rewriting rule content (this is about delivery, not authorship).
+
+## Behavior Invariants
+
+1. The default Claude-session payload injects a compact core (target ≤ ~30 effective constraints), not all ~126 rules in full text.
+2. The compact core always includes the always-on constraints: security-critical rules, verification rules, and the L1-L7 layer summary.
+3. Language/path-scoped rule files (`rules/claude-rules/<lang>/`) are available to load when the session touches matching files, rather than being injected up front.
+4. A user can opt into full-set injection via the `strict` profile.
+5. `count_active_constraints.sh` run against the default payload does not exceed U-32's block threshold.
+
+## Acceptance Criteria
+
+- [ ] Default install injects the compact core, not the full rule text (verified by measuring the injected payload).
+- [ ] `count_active_constraints.sh` on the default payload reports within the U-32 budget (no block-level violation).
+- [ ] The `strict` profile still loads the full set for users who want it.
+- [ ] Security/verification/core rules remain present in the default payload.
+
+## Edge Cases
+
+- Mixed-language edit session (must still surface cross-cutting rules from the core).
+- User with `strict` profile expecting full load (must be unchanged).
+- Path-scoped loading unavailable in a given host — must degrade to the compact core, not to nothing.
+
+## Rollout Notes
+
+This changes what every Claude session sees by default. Communicate clearly: the full rule set is still installed and available, but not all injected at once. Provide the `strict` opt-in for users who prefer the old behavior. Measure agent-compliance before/after if possible to validate the U-32 premise on this repo's own payload.

--- a/docs/specs/GH541/tasks.md
+++ b/docs/specs/GH541/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-541
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP541-T1` Owner: agent — Curate the compact always-on core (L1-L7 summary + security/verification/core rules) as the default Claude injection surface, mirroring the Codex compact path. Done when: a defined compact core exists and lists its always-on members. Verify: review the core against a checklist of security/verification rule IDs.
+- [ ] `SP541-T2` Owner: agent — Change `scripts/setup/targets/claude-home.sh` so the default profile installs the compact core, keeping full `rules/claude-rules/<lang>/` files installed but not front-injected. Done when: default install injects compact core only. Verify: inspect `~/.claude/rules/vibeguard/` after a default install.
+- [ ] `SP541-T3` Owner: agent — Add path-scoped rule loading (or a reference-pull mechanism) so language rules load on matching file context. Done when: editing a `.rs` file surfaces Rust rules without front-loading them globally. Verify: scoped-load test on `.rs` vs `.py` context.
+- [ ] `SP541-T4` Owner: agent — Gate full-set injection behind the `strict` profile in `hooks/manifest.json`/setup. Done when: `strict` loads the full set, default does not. Verify: install both profiles, compare payloads.
+- [ ] `SP541-T5` Owner: agent — Add a test asserting `count_active_constraints.sh` on the default payload is within U-32 budget. Done when: default payload does not hit the block threshold. Verify: run `bash hooks/count_active_constraints.sh` against default payload.
+- [ ] `SP541-T6` Owner: human — Approve the compact-core membership (which rules are always-on) and the default-vs-strict boundary. Done when: maintainer approves the core list. Verify: PR review approval recorded.
+
+## Parallelization
+
+T1 defines the core that T2/T4 consume, so T1 lands first. T3 (scoped loading) is independent of T2 but both edit the claude-home target — single owner. T5 depends on T2/T4 landing. T6 gates merge.
+
+## Verification
+
+- Run `bash hooks/count_active_constraints.sh` on the default payload; confirm within U-32 budget.
+- Manual: default profile shows compact core; `strict` profile shows full set; `.rs` edit surfaces Rust rules.
+
+## Handoff Notes
+
+The always-on core must not drop security or verification rules — mis-scoping here is a real regression. Keep the compact core in sync with canonical rule text via the existing doc-generation pipeline rather than hand-maintaining a divergent copy. This fixes the self-violation without deleting any rule.

--- a/docs/specs/GH541/tech.md
+++ b/docs/specs/GH541/tech.md
@@ -1,0 +1,64 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-541
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Rule count | `claude-md/vibeguard-rules.md:4` (`__VIBEGUARD_RULE_COUNT__`), `rules/claude-rules/**` (123 `## X-NN`) | ~126 rules defined | Scale of the payload |
+| Claude injection | `~/.claude/rules/vibeguard/` (symlinked full set), `scripts/setup/targets/claude-home.sh` | Full text loaded per session | The over-injection site |
+| Codex compact | `claude-md/vibeguard-rules.md` (L1-L7 + 16-row table) | ~82 lines, in budget | The model to emulate for the default |
+| Self-check | `hooks/count_active_constraints.sh`, `scripts/constraints/count_active_constraints.py`, `vibeguard-runtime/src/active_constraints.rs` | Counts effective constraints | Must pass on the new default |
+| Profiles | `hooks/manifest.json` (`claude.profiles`), setup | `strict` vs default profiles exist | Opt-in mechanism for full load |
+
+## Proposed Design
+
+Split rule delivery into a compact always-on core plus lazy, path-scoped rule files:
+
+1. Author/curate a compact core (L1-L7 summary + the always-on security/verification/core rules) as the default injected surface — mirror what the Codex path already ships.
+2. Keep the full `rules/claude-rules/<lang>/` files installed but not injected by default. Load them on demand keyed on the files a session touches (host permitting), or expose them via reference so the agent can pull them when relevant.
+3. Gate full-set injection behind the `strict` profile in `manifest.json`/setup.
+4. Ensure `count_active_constraints.sh` measures the default payload and stays within U-32.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 compact default | claude-home install target | measure injected payload size/count |
+| P2 always-on core present | compact core content | assert security/verification rules in default |
+| P3 path-scoped load | rule loader / reference | test loads Rust rules only on `.rs` context |
+| P4 strict opt-in | `manifest.json` profiles | strict profile still full-loads |
+| P5 within budget | `count_active_constraints.sh` | run on default payload, no block |
+
+## Data Flow
+
+setup → writes compact core into `~/.claude/rules/vibeguard/` default surface; full rule files remain installed but not front-loaded. `count_active_constraints` reads the active payload. No new persistence.
+
+## Alternatives Considered
+
+- Trim the rule set to <30 rules total: rejected — loses coverage; the issue is delivery, not authorship.
+- Keep full load, suppress the self-check: rejected — hides the violation instead of fixing it.
+
+## Risks
+
+- Security: must guarantee security-critical rules stay in the default core (regression risk if mis-scoped).
+- Compatibility: users relying on full-load must move to `strict`; document clearly.
+- Performance: smaller default payload should help agent compliance (the whole point of U-32).
+- Maintenance: compact core must be kept in sync with canonical rules — reuse the existing doc-generation pipeline where possible.
+
+## Test Plan
+
+- [ ] Unit tests: `count_active_constraints.sh` on default payload within budget; strict profile full.
+- [ ] Integration tests: path-scoped load surfaces language rules on matching edits.
+- [ ] Manual verification: start a Claude session on default profile, confirm compact payload; switch to strict, confirm full.
+
+## Rollback Plan
+
+Revert the install target to symlink the full set by default; the `strict` profile and compact core remain available. No data migration.


### PR DESCRIPTION
Spec packet for #541.

Default Claude sessions inject the full ~126-rule set — ~4x U-32's own 30-constraint block threshold. This spec ships a compact always-on core by default (mirroring the Codex compact path), keeps full rules installed but path-scoped/lazy, and gates full load behind the `strict` profile. Spec-only PR — no version bump.

- product.md — invariants (compact default within budget, always-on security/verification core)
- tech.md — split delivery; strict opt-in; count_active_constraints stays green
- tasks.md — SP541-T1..T6 (T6 human approval of core membership)

Refs #541