### PR TITLE
fix(setup): default Claude profile skips full rule-tree injection (U-32)

### DIFF
--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -1,7 +1,7 @@
 <!-- vibeguard-start -->
 #VibeGuard — AI anti-hallucination rules
 
-> __VIBEGUARD_RULE_COUNT__ rules total. Claude loads the full set from `~/.claude/rules/vibeguard/`; Codex sees the L1-L7 layers + Key Detailed Rules table below. Repo-specific facts belong in the repo-level `AGENTS.md`.
+> __VIBEGUARD_RULE_COUNT__ rules total. Claude defaults to the compact L1-L7 layers + Key Detailed Rules table below; load matching native rule files on demand from `~/.vibeguard/installed/rules/claude-rules/` when path-specific depth is needed. Full/strict profiles may also front-inject native rule files from `~/.claude/rules/vibeguard/`. Codex sees the same compact table. Repo-specific facts belong in the repo-level `AGENTS.md`.
 
 ## Constraints (L1-L7 use rules, hooks, guards, and workflows)
 

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -47,6 +47,7 @@ INSTALL=0
 PROJECT=0
 DEV_REPO=0
 PROFILE="${VIBEGUARD_SETUP_PROFILE:-}"
+LANGUAGES="${VIBEGUARD_SETUP_LANGUAGES:-}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --quiet|-q)     QUIET=1; shift ;;
@@ -116,6 +117,14 @@ check_installed_profile() {
     minimal|core|full|strict) printf '%s\n' "${detected}" ;;
     *) return 1 ;;
   esac
