### PR TITLE
fix(hooks): reset W-13 on mutating tools and project triage

### DIFF
--- a/hooks/analysis-paralysis-guard.sh
+++ b/hooks/analysis-paralysis-guard.sh
@@ -14,10 +14,12 @@
 set -euo pipefail
 
 if [[ ! -t 0 ]]; then
-  if ! cat >/dev/null; then
+  if ! INPUT="$(cat)"; then
     echo "ERROR: failed to drain analysis-paralysis hook stdin" >&2
     exit 1
   fi
+else
+  INPUT=""
 fi
 
 if [[ "${VIBEGUARD_SUPPRESS_PARALYSIS:-0}" == "1" ]]; then
@@ -28,6 +30,43 @@ source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/circuit-breaker.sh"
 vg_start_timer
 VG_EVENT_LOG_LIB="${VG_EVENT_LOG_LIB:-$(cd "$(dirname "$0")/_lib" && pwd)}"
+
+analysis_tool_field() {
+  local field="$1" value
+  value="$(printf '%s' "${INPUT}" | vg_json_field "${field}" 2>/dev/null || true)"
+  [[ -n "${value}" ]] && printf '%s' "${value}"
+}
+
+analysis_infer_tool() {
+  local tool
+  tool="$(analysis_tool_field "tool_name")"
+  [[ -n "${tool}" ]] && { printf '%s\n' "${tool}"; return 0; }
+  tool="$(analysis_tool_field "tool")"
+  [[ -n "${tool}" ]] && { printf '%s\n' "${tool}"; return 0; }
+
+  if [[ -n "$(analysis_tool_field "tool_input.command")" ]]; then
+    printf '%s\n' "Bash"
+  elif [[ -n "$(analysis_tool_field "tool_input.new_string")" || -n "$(analysis_tool_field "tool_input.old_string")" ]]; then
+    printf '%s\n' "Edit"
+  elif [[ -n "$(analysis_tool_field "tool_input.content")" ]]; then
+    printf '%s\n' "Write"
+  elif [[ -n "$(analysis_tool_field "tool_input.pattern")" ]]; then
+    printf '%s\n' "Grep"
+  elif [[ -n "$(analysis_tool_field "tool_input.file_path")" ]]; then
+    printf '%s\n' "Read"
+  elif [[ -z "${INPUT}" ]]; then
+    printf '%s\n' "Read"
+  else
+    printf '%s\n' "PostToolUse"
+  fi
+}
+
+analysis_is_research_tool() {
+  case "$1" in
+    Read|Glob|Grep) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 _emit_cb_state_error() {
   cat <<'EOF'
@@ -44,6 +83,16 @@ EOF
 vg_is_ci && exit 0
 
 vg_config_get_int_result THRESHOLD VG_PARALYSIS_THRESHOLD paralysis.threshold 7
+TOOL_NAME="$(analysis_infer_tool)"
+
+if ! analysis_is_research_tool "${TOOL_NAME}"; then
+  vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "pass" "consecutive_reads=0 reset_by=${TOOL_NAME}" ""
+  if ! vg_cb_record_pass "analysis-paralysis-guard"; then
+    vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "block" "Circuit breaker state error; fail-visible" ""
+    _emit_cb_state_error
+  fi
+  exit 0
+fi
 
 # Count consecutive research-only tool calls (Read/Glob/Grep) at the tail of the session log.
 # Exclude this hook's own log entries (hook == "analysis-paralysis-guard") to avoid self-inflation.
@@ -55,8 +104,8 @@ CONSECUTIVE=$(tail -300 "$VIBEGUARD_LOG_FILE" 2>/dev/null \
 
 CONSECUTIVE="${CONSECUTIVE:-0}"
 
-# Log the Read event itself (always, regardless of circuit breaker state)
-vg_log "analysis-paralysis-guard" "Read" "pass" "consecutive_reads=${CONSECUTIVE}" ""
+# Log the triggering tool itself (always, regardless of circuit breaker state).
+vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "pass" "consecutive_reads=${CONSECUTIVE}" ""
 
 if [[ "$CONSECUTIVE" -ge "$THRESHOLD" ]]; then
   # Circuit breaker check: if this hook has been firing repeatedly without
@@ -71,9 +120,9 @@ if [[ "$CONSECUTIVE" -ge "$THRESHOLD" ]]; then
   if [[ "$CB_STATUS" -eq 0 ]]; then
     WARNING="[ANALYSIS PARALYSIS] There have been ${CONSECUTIVE} consecutive read-only operations (Read/Glob/Grep) without any writes. You may be stuck in a \"read-read\" loop. You must choose: (1) Start writing code/editing files (2) Report the blocker to the user and explain where it is stuck."
 
-    vg_log "analysis-paralysis-guard" "Read" "warn" "paralysis ${CONSECUTIVE}x" ""
+    vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "warn" "W-13 paralysis ${CONSECUTIVE}x" ""
     if ! vg_cb_record_block "analysis-paralysis-guard"; then
-      vg_log "analysis-paralysis-guard" "Read" "block" "Circuit breaker state error; fail-visible" ""
+      vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "block" "Circuit breaker state error; fail-visible" ""
       _emit_cb_state_error
       exit 0
     fi
@@ -83,12 +132,12 @@ if [[ "$CONSECUTIVE" -ge "$THRESHOLD" ]]; then
   elif [[ "$CB_STATUS" -eq 1 ]]; then
     : # Circuit OPEN: vg_cb_check already logged the auto-pass.
   else
-    vg_log "analysis-paralysis-guard" "Read" "block" "Circuit breaker state error; fail-visible" ""
+    vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "block" "Circuit breaker state error; fail-visible" ""
     _emit_cb_state_error
   fi
 else
   if ! vg_cb_record_pass "analysis-paralysis-guard"; then
-    vg_log "analysis-paralysis-guard" "Read" "block" "Circuit breaker state error; fail-visible" ""
+    vg_log "analysis-paralysis-guard" "${TOOL_NAME}" "block" "Circuit breaker state error; fail-visible" ""
     _emit_cb_state_error
   fi
 fi

--- a/tests/hooks/test_analysis_paralysis_guard.sh
+++ b/tests/hooks/test_analysis_paralysis_guard.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
+hook_test_init
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR" "$VIBEGUARD_LOG_DIR"' EXIT
+
+RUNTIME_BIN="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
+export VIBEGUARD_RUNTIME="${RUNTIME_BIN}"
+
+hook_no_ci_env=(
+  CI=false
+  GITHUB_ACTIONS=false
+  TRAVIS=false
+  CIRCLECI=false
+  JENKINS_URL=
+  GITLAB_CI=false
+  TF_BUILD=false
+)
+
+make_log_dir() {
+  mktemp -d "$WORK_DIR/logs.XXXXXX"
+}
+
+event_log_file() {
+  local log_dir="$1" session="$2"
+  VIBEGUARD_LOG_DIR="$log_dir" VIBEGUARD_SESSION_ID="$session" bash -c '
+    source hooks/log.sh
+    printf "%s" "$VIBEGUARD_LOG_FILE"
+  '
+}
+
+seed_research_events() {
+  local log_dir="$1" session="$2" count="$3" log_file
+  log_file="$(event_log_file "$log_dir" "$session")"
+  mkdir -p "$(dirname "$log_file")"
+  python3 - "$log_file" "$session" "$count" <<'PY'
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+log_file, session, count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+now = datetime.now(timezone.utc)
+with open(log_file, "w", encoding="utf-8") as fh:
+    for i in range(count):
+        ts = now - timedelta(seconds=count - i)
+        fh.write(json.dumps({
+            "ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "session": session,
+            "hook": "analysis-paralysis-guard",
+            "tool": "Read",
+            "decision": "pass",
+            "reason": "",
+            "detail": "",
+        }) + "\n")
+PY
+}
+
+header "analysis-paralysis guard — mutating tool reset"
+
+bash_log="$(make_log_dir)"
+bash_session="analysis-bash-reset"
+seed_research_events "$bash_log" "$bash_session" 7
+bash_out="$(env "${hook_no_ci_env[@]}" \
+  VIBEGUARD_LOG_DIR="$bash_log" VIBEGUARD_SESSION_ID="$bash_session" VG_PARALYSIS_THRESHOLD=7 \
+  bash hooks/analysis-paralysis-guard.sh <<'JSON'
+{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"sed -i '' -e s/a/b/ file.txt"}}
+JSON
+)"
+bash_events="$(cat "$(event_log_file "$bash_log" "$bash_session")")"
+assert_not_contains "$bash_out" "ANALYSIS PARALYSIS" "Bash invocation resets read-only streak instead of warning"
+assert_contains "$bash_events" '"tool": "Bash"' "Bash invocation is logged with the real tool"
+assert_contains "$bash_events" "reset_by=Bash" "Bash reset reason is visible"
+
+edit_log="$(make_log_dir)"
+edit_session="analysis-edit-reset"
+seed_research_events "$edit_log" "$edit_session" 7
+edit_out="$(env "${hook_no_ci_env[@]}" \
+  VIBEGUARD_LOG_DIR="$edit_log" VIBEGUARD_SESSION_ID="$edit_session" VG_PARALYSIS_THRESHOLD=7 \
+  bash hooks/analysis-paralysis-guard.sh <<'JSON'
+{"hook_event_name":"PostToolUse","tool_input":{"file_path":"src/lib.rs","old_string":"a","new_string":"b"}}
+JSON
+)"
+edit_events="$(cat "$(event_log_file "$edit_log" "$edit_session")")"
+assert_not_contains "$edit_out" "ANALYSIS PARALYSIS" "Edit payload without tool_name still resets read-only streak"
+assert_contains "$edit_events" '"tool": "Edit"' "Edit payload is inferred from tool_input"
+
+header "analysis-paralysis guard — W-13 triage"
+
+read_log="$(make_log_dir)"
+read_session="analysis-read-warn"
+triage_file="$WORK_DIR/triage.jsonl"
+seed_research_events "$read_log" "$read_session" 2
+read_out="$(env "${hook_no_ci_env[@]}" \
+  VIBEGUARD_LOG_DIR="$read_log" VIBEGUARD_SESSION_ID="$read_session" VG_PARALYSIS_THRESHOLD=2 \
+  VIBEGUARD_TRIAGE_FILE="$triage_file" bash hooks/analysis-paralysis-guard.sh <<'JSON'
+{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"README.md"}}
+JSON
+)"
+read_events="$(cat "$(event_log_file "$read_log" "$read_session")")"
+triage_out="$(python3 - "$triage_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    rows = [json.loads(line) for line in fh if line.strip()]
+assert len(rows) == 1, rows
+assert rows[0]["rule"] == "W-13", rows[0]
+assert rows[0]["decision"] == "warn", rows[0]
+print("w13-triage-ok")
+PY
+)"
+assert_contains "$read_out" "ANALYSIS PARALYSIS" "Read streak still triggers W-13 warning"
+assert_contains "$read_events" "W-13 paralysis 2x" "W-13 warning reason is logged"
+assert_contains "$triage_out" "w13-triage-ok" "W-13 warning projects into triage"
+
+hook_test_finish

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -33,6 +33,7 @@ shards=(
   "tests/hooks/test_log_session.sh"
   "tests/hooks/test_post_edit_suppression.sh"
   "tests/hooks/test_log_timer.sh"
+  "tests/hooks/test_analysis_paralysis_guard.sh"
   "tests/hooks/test_skills_loader.sh"
   "tests/hooks/test_post_edit_w14.sh"
   "tests/hooks/test_post_edit_w15.sh"

--- a/vibeguard-runtime/src/event_schema.rs
+++ b/vibeguard-runtime/src/event_schema.rs
@@ -87,10 +87,15 @@ pub mod tool {
     pub const GREP: &str = "Grep";
     pub const WRITE: &str = "Write";
     pub const EDIT: &str = "Edit";
+    pub const MULTI_EDIT: &str = "MultiEdit";
+    pub const NOTEBOOK_EDIT: &str = "NotebookEdit";
     pub const BASH: &str = "Bash";
+    pub const TASK: &str = "Task";
+    pub const AGENT: &str = "Agent";
+    pub const POST_TOOL_USE: &str = "PostToolUse";
 
     pub const RESEARCH_ONLY: [&str; 3] = [READ, GLOB, GREP];
-    pub const MUTATING: [&str; 3] = [WRITE, EDIT, BASH];
+    pub const MUTATING: [&str; 7] = [WRITE, EDIT, MULTI_EDIT, NOTEBOOK_EDIT, BASH, TASK, AGENT];
 }
 
 pub mod metric_field {

--- a/vibeguard-runtime/src/event_schema.rs
+++ b/vibeguard-runtime/src/event_schema.rs
@@ -112,3 +112,28 @@ pub mod metric_field {
     pub const CORRECTION_SIGNALS: &str = "correction_signals";
     pub const WARN_RATIO: &str = "warn_ratio";
 }
+
+#[cfg(test)]
+mod tests {
+    use super::tool;
+
+    #[test]
+    fn tool_groups_keep_analysis_paralysis_boundaries() {
+        for research_tool in [tool::READ, tool::GLOB, tool::GREP] {
+            assert!(tool::RESEARCH_ONLY.contains(&research_tool));
+            assert!(!tool::MUTATING.contains(&research_tool));
+        }
+        for mutating_tool in [
+            tool::WRITE,
+            tool::EDIT,
+            tool::MULTI_EDIT,
+            tool::NOTEBOOK_EDIT,
+            tool::BASH,
+            tool::TASK,
+            tool::AGENT,
+        ] {
+            assert!(tool::MUTATING.contains(&mutating_tool));
+            assert!(!tool::RESEARCH_ONLY.contains(&mutating_tool));
+        }
+    }
+}

--- a/vibeguard-runtime/src/log_query.rs
+++ b/vibeguard-runtime/src/log_query.rs
@@ -320,7 +320,9 @@ fn count_paralysis_events(events: &[Value], now_secs: u64) -> u32 {
         match e.get(field::TOOL).and_then(Value::as_str) {
             Some(tool_name) if tool::RESEARCH_ONLY.contains(&tool_name) => consecutive += 1,
             Some(tool_name) if tool::MUTATING.contains(&tool_name) => break,
-            _ => {}
+            Some(tool::POST_TOOL_USE) => break,
+            Some(_) => break,
+            None => {}
         }
     }
     consecutive
@@ -673,6 +675,38 @@ mod tests {
 
         let now = parse_iso_ts("2026-05-01T00:20:00Z").expect("valid timestamp");
         assert_eq!(count_paralysis_events(&events, now), 2);
+    }
+
+    #[test]
+    fn paralysis_count_stops_at_posttool_and_unknown_tools() {
+        let now = parse_iso_ts("2026-05-01T00:20:00Z").expect("valid timestamp");
+        let events_with_posttool = vec![
+            json!({"tool": "Read", "ts": "2026-05-01T00:10:00Z"}),
+            json!({"tool": "PostToolUse", "ts": "2026-05-01T00:11:00Z"}),
+            json!({"tool": "Read", "ts": "2026-05-01T00:12:00Z"}),
+        ];
+        let events_with_unknown = vec![
+            json!({"tool": "Read", "ts": "2026-05-01T00:10:00Z"}),
+            json!({"tool": "CustomMutator", "ts": "2026-05-01T00:11:00Z"}),
+            json!({"tool": "Read", "ts": "2026-05-01T00:12:00Z"}),
+        ];
+
+        assert_eq!(count_paralysis_events(&events_with_posttool, now), 1);
+        assert_eq!(count_paralysis_events(&events_with_unknown, now), 1);
+    }
+
+    #[test]
+    fn paralysis_count_stops_at_extended_mutating_tools() {
+        let now = parse_iso_ts("2026-05-01T00:20:00Z").expect("valid timestamp");
+        for mutating_tool in ["MultiEdit", "NotebookEdit", "Task", "Agent"] {
+            let events = vec![
+                json!({"tool": "Read", "ts": "2026-05-01T00:10:00Z"}),
+                json!({"tool": mutating_tool, "ts": "2026-05-01T00:11:00Z"}),
+                json!({"tool": "Read", "ts": "2026-05-01T00:12:00Z"}),
+            ];
+
+            assert_eq!(count_paralysis_events(&events, now), 1, "{mutating_tool}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Stop `analysis-paralysis-guard` from logging every invocation as `Read`; it now preserves/inferes the real triggering tool and resets the read-only streak for mutating or unknown PostToolUse events.
- Add W-13 to the analysis-paralysis warn reason so triage projection records precision events for false-positive tracking.
- Extend runtime paralysis counting to stop on `MultiEdit`, `NotebookEdit`, `Task`, `Agent`, `PostToolUse`, and unknown tool names instead of silently ignoring them.
- Add focused W-13 regression coverage and event-schema boundary coverage.

Refs #554
Refs #555

## Stack
- Stacked on #549 (`fix/split-runtime-policy-test`) because current `main` still fails the test file-size guard.
- After #549 lands, retarget this PR to `main` and switch the references above to closing keywords if no further work remains.

## Verification
- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml tool_groups_keep_analysis_paralysis_boundaries -- --nocapture
- bash tests/hooks/test_analysis_paralysis_guard.sh
- bash tests/hooks/test_runtime_config.sh
- bash tests/hooks/test_log_injection.sh
- bash tests/hooks/test_post_edit_churn.sh
- bash tests/test_hooks.sh
- bash tests/test_self_application_ci.sh
- env VIBEGUARD_U22_STRICT=1 bash scripts/ci/self-application/check-u22-coverage.sh .
- bash scripts/verify/check-test-file-sizes.sh
- bash scripts/ci/validate-hooks.sh
- bash scripts/ci/validate-hooks-manifest.sh
- bash tests/test_manifest_contract.sh

## Notes
- One earlier full `tests/test_hooks.sh` run failed inside `test_post_edit_churn.sh`; the shard passed in isolation and the full suite passed on rerun, so this is recorded as a non-reproduced test-environment failure, not used as completion evidence.
- An attempted force-with-lease after amend was blocked by VibeGuard as designed; the branch was updated by a fast-forward follow-up commit instead.