### PR TITLE
docs(spec): GH566 Codex stale PreToolUse repair

### DIFF
--- a/docs/specs/GH566/product.md
+++ b/docs/specs/GH566/product.md
@@ -1,0 +1,90 @@
+# Product Spec
+
+## Linked Issue
+
+GH-566
+
+## User Problem
+
+Codex 会在每次 Bash 工具调用前执行 `~/.codex/hooks.json` 里的
+`PreToolUse` hook。当前 VibeGuard 安装/清理逻辑会保留 unmanaged
+第三方 hook，这是正确的安全默认值；但如果一个 unmanaged `PreToolUse`
+命令指向不存在的本地文件，Codex 会在真实命令执行前持续显示：
+
+```text
+PreToolUse hook (failed)
+error: hook exited with code 1
+```
+
+这会让用户误以为 SpecRail、构建或仓库命令失败。实际情况可能是业务检查
+已经通过，只是坏的全局 `PreToolUse` 残留每次都退出 1。
+
+一个具体风险是测试 fixture 'node /existing/non-vibeguard.js'。它原本用于
+验证 VibeGuard 不误删第三方 hook；但如果 fixture 进入真实
+`~/.codex/hooks.json`，Node 会因为 `MODULE_NOT_FOUND` 失败，而 VibeGuard
+又会把它当作第三方 hook 保留下来。
+
+## Goals
+
+- 让 `setup --check --strict` 能把缺失目标的 unmanaged Codex
+  `PreToolUse` hook 报为 repair-required 或 broken，而不是只作为一般
+  timeout 警告。
+- 提供显式、可审计的修复路径，能移除确认缺失目标的 unmanaged stale hook，
+  同时继续保留合法第三方 hook。
+- 防止 VibeGuard 测试 fixture 被误认为真实可保留 hook，降低真实 HOME 被
+  测试污染后的恢复成本。
+- 在 troubleshooting 文档中给出 `PreToolUse hook (failed)` 的定位和修复
+  步骤。
+
+## Non-Goals
+
+- 不删除所有 unmanaged hook。
+- 不改变 Codex `hooks.json` schema。
+- 不默认覆盖用户自定义 hook 命令。
+- 不把第三方 hook 统一纳入 VibeGuard 管理范围。
+- 不修改 Codex host 的 hook 执行语义。
+
+## Behavior Invariants
+
+1. VibeGuard-managed hook 的识别仍然只基于 `hooks/manifest.json` 和
+   namespaced `vibeguard-*.sh` 命令；不得把普通第三方 hook 标成 managed。
+2. `setup --check` 默认只检查和报告，不修改 `~/.codex/hooks.json`。
+3. 显式修复只删除可证明目标缺失的 stale hook entry，并在输出中列出
+   `config`、`event`、`matcher`、`command` 或解析出的 `command_path`。
+4. 合法存在的第三方 hook 必须继续被保留，即使命令不带 timeout。
+5. 修复路径必须保留 JSON 格式、其他 event、其他 hook entry 和原字段顺序的
+   语义，不做无关重写。
+6. 测试必须在临时 HOME 中构造 fixture；测试退出后不得把 fixture 命令写入
+   真实 `~/.codex/hooks.json`。
+
+## Acceptance Criteria
+
+- [ ] `setup --check --strict` 对缺失目标的 unmanaged Codex
+      `PreToolUse(Bash)` entry 返回 broken/repair-required verdict，并显示
+      精确 command path 和修复提示。
+- [ ] 新增显式修复命令或 setup flag，能删除 stale unmanaged `PreToolUse`
+      entry；同一个测试中存在的有效第三方 hook 和 VibeGuard-managed hook
+      都被保留。
+- [ ] 现有“保留第三方 hook”回归测试改用临时 HOME 下真实存在的第三方脚本，
+      不再依赖 '/existing/non-vibeguard.js' 作为可保留 hook。
+- [ ] 新增测试覆盖 fixture 泄漏场景：当 'node /existing/non-vibeguard.js'
+      出现在 Codex `PreToolUse` 中时，检查命令必须报告为不可用。
+- [ ] troubleshooting 文档说明如何区分业务命令失败和 Codex
+      `PreToolUse` 残留失败。
+
+## Edge Cases
+
+- 命令通过解释器调用脚本：`node /path/to/hook.js`、`bash /path/to/hook.sh`、
+  `python3 /path/to/hook.py`。
+- 命令直接调用绝对路径：`/path/to/hook --flag`。
+- 命令前有 `env VAR=value` 或简单 shell quoting。
+- hook entry 里有多个 hook，修复只能删除 stale hook 本身，不能删除同 entry
+  下其他可用 hook。
+- 非 `PreToolUse` 的 stale unmanaged hook 仍可先保持 warning，除非后续实现
+  证明它同样会阻断关键工作流。
+
+## Rollout Notes
+
+先落诊断和测试 fixture 隔离，再落显式修复路径。修复行为涉及用户高上下文
+配置文件，必须保持 opt-in、输出可审计，并在 PR 中展示 before/after fixture
+证据。