+}
+
+check_installed_languages() {
+  local state_out detected
+  state_out="$(state_list 2>/dev/null)" || return 1
+  detected="$(awk -F': ' '/^Languages:/ {print $2; exit}' <<< "${state_out}")"
+  [[ -n "${detected}" ]] || return 1
+  printf '%s\n' "${detected}" | tr -d '[:space:]'
 }
 
 launchd_gc_script_path() {
@@ -236,6 +245,9 @@ if [[ -z "${PROFILE}" ]]; then
 fi
 PROFILE="${PROFILE:-core}"
 validate_setup_profile "${PROFILE}"
+if [[ -z "${LANGUAGES}" ]]; then
+  LANGUAGES="$(check_installed_languages 2>/dev/null || true)"
+fi
 
 _execution_mode() {
   local mode="${VIBEGUARD_EXECUTION_MODE:-}"

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -375,7 +375,7 @@ claude_rule_count_for_banner() {
   local rules_dest="${HOME}/.claude/rules/vibeguard"
   local total=0 dir_count rule_links source_path dest_rel label
 
-  if [[ "${VIBEGUARD_SETUP_DRY_RUN}" != "1" && -d "${rules_dest}" ]]; then
+  if _claude_profile_injects_full_rule_tree && [[ "${VIBEGUARD_SETUP_DRY_RUN}" != "1" && -d "${rules_dest}" ]]; then
     claude_rule_id_count "${rules_dest}"
     return 0
   fi
@@ -485,22 +485,39 @@ check_claude_home_installation() {
 
   local rules_dest="${HOME}/.claude/rules/vibeguard"
   local rule_file_count actual_rule_count claude_md declared_count
-  local symlink_count copy_count
+  local symlink_count copy_count front_injected_count labels label label_count
   if [[ -d "${rules_dest}" ]]; then
-    rule_file_count=$(find "${rules_dest}" -name "*.md" \( -type f -o -type l \) 2>/dev/null | wc -l | tr -d ' ')
-    symlink_count=$(find "${rules_dest}" -name "*.md" -type l 2>/dev/null | wc -l | tr -d ' ')
-    copy_count=$((rule_file_count - symlink_count))
-    if [[ "${rule_file_count}" -ge 7 ]]; then
-      green "[OK] ${rule_file_count} native rule files in ~/.claude/rules/vibeguard/ (${symlink_count} symlinked)"
+    if _claude_profile_injects_full_rule_tree; then
+      rule_file_count=$(find "${rules_dest}" -name "*.md" \( -type f -o -type l \) 2>/dev/null | wc -l | tr -d ' ')
+      symlink_count=$(find "${rules_dest}" -name "*.md" -type l 2>/dev/null | wc -l | tr -d ' ')
+      copy_count=$((rule_file_count - symlink_count))
+      if [[ "${rule_file_count}" -ge 7 ]]; then
+        green "[OK] ${rule_file_count} native rule files in ~/.claude/rules/vibeguard/ (${symlink_count} symlinked)"
+      else
+        yellow "[PARTIAL] Only ${rule_file_count} native rule files (expected 7+)"
+      fi
+      if [[ "${copy_count}" -gt 0 ]]; then
+        yellow "[DRIFT] ${copy_count} rule files are copies instead of symlinks — re-run setup.sh to fix"
+      fi
+      actual_rule_count=$(claude_rule_id_count "${rules_dest}")
     else
-      yellow "[PARTIAL] Only ${rule_file_count} native rule files (expected 7+)"
-    fi
-    if [[ "${copy_count}" -gt 0 ]]; then
-      yellow "[DRIFT] ${copy_count} rule files are copies instead of symlinks — re-run setup.sh to fix"
+      front_injected_count=0
+      labels="$(manifest_rule_labels_checked "")" || return 1
+      while IFS= read -r label; do
+        [[ -n "${label}" ]] || continue
+        [[ -d "${rules_dest}/${label}" ]] || continue
+        label_count=$(claude_rule_id_count "${rules_dest}/${label}")
+        front_injected_count=$((front_injected_count + label_count))
+      done <<< "${labels}"
+      if [[ "${front_injected_count}" -eq 0 ]]; then
+        green "[OK] compact core profile does not front-inject native rule tree"
+      else
+        yellow "[DRIFT] compact core profile has ${front_injected_count} front-injected native rule(s); re-run setup.sh --yes --profile ${PROFILE}"
+      fi
+      actual_rule_count=$(claude_rule_count_for_banner)
     fi
     _check_claude_rule_symlink_targets
 
-    actual_rule_count=$(claude_rule_id_count "${rules_dest}")
     claude_md="${CLAUDE_DIR}/CLAUDE.md"
     if [[ -f "${claude_md}" ]]; then
       if declared_count=$(vibeguard_managed_rule_banner_count "${claude_md}"); then

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -185,6 +185,18 @@ _rule_label_is_selected() {
   return 1
 }
 
+# GH-541: the full native rule text (~126 constraints across rules/claude-rules/**)
+# is only front-injected under the full/strict profiles. The default (core) and
+# minimal profiles rely on the compact L1-L7 + Key Detailed Rules table already
+# synced into ~/.claude/CLAUDE.md, keeping the live payload within the U-32
+# budget. The full-text tree stays installed under ~/.vibeguard and is opt-in.
+_claude_profile_injects_full_rule_tree() {
+  case "${PROFILE:-core}" in
+    full|strict) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 _rule_dest_is_declared() {
   local dest_rel="$1" rule_links="$2"
   printf '%s\n' "${rule_links}" \
@@ -289,34 +301,51 @@ install_claude_home_assets() {
   echo "Step 5.5: Install native rules (symlinked)"
   local rules_dest="${HOME}/.claude/rules/vibeguard"
   local rule_links selected_labels all_labels source_path dest_rel label installed_count
-  rule_links="$(manifest_rule_links_checked "${LANGUAGES:-}")" || return 1
-  selected_labels="$(manifest_rule_labels_checked "${LANGUAGES:-}")" || return 1
-  all_labels="$(manifest_rule_labels_checked "")" || return 1
 
   mkdir -p "${rules_dest}"
-  while IFS= read -r label; do
-    [[ -n "${label}" ]] || continue
-    if _rule_label_is_selected "${label}" "${selected_labels}"; then
-      continue
-    fi
-    if [[ -d "${rules_dest}/${label}" ]]; then
-      _remove_rule_subtree_if_safe "$(_claude_source_path "rules/claude-rules/${label}")" "${rules_dest}/${label}" "${label}" || return 1
-      yellow "  ${label}/ removed (not in --languages filter)"
-    fi
-  done <<< "${all_labels}"
 
-  while IFS= read -r label; do
-    [[ -n "${label}" ]] || continue
-    _cleanup_unlisted_rule_files "${rules_dest}/${label}" "${label}" "${rule_links}" || return 1
-  done <<< "${selected_labels}"
+  if _claude_profile_injects_full_rule_tree; then
+    rule_links="$(manifest_rule_links_checked "${LANGUAGES:-}")" || return 1
+    selected_labels="$(manifest_rule_labels_checked "${LANGUAGES:-}")" || return 1
+    all_labels="$(manifest_rule_labels_checked "")" || return 1
 
-  installed_count=0
-  while IFS=$'\t' read -r source_path dest_rel label; do
-    [[ -n "${source_path}" && -n "${dest_rel}" && -n "${label}" ]] || continue
-    _install_manifest_rule_file "${source_path}" "${dest_rel}" "${label}" "${rules_dest}" || return 1
-    installed_count=$((installed_count + 1))
-  done <<< "${rule_links}"
-  green "  manifest rules -> ~/.claude/rules/vibeguard/ (${installed_count} files, symlinked)"
+    while IFS= read -r label; do
+      [[ -n "${label}" ]] || continue
+      if _rule_label_is_selected "${label}" "${selected_labels}"; then
+        continue
+      fi
+      if [[ -d "${rules_dest}/${label}" ]]; then
+        _remove_rule_subtree_if_safe "$(_claude_source_path "rules/claude-rules/${label}")" "${rules_dest}/${label}" "${label}" || return 1
+        yellow "  ${label}/ removed (not in --languages filter)"
+      fi
+    done <<< "${all_labels}"
+
+    while IFS= read -r label; do
+      [[ -n "${label}" ]] || continue
+      _cleanup_unlisted_rule_files "${rules_dest}/${label}" "${label}" "${rule_links}" || return 1
+    done <<< "${selected_labels}"
+
+    installed_count=0
+    while IFS=$'\t' read -r source_path dest_rel label; do
+      [[ -n "${source_path}" && -n "${dest_rel}" && -n "${label}" ]] || continue
+      _install_manifest_rule_file "${source_path}" "${dest_rel}" "${label}" "${rules_dest}" || return 1
+      installed_count=$((installed_count + 1))
+    done <<< "${rule_links}"
+    green "  manifest rules -> ~/.claude/rules/vibeguard/ (${installed_count} files, symlinked, ${PROFILE} profile)"
+  else
+    # GH-541: compact core default — remove any previously front-injected full
+    # rule tree so switching down from full/strict shrinks the live payload.
+    # The compact L1-L7 + Key Detailed Rules table in ~/.claude/CLAUDE.md is the
+    # always-on surface; custom/ user rules below are preserved.
+    all_labels="$(manifest_rule_labels_checked "")" || return 1
+    while IFS= read -r label; do
+      [[ -n "${label}" ]] || continue
+      if [[ -d "${rules_dest}/${label}" ]]; then
+        _remove_rule_subtree_if_safe "$(_claude_source_path "rules/claude-rules/${label}")" "${rules_dest}/${label}" "${label}" || return 1
+      fi
+    done <<< "${all_labels}"
+    green "  compact core (${PROFILE} profile): L1-L7 + Key Detailed Rules table via ~/.claude/CLAUDE.md; full rule text opt-in with --profile full|strict"
+  fi
 
   if [[ -d "${rules_dest}" ]]; then
     if [[ -d "${VIBEGUARD_HOME}/user-rules" ]]; then

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -413,7 +413,7 @@ check_codex_agents_hygiene() {
   local rules_dest="${HOME}/.claude/rules/vibeguard"
   local actual_rule_count declared_count
   if [[ -d "${rules_dest}" ]]; then
-    actual_rule_count=$(vibeguard_rule_id_count "${rules_dest}")
+    actual_rule_count=$(claude_rule_count_for_banner)
     if declared_count=$(vibeguard_managed_rule_banner_count "${agents_md}"); then
       if [[ "${actual_rule_count}" -eq "${declared_count}" ]]; then
         green "[OK] Rule count in ~/.codex/AGENTS.md: ${actual_rule_count} rules"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -164,4 +164,39 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "GH-541 rule-delivery budget (compact core default vs full-tree opt-in)"
+# The default (core/minimal) Claude profile injects only the compact L1-L7 +
+# Key Detailed Rules table into ~/.claude/CLAUDE.md; the full rules/claude-rules
+# tree is opt-in under full/strict. This asserts the actual production content:
+# the compact core stays within the U-32 budget, while the full common/ tree —
+# the payload the default profile must NOT front-inject — blows past the block
+# threshold. See scripts/setup/targets/claude-home.sh Step 5.5.
+
+COMPACT_SRC="${REPO_DIR}/claude-md/vibeguard-rules.md"
+TOTAL=$((TOTAL + 1))
+if [[ -f "${COMPACT_SRC}" ]]; then
+  green "compact core source present: claude-md/vibeguard-rules.md"
+  PASS=$((PASS + 1))
+
+  CORE_HOME="${TMP_ROOT}/home-gh541-core"
+  CORE_REPO="${TMP_ROOT}/repo-gh541-core"
+  make_home "${CORE_HOME}"
+  make_repo "${CORE_REPO}"
+  cp "${COMPACT_SRC}" "${CORE_HOME}/.claude/CLAUDE.md"
+  core_json="$(python3 "${COUNTER}" --root "${CORE_REPO}" --home "${CORE_HOME}" --json)"
+  assert_contains "${core_json}" '"status": "ok"' "compact core default payload stays within U-32 budget"
+
+  FULL_HOME="${TMP_ROOT}/home-gh541-full"
+  FULL_REPO="${TMP_ROOT}/repo-gh541-full"
+  make_home "${FULL_HOME}"
+  make_repo "${FULL_REPO}"
+  mkdir -p "${FULL_HOME}/.claude/rules/vibeguard/common"
+  cp "${REPO_DIR}/rules/claude-rules/common/"*.md "${FULL_HOME}/.claude/rules/vibeguard/common/"
+  assert_exit_nonzero "full common/ tree exceeds the block budget (must stay opt-in, not default)" \
+    python3 "${COUNTER}" --root "${FULL_REPO}" --home "${FULL_HOME}" --fail-on-block
+else
+  red "compact core source present: claude-md/vibeguard-rules.md"
+  FAIL=$((FAIL + 1))
+fi
+
 hook_test_finish

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -361,7 +361,7 @@ assert_cmd "repo pre-commit hook is installed after setup" assert_repo_git_hook_
 assert_cmd "repo pre-push hook is installed after setup" assert_repo_git_hook_target "pre-push" "${HOME}/.vibeguard/pre-push"
 assert_cmd "Claude vibeguard skill targets installed snapshot" bash -c "[[ \"\$(readlink '${HOME}/.claude/skills/vibeguard')\" == '${HOME}/.vibeguard/installed/skills/vibeguard' ]]"
 assert_cmd "Claude command target uses installed snapshot" bash -c "[[ \"\$(readlink '${HOME}/.claude/commands/vg')\" == '${HOME}/.vibeguard/installed/.claude/commands/vg' ]]"
-assert_cmd "native rule target uses installed snapshot" bash -c "[[ \"\$(readlink '${HOME}/.claude/rules/vibeguard/common/security.md')\" == '${HOME}/.vibeguard/installed/rules/claude-rules/common/security.md' ]]"
+assert_cmd "core profile does not front-inject the native rule tree (GH-541)" test ! -e "${HOME}/.claude/rules/vibeguard/common/security.md"
 fake_live_repo="${TMP_HOME}/fake-live-repo"
 mkdir -p "${fake_live_repo}/hooks/git" "${fake_live_repo}/hooks"
 cat > "${fake_live_repo}/hooks/git/pre-push" <<'SH'
@@ -400,7 +400,9 @@ assert_not_contains "${default_scheduler_check_out}" "[WARN] Scheduled GC" "--ch
 
 dev_linked_home="${TMP_HOME}/dev-linked-home"
 mkdir -p "${dev_linked_home}"
-dev_linked_out="$(HOME="${dev_linked_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --dev-linked)"
+# GH-541: the native rule tree is only front-injected under full/strict, so use
+# the full profile here to exercise dev-linked rule-symlink target resolution.
+dev_linked_out="$(HOME="${dev_linked_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --dev-linked --profile full)"
 assert_contains "${dev_linked_out}" "Mode: dev-linked repo (execution uses live repository paths)" "--dev-linked mode is visible during setup"
 assert_cmd "--dev-linked writes explicit execution mode" grep -q '^dev-linked-repo$' "${dev_linked_home}/.vibeguard/execution-mode"
 assert_cmd "--dev-linked Claude skill targets repo" bash -c "[[ \"\$(readlink '${dev_linked_home}/.claude/skills/vibeguard')\" == '${REPO_DIR}/skills/vibeguard' ]]"
@@ -541,6 +543,9 @@ rm -f "${HOME}/.claude/skills/vibeguard"
 ln -s "${HOME}/.vibeguard/installed/skills/vibeguard" "${HOME}/.claude/skills/vibeguard"
 wrong_rule_target="${TMP_HOME}/wrong-security-rule.md"
 printf '## U-17: Wrong source\n' > "${wrong_rule_target}"
+# GH-541: the core profile no longer front-injects the tree, so create the
+# common/ dir before injecting the drift/stale symlinks the --check must catch.
+mkdir -p "${HOME}/.claude/rules/vibeguard/common"
 rm -f "${HOME}/.claude/rules/vibeguard/common/security.md"
 ln -s "${wrong_rule_target}" "${HOME}/.claude/rules/vibeguard/common/security.md"
 drift_claude_rule_check_out="$(bash "${REPO_DIR}/setup.sh" --check 2>&1 || true)"

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -634,10 +634,10 @@ assert_cmd "run-hook-codex rejects non-namespaced hook names" bash -c "out=\$(pr
 assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 assert_cmd "~/.claude/CLAUDE.md includes the chat contract anchor after installation" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${HOME}/.claude/CLAUDE.md"
-assert_cmd "~/.claude/CLAUDE.md rule banner matches installed rules" assert_claude_rule_banner_matches_installed_rules
+assert_cmd "~/.claude/CLAUDE.md rule banner matches expected rules" assert_claude_rule_banner_matches_expected_rules
 assert_cmd "~/.codex/AGENTS.md exists after installation" test -f "${HOME}/.codex/AGENTS.md"
 assert_cmd "~/.codex/AGENTS.md includes managed markers after installation" bash -c "grep -q '<!-- vibeguard-start -->' '${HOME}/.codex/AGENTS.md' && grep -q '<!-- vibeguard-end -->' '${HOME}/.codex/AGENTS.md'"
-assert_cmd "~/.codex/AGENTS.md rule banner matches installed rules" assert_codex_rule_banner_matches_installed_rules
+assert_cmd "~/.codex/AGENTS.md rule banner matches expected rules" assert_codex_rule_banner_matches_expected_rules
 assert_cmd "~/.codex/AGENTS.md includes key Codex-visible anchors" bash -c "grep -qF 'Compact Chat Contract' '${HOME}/.codex/AGENTS.md' && grep -qF '| W-03 |' '${HOME}/.codex/AGENTS.md' && grep -qF '| SEC-13 |' '${HOME}/.codex/AGENTS.md'"
 assert_cmd "templates/AGENTS.md includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/templates/AGENTS.md"
 assert_cmd "docs/CLAUDE.md.example includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/docs/CLAUDE.md.example"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -307,7 +307,7 @@ old_runtime_check_out="$(VIBEGUARD_SETUP_RUNTIME="${old_profile_runtime}" bash "
 assert_not_contains "${old_runtime_check_out}" "[MISSING] Claude hooks missing for core profile" "setup --check skips stale runtime profile-hook false missing"
 
 header "setup install --languages rust"
-install_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core --languages rust)"
+install_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile full --languages rust)"
 assert_contains "${install_lang_out}" "Languages: rust" "--languages parameter takes effect"
 assert_cmd "--languages keeps common native rules" test -L "${HOME}/.claude/rules/vibeguard/common/security.md"
 assert_cmd "--languages installs selected Rust native rules" test -L "${HOME}/.claude/rules/vibeguard/rust/quality.md"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -306,6 +306,18 @@ chmod +x "${old_profile_runtime}"
 old_runtime_check_out="$(VIBEGUARD_SETUP_RUNTIME="${old_profile_runtime}" bash "${REPO_DIR}/setup.sh" --check --strict 2>&1 || true)"
 assert_not_contains "${old_runtime_check_out}" "[MISSING] Claude hooks missing for core profile" "setup --check skips stale runtime profile-hook false missing"
 
+header "setup install core --languages rust"
+install_core_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core --languages rust)"
+assert_contains "${install_core_lang_out}" "Languages: rust" "core --languages parameter takes effect"
+assert_cmd "core --languages does not front-inject Rust native rules" test ! -e "${HOME}/.claude/rules/vibeguard/rust/quality.md"
+core_lang_check_rc=0
+core_lang_check_out="$(bash "${REPO_DIR}/setup.sh" --check --strict 2>&1)" || core_lang_check_rc=$?
+assert_cmd "core --languages setup --check --strict does not exit broken" test "${core_lang_check_rc}" -ne 2
+assert_not_contains "${core_lang_check_out}" "CLAUDE.md declares" "core --languages check preserves Claude rule banner count"
+assert_not_contains "${core_lang_check_out}" "~/.codex/AGENTS.md declares" "core --languages check preserves Codex rule banner count"
+assert_cmd "core --languages CLAUDE.md rule banner matches selected rules" assert_claude_rule_banner_matches_expected_rules
+assert_cmd "core --languages Codex AGENTS.md rule banner matches selected rules" assert_codex_rule_banner_matches_expected_rules
+
 header "setup install --languages rust"
 install_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile full --languages rust)"
 assert_contains "${install_lang_out}" "Languages: rust" "--languages parameter takes effect"

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -116,9 +116,21 @@ assert_cmd "Pre-existing non-VibeGuard hook remains after cleaning" grep -q 'nod
 
 header "setup install default languages before rust filter"
 install_default_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core)"
-assert_contains "${install_default_lang_out}" "manifest rules -> ~/.claude/rules/vibeguard/" "default install writes manifest native rules"
-assert_cmd "default install includes Python native rules" test -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
-assert_cmd "default install includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
+# GH-541: the default (core) profile delivers only the compact L1-L7 + Key
+# Detailed Rules table via ~/.claude/CLAUDE.md and must NOT front-inject the
+# full native rule tree, so the live payload stays within the U-32 budget.
+assert_contains "${install_default_lang_out}" "compact core (core profile)" "core profile install reports compact core delivery"
+assert_cmd "core profile does not front-inject Python native rules" test ! -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
+assert_cmd "core profile does not front-inject Go native rules" test ! -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
+
+# The full rule text stays opt-in under the full/strict profiles.
+install_full_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile full)"
+assert_contains "${install_full_lang_out}" "manifest rules -> ~/.claude/rules/vibeguard/" "full profile install writes manifest native rules"
+assert_cmd "full profile includes Python native rules" test -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
+assert_cmd "full profile includes Go native rules" test -L "${HOME}/.claude/rules/vibeguard/golang/quality.md"
+# Switching back to core removes the previously front-injected tree.
+install_core_again_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core)"
+assert_cmd "core profile removes previously injected Python native rules" test ! -L "${HOME}/.claude/rules/vibeguard/python/quality.md"
 assert_cmd "core profile hooks match manifest" python3 "${SETTINGS_HELPER}" check --settings-file "${HOME}/.claude/settings.json" --target profile-hooks:core
 BASH_C_PROFILE_SETTINGS="${TMP_HOME}/bash-c-profile-settings.json"
 python3 - "${HOME}/.claude/settings.json" "${BASH_C_PROFILE_SETTINGS}" <<'PY'

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -39,15 +39,15 @@ mixed_clean_out="$(bash "${REPO_DIR}/setup.sh" --clean 2>&1)"
 assert_contains "${mixed_clean_out}" "VibeGuard cleaned." "setup --clean succeeds with mixed Claude hook entry"
 assert_cmd "setup --clean preserves third-party Claude hook in mixed entry" grep -q "/tmp/third-party-pre-bash.sh" "${HOME}/.claude/settings.json"
 assert_cmd "setup --clean removes VibeGuard hook from mixed entry" bash -c "! grep -q 'pre-bash-guard.sh' '${HOME}/.claude/settings.json'"
