### PR TITLE
Add runtime hook orchestrator scaffold

### DIFF
--- a/vibeguard-runtime/src/git_root.rs
+++ b/vibeguard-runtime/src/git_root.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -17,6 +18,22 @@ pub(crate) fn git_root_for(cwd: &Path) -> Option<PathBuf> {
         .output()
         .ok()?;
     parse_git_root_output(output)
+}
+
+pub(crate) fn current_git_root_by_marker() -> Option<PathBuf> {
+    git_root_by_marker_for(&std::env::current_dir().ok()?)
+}
+
+pub(crate) fn git_root_by_marker_for(cwd: &Path) -> Option<PathBuf> {
+    let mut current = cwd.to_path_buf();
+    loop {
+        if current.join(".git").exists() {
+            return fs::canonicalize(&current).ok().or(Some(current));
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
 }
 
 fn parse_git_root_output(output: Output) -> Option<PathBuf> {

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -1,0 +1,184 @@
+use serde_json::{Value, json};
+use std::time::Instant;
+
+use crate::event_schema::{decision, field, status, tool};
+use crate::hook_checks_common::{append_jsonl, nested_str, read_stdin, truncate_chars};
+use crate::hook_orchestrator_context::RuntimeContext;
+use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
+use crate::wrapper_env::env_nonempty;
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HookKind {
+    PreWrite,
+    PreBash,
+    PreEdit,
+    PostWrite,
+    PostEdit,
+    Stop,
+    Learn,
+}
+
+impl HookKind {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pre-write" | "pre-write-guard" => Some(Self::PreWrite),
+            "pre-bash" | "pre-bash-guard" => Some(Self::PreBash),
+            "pre-edit" | "pre-edit-guard" => Some(Self::PreEdit),
+            "post-write" | "post-write-guard" => Some(Self::PostWrite),
+            "post-edit" | "post-edit-guard" => Some(Self::PostEdit),
+            "stop" | "stop-guard" => Some(Self::Stop),
+            "learn" | "learn-evaluator" => Some(Self::Learn),
+            _ => None,
+        }
+    }
+
+    fn hook_name(self) -> &'static str {
+        match self {
+            Self::PreWrite => "pre-write-guard",
+            Self::PreBash => "pre-bash-guard",
+            Self::PreEdit => "pre-edit-guard",
+            Self::PostWrite => "post-write-guard",
+            Self::PostEdit => "post-edit-guard",
+            Self::Stop => "stop-guard",
+            Self::Learn => "learn-evaluator",
+        }
+    }
+
+    fn tool_name(self) -> &'static str {
+        match self {
+            Self::PreWrite | Self::PostWrite => tool::WRITE,
+            Self::PreBash => tool::BASH,
+            Self::PreEdit | Self::PostEdit => tool::EDIT,
+            Self::Stop | Self::Learn => "Stop",
+        }
+    }
+}
+
+pub(crate) fn run(args: &[String]) -> Result {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime hook <pre-write|pre-bash|pre-edit|post-write|post-edit|stop|learn>".into());
+    }
+    let kind = HookKind::parse(&args[0]).ok_or_else(|| format!("unknown hook: {}", args[0]))?;
+    let start = Instant::now();
+    let input = read_stdin()?;
+    let ctx = RuntimeContext::collect()?;
+
+    let parsed = serde_json::from_str::<Value>(&input);
+    match parsed {
+        Ok(data) if data.is_object() => {
+            append_hook_event(
+                &ctx,
+                kind,
+                decision::PASS,
+                status::PASS,
+                "runtime hook orchestrator scaffold",
+                &detail_for(kind, &data),
+                elapsed_ms(start),
+            )?;
+            Ok(())
+        }
+        _ => {
+            let reason = format!(
+                "VIBEGUARD interception: invalid {} hook input JSON; fail-closed because runtime hook orchestrator could not parse stdin.",
+                kind.hook_name()
+            );
+            append_hook_event(
+                &ctx,
+                kind,
+                decision::BLOCK,
+                status::BLOCK,
+                &reason,
+                "",
+                elapsed_ms(start),
+            )?;
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "decision": "block",
+                    "reason": reason,
+                }))?
+            );
+            Ok(())
+        }
+    }
+}
+
+fn append_hook_event(
+    ctx: &RuntimeContext,
+    kind: HookKind,
+    decision_value: &str,
+    status_value: &str,
+    reason: &str,
+    detail: &str,
+    duration_ms: u64,
+) -> Result {
+    let mut event = json!({
+        "schema_version": 1,
+        field::TS: format_unix_secs_utc(now_unix_secs()),
+        field::SESSION: ctx.session_id,
+        field::HOOK: kind.hook_name(),
+        field::TOOL: kind.tool_name(),
+        field::DECISION: decision_value,
+        field::STATUS: status_value,
+        field::REASON: reason,
+        field::DETAIL: truncate_chars(detail, 200),
+        field::DURATION_MS: duration_ms,
+        field::CLI: ctx.cli,
+        field::CLIENT: ctx.client,
+        field::CLIENT_VARIANT: ctx.client_variant,
+        field::CALLER_EVIDENCE: ctx.caller_evidence,
+    });
+    event["project_hash"] = json!(ctx.project_hash);
+    append_optional_env(&mut event, "VIBEGUARD_AGENT_TYPE", field::AGENT);
+    append_optional_env(&mut event, "VIBEGUARD_WRAPPER", field::WRAPPER);
+    append_optional_env(&mut event, "VIBEGUARD_SOURCE_CONFIG", field::SOURCE_CONFIG);
+    append_optional_env(
+        &mut event,
+        "VIBEGUARD_HOOK_PROTOCOL_VERSION",
+        field::HOOK_PROTOCOL_VERSION,
+    );
+
+    let line = serde_json::to_string(&event)?;
+    append_jsonl(&ctx.log_file, &line)?;
+    let global_log = ctx.log_root.join("events.jsonl");
+    if global_log != ctx.log_file {
+        append_jsonl(&global_log, &line)?;
+    }
+    Ok(())
+}
+
+fn append_optional_env(event: &mut Value, env_name: &str, field_name: &str) {
+    if let Some(value) = env_nonempty(env_name) {
+        event[field_name] = Value::String(value);
+    }
+}
+
+fn detail_for(kind: HookKind, data: &Value) -> String {
+    let path = match kind {
+        HookKind::PreWrite | HookKind::PostWrite => nested_str(data, "tool_input.file_path"),
+        HookKind::PreEdit | HookKind::PostEdit => {
+            nested_str(data, "tool_input.file_path").or_else(|| nested_str(data, "tool_input.path"))
+        }
+        HookKind::PreBash => nested_str(data, "tool_input.command"),
+        HookKind::Stop | HookKind::Learn => nested_str(data, "transcript_path"),
+    };
+    path.unwrap_or_default()
+}
+
+fn elapsed_ms(start: Instant) -> u64 {
+    start.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_kind_accepts_short_and_script_names() {
+        assert_eq!(HookKind::parse("pre-write"), Some(HookKind::PreWrite));
+        assert_eq!(HookKind::parse("pre-write-guard"), Some(HookKind::PreWrite));
+        assert_eq!(HookKind::parse("nope"), None);
+    }
+}

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -63,12 +63,18 @@ pub(crate) fn run(args: &[String]) -> Result {
     let kind = HookKind::parse(&args[0]).ok_or_else(|| format!("unknown hook: {}", args[0]))?;
     let start = Instant::now();
     let input = read_stdin()?;
-    let ctx = RuntimeContext::collect()?;
 
     let parsed = serde_json::from_str::<Value>(&input);
     match parsed {
         Ok(data) if data.is_object() => {
-            append_hook_event(
+            let ctx = match RuntimeContext::collect() {
+                Ok(ctx) => ctx,
+                Err(err) => {
+                    emit_runtime_failure_block(kind, "collect runtime context", err)?;
+                    return Ok(());
+                }
+            };
+            if let Err(err) = append_hook_event(
                 &ctx,
                 kind,
                 decision::PASS,
@@ -76,7 +82,9 @@ pub(crate) fn run(args: &[String]) -> Result {
                 "runtime hook orchestrator scaffold",
                 &detail_for(kind, &data),
                 elapsed_ms(start),
-            )?;
+            ) {
+                emit_runtime_failure_block(kind, "append hook event", err)?;
+            }
             Ok(())
         }
         _ => {
@@ -84,25 +92,60 @@ pub(crate) fn run(args: &[String]) -> Result {
                 "VIBEGUARD interception: invalid {} hook input JSON; fail-closed because runtime hook orchestrator could not parse stdin.",
                 kind.hook_name()
             );
-            append_hook_event(
-                &ctx,
-                kind,
-                decision::BLOCK,
-                status::BLOCK,
-                &reason,
-                "",
-                elapsed_ms(start),
-            )?;
-            println!(
-                "{}",
-                serde_json::to_string(&json!({
-                    "decision": "block",
-                    "reason": reason,
-                }))?
-            );
+            print_block(&reason)?;
+            match RuntimeContext::collect() {
+                Ok(ctx) => {
+                    if let Err(err) = append_hook_event(
+                        &ctx,
+                        kind,
+                        decision::BLOCK,
+                        status::BLOCK,
+                        &reason,
+                        "",
+                        elapsed_ms(start),
+                    ) {
+                        eprintln!(
+                            "VIBEGUARD: failed to log fail-closed {} event: {err}",
+                            kind.hook_name()
+                        );
+                    }
+                }
+                Err(err) => {
+                    eprintln!(
+                        "VIBEGUARD: failed to collect context for fail-closed {} event: {err}",
+                        kind.hook_name()
+                    );
+                }
+            }
             Ok(())
         }
     }
+}
+
+fn emit_runtime_failure_block(
+    kind: HookKind,
+    operation: &str,
+    err: Box<dyn std::error::Error>,
+) -> Result {
+    let reason = format!(
+        "VIBEGUARD interception: {} runtime orchestrator failed to {}; fail-closed.",
+        kind.hook_name(),
+        operation
+    );
+    print_block(&reason)?;
+    eprintln!("VIBEGUARD: {reason}: {err}");
+    Ok(())
+}
+
+fn print_block(reason: &str) -> Result {
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "decision": "block",
+            "reason": reason,
+        }))?
+    );
+    Ok(())
 }
 
 fn append_hook_event(

--- a/vibeguard-runtime/src/hook_orchestrator_context.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_context.rs
@@ -68,18 +68,28 @@ impl RuntimeContext {
             );
         }
 