--- a/docs/specs/GH566/tasks.md
+++ b/docs/specs/GH566/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-566
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP566-T1` Owner: agent — Add Codex hook command classification to `scripts/lib/codex_hooks_json.py` for managed, valid unmanaged, missing-target unmanaged, and unresolved unmanaged commands. Done when: direct absolute paths, interpreter script paths, and simple `env` prefixes are classified without deleting anything. Verify: helper unit coverage plus `python3 -m py_compile scripts/lib/codex_hooks_json.py`.
+- [ ] `SP566-T2` Owner: agent — Promote missing-target unmanaged `PreToolUse` and `PermissionRequest` hooks to strict-check broken state in `scripts/setup/targets/codex-home.sh` / `scripts/setup/check.sh`. Done when: `setup --check --strict` names `config`, `event`, `matcher`, and `command_path`, and exits non-zero for the stale `PreToolUse` fixture. Verify: focused cases in `tests/test_setup_check.sh`.
+- [ ] `SP566-T3` Owner: agent — Add an explicit repair command and setup flag for pruning missing-target unmanaged blocking hooks while preserving valid third-party hooks and VibeGuard-managed hooks. Done when: stale `PreToolUse` hook is removed, sibling valid hooks remain, JSON stays valid, and normal `setup.sh --yes` does not silently delete unmanaged hooks. Verify: focused setup flow test.
+- [ ] `SP566-T4` Owner: agent — Replace preserved third-party hook fixtures in setup tests with real temporary scripts under `${TMP_HOME}` and add a HOME guard before writing hook fixtures. Done when: preservation tests no longer use '/existing/non-vibeguard.js' as a valid hook and fail fast if HOME is not a test temp directory. Verify: `bash tests/setup/install_flow_tests.sh` focused section or equivalent setup test command.
+- [ ] `SP566-T5` Owner: agent — Add troubleshooting documentation for Codex `PreToolUse hook (failed)` caused by stale unmanaged hooks. Done when: docs explain inspection, direct reproduction, strict check, and explicit repair. Verify: `bash scripts/ci/validate-doc-paths.sh` and `bash scripts/ci/validate-doc-command-paths.sh`.
+- [ ] `SP566-T6` Owner: human — Review repair semantics before implementation PR merge because it mutates `~/.codex/hooks.json`. Done when: maintainer confirms opt-in deletion boundaries are acceptable. Verify: PR review approval recorded.
+
+## Parallelization
+
+- T1 must land before T2 and T3.
+- T2 and T3 can proceed after T1 but should share one owner for `scripts/lib/codex_hooks_json.py`.
+- T4 can run in parallel with T1 if it only changes tests and fixture setup.
+- T5 can run after T2/T3 wording stabilizes.
+- T6 gates merge readiness for the implementation PR.
+
+## Verification
+
+- `python3 -m py_compile scripts/lib/codex_hooks_json.py`
+- `bash tests/test_setup_check.sh`
+- Focused setup flow test covering valid third-party preservation plus stale unmanaged pruning
+- `bash scripts/ci/validate-doc-paths.sh`
+- `bash scripts/ci/validate-doc-command-paths.sh`
+
+## Handoff Notes
+
+- This spec intentionally preserves the “do not delete third-party hooks by default” safety rule.
+- Do not repair by wiping `~/.codex/hooks.json` or replacing the whole file.
+- Do not weaken existing assertions that VibeGuard-managed hooks are preserved/removed correctly.
+- Keep all user-facing output explicit: stale hook command, event, matcher, and exact repair command.

--- a/docs/specs/GH566/tech.md
+++ b/docs/specs/GH566/tech.md
@@ -1,0 +1,153 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-566
+
+## Product Spec
+
+`docs/specs/GH566/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Codex hook config helper | `scripts/lib/codex_hooks_json.py` | upsert/remove 只管理 VibeGuard-owned entries；`check-stale-hooks` 只解析部分安装路径；`check-timeouts` 把 unmanaged hook without timeout 报为 warning | 需要在这里区分 “合法第三方 hook” 和 “目标缺失且会阻断 PreToolUse 的 stale hook” |
+| Setup status | `scripts/setup/targets/codex-home.sh`, `scripts/setup/check.sh` | 报告 VibeGuard hooks 是否完整、stale installed hooks、timeout drift | 需要把 blocking unmanaged `PreToolUse` 作为更高严重度输出 |
+| Setup install/repair | `scripts/setup/install.sh`, `scripts/setup/targets/codex-home.sh` | `setup.sh --yes` upsert VibeGuard hooks 并保留第三方 hooks；`--clean` 只移除 managed entries | 需要显式 repair path，不能静默删除第三方 hooks |
+| Setup tests | `tests/setup/install_flow_tests.sh`, `tests/setup/profile_flow_tests.sh`, `tests/test_setup_check.sh` | 使用 'node /existing/non-vibeguard.js' 证明第三方 hook 会保留 | 这个 fixture 代表“保留行为”，但如果进入真实 HOME 会成为不可执行 blocker |
+| User docs | `docs/how/troubleshooting.md`, `docs/reference/codex-hook-status.md` | 说明 hook 安装状态和 timeout warning | 需要补充 PreToolUse stale hook 的诊断和修复说明 |
+
+## Proposed Design
+
+### 1. Add explicit Codex hook health classification
+
+Extend `scripts/lib/codex_hooks_json.py` with a shared classifier for hook
+commands:
+
+```text
+managed_vibeguard
+unmanaged_valid
+unmanaged_missing_target
+unmanaged_unresolved
+```
+
+The classifier should parse command tokens with `shlex.split` and identify a
+best-effort executable target:
+
+- direct absolute path: `/abs/hook --flag`
+- interpreter plus absolute script: `node /abs/hook.js`, `bash /abs/hook.sh`,
+  `python3 /abs/hook.py`
+- simple `env KEY=value ...` prefix before either form
+- existing VibeGuard wrapper and installed hook paths already handled today
+
+If the target cannot be resolved safely, classify as `unmanaged_unresolved`
+and do not delete it.
+
+### 2. Severity matrix
+
+Use event severity rather than treating all unmanaged drift equally:
+
+| Event | Missing target | Default check | Strict check |
+| --- | --- | --- | --- |
+| `PreToolUse` | `unmanaged_missing_target` | `WARN` with repair hint | `BROKEN` / non-zero |
+| `PermissionRequest` | `unmanaged_missing_target` | `WARN` with repair hint | `BROKEN` / non-zero |
+| `PostToolUse` | `unmanaged_missing_target` | `WARN` | `WARN` unless evidence shows it blocks command completion |
+| `Stop` | `unmanaged_missing_target` | `WARN` | `WARN` |
+
+Rationale: `PreToolUse` and `PermissionRequest` run before permission/tool
+execution and can block the user's intended command. Post/Stop failures are
+still unhealthy but should not be promoted without a separate issue.
+
+### 3. Add explicit repair path
+
+Add a helper subcommand such as:
+
+```sh
+python3 scripts/lib/codex_hooks_json.py prune-stale-unmanaged \
+  --hooks-file ~/.codex/hooks.json \
+  --event PreToolUse
+```
+
+Then expose it through a setup flag, for example:
+
+```sh
+bash setup.sh --yes --repair-stale-unmanaged-hooks
+```
+
+Repair rules:
+
+- Remove only hooks classified as `unmanaged_missing_target`.
+- Default to `PreToolUse` and `PermissionRequest`; require an explicit event
+  argument before pruning Post/Stop events.
+- Preserve valid third-party hooks, unresolved commands, managed VibeGuard
+  hooks, and sibling hooks in the same entry.
+- Print a summary of removed commands.
+- Validate JSON after write.
+
+Do not make ordinary `setup.sh --yes` silently delete unmanaged hooks unless
+the implementation introduces an interactive confirmation path and tests it.
+
+### 4. Replace unsafe preserved-hook fixture
+
+Change tests that assert “third-party hook is preserved” to create a real
+temporary script under `${TMP_HOME}` and reference it from `hooks.json`.
+
+Keep a separate stale fixture test for '/existing/non-vibeguard.js', but use it
+only to assert detection/remediation, not as a valid preserved hook.
+
+Add a small test guard near fixture setup:
+
+```sh
+case "${HOME}" in
+  "${TMP_HOME}"*) ;;
+  *) echo "refusing to write hook fixture outside TMP_HOME" >&2; exit 1 ;;
+esac
+```
+
+### 5. Documentation
+
+Add troubleshooting guidance:
+
+1. Run `jq '.hooks.PreToolUse' ~/.codex/hooks.json`.
+2. Reproduce the configured command directly.
+3. Run `bash setup.sh --check --strict`.
+4. Use the explicit repair flag when the stale command points to a missing
+   file and is not a real third-party integration.
+
+## Product-to-Test Mapping
+
+| Product requirement | Implementation area | Verification |
+| --- | --- | --- |
+| P1 strict check reports blocking stale `PreToolUse` | `codex_hooks_json.py`, `codex-home.sh`, `check.sh` | `tests/test_setup_check.sh` fixture exits broken and names config/event/matcher/path |
+| P2 explicit repair removes only stale hook | `codex_hooks_json.py`, `install.sh` flag wiring | New setup test with stale + valid third-party + managed hooks |
+| P3 valid third-party hooks preserved | setup tests | Existing preservation assertions updated to use an existing temp script |
+| P4 fixture leak detected | setup check tests | '/existing/non-vibeguard.js' in `PreToolUse` is reported as missing target |
+| P5 docs explain recovery | docs | `bash scripts/ci/validate-doc-paths.sh` and `bash scripts/ci/validate-doc-command-paths.sh` |
+
+## Risks
+
+- False positive deletion of third-party hook: mitigated by opt-in repair,
+  missing-target-only classification, and preserving unresolved commands.
+- Overfitting to 'node /existing/non-vibeguard.js': mitigated by testing
+  interpreter, direct absolute path, and `env` prefix forms.
+- High-context config mutation: repair command must be explicit and must print
+  removed commands before/after in tests.
+- User confusion if strict check becomes louder: message must explain that
+  unmanaged hooks are preserved by default and the repair is opt-in.
+
+## Test Plan
+
+- [ ] `python3 -m py_compile scripts/lib/codex_hooks_json.py`.
+- [ ] Focused helper tests for command classification and prune behavior.
+- [ ] `bash tests/test_setup_check.sh` for strict check severity and stale
+      detection.
+- [ ] Focused setup flow test for `--repair-stale-unmanaged-hooks`.
+- [ ] `bash scripts/ci/validate-doc-paths.sh`.
+- [ ] `bash scripts/ci/validate-doc-command-paths.sh`.
+
+## Rollback Plan
+
+Rollback is reverting the helper, setup flag, test, and doc changes. Existing
+managed hook upsert/remove behavior remains compatible because this spec does
+not alter the VibeGuard-managed identity model or Codex `hooks.json` schema.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 |---|---|---|
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
 | `GH556/` | Draft | Weekly health report for rule trigger counts, precision risk, unclassified backlog, and idle asset detection |
+| `GH566/` | Draft | Codex unmanaged stale `PreToolUse` hook detection, explicit repair, and setup-test fixture isolation |
 | `install-friction-reduction.md` | Implemented reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
 | `learn-first-class-signal-inbox.md` | Draft | Learn signal inbox, signal classification, triage state, adoption compiler, and outcome evaluator planning |
 | `rust-only-production-path.md` | Implemented reference | Python-free production path, Rust runtime boundaries, and remaining validation expectations |


### PR DESCRIPTION
## Summary

- Refs #566.
- Adds the GH566 SpecRail packet for Codex stale unmanaged `PreToolUse` hook detection and explicit repair.
- Defines product requirements, technical design, task plan, and spec index entry.

## Scope

Spec-only. This PR does not change setup/runtime behavior yet.

## Verification

- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

## Notes

Implementation must keep third-party hook preservation as the default and make stale unmanaged hook pruning explicit/opt-in.