-bash "${REPO_DIR}/setup.sh" --yes >/dev/null
+bash "${REPO_DIR}/setup.sh" --yes --profile full >/dev/null
 
 _CUSTOM_RULE="${HOME}/.claude/rules/vibeguard/common/security.md"
 rm -f "${_CUSTOM_RULE}"
 printf 'local custom security rule\n' > "${_CUSTOM_RULE}"
-rule_protect_out="$(bash "${REPO_DIR}/setup.sh" --yes 2>&1 || true)"
+rule_protect_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile full 2>&1 || true)"
 assert_contains "${rule_protect_out}" "refusing to overwrite modified local rule file" "setup refuses to overwrite modified local rule copies"
 assert_cmd "modified local rule copy remains a regular file" bash -c "[ -f '${_CUSTOM_RULE}' ] && [ ! -L '${_CUSTOM_RULE}' ]"
-rule_force_out="$(bash "${REPO_DIR}/setup.sh" --yes --force-overwrite 2>&1)"
+rule_force_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile full --force-overwrite 2>&1)"
 assert_contains "${rule_force_out}" "FORCE: replacing local rule copy" "--force-overwrite reports local rule replacement"
 assert_cmd "--force-overwrite restores rule symlink" test -L "${_CUSTOM_RULE}"
 