-        let parent = infer_parent();
-        let cli = env_nonempty("VIBEGUARD_CLI")
+        let explicit_cli = env_nonempty("VIBEGUARD_CLI");
+        let explicit_session_id = env_nonempty("VIBEGUARD_SESSION_ID");
+        let skip_parent_inference = explicit_cli.is_none() && explicit_session_id.is_some();
+        let parent = if skip_parent_inference {
+            None
+        } else {
+            infer_parent()
+        };
+        let cli = explicit_cli
             .or_else(|| parent.as_ref().map(|info| info.cli.clone()))
             .unwrap_or_else(|| "unknown".to_string());
-        let session_id = env_nonempty("VIBEGUARD_SESSION_ID").unwrap_or_else(|| {
+        let session_id = explicit_session_id.unwrap_or_else(|| {
             resolve_session_id(&project_log_dir, &cli, &project_root_text, parent.as_ref())
         });
-        let client = env_nonempty("VIBEGUARD_CLIENT").unwrap_or_else(|| match cli.as_str() {
-            "claude" => "claude".to_string(),
-            "codex" => "codex".to_string(),
-            _ => "unknown".to_string(),
-        });
+        let explicit_client = env_nonempty("VIBEGUARD_CLIENT");
+        let client = explicit_client
+            .clone()
+            .unwrap_or_else(|| match cli.as_str() {
+                "claude" => "claude".to_string(),
+                "codex" => "codex".to_string(),
+                _ => "unknown".to_string(),
+            });
         let client_variant =
             env_nonempty("VIBEGUARD_CLIENT_VARIANT").unwrap_or_else(|| match client.as_str() {
                 "claude" => "claude-code-hooks".to_string(),
@@ -87,12 +97,12 @@ impl RuntimeContext {
                 _ => "unknown".to_string(),
             });
         let caller_evidence = env_nonempty("VIBEGUARD_CALLER_EVIDENCE").unwrap_or_else(|| {
-            if parent.is_some() {
-                "parent-process".to_string()
-            } else if cli == "unknown" {
-                "no-client-evidence".to_string()
-            } else {
+            if explicit_client.is_some() {
                 "explicit-client".to_string()
+            } else if matches!(cli.as_str(), "claude" | "codex") {
+                "parent-process".to_string()
+            } else {
+                "no-client-evidence".to_string()
             }
         });
 

--- a/vibeguard-runtime/src/hook_orchestrator_context.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_context.rs
@@ -1,0 +1,258 @@
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::git_root::current_git_root_by_marker;
+use crate::setup_support::sha256_text_short;
+use crate::wrapper_env::{
+    cleanup_old_sessions, env_nonempty, hash_slug_from_log_dir, log_root, read_recent_session,
+    sanitize_token, write_session_file,
+};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug)]
+pub(crate) struct RuntimeContext {
+    pub(crate) log_root: PathBuf,
+    pub(crate) log_file: PathBuf,
+    pub(crate) project_hash: String,
+    pub(crate) session_id: String,
+    pub(crate) cli: String,
+    pub(crate) client: String,
+    pub(crate) client_variant: String,
+    pub(crate) caller_evidence: String,
+}
+
+#[derive(Debug)]
+struct ParentInfo {
+    pid: i32,
+    cli: String,
+    start: String,
+}
+
+impl RuntimeContext {
+    pub(crate) fn collect() -> Result<Self> {
+        let log_root = log_root();
+        let project_root = current_git_root_by_marker();
+        let project_root_text = project_root
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_else(|| "global".to_string());
+        let computed_hash = sha256_text_short(&project_root_text);
+        let explicit_project_log_dir = env_nonempty("VIBEGUARD_PROJECT_LOG_DIR").map(PathBuf::from);
+        let explicit_log_file = env_nonempty("VIBEGUARD_LOG_FILE").map(PathBuf::from);
+        let (project_hash, project_log_dir, log_file) =
+            match (explicit_project_log_dir, explicit_log_file) {
+                (Some(project_log_dir), Some(log_file)) => {
+                    let project_hash = env_nonempty("VIBEGUARD_PROJECT_HASH")
+                        .or_else(|| hash_slug_from_log_dir(&project_log_dir))
+                        .unwrap_or_else(|| computed_hash.clone());
+                    (project_hash, project_log_dir, log_file)
+                }
+                _ => {
+                    let project_hash = computed_hash;
+                    let project_log_dir = log_root.join("projects").join(&project_hash);
+                    let log_file = project_log_dir.join("events.jsonl");
+                    (project_hash, project_log_dir, log_file)
+                }
+            };
+
+        fs::create_dir_all(&project_log_dir)?;
+        if project_root.is_some() {
+            let _ = fs::write(
+                project_log_dir.join(".project-root"),
+                project_root_text.as_bytes(),
+            );
+        }
+
+        let parent = infer_parent();
+        let cli = env_nonempty("VIBEGUARD_CLI")
+            .or_else(|| parent.as_ref().map(|info| info.cli.clone()))
+            .unwrap_or_else(|| "unknown".to_string());
+        let session_id = env_nonempty("VIBEGUARD_SESSION_ID").unwrap_or_else(|| {
+            resolve_session_id(&project_log_dir, &cli, &project_root_text, parent.as_ref())
+        });
+        let client = env_nonempty("VIBEGUARD_CLIENT").unwrap_or_else(|| match cli.as_str() {
+            "claude" => "claude".to_string(),
+            "codex" => "codex".to_string(),
+            _ => "unknown".to_string(),
+        });
+        let client_variant =
+            env_nonempty("VIBEGUARD_CLIENT_VARIANT").unwrap_or_else(|| match client.as_str() {
+                "claude" => "claude-code-hooks".to_string(),
+                "codex" => "codex-cli-hooks".to_string(),
+                _ => "unknown".to_string(),
+            });
+        let caller_evidence = env_nonempty("VIBEGUARD_CALLER_EVIDENCE").unwrap_or_else(|| {
+            if parent.is_some() {
+                "parent-process".to_string()
+            } else if cli == "unknown" {
+                "no-client-evidence".to_string()
+            } else {
+                "explicit-client".to_string()
+            }
+        });
+
+        Ok(Self {
+            log_root,
+            log_file,
+            project_hash,
+            session_id,
+            cli,
+            client,
+            client_variant,
+            caller_evidence,
+        })
+    }
+}
+
+fn resolve_session_id(
+    project_log_dir: &Path,
+    cli: &str,
+    project_root: &str,
+    parent: Option<&ParentInfo>,
+) -> String {
+    cleanup_old_sessions(project_log_dir);
+    if let Some(parent) = parent {
+        let token = sanitize_token(cli);
+        let session_file = project_log_dir.join(format!(".session_{token}_{}", parent.pid));
+        if let Some(session_id) = read_recent_session(&session_file, &parent.start) {
+            let _ = write_session_file(&session_file, &parent.start, &session_id);
+            return session_id;
+        }
+        let session_id = new_hook_session_id(parent.pid, &parent.start, project_root);
+        let _ = write_session_file(&session_file, &parent.start, &session_id);
+        return session_id;
+    }
+
+    let token = sanitize_token(cli);
+    let session_file = project_log_dir.join(format!(".session_id_{token}"));
+    if let Some(session_id) = read_recent_session(&session_file, "") {
+        let _ = fs::write(&session_file, &session_id);
+        return session_id;
+    }
+    let session_id = new_hook_session_id(0, "unknown", project_root);
+    let _ = fs::write(&session_file, &session_id);
+    session_id
+}
+
+fn new_hook_session_id(pid: i32, start: &str, project_root: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    pid.hash(&mut hasher);
+    start.hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    project_root.hash(&mut hasher);
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn infer_parent() -> Option<ParentInfo> {
+    let mut pid = env_nonempty("VIBEGUARD_WRAPPER_PARENT_PID")
+        .and_then(|value| value.parse::<i32>().ok())
+        .filter(|pid| *pid > 1)
+        .unwrap_or_else(parent_pid);
+    for _ in 0..8 {
+        let ppid = ps_field(pid, "ppid")?.parse::<i32>().ok()?;
+        if ppid <= 1 {
+            return None;
+        }
+        let comm = ps_field(ppid, "comm").unwrap_or_default();
+        if let Some(cli) = cli_from_process(&comm, None) {
+            return Some(parent_info(ppid, cli));
+        }
+        if comm == "node" {
+            let args = ps_field(ppid, "args").unwrap_or_default();
+            if let Some(cli) = cli_from_process(&comm, Some(&args)) {
+                return Some(parent_info(ppid, cli));
+            }
+        }
+        pid = ppid;
+    }
+    None
+}
+
+#[cfg(unix)]
+fn parent_pid() -> i32 {
+    unsafe { libc::getppid() }
+}
+
+#[cfg(not(unix))]
+fn parent_pid() -> i32 {
+    0
+}
+
+fn parent_info(pid: i32, cli: &str) -> ParentInfo {
+    ParentInfo {
+        pid,
+        cli: cli.to_string(),
+        start: process_start_token(pid).unwrap_or_else(|| "unknown".to_string()),
+    }
+}
+
+fn cli_from_process(comm: &str, args: Option<&str>) -> Option<&'static str> {
+    let haystack = match args {
+        Some(args) => format!("{comm} {args}").to_ascii_lowercase(),
+        None => comm.to_ascii_lowercase(),
+    };
+    if haystack.contains("codex") {
+        Some("codex")
+    } else if haystack.contains("claude") || haystack.contains("electron") {
+        Some("claude")
+    } else {
+        None
+    }
+}
+
+fn ps_field(pid: i32, field_name: &str) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-o", &format!("{field_name}="), "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn process_start_token(pid: i32) -> Option<String> {
+    let output = Command::new("ps")
+        .env("TZ", "UTC")
+        .args(["-o", "lstart=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn explicit_session_file_reuses_recent_id() {
+        let temp = env::temp_dir().join(format!(
+            "vibeguard-hook-orchestrator-session-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp).unwrap();
+        let file = temp.join(".session_id_codex");
+        fs::write(&file, "session-one").unwrap();
+        assert_eq!(
+            read_recent_session(&file, "").as_deref(),
+            Some("session-one")
+        );
+        let _ = fs::remove_dir_all(temp);
+    }
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -18,6 +18,8 @@ mod hook_checks_history;
 mod hook_checks_scan;
 mod hook_checks_write;
 mod hook_checks_write_scan;
+mod hook_orchestrator;
+mod hook_orchestrator_context;
 mod hook_output;
 mod hook_status;
 mod json_field;
@@ -131,6 +133,11 @@ static COMMANDS: &[Command] = &[
         name: "pre-bash-check",
         usage: "<vibeguard-root>  — classify PreToolUse(Bash) input for hooks",
         handler: hook_checks_bash::pre_bash_check,
+    },
+    Command {
+        name: "hook",
+        usage: "<pre-write|pre-bash|pre-edit|post-write|post-edit|stop|learn>  — run a single-process hook orchestrator scaffold",
+        handler: hook_orchestrator::run,
     },
     Command {
         name: "session-metrics",

--- a/vibeguard-runtime/src/wrapper_env.rs
+++ b/vibeguard-runtime/src/wrapper_env.rs
@@ -70,18 +70,18 @@ pub(crate) fn run(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn env_nonempty(name: &str) -> Option<String> {
+pub(crate) fn env_nonempty(name: &str) -> Option<String> {
     env::var(name).ok().filter(|value| !value.trim().is_empty())
 }
 
-fn log_root() -> PathBuf {
+pub(crate) fn log_root() -> PathBuf {
     env_nonempty("VIBEGUARD_LOG_DIR")
         .map(PathBuf::from)
         .or_else(|| home_dir().map(|home| home.join(".vibeguard")))
         .unwrap_or_else(|| PathBuf::from(".vibeguard"))
 }
 
-fn hash_slug_from_log_dir(path: &Path) -> Option<String> {
+pub(crate) fn hash_slug_from_log_dir(path: &Path) -> Option<String> {
     let slug = path.file_name()?.to_string_lossy();
     is_hash_slug(&slug).then(|| slug.to_string())
 }
@@ -140,7 +140,7 @@ fn parse_pid(value: &str) -> Option<libc::pid_t> {
     (parsed > 1).then_some(parsed)
 }
 
-fn read_recent_session(path: &Path, expected_start: &str) -> Option<String> {
+pub(crate) fn read_recent_session(path: &Path, expected_start: &str) -> Option<String> {
     let modified = fs::metadata(path).ok()?.modified().ok()?;
     if modified.elapsed().ok()? > SESSION_TTL {
         return None;
@@ -163,11 +163,15 @@ fn read_recent_session(path: &Path, expected_start: &str) -> Option<String> {
     }
 }
 
-fn write_session_file(path: &Path, start: &str, session_id: &str) -> std::io::Result<()> {
+pub(crate) fn write_session_file(
+    path: &Path,
+    start: &str,
+    session_id: &str,
+) -> std::io::Result<()> {
     fs::write(path, format!("{start}\n{session_id}\n"))
 }
 
-fn cleanup_old_sessions(project_log_dir: &Path) {
+pub(crate) fn cleanup_old_sessions(project_log_dir: &Path) {
     let Ok(entries) = fs::read_dir(project_log_dir) else {
         return;
     };
@@ -248,7 +252,7 @@ fn process_start_token(_pid: libc::pid_t) -> Option<String> {
     None
 }
 
-fn sanitize_token(value: &str) -> String {
+pub(crate) fn sanitize_token(value: &str) -> String {
     let token: String = value
         .chars()
         .map(|ch| {

--- a/vibeguard-runtime/tests/cli_hook_orchestrator.rs
+++ b/vibeguard-runtime/tests/cli_hook_orchestrator.rs
@@ -170,3 +170,95 @@ fn hook_orchestrator_malformed_input_fails_closed() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn hook_orchestrator_malformed_input_blocks_even_when_context_collection_fails() {
+    let root = unique_temp_dir("hook-orchestrator-malformed-context-failure");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    let bad_parent = root.join("not-a-dir");
+    let bad_project_log_dir = bad_parent.join("project");
+    let bad_log_file = bad_project_log_dir.join("events.jsonl");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+    fs::write(&bad_parent, "not a directory").unwrap();
+
+    let mut child = hook_command(&repo, &log_root)
+        .args(["hook", "pre-write"])
+        .env("VIBEGUARD_PROJECT_LOG_DIR", &bad_project_log_dir)
+        .env("VIBEGUARD_LOG_FILE", &bad_log_file)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"not-json")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"decision\":\"block\""), "{stdout}");
+    assert!(
+        stdout.contains("invalid pre-write-guard hook input JSON; fail-closed"),
+        "{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("failed to collect context for fail-closed pre-write-guard event"),
+        "{stderr}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn hook_orchestrator_manual_session_without_cli_stays_unknown() {
+    let root = unique_temp_dir("hook-orchestrator-manual-session");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+
+    let mut child = hook_command(&repo, &log_root)
+        .args(["hook", "pre-bash"])
+        .env_remove("VIBEGUARD_CLI")
+        .env_remove("VIBEGUARD_CLIENT")
+        .env_remove("VIBEGUARD_CLIENT_VARIANT")
+        .env_remove("VIBEGUARD_CALLER_EVIDENCE")
+        .env("VIBEGUARD_SESSION_ID", "manual-session")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(br#"{"tool_input":{"command":"echo manual"}}"#)
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let event = read_first_json(&project_dir.join("events.jsonl"));
+    assert_eq!(event["session"], "manual-session");
+    assert_eq!(event["cli"], "unknown");
+    assert_eq!(event["client"], "unknown");
+    assert_eq!(event["client_variant"], "unknown");
+    assert_eq!(event["caller_evidence"], "no-client-evidence");
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/vibeguard-runtime/tests/cli_hook_orchestrator.rs
+++ b/vibeguard-runtime/tests/cli_hook_orchestrator.rs
@@ -1,0 +1,172 @@
+mod common;
+
+use common::{bin, unique_temp_dir};
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+fn run_hook(repo: &Path, log_root: &Path, hook: &str, input: &str) -> Output {
+    let mut child = hook_command(repo, log_root)
+        .args(["hook", hook])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn hook_command(repo: &Path, log_root: &Path) -> Command {
+    let mut command = bin();
+    command
+        .current_dir(repo)
+        .env("VIBEGUARD_LOG_DIR", log_root)
+        .env("VIBEGUARD_CLI", "codex")
+        .env("VIBEGUARD_SESSION_ID", "session-test")
+        .env("VIBEGUARD_CALLER_EVIDENCE", "explicit-test")
+        .env("VIBEGUARD_WRAPPER", "test-wrapper")
+        .env("VIBEGUARD_SOURCE_CONFIG", "test-config")
+        .env("VIBEGUARD_HOOK_PROTOCOL_VERSION", "1");
+    command
+}
+
+fn read_first_json(path: &Path) -> Value {
+    let text = fs::read_to_string(path).unwrap();
+    let first = text.lines().next().unwrap();
+    serde_json::from_str(first).unwrap()
+}
+
+#[test]
+fn hook_orchestrator_writes_project_and_global_events() {
+    let root = unique_temp_dir("hook-orchestrator-pass");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+    fs::create_dir_all(repo.join("src")).unwrap();
+
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "content": "fn main() {}"
+        }
+    })
+    .to_string();
+    let out = run_hook(&repo, &log_root, "pre-write", &input);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.stdout.is_empty());
+
+    let projects_dir = log_root.join("projects");
+    let project_entries = fs::read_dir(&projects_dir).unwrap().collect::<Vec<_>>();
+    assert_eq!(project_entries.len(), 1);
+    let project_dir = project_entries[0].as_ref().unwrap().path();
+    let project_log = project_dir.join("events.jsonl");
+    let global_log = log_root.join("events.jsonl");
+    assert_eq!(
+        fs::read_to_string(&project_log).unwrap(),
+        fs::read_to_string(&global_log).unwrap()
+    );
+    assert_eq!(
+        fs::read_to_string(project_dir.join(".project-root")).unwrap(),
+        fs::canonicalize(&repo).unwrap().to_string_lossy()
+    );
+
+    let event = read_first_json(&project_log);
+    assert_eq!(event["hook"], "pre-write-guard");
+    assert_eq!(event["tool"], "Write");
+    assert_eq!(event["decision"], "pass");
+    assert_eq!(event["status"], "pass");
+    assert_eq!(event["session"], "session-test");
+    assert_eq!(event["cli"], "codex");
+    assert_eq!(event["client"], "codex");
+    assert_eq!(event["client_variant"], "codex-cli-hooks");
+    assert_eq!(event["caller_evidence"], "explicit-test");
+    assert_eq!(event["wrapper"], "test-wrapper");
+    assert_eq!(event["source_config"], "test-config");
+    assert_eq!(event["hook_protocol_version"], "1");
+    assert_eq!(event["detail"], "src/lib.rs");
+    assert!(event["duration_ms"].as_u64().is_some(), "{event}");
+    assert_eq!(event["project_hash"].as_str().unwrap().len(), 8);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn hook_orchestrator_honors_log_file_overrides() {
+    let root = unique_temp_dir("hook-orchestrator-overrides");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    let project_log_dir = root.join("explicit-project");
+    let log_file = project_log_dir.join("events.jsonl");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+
+    let mut child = hook_command(&repo, &log_root)
+        .args(["hook", "pre-bash"])
+        .env("VIBEGUARD_PROJECT_LOG_DIR", &project_log_dir)
+        .env("VIBEGUARD_LOG_FILE", &log_file)
+        .env("VIBEGUARD_PROJECT_HASH", "feedface")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(br#"{"tool_input":{"command":"git status"}}"#)
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+
+    let event = read_first_json(&log_file);
+    assert_eq!(event["hook"], "pre-bash-guard");
+    assert_eq!(event["tool"], "Bash");
+    assert_eq!(event["detail"], "git status");
+    assert_eq!(event["project_hash"], "feedface");
+    assert!(log_root.join("events.jsonl").exists());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn hook_orchestrator_malformed_input_fails_closed() {
+    let root = unique_temp_dir("hook-orchestrator-malformed");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+
+    let out = run_hook(&repo, &log_root, "pre-write-guard", "not-json");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"decision\":\"block\""), "{stdout}");
+    assert!(
+        stdout.contains("invalid pre-write-guard hook input JSON; fail-closed"),
+        "{stdout}"
+    );
+
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let event = read_first_json(&project_dir.join("events.jsonl"));
+    assert_eq!(event["hook"], "pre-write-guard");
+    assert_eq!(event["decision"], "block");
+    assert_eq!(event["status"], "block");
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
Refs #551

Implements the SP551-T2/T3 runtime plumbing slice:
- Adds `vibeguard-runtime hook <name>` scaffold for configured hook names.
- Writes schema-compatible project and global events with project hash, duration, session, and caller fields.
- Ports the session/caller attribution base into Rust with env overrides preserved.
- Leaves hook behavior migration for later T4-T6 PRs; current hook wrappers are unchanged.

Verification:
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_observability_schemas.sh`
- `git diff --check`