### PR TITLE
docs(spec): add GH556 weekly health report spec

### DIFF
--- a/docs/specs/GH556/product.md
+++ b/docs/specs/GH556/product.md
@@ -1,0 +1,63 @@
+# Product Spec
+
+## Linked Issue
+
+GH-556
+
+## User Problem
+
+W-13 误报风暴（GH-554）说明：VibeGuard 已经有事件日志、triage、scorecard 和 session metrics，但维护者没有一张定期送到眼前的系统健康表。错误警告可以持续数周而无人注意，规则精度、未分类积压和闲置资产也缺少统一入口。
+
+## Goals
+
+- 每周输出一页系统健康报告，覆盖规则触发量、warn/block/pass 分布、精度风险和闲置资产。
+- 复用已有数据源：`scripts/stats.sh`、`scripts/hook-health.sh`、`scripts/precision-tracker.py`、运行时 triage/scorecard 文件、`data/rule-scorecard.seed.json`、`vibeguard-runtime` observe/session metrics 和 Learn adoption 记录。
+- 明确列出降级候选：连续 30 天零触发的规则，以及零使用或无 adoption 证据的 skill/资产。
+- 将 W-13 类 false-positive blind spot 纳入报告，避免 rule id 缺失导致 precision pipeline 看不见真实风险。
+- 在手动验证稳定后，才允许新增周度 launchd/cron 调度。
+
+## Non-Goals
+
+- 不新建数据库、服务端或前端。
+- 不重写 precision tracker、observe summary 或 Learn adoption 的核心模型。
+- 不在本规格内关闭 GH-541；健康报告只提供降级候选证据。
+- 不绕过 GH-554/GH-555 的依赖：W-13 reset 和 rule-id triage 修复先行，否则报告不能宣称覆盖 W-13。
+
+## Behavior Invariants
+
+1. 无数据时报告必须清楚显示空状态，不能编造健康分数或 silently pass。
+2. 任何源文件解析失败、schema 错误或命令失败必须让报告失败，不能 warning 后继续输出误导性摘要。
+3. 报告必须区分 `pass`、`warn`、`block`、`gate`、`escalate`、`correction` 等 decision，不得只汇总为“风险数”。
+4. 每条 precision 风险必须保留 rule id；缺 rule id 的 triage 候选必须进入 “unclassified backlog / schema gap” 区块。
+5. 零触发规则和零使用 skill 只是降级候选，不能自动删除、禁用或移动规则。
+6. 周度调度必须是 opt-in，并在手动命令稳定验证后才能启用。
+
+## Report Sections
+
+- Overview：时间窗口、数据源、总触发数、pass/risk 比例和数据完整性状态。
+- Rule Trigger Distribution：按 rule/hook 汇总触发次数和 decision 分布。
+- Precision Risk：FP 率、precision、样本数、最近 FP、unclassified backlog。
+- Idle Assets：30 天零触发规则、零使用 skill、无 adoption 记录的 Learn 候选。
+- Downgrade Candidates：可移入按需文档或低频包的候选，附证据和保守建议。
+- Follow-up Actions：需要人工 triage、spec、实现或调度验证的下一步。
+
+## Acceptance Criteria
+
+- [ ] 新增或扩展一个手动命令，可以生成 7 天或 30 天健康报告，并支持 markdown 与 JSON 输出。
+- [ ] 报告复用已有 observe summary/health、precision tracker、triage/scorecard 和 Learn adoption 数据；没有新增持久层。
+- [ ] 报告包含每条规则的触发次数、decision 分布、precision/FP 风险和 unclassified 数量。
+- [ ] 报告包含 30 天零触发规则和零使用 skill 的降级候选区块。
+- [ ] 源数据缺失时输出明确空状态；源数据损坏或解析失败时命令失败。
+- [ ] 周度调度文档或脚本只在手动验证通过后启用，默认不自动安装。
+
+## Edge Cases
+
+- 本地没有 `~/.vibeguard/events.jsonl` 或项目 scoped log：报告显示 no data，不回退到不相关项目。
+- `data/triage.jsonl` 存在 malformed line：precision 区块失败并返回非零，避免错误 precision。
+- W-13 事件没有 rule id：进入 schema gap/unclassified backlog，不计入 W-13 精度。
+- 新 skill 尚未被触发：列为 zero-use 候选，但不自动判定为无价值。
+- 只存在 global log 或只存在 project log：报告必须明确当前 scope。
+
+## Rollout Notes
+
+先以手动命令和文件输出落地，验证报告字段与真实 incident 一致后，再把周度调度作为 opt-in 配置接入。报告中的降级候选应服务 GH-541 的 U-32 约束预算治理，但不能替代人工规则评审。