@@ -216,8 +216,8 @@ assert_cmd "--check does not rewrite ~/.codex/AGENTS.md" test "${agents_before_s
 assert_cmd "--check does not drop or duplicate the chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 repair_out="$(bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${repair_out}" "Setup complete! All components installed." "re-running setup after drift still succeeds"
-assert_cmd "repair restores CLAUDE.md rule banner count" assert_claude_rule_banner_matches_installed_rules
-assert_cmd "repair restores Codex AGENTS.md rule banner count" assert_codex_rule_banner_matches_installed_rules
+assert_cmd "repair restores CLAUDE.md rule banner count" assert_claude_rule_banner_matches_expected_rules
+assert_cmd "repair restores Codex AGENTS.md rule banner count" assert_codex_rule_banner_matches_expected_rules
 assert_cmd "repeat setup keeps exactly one chat contract block" python3 -c "from pathlib import Path; text = Path('${HOME}/.claude/CLAUDE.md').read_text(encoding='utf-8'); raise SystemExit(0 if text.count('${CHAT_CONTRACT_ANCHOR}') == 1 else 1)"
 
 header "upsert idempotency with non-standard wrapper path"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -148,9 +148,44 @@ rule_id_count_for_test() {
   printf '%s\n' "${actual}"
 }
 
+installed_languages_for_test() {
+  python3 - <<'PY' "${HOME}/.vibeguard/install-state.json"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if not path.exists():
+    raise SystemExit(1)
+data = json.loads(path.read_text(encoding="utf-8"))
+languages = data.get("languages") or []
+print(",".join(str(item).strip() for item in languages if str(item).strip()))
+PY
+}
+
+manifest_rule_count_for_test() {
+  local languages="${1:-}"
+  local links source_path dest_rel label total=0 file_count
+  if [[ -n "${languages}" ]]; then
+    links="$(python3 "${MANIFEST_HELPER}" rule-links --languages "${languages}")"
+  else
+    links="$(python3 "${MANIFEST_HELPER}" rule-links)"
+  fi
+  while IFS=$'\t' read -r source_path dest_rel label; do
+    [[ -n "${source_path}" && -n "${dest_rel}" && -n "${label}" ]] || continue
+    file_count=$(rule_id_count_for_test "${REPO_DIR}/${source_path}")
+    total=$((total + file_count))
+  done <<< "${links}"
+  if [[ -d "${HOME}/.vibeguard/user-rules" ]]; then
+    file_count=$(rule_id_count_for_test "${HOME}/.vibeguard/user-rules")
+    total=$((total + file_count))
+  fi
+  printf '%s\n' "${total}"
+}
+
 expected_rule_banner_count_for_test() {
   local rules_dest="${HOME}/.claude/rules/vibeguard"
-  local front_injected_count=0 label label_count
+  local front_injected_count=0 label label_count languages
   for label in common golang python rust typescript taste; do
     [[ -d "${rules_dest}/${label}" ]] || continue
     label_count=$(rule_id_count_for_test "${rules_dest}/${label}")
@@ -160,7 +195,8 @@ expected_rule_banner_count_for_test() {
     printf '%s\n' "${front_injected_count}"
     return
   fi
-  rule_id_count_for_test "${REPO_DIR}/rules/claude-rules"
+  languages="$(installed_languages_for_test 2>/dev/null || true)"
+  manifest_rule_count_for_test "${languages}"
 }
 
 assert_claude_rule_banner_matches_expected_rules() {

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -138,24 +138,41 @@ raise SystemExit(0 if len(set(blocks)) == 1 else 1)
 PY
 }
 
-assert_claude_rule_banner_matches_installed_rules() {
-  local rules_dest="${HOME}/.claude/rules/vibeguard"
-  local actual=0 declared file_count rule_file
+rule_id_count_for_test() {
+  local root="$1"
+  local actual=0 file_count rule_file
   while IFS= read -r rule_file; do
     file_count=$(grep -cE '^##[[:space:]]+(RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+([[:space:]:]|$)' "${rule_file}" 2>/dev/null || true)
     actual=$((actual + file_count))
-  done < <(find "${rules_dest}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
+  done < <(find "${root}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
+  printf '%s\n' "${actual}"
+}
+
+expected_rule_banner_count_for_test() {
+  local rules_dest="${HOME}/.claude/rules/vibeguard"
+  local front_injected_count=0 label label_count
+  for label in common golang python rust typescript taste; do
+    [[ -d "${rules_dest}/${label}" ]] || continue
+    label_count=$(rule_id_count_for_test "${rules_dest}/${label}")
+    front_injected_count=$((front_injected_count + label_count))
+  done
+  if [[ "${front_injected_count}" -gt 0 ]]; then
+    printf '%s\n' "${front_injected_count}"
+    return
+  fi
+  rule_id_count_for_test "${REPO_DIR}/rules/claude-rules"
+}
+
+assert_claude_rule_banner_matches_expected_rules() {
+  local actual declared
+  actual=$(expected_rule_banner_count_for_test)
   declared=$(managed_rule_banner_count_for_test "${HOME}/.claude/CLAUDE.md")
   [[ "${declared}" == "${actual}" ]]
 }
 
-assert_codex_rule_banner_matches_installed_rules() {
-  local rules_dest="${HOME}/.claude/rules/vibeguard"
-  local actual=0 declared file_count rule_file
-  while IFS= read -r rule_file; do
-    file_count=$(grep -cE '^##[[:space:]]+(RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+([[:space:]:]|$)' "${rule_file}" 2>/dev/null || true)
-    actual=$((actual + file_count))
-  done < <(find "${rules_dest}" \( -type f -o -type l \) -name "*.md" 2>/dev/null)
+assert_codex_rule_banner_matches_expected_rules() {
+  local actual declared
+  actual=$(expected_rule_banner_count_for_test)
   declared=$(managed_rule_banner_count_for_test "${HOME}/.codex/AGENTS.md")
   [[ "${declared}" == "${actual}" ]]
 }


### PR DESCRIPTION
Implements #541 (spec merged in #546).

## What
Under the `core`/`minimal` profiles (`core` is the install default), the full `rules/claude-rules` tree is no longer front-injected into `~/.claude/rules/vibeguard`. Those profiles now rely on the compact L1-L7 + Key Detailed Rules table already synced into `~/.claude/CLAUDE.md`, keeping the live constraint payload within the U-32 budget. The full-text tree stays installed under `~/.vibeguard` and is opt-in via `--profile full|strict`.

## Why
VibeGuard's own U-32 rule blocks at >30 effective constraints, but the default install front-injected the full native rule tree — measured at **224 effective always-on constraints** (7.5x the block threshold), dominated by `common/security.md` (58), `common/workflow.md` (55), `common/coding-style.md` (45). This was the flagship anti-bloat rule being violated by the rule set's own delivery.

## Approach
Profile-gated at install time (`scripts/setup/targets/claude-home.sh` Step 5.5) via `_claude_profile_injects_full_rule_tree()`. No rule is deleted — full text remains opt-in. Zero security-rule loss on the compact path (security stays in the always-on Key Detailed Rules table).

## Verification
`bash tests/hooks/test_count_active_constraints.sh` — 24/24 pass, including:
- compact core default payload stays within U-32 budget (status ok)
- full common/ tree exceeds the block budget (must stay opt-in, not default)

## AI Role
Implementation gated at the setup layer; the U-32 budget change affects what every default Claude session sees — human review recommended on the compact-core boundary.

Fixes #541