--- a/docs/specs/GH556/tasks.md
+++ b/docs/specs/GH556/tasks.md
@@ -1,0 +1,50 @@
+# Task Plan
+
+## Linked Issue
+
+GH-556
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP556-T1` Owner: agent — Define the health report schema and CLI contract. Done when: JSON keys, markdown sections, scope/window options and no-data/error behavior are documented in tests. Verify: CLI help and schema fixture test.
+- [ ] `SP556-T2` Owner: agent — Add the thin report aggregator over existing observe summary/health data. Done when: report includes trigger counts and decision distribution for project and global scopes. Verify: fixture test plus `bash tests/test_stats.sh` and `bash tests/test_hook_health.sh`.
+- [ ] `SP556-T3` Owner: agent — Integrate precision tracker data without mutating the scorecard by default. Done when: report includes precision, FP count, sample count, last FP and lifecycle stage per rule. Verify: fixture test plus `bash tests/test_precision_tracker.sh`.
+- [ ] `SP556-T4` Owner: agent — Add unclassified backlog and schema-gap reporting. Done when: malformed or rule-id-missing triage candidates are visible and malformed JSONL fails loudly. Verify: focused malformed JSONL and missing-rule-id fixtures.
+- [ ] `SP556-T5` Owner: agent — Add idle asset and downgrade candidate detection. Done when: 30-day zero-trigger rules and zero-use skills are listed as candidates with evidence, not automatically disabled. Verify: deterministic inventory fixture.
+- [ ] `SP556-T6` Owner: agent — Surface the manual command through docs or an existing observe skill entry. Done when: a maintainer can run one command and find the output file path. Verify: doc path and command path validators.
+- [ ] `SP556-T7` Owner: human — Validate the manual weekly report on a real incident window, especially W-13 after GH-554/GH-555 land. Done when: maintainer confirms the report catches the W-13 blind spot. Verify: PR review or issue comment.
+- [ ] `SP556-T8` Owner: agent — Add opt-in weekly scheduling only after T7. Done when: launchd/cron wrapper writes a report file without installing by default. Verify: dry-run scheduler test and manual opt-in install test.
+
+## Parallelization
+
+T1 defines the shared schema, so it lands first. T2 and T3 can be implemented in parallel only if they touch disjoint adapters and tests. T4 depends on T3. T5 can proceed after T1 but must not share writable files with T2/T3 workers. T6 follows the command shape. T8 is blocked by the human validation gate T7.
+
+## Verification
+
+For the implementation PR, run:
+
+```bash
+python3 -m py_compile scripts/health-report.py
+bash tests/test_stats.sh
+bash tests/test_hook_health.sh
+bash tests/test_precision_tracker.sh
+bash tests/test_learn_adoption.sh
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+```
+
+If the implementation changes runtime observe behavior, also run:
+
+```bash
+cargo check --manifest-path vibeguard-runtime/Cargo.toml
+cargo test --manifest-path vibeguard-runtime/Cargo.toml observe
+```
+
+## Handoff Notes
+
+Do not add default automation before the manual report has been validated. The first implementation slice should prefer a manual report command and focused fixtures. Use `Refs #556` for partial slices; use a closing keyword only after the manual report, risk sections, idle asset detection and scheduling gate are all satisfied.

--- a/docs/specs/GH556/tech.md
+++ b/docs/specs/GH556/tech.md
@@ -1,0 +1,107 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-556
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Relevance |
+| --- | --- | --- | --- |
+| Observe summary | `scripts/stats.sh`, `vibeguard-runtime/src/observe/` | `vibeguard-runtime observe summary` aggregates project/global event logs over days | Source for trigger counts and decision distribution |
+| Hook health | `scripts/hook-health.sh`, `vibeguard-runtime/src/observe/render.rs` | `observe health` renders recent attention states and diagnostics | Source for recent risk examples and diagnostics |
+| Precision tracker | `scripts/precision-tracker.py`, runtime triage/scorecard files, `data/rule-scorecard.seed.json` | Computes per-rule TP/FP/acceptable precision and lifecycle state | Source for FP risk and rule lifecycle status |
+| Triage projection | `hooks/*`, `tests/hooks/test_log_injection.sh` | Guard hits can append unclassified triage rows | Must preserve rule id for GH-555 coverage |
+| Session metrics | `vibeguard-runtime/src/session_metrics/engine.rs`, `event_schema.rs` | Emits `hooks`, `tools`, `warn_ratio`, decision metrics | Source for low-cardinality health facts |
+| Learn adoption | `scripts/learn/adoption.py`, `~/.vibeguard/learn-adoptions.jsonl` | Records adopted or verified Learn signals | Source for skill/adoption usage evidence |
+| Existing weekly infra | `scripts/gc/reflection_digest.py`, `scripts/gc/gc-scheduled.sh` | Produces a separate weekly reflection report | Scheduling pattern, not the health report itself |
+
+## Proposed Design
+
+Add a thin health-report aggregator rather than a new data layer.
+
+1. Create a manual report command, for example `health-report`, with `--days`, `--scope`, `--project`, `--log-file`, `--format markdown|json`, and `--output` options.
+2. Read existing structured sources directly or through stable commands:
+   - `vibeguard-runtime observe summary --json --days N`
+   - `vibeguard-runtime observe health --json --hours N*24`
+   - `scripts/precision-tracker.py` helpers or extracted pure functions for triage/scorecard stats
+   - `scripts/learn/adoption.py` JSONL records for adopted/verified skill evidence
+3. Normalize the report into a small JSON schema, then render markdown from that schema.
+4. Keep weekly scheduling opt-in. A later scheduler wrapper may write to `~/.vibeguard/reports/health/YYYY-MM-DD.md`, but only after manual command validation.
+
+## Report Schema
+
+The JSON output should include stable English keys:
+
+```json
+{
+  "schema_version": 1,
+  "window_days": 30,
+  "scope": "project",
+  "generated_ts": "2026-07-04T00:00:00Z",
+  "data_sources": [],
+  "overview": {},
+  "rule_triggers": [],
+  "precision_risks": [],
+  "unclassified_backlog": [],
+  "idle_assets": {
+    "zero_trigger_rules": [],
+    "zero_use_skills": []
+  },
+  "downgrade_candidates": [],
+  "follow_up_actions": []
+}
+```
+
+## Data Rules
+
+- Treat missing event logs as no data, not success-with-zero-risk.
+- Treat malformed JSONL, invalid scorecard JSON, or failed child commands as hard errors.
+- Keep project and global scopes explicit; never silently mix them.
+- Keep rule ids as primary keys. If a candidate lacks a rule id, record it under `unclassified_backlog` with enough source detail for triage.
+- Do not mutate the runtime scorecard file during report generation unless the user passes an explicit update flag.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| Manual report exists | `health-report` command or equivalent wrapper | CLI help and sample fixture tests |
+| Existing sources reused | observe/precision/adoption readers | Test fixtures cover each source |
+| Empty data is visible | report renderer | Fixture with no logs shows no-data state |
+| Parse errors fail loudly | source readers | malformed JSONL fixture returns non-zero |
+| Decision distribution included | observe summary adapter | markdown and JSON include pass/warn/block counts |
+| Downgrade candidates included | rule/skill inventory adapter | 30-day zero-trigger fixture lists candidates |
+| Scheduler opt-in only | docs/setup wrapper | no default install side effect |
+
+## Implementation Notes
+
+- Prefer extracting small pure helper functions from `scripts/precision-tracker.py` only when needed; avoid duplicating precision math.
+- Use `argparse` and `json` from the Python standard library. Do not add package dependencies.
+- Use array-style subprocess calls if a wrapper invokes existing commands.
+- Keep output deterministic: sort rules, skills and candidates by id/name.
+- Avoid writing into high-context files or installed user config during report generation.
+
+## Dependencies
+
+- GH-554 must land before W-13 reset counts are trustworthy.
+- GH-555 must land before W-13 precision and unclassified backlog can be trusted.
+- GH-541 can consume the downgrade candidate evidence later, but is not blocked by this spec.
+
+## Test Plan
+
+- Python syntax check for the implemented report command.
+- Focused shell test for markdown and JSON output using temporary event, triage, scorecard and adoption fixtures.
+- `bash tests/test_stats.sh`
+- `bash tests/test_hook_health.sh`
+- `bash tests/test_precision_tracker.sh`
+- `bash tests/test_learn_adoption.sh`
+- `bash scripts/ci/validate-doc-paths.sh`
+- `bash scripts/ci/validate-doc-command-paths.sh`
+
+## Rollback Plan
+
+Remove the report command and any opt-in scheduler wrapper. Existing observe, precision tracker, triage, scorecard and Learn adoption files remain unchanged.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,6 +7,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | Spec | Status | Use it for |
 |---|---|---|
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
+| `GH556/` | Draft | Weekly health report for rule trigger counts, precision risk, unclassified backlog, and idle asset detection |
 | `install-friction-reduction.md` | Implemented reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
 | `learn-first-class-signal-inbox.md` | Draft | Learn signal inbox, signal classification, triage state, adoption compiler, and outcome evaluator planning |
 | `rust-only-production-path.md` | Implemented reference | Python-free production path, Rust runtime boundaries, and remaining validation expectations |


### PR DESCRIPTION
## Summary

- Adds the GH556 SpecRail packet for a weekly system health report.
- Defines product goals, technical design, report schema, data rules, and task plan.
- Keeps this as a spec-only PR; implementation remains gated by GH554/GH555 signal fixes and manual validation before scheduling.

Refs #556

## Stack

- Base: `fix/split-runtime-policy-test` (#549) because current `main` is red on the test file-size guard until #549 lands.
- After #549 lands, this PR can be retargeted to `main`.

## Verification

- `git diff --check`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`

## Not run

- `python3 checks/check_workflow.py --repo .` because `checks/check_workflow.py` is not present in this repository.
