### PR TITLE
fix(setup): repair stale unmanaged Codex hooks

### DIFF
--- a/docs/how/troubleshooting.md
+++ b/docs/how/troubleshooting.md
@@ -38,6 +38,33 @@ Read-only exploration hooks such as Read/Glob/Grep are not available on the
 native Codex path. Use Claude Code or the optional app-server-wrapper when that
 coverage is required.
 
+### Codex `PreToolUse hook (failed)`
+
+If Codex shows a failure before every Bash command, first separate the requested
+command from the global Codex hook:
+
+```bash
+jq '.hooks.PreToolUse' ~/.codex/hooks.json
+bash setup.sh --check --strict
+```
+
+For an unmanaged entry, reproduce the hook command directly. A stale command
+such as `node /existing/non-vibeguard.js` fails before the requested Bash tool
+starts and should be repaired as hook configuration, not as a repo command
+failure.
+
+VibeGuard preserves third-party hooks by default. When `--check --strict`
+reports a missing-target unmanaged `PreToolUse` or `PermissionRequest` hook and
+the command is not a real integration, use the explicit repair path:
+
+```bash
+bash setup.sh --yes --repair-stale-unmanaged-hooks
+```
+
+The repair removes only missing-target unmanaged blocking hooks and leaves
+VibeGuard-managed hooks, valid third-party hooks, and unresolved third-party
+commands in place.
+
 ## Runtime and Provenance
 
 ```bash

--- a/docs/reference/codex-hook-status.md
+++ b/docs/reference/codex-hook-status.md
@@ -27,3 +27,5 @@ JSON mode is intended for UI polling:
 The JSON payload follows `schemas/hook-status.schema.json`. Each entry includes the hook name, event, matcher, normalized status, reason, duration, model-context flag, and log path.
 
 `setup.sh --check` also inspects `~/.codex/hooks.json` for non-Stop hook entries without `timeout`. VibeGuard-managed timeout drift is reported as broken install state. External hooks without timeout, such as an Orca bridge entry, are reported as warnings with the owning command so the user can add a timeout or consult that hook owner.
+
+`setup.sh --check --strict` reports unmanaged `PreToolUse` and `PermissionRequest` hooks whose target file is missing as repair-required broken state. This catches stale commands such as `node /existing/non-vibeguard.js` that fail before the requested Bash command starts. Ordinary `setup.sh --yes` preserves unmanaged hooks; use `setup.sh --yes --repair-stale-unmanaged-hooks` only when the reported missing target is not a real third-party integration.

--- a/scripts/lib/codex_hooks_json.py
+++ b/scripts/lib/codex_hooks_json.py
@@ -26,6 +26,11 @@ MANAGED_SPECS: list[HookSpec] = [HookSpec(spec) for spec in codex_specs(MANIFEST
 # wrapper path, so removal works even when a non-standard wrapper is used.
 _MANAGED_SCRIPT_NAMES: frozenset[str] = frozenset(spec["script"] for spec in MANAGED_SPECS)
 _WRAPPER_NAMES: frozenset[str] = frozenset({"run-hook-codex.sh"})
+_BLOCKING_EVENTS: frozenset[str] = frozenset({"PreToolUse", "PermissionRequest"})
+_DEFAULT_REPAIR_EVENTS: tuple[str, ...] = ("PreToolUse", "PermissionRequest")
+_INTERPRETERS: frozenset[str] = frozenset(
+    {"node", "bash", "sh", "python", "python3", "python2", "ruby", "perl", "deno", "bun"}
+)
 
 
 def _display_path(path: Path, home: Path) -> str:
@@ -66,6 +71,43 @@ def _hook_target_from_command(command: str, home: Path) -> Path | None:
                 installed_dir = path.parent / "installed/hooks"
                 if installed_dir.exists():
                     return installed_dir / script_name
+    return None
+
+
+def _is_env_assignment(token: str) -> bool:
+    name, sep, _ = token.partition("=")
+    return bool(sep and name and all(ch.isalnum() or ch == "_" for ch in name))
+
+
+def _command_start_after_env(parts: list[str]) -> int | None:
+    index = 0
+    if parts and Path(parts[0]).name == "env":
+        index += 1
+    while index < len(parts) and _is_env_assignment(parts[index]):
+        index += 1
+    return index if index < len(parts) else None
+
+
+def _unmanaged_target_from_command(command: str, home: Path) -> Path | None:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    start = _command_start_after_env(parts)
+    if start is None:
+        return None
+    first = parts[start]
+    direct = _expand_shell_path(first, home)
+    if direct is not None:
+        return direct
+    if Path(first).name not in _INTERPRETERS:
+        return None
+    for token in parts[start + 1 :]:
+        if token.startswith("-") or _is_env_assignment(token):
+            continue
+        target = _expand_shell_path(token, home)
+        if target is not None:
+            return target
     return None
 
 
@@ -203,18 +245,48 @@ def _iter_hook_commands(data: dict[str, Any]) -> list[tuple[str, str, str]]:
 def stale_hook_findings(path: Path, home: Path) -> list[dict[str, str]]:
     data = load_hooks(path)
     findings: list[dict[str, str]] = []
-    for event, matcher, command in _iter_hook_commands(data):
-        hook_target = _hook_target_from_command(command, home)
-        if hook_target is None or hook_target.exists():
+    for event, matcher, hook in _iter_hook_records(data):
+        command = hook.get("command")
+        if not isinstance(command, str) or not command:
             continue
+        hook_target = _hook_target_from_command(command, home)
+        if hook_target is not None:
+            if hook_target.exists():
+                continue
+            findings.append(
+                {
+                    "label": "stale Codex hook command",
+                    "client": "Codex",
+                    "config": _display_path(path, home),
+                    "event": event,
+                    "matcher": matcher,
+                    "command": "",
+                    "command_path": str(hook_target),
+                    "repair": "bash setup.sh --yes",
+                }
+            )
+            continue
+        identity = _identity_for_hook(event, None if matcher == "<none>" else matcher, hook)
+        if identity.is_managed:
+            continue
+        unmanaged_target = _unmanaged_target_from_command(command, home)
+        if unmanaged_target is None or unmanaged_target.exists():
+            continue
+        label = (
+            "repair-required unmanaged Codex blocking hook"
+            if event in _BLOCKING_EVENTS
+            else "stale unmanaged Codex hook"
+        )
         findings.append(
             {
+                "label": label,
                 "client": "Codex",
                 "config": _display_path(path, home),
                 "event": event,
                 "matcher": matcher,
-                "command_path": str(hook_target),
-                "repair": "bash setup.sh --yes",
+                "command": command,
+                "command_path": str(unmanaged_target),
+                "repair": "bash setup.sh --yes --repair-stale-unmanaged-hooks",
             }
         )
     return findings
@@ -302,6 +374,62 @@ def _prune_stale_installed_hook_entries(data: dict[str, Any], home: Path) -> boo
         changed = True
 
     return changed
+
+
+def _prune_stale_unmanaged_hook_entries(data: dict[str, Any], home: Path, events: set[str]) -> list[str]:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+
+    removed: list[str] = []
+    for event, entries in list(hooks.items()):
+        if str(event) not in events or not isinstance(entries, list):
+            continue
+
+        new_entries: list[Any] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                new_entries.append(entry)
+                continue
+            matcher_value = entry.get("matcher")
+            matcher = matcher_value if isinstance(matcher_value, str) and matcher_value else "<none>"
+            hook_entries = entry.get("hooks")
+            if not isinstance(hook_entries, list):
+                new_entries.append(entry)
+                continue
+
+            kept_hooks: list[Any] = []
+            for hook in hook_entries:
+                if not isinstance(hook, dict):
+                    kept_hooks.append(hook)
+                    continue
+                command = hook.get("command")
+                if not isinstance(command, str) or not command:
+                    kept_hooks.append(hook)
+                    continue
+                identity = _identity_for_hook(str(event), None if matcher == "<none>" else matcher, hook)
+                target = _unmanaged_target_from_command(command, home)
+                if identity.is_managed or target is None or target.exists():
+                    kept_hooks.append(hook)
+                    continue
+                removed.append(
+                    "removed stale unmanaged Codex hook: "
+                    f"event={event} matcher={matcher} command={command} command_path={target}"
+                )
+
+            if kept_hooks:
+                next_entry = dict(entry)
+                next_entry["hooks"] = kept_hooks
+                new_entries.append(next_entry)
+
+        if new_entries:
+            hooks[event] = new_entries
+        else:
+            hooks.pop(event, None)
+
+    if not hooks:
+        data.pop("hooks", None)
+    return removed
 
 
 def _build_entry(wrapper: str, spec: HookSpec) -> dict[str, Any]:
@@ -421,11 +549,32 @@ def cmd_check_stale_hooks(args: argparse.Namespace) -> int:
         return 0
     findings = stale_hook_findings(hooks_path, Path.home())
     for finding in findings:
+        command = f" command={finding['command']}" if finding.get("command") else ""
+        fields = dict(finding)
+        fields["command_suffix"] = command
         print(
-            "stale {client} hook command: config={config} event={event} "
-            "matcher={matcher} command_path={command_path} repair={repair}".format(**finding)
+            "{label}: config={config} event={event} matcher={matcher}{command_suffix} "
+            "command_path={command_path} repair={repair}".format(**fields)
         )
     return 1 if findings else 0
+
+
+def cmd_prune_stale_unmanaged(args: argparse.Namespace) -> int:
+    hooks_path = Path(args.hooks_file)
+    if not hooks_path.exists():
+        print("SKIP")
+        return 0
+    events = set(args.event or _DEFAULT_REPAIR_EVENTS)
+    data = load_hooks(hooks_path)
+    removed = _prune_stale_unmanaged_hook_entries(data, Path.home(), events)
+    for line in removed:
+        print(f"{line} config={_display_path(hooks_path, Path.home())}")
+    if removed:
+        save_hooks(hooks_path, data)
+        print("CHANGED")
+    else:
+        print("SKIP")
+    return 0
 
 
 def cmd_check_timeouts(args: argparse.Namespace) -> int:
@@ -483,6 +632,11 @@ def build_parser() -> argparse.ArgumentParser:
     stale = sub.add_parser("check-stale-hooks", help="Detect stale hook commands")
     stale.add_argument("--hooks-file", required=True)
     stale.set_defaults(func=cmd_check_stale_hooks)
+
+    prune = sub.add_parser("prune-stale-unmanaged", help="Remove stale unmanaged blocking hooks")
+    prune.add_argument("--hooks-file", required=True)
+    prune.add_argument("--event", action="append")
+    prune.set_defaults(func=cmd_prune_stale_unmanaged)
 
     timeouts = sub.add_parser("check-timeouts", help="Detect hook entries without timeout")
     timeouts.add_argument("--hooks-file", required=True)

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 # bash setup.sh --runtime-version v1.2.3 # Download a specific vibeguard-runtime release tag
 # bash setup.sh --require-provenance # Require GitHub artifact attestation verification for release binaries
 # bash setup.sh --with-scheduler # Opt in to launchd/systemd scheduled GC
+# bash setup.sh --repair-stale-unmanaged-hooks # Opt in to prune missing-target Codex PreToolUse/PermissionRequest hooks
 # bash setup.sh --force-overwrite # Replace user-customized managed files/commands
 # bash setup.sh --dev-linked # Opt in to live-repo execution for local development
 # bash setup.sh --check # Check status only
@@ -44,6 +45,7 @@ VIBEGUARD_SETUP_DRY_RUN="${VIBEGUARD_SETUP_DRY_RUN:-0}"
 VIBEGUARD_SETUP_AUTO="${VIBEGUARD_SETUP_AUTO:-0}"
 VIBEGUARD_SETUP_FORCE_OVERWRITE="${VIBEGUARD_SETUP_FORCE_OVERWRITE:-0}"
 WITH_SCHEDULER="${VIBEGUARD_SETUP_WITH_SCHEDULER:-0}"
+REPAIR_STALE_UNMANAGED_HOOKS="${VIBEGUARD_SETUP_REPAIR_STALE_UNMANAGED_HOOKS:-0}"
 BUILD_FROM_SOURCE="${VIBEGUARD_SETUP_BUILD_FROM_SOURCE:-0}"
 REQUIRE_PROVENANCE="${VIBEGUARD_SETUP_REQUIRE_PROVENANCE:-0}"
 DEV_LINKED="${VIBEGUARD_SETUP_DEV_LINKED:-0}"
@@ -79,6 +81,8 @@ while [[ $# -gt 0 ]]; do
       REQUIRE_PROVENANCE=1; shift ;;
     --with-scheduler)
       WITH_SCHEDULER=1; shift ;;
+    --repair-stale-unmanaged-hooks)
+      REPAIR_STALE_UNMANAGED_HOOKS=1; shift ;;
     --force-overwrite)
       VIBEGUARD_SETUP_FORCE_OVERWRITE=1; shift ;;
     --dev-linked)
@@ -95,11 +99,12 @@ while [[ $# -gt 0 ]]; do
       LANGUAGES="${1#*=}"; shift ;;
     *)
       red "ERROR: unknown argument: $1"
-      red "Usage: bash setup.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--require-provenance] [--with-scheduler] [--force-overwrite] [--dev-linked] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean [--purge-data]"
+      red "Usage: bash setup.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--require-provenance] [--with-scheduler] [--repair-stale-unmanaged-hooks] [--force-overwrite] [--dev-linked] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean [--purge-data]"
       exit 1 ;;
   esac
 done
 export VIBEGUARD_SETUP_DRY_RUN VIBEGUARD_SETUP_AUTO VIBEGUARD_SETUP_FORCE_OVERWRITE
+export VIBEGUARD_SETUP_REPAIR_STALE_UNMANAGED_HOOKS="${REPAIR_STALE_UNMANAGED_HOOKS}"
 export VIBEGUARD_SETUP_REQUIRE_PROVENANCE="${REQUIRE_PROVENANCE}"
 export VIBEGUARD_SETUP_DEV_LINKED="${DEV_LINKED}"
 

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -89,6 +89,7 @@ setup_runtime_supports() {
     setup-codex-hooks-upsert \
     setup-codex-hooks-check \
     setup-codex-hooks-check-stale \
+    setup-codex-hooks-prune-stale-unmanaged \
     setup-codex-hooks-check-timeouts; do
     probe_out="$("${runtime}" "${command}" 2>&1 || true)"
     if printf '%s\n' "${probe_out}" | grep -q "Unknown command"; then

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -70,6 +70,23 @@ install_codex_home_assets() {
     red "  Failed to update ~/.codex/hooks.json"
   fi
 
+  if [[ "${VIBEGUARD_SETUP_REPAIR_STALE_UNMANAGED_HOOKS:-0}" == "1" ]]; then
+    local repair_result
+    repair_result=$(setup_runtime setup-codex-hooks-prune-stale-unmanaged "${REPO_DIR}" "${hooks_file}" 2>&1 || echo "ERROR")
+    if grep -q '^ERROR$' <<< "${repair_result}"; then
+      red "  Failed to repair stale unmanaged Codex hooks"
+    else
+      while IFS= read -r line; do
+        case "${line}" in
+          "removed stale unmanaged Codex hook:"*) yellow "  ${line}" ;;
+          CHANGED) green "  Stale unmanaged Codex hooks repaired" ;;
+          SKIP) yellow "  No stale unmanaged Codex hooks to repair" ;;
+        esac
+      done <<< "${repair_result}"
+      state_record_file "${hooks_file}" "generated/codex-hooks.json" "copy"
+    fi
+  fi
+
   # Enable native Codex hooks feature flag in config.toml
   _enable_codex_hooks_feature
   echo
@@ -173,11 +190,22 @@ check_codex_home_installation() {
     fi
 
     local stale_hooks_report
-    if stale_hooks_report="$(setup_runtime setup-codex-hooks-check-stale "${CODEX_DIR}/hooks.json" 2>&1)"; then
+    if stale_hooks_report="$(setup_runtime setup-codex-hooks-check-stale "${REPO_DIR}" "${CODEX_DIR}/hooks.json" 2>&1)"; then
       :
     else
       while IFS= read -r line; do
-        [[ -n "${line}" ]] && red "[BROKEN] ${line}"
+        [[ -n "${line}" ]] || continue
+        if [[ "${line}" == repair-required\ unmanaged\ Codex\ blocking\ hook:* ]]; then
+          if [[ "${STRICT:-0}" == "1" || "${INSTALL:-0}" == "1" || "${PROJECT:-0}" == "1" || "${DEV_REPO:-0}" == "1" ]]; then
+            red "[BROKEN] ${line}"
+          else
+            yellow "[WARN] ${line}"
+          fi
+        elif [[ "${line}" == stale\ unmanaged\ Codex\ hook:* ]]; then
+          yellow "[WARN] ${line}"
+        else
+          red "[BROKEN] ${line}"
+        fi
       done <<< "${stale_hooks_report}"
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -35,6 +35,7 @@ Install options:
   --runtime-version vX.Y.Z
   --require-provenance
   --with-scheduler
+  --repair-stale-unmanaged-hooks
   --force-overwrite
   --profile minimal|core|full|strict
   --languages lang1,lang2

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -12,12 +12,18 @@ assert_cmd "scheduled GC installers do not reference retired root path" bash -c 
 
 header "seed existing config"
 mkdir -p "${HOME}/.claude" "${HOME}/.codex"
+case "${HOME}" in
+  "${TMP_HOME}"*) ;;
+  *) red "refusing to write hook fixture outside TMP_HOME"; exit 1 ;;
+esac
+PREEXISTING_CODEX_HOOK_SCRIPT="${HOME}/codex-third-party-hook.js"
+printf 'process.exit(0)\n' > "${PREEXISTING_CODEX_HOOK_SCRIPT}"
 cat > "${HOME}/.claude/settings.json" <<'JSON'
 {
   "hooks": {}
 }
 JSON
-cat > "${HOME}/.codex/hooks.json" <<'JSON'
+cat > "${HOME}/.codex/hooks.json" <<JSON
 {
   "hooks": {
     "PreToolUse": [
@@ -26,7 +32,7 @@ cat > "${HOME}/.codex/hooks.json" <<'JSON'
         "hooks": [
           {
             "type": "command",
-            "command": "node /existing/non-vibeguard.js"
+            "command": "node ${PREEXISTING_CODEX_HOOK_SCRIPT}"
           }
         ]
       }
@@ -38,7 +44,7 @@ cat > "${HOME}/.codex/config.toml" <<'TOML'
 [features]
 hooks = true
 TOML
-assert_cmd "Pre-existing non-VibeGuard Codex hook is present" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
+assert_cmd "Pre-existing non-VibeGuard Codex hook is present" grep -q "node ${PREEXISTING_CODEX_HOOK_SCRIPT}" "${HOME}/.codex/hooks.json"
 
 header "setup --check"
 check_out="$(bash "${REPO_DIR}/setup.sh" --check)"
@@ -631,7 +637,36 @@ assert_cmd "Codex hooks are namespaced (vibeguard prefix)" bash -c "grep -q 'vib
 assert_cmd "Codex hooks include PermissionRequest native gates" bash -c "grep -q '\"PermissionRequest\"' '${HOME}/.codex/hooks.json' && grep -q '\"matcher\": \"Edit\"' '${HOME}/.codex/hooks.json' && grep -q '\"matcher\": \"Write\"' '${HOME}/.codex/hooks.json'"
 assert_cmd "Codex helper validates managed hooks" python3 "${CODEX_HOOKS_HELPER}" check-vibeguard --hooks-file "${HOME}/.codex/hooks.json" --wrapper "${HOME}/.vibeguard/run-hook-codex.sh"
 assert_cmd "run-hook-codex rejects non-namespaced hook names" bash -c "out=\$(printf '{\"hook_event_name\":\"PreToolUse\",\"tool_input\":{\"command\":\"rm -rf /\"}}' | bash '${REPO_DIR}/hooks/run-hook-codex.sh' pre-bash-guard.sh); test -z \"\$out\""
-assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
+assert_cmd "Pre-existing non-VibeGuard hook is preserved" grep -q "node ${PREEXISTING_CODEX_HOOK_SCRIPT}" "${HOME}/.codex/hooks.json"
+python3 - "${HOME}/.codex/hooks.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+entry = data["hooks"]["PreToolUse"][0]
+entry["hooks"].append({"type": "command", "command": "node /existing/non-vibeguard.js"})
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+set +e
+setup_without_stale_repair_out="$(bash "${REPO_DIR}/setup.sh" --yes 2>&1)"
+setup_without_stale_repair_rc=$?
+set -e
+TOTAL=$((TOTAL + 1))
+if [[ "${setup_without_stale_repair_rc}" -ne 0 ]]; then
+  green "setup without stale unmanaged repair fails install verification"
+  PASS=$((PASS + 1))
+else
+  red "setup without stale unmanaged repair fails install verification (expected nonzero)"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "${setup_without_stale_repair_out}" "repair-required unmanaged Codex blocking hook" "setup without stale unmanaged repair reports blocker"
+assert_cmd "ordinary setup preserves stale unmanaged Codex hook by default" grep -q '/existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
+setup_with_stale_repair_out="$(bash "${REPO_DIR}/setup.sh" --yes --repair-stale-unmanaged-hooks)"
+assert_contains "${setup_with_stale_repair_out}" "Stale unmanaged Codex hooks repaired" "setup repair flag reports stale unmanaged repair"
+assert_cmd "repair flag removes stale unmanaged Codex hook" bash -c "! grep -q '/existing/non-vibeguard.js' '${HOME}/.codex/hooks.json'"
+assert_cmd "repair flag preserves valid third-party Codex hook" grep -q "node ${PREEXISTING_CODEX_HOOK_SCRIPT}" "${HOME}/.codex/hooks.json"
 assert_cmd "Codex hooks include managed + preserved entries" python3 -c "import json; data=json.load(open('${HOME}/.codex/hooks.json')); total=sum(len(entries) for entries in data.get('hooks', {}).values() if isinstance(entries, list)); raise SystemExit(0 if total >= 5 else 1)"
 assert_cmd "~/.claude/CLAUDE.md includes the chat contract anchor after installation" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${HOME}/.claude/CLAUDE.md"
 assert_cmd "~/.claude/CLAUDE.md rule banner matches expected rules" assert_claude_rule_banner_matches_expected_rules

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -112,7 +112,7 @@ assert_cmd "~/.codex/hooks.json is preserved after cleaning (for non-VibeGuard h
 assert_cmd "VibeGuard managed Codex AGENTS block removed after cleaning" bash -c "! grep -q 'vibeguard-start' '${HOME}/.codex/AGENTS.md'"
 assert_cmd "Unmanaged Codex AGENTS content remains after cleaning" grep -q 'user codex note' "${HOME}/.codex/AGENTS.md"
 assert_cmd "VibeGuard managed Codex hooks removed after cleaning" bash -c "! grep -qE 'vibeguard-(pre-bash-guard|pre-edit-guard|pre-write-guard|post-edit-guard|post-write-guard|post-build-check|stop-guard|learn-evaluator)\\.sh' '${HOME}/.codex/hooks.json'"
-assert_cmd "Pre-existing non-VibeGuard hook remains after cleaning" grep -q 'node /existing/non-vibeguard.js' "${HOME}/.codex/hooks.json"
+assert_cmd "Pre-existing non-VibeGuard hook remains after cleaning" grep -q "node ${PREEXISTING_CODEX_HOOK_SCRIPT}" "${HOME}/.codex/hooks.json"
 
 header "setup install default languages before rust filter"
 install_default_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core)"

--- a/tests/test_setup_check.sh
+++ b/tests/test_setup_check.sh
@@ -16,6 +16,7 @@ CHECK_SCRIPT="${REPO_DIR}/scripts/setup/check.sh"
 SETUP_SCRIPT="${REPO_DIR}/setup.sh"
 AWK_PORTABILITY_FIXTURE=""
 STALE_HOOK_HOME=""
+UNMANAGED_HOOK_HOME=""
 TIMEOUT_HOOK_HOME=""
 BROKEN_HOME=""
 PROJECT_HOOK_HOME=""
@@ -27,6 +28,9 @@ cleanup() {
   fi
   if [[ -n "${STALE_HOOK_HOME}" ]]; then
     rm -rf "${STALE_HOOK_HOME}"
+  fi
+  if [[ -n "${UNMANAGED_HOOK_HOME}" ]]; then
+    rm -rf "${UNMANAGED_HOOK_HOME}"
   fi
   if [[ -n "${TIMEOUT_HOOK_HOME}" ]]; then
     rm -rf "${TIMEOUT_HOOK_HOME}"
@@ -463,6 +467,56 @@ assert_cmd "stale hook repair: Claude installed hook path removed" bash -c "! gr
 assert_cmd "stale hook repair: Codex installed hook path removed" bash -c "! grep -q '.vibeguard/installed/hooks/session-tagger.sh' '${STALE_HOOK_HOME}/.codex/hooks.json'"
 assert_cmd "stale hook repair: Claude stale check passes" env HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/settings_json.py" check-stale-hooks --settings-file "${STALE_HOOK_HOME}/.claude/settings.json"
 assert_cmd "stale hook repair: Codex stale check passes" env HOME="${STALE_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" check-stale-hooks --hooks-file "${STALE_HOOK_HOME}/.codex/hooks.json"
+
+# --- Codex unmanaged PreToolUse stale hook detection and explicit repair ---
+header "codex unmanaged stale pretool repair"
+UNMANAGED_HOOK_HOME="$(mktemp -d)"
+mkdir -p "${UNMANAGED_HOOK_HOME}/.codex" "${UNMANAGED_HOOK_HOME}/.vibeguard"
+printf '#!/usr/bin/env bash\n' > "${UNMANAGED_HOOK_HOME}/.vibeguard/run-hook-codex.sh"
+chmod +x "${UNMANAGED_HOOK_HOME}/.vibeguard/run-hook-codex.sh"
+valid_third_party="${UNMANAGED_HOOK_HOME}/valid-third-party.js"
+printf 'process.exit(0)\n' > "${valid_third_party}"
+cat > "${UNMANAGED_HOOK_HOME}/.codex/hooks.json" <<JSON
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /existing/non-vibeguard.js"
+          },
+          {
+            "type": "command",
+            "command": "env FOO=1 node ${valid_third_party}"
+          },
+          {
+            "type": "command",
+            "command": "bash ${UNMANAGED_HOOK_HOME}/.vibeguard/run-hook-codex.sh vibeguard-pre-bash-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+unmanaged_helper_out="$(HOME="${UNMANAGED_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" check-stale-hooks --hooks-file "${UNMANAGED_HOOK_HOME}/.codex/hooks.json" 2>&1 || true)"
+assert_contains "$unmanaged_helper_out" "repair-required unmanaged Codex blocking hook" "unmanaged stale helper: reports repair-required blocking hook"
+assert_contains "$unmanaged_helper_out" "event=PreToolUse matcher=Bash command=node /existing/non-vibeguard.js" "unmanaged stale helper: names event matcher and command"
+assert_contains "$unmanaged_helper_out" "command_path=/existing/non-vibeguard.js" "unmanaged stale helper: names missing command path"
+assert_contains "$unmanaged_helper_out" "repair=bash setup.sh --yes --repair-stale-unmanaged-hooks" "unmanaged stale helper: names explicit repair flag"
+
+unmanaged_strict_out="$(HOME="${UNMANAGED_HOOK_HOME}" bash "${SETUP_SCRIPT}" --check --strict 2>&1 || true)"
+assert_contains "$unmanaged_strict_out" "[BROKEN] repair-required unmanaged Codex blocking hook" "setup --check --strict: promotes stale PreToolUse to broken"
+
+HOME="${UNMANAGED_HOOK_HOME}" python3 "${REPO_DIR}/scripts/lib/codex_hooks_json.py" prune-stale-unmanaged \
+  --hooks-file "${UNMANAGED_HOOK_HOME}/.codex/hooks.json" >/dev/null
+assert_cmd "unmanaged stale repair removes missing PreToolUse hook" bash -c "! grep -q '/existing/non-vibeguard.js' '${UNMANAGED_HOOK_HOME}/.codex/hooks.json'"
+assert_cmd "unmanaged stale repair preserves valid third-party hook" grep -q "${valid_third_party}" "${UNMANAGED_HOOK_HOME}/.codex/hooks.json"
+assert_cmd "unmanaged stale repair preserves managed VibeGuard hook" grep -q "vibeguard-pre-bash-guard.sh" "${UNMANAGED_HOOK_HOME}/.codex/hooks.json"
+assert_cmd "unmanaged stale repair leaves valid JSON" python3 -c 'import json,sys; json.load(open(sys.argv[1], encoding="utf-8"))' "${UNMANAGED_HOOK_HOME}/.codex/hooks.json"
 
 # --- Project git hook detection ---
 header "verify-project project git hooks"

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -35,6 +35,7 @@ mod runtime_policy;
 mod session_metrics;
 mod setup_codex_config;
 mod setup_codex_hooks;
+mod setup_codex_hooks_health;
 mod setup_install_state;
 mod setup_manifest;
 mod setup_markdown;
@@ -466,8 +467,13 @@ static COMMANDS: &[Command] = &[
     },
     Command {
         name: "setup-codex-hooks-check-stale",
-        usage: "<hooks-file>  — detect stale Codex hook commands",
+        usage: "[repo-dir] <hooks-file>  — detect stale Codex hook commands",
         handler: setup_codex_hooks::codex_hooks_check_stale,
+    },
+    Command {
+        name: "setup-codex-hooks-prune-stale-unmanaged",
+        usage: "<repo-dir> <hooks-file> [event...]  — remove missing-target unmanaged Codex hooks for selected events",
+        handler: setup_codex_hooks::codex_hooks_prune_stale_unmanaged,
     },
     Command {
         name: "setup-codex-hooks-check-timeouts",

--- a/vibeguard-runtime/src/setup_codex_hooks.rs
+++ b/vibeguard-runtime/src/setup_codex_hooks.rs
@@ -1,10 +1,13 @@
 use crate::setup_support::{
-    SetupResult, basename, display_home_path, home_dir, read_json_object, shell_quote, shell_split,
-    write_json_atomic,
+    SetupResult, basename, home_dir, read_json_object, shell_quote, shell_split, write_json_atomic,
 };
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+
+pub use crate::setup_codex_hooks_health::{
+    codex_hooks_check_stale, codex_hooks_check_timeouts, codex_hooks_prune_stale_unmanaged,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CodexSpec {
@@ -138,70 +141,6 @@ pub fn codex_hooks_count(args: &[String]) -> SetupResult<()> {
         })
         .unwrap_or(0);
     println!("{total}");
-    Ok(())
-}
-
-pub fn codex_hooks_check_stale(args: &[String]) -> SetupResult<()> {
-    if args.len() != 1 {
-        return Err("Usage: vibeguard-runtime setup-codex-hooks-check-stale <hooks-file>".into());
-    }
-    let hooks_path = Path::new(&args[0]);
-    if !hooks_path.exists() {
-        return Ok(());
-    }
-    let data = Value::Object(read_json_object(hooks_path, false)?);
-    let findings = codex_stale_findings(&data, hooks_path);
-    for finding in &findings {
-        println!("{finding}");
-    }
-    if !findings.is_empty() {
-        std::process::exit(1);
-    }
-    Ok(())
-}
-
-pub fn codex_hooks_check_timeouts(args: &[String]) -> SetupResult<()> {
-    if args.len() != 2 {
-        return Err(
-            "Usage: vibeguard-runtime setup-codex-hooks-check-timeouts <repo-dir> <hooks-file>"
-                .into(),
-        );
-    }
-    let repo_dir = Path::new(&args[0]);
-    let hooks_path = Path::new(&args[1]);
-    if !hooks_path.exists() {
-        return Ok(());
-    }
-    let data = Value::Object(read_json_object(hooks_path, false)?);
-    let mut findings = Vec::new();
-    for (event, matcher, hook) in codex_hook_records(&data) {
-        let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
-        if command.is_empty()
-            || hook
-                .get("timeout")
-                .and_then(Value::as_i64)
-                .is_some_and(|v| v > 0)
-        {
-            continue;
-        }
-        let managed = codex_command_is_managed(repo_dir, command);
-        let state = if managed { "managed" } else { "unmanaged" };
-        let repair = if managed {
-            "bash setup.sh --yes"
-        } else {
-            "add timeout or consult hook owner"
-        };
-        findings.push(format!(
-            "{state} Codex hook without timeout: config={} event={event} matcher={matcher} command={command} repair={repair}",
-            display_home_path(hooks_path)
-        ));
-    }
-    for finding in &findings {
-        println!("{finding}");
-    }
-    if !findings.is_empty() {
-        std::process::exit(1);
-    }
     Ok(())
 }
 
@@ -409,7 +348,7 @@ fn codex_has_entry(
     })
 }
 
-fn codex_command_is_managed(repo_dir: &Path, command: &str) -> bool {
+pub(crate) fn codex_command_is_managed(repo_dir: &Path, command: &str) -> bool {
     let scripts = codex_managed_scripts(repo_dir);
     let parts = shell_split(command);
     for (idx, token) in parts.iter().enumerate() {
@@ -447,61 +386,6 @@ fn codex_managed_scripts(repo_dir: &Path) -> BTreeSet<String> {
     scripts
 }
 
-fn codex_hook_records(data: &Value) -> Vec<(String, String, serde_json::Map<String, Value>)> {
-    let mut records = Vec::new();
-    let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
-        return records;
-    };
-    for (event, entries) in hooks {
-        let Some(entries) = entries.as_array() else {
-            continue;
-        };
-        for entry in entries {
-            let Some(entry_obj) = entry.as_object() else {
-                continue;
-            };
-            let matcher = entry_obj
-                .get("matcher")
-                .and_then(Value::as_str)
-                .filter(|s| !s.is_empty())
-                .unwrap_or("<none>")
-                .to_string();
-            let Some(hook_entries) = entry_obj.get("hooks").and_then(Value::as_array) else {
-                continue;
-            };
-            for hook in hook_entries {
-                if let Some(hook_obj) = hook.as_object() {
-                    records.push((event.clone(), matcher.clone(), hook_obj.clone()));
-                }
-            }
-        }
-    }
-    records
-}
-
-fn codex_stale_findings(data: &Value, config: &Path) -> Vec<String> {
-    codex_hook_records(data)
-        .into_iter()
-        .filter_map(|(event, matcher, hook)| {
-            let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
-            let target = if let Some(target) = codex_direct_installed_hook_target(command) {
-                target
-            } else {
-                let target = codex_hook_target(command)?;
-                if target.exists() {
-                    return None;
-                }
-                target
-            };
-            Some(format!(
-                "stale Codex hook command: config={} event={event} matcher={matcher} command_path={} repair=bash setup.sh --yes",
-                display_home_path(config),
-                target.display()
-            ))
-        })
-        .collect()
-}
-
 fn codex_direct_installed_hook_target(command: &str) -> Option<PathBuf> {
     let home = home_dir()?;
     shell_split(command).into_iter().find_map(|token| {
@@ -516,7 +400,9 @@ fn codex_hook_target(command: &str) -> Option<PathBuf> {
     let home = home_dir()?;
     let parts = shell_split(command);
     for (idx, token) in parts.iter().enumerate() {
-        let path = codex_expand_path(token, &home)?;
+        let Some(path) = codex_expand_path(token, &home) else {
+            continue;
+        };
         if path
             .to_string_lossy()
             .ends_with("/.vibeguard/run-hook-codex.sh")
@@ -533,7 +419,7 @@ fn codex_hook_target(command: &str) -> Option<PathBuf> {
     None
 }
 
-fn codex_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
+pub(crate) fn codex_expand_path(token: &str, home: &Path) -> Option<PathBuf> {
     token
         .strip_prefix("~/")
         .map(|tail| home.join(tail))

--- a/vibeguard-runtime/src/setup_codex_hooks_health.rs
+++ b/vibeguard-runtime/src/setup_codex_hooks_health.rs
@@ -1,0 +1,392 @@
+use crate::setup_codex_hooks::{codex_command_is_managed, codex_expand_path};
+use crate::setup_support::{
+    SetupResult, basename, display_home_path, home_dir, read_json_object, shell_split,
+    write_json_atomic,
+};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CodexCommandState {
+    ManagedVibeguard,
+    UnmanagedValid { target: PathBuf },
+    UnmanagedMissingTarget { target: PathBuf },
+    UnmanagedUnresolved,
+}
+
+pub fn codex_hooks_check_stale(args: &[String]) -> SetupResult<()> {
+    let (repo_dir, hooks_path) = match args {
+        [hooks_file] => (None, Path::new(hooks_file)),
+        [repo_dir, hooks_file] => (Some(Path::new(repo_dir)), Path::new(hooks_file)),
+        _ => {
+            return Err(
+                "Usage: vibeguard-runtime setup-codex-hooks-check-stale [repo-dir] <hooks-file>"
+                    .into(),
+            );
+        }
+    };
+    if !hooks_path.exists() {
+        return Ok(());
+    }
+    let data = Value::Object(read_json_object(hooks_path, false)?);
+    let findings = codex_stale_findings(&data, hooks_path, repo_dir);
+    for finding in &findings {
+        println!("{finding}");
+    }
+    if !findings.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+pub fn codex_hooks_prune_stale_unmanaged(args: &[String]) -> SetupResult<()> {
+    if args.len() < 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-hooks-prune-stale-unmanaged <repo-dir> <hooks-file> [event...]"
+                .into(),
+        );
+    }
+    let repo_dir = Path::new(&args[0]);
+    let hooks_path = Path::new(&args[1]);
+    if !hooks_path.exists() {
+        println!("SKIP");
+        return Ok(());
+    }
+    let events: BTreeSet<String> = if args.len() > 2 {
+        args[2..].iter().cloned().collect()
+    } else {
+        ["PreToolUse", "PermissionRequest"]
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    };
+    let mut data = Value::Object(read_json_object(hooks_path, false)?);
+    let removed = codex_prune_stale_unmanaged(&mut data, repo_dir, hooks_path, &events);
+    for finding in &removed {
+        println!("{finding}");
+    }
+    if removed.is_empty() {
+        println!("SKIP");
+    } else {
+        write_json_atomic(hooks_path, &data)?;
+        println!("CHANGED");
+    }
+    Ok(())
+}
+
+pub fn codex_hooks_check_timeouts(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-codex-hooks-check-timeouts <repo-dir> <hooks-file>"
+                .into(),
+        );
+    }
+    let repo_dir = Path::new(&args[0]);
+    let hooks_path = Path::new(&args[1]);
+    if !hooks_path.exists() {
+        return Ok(());
+    }
+    let data = Value::Object(read_json_object(hooks_path, false)?);
+    let mut findings = Vec::new();
+    for (event, matcher, hook) in codex_hook_records(&data) {
+        let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+        if command.is_empty()
+            || hook
+                .get("timeout")
+                .and_then(Value::as_i64)
+                .is_some_and(|v| v > 0)
+        {
+            continue;
+        }
+        let managed = codex_command_is_managed(repo_dir, command);
+        let state = if managed { "managed" } else { "unmanaged" };
+        let repair = if managed {
+            "bash setup.sh --yes"
+        } else {
+            "add timeout or consult hook owner"
+        };
+        findings.push(format!(
+            "{state} Codex hook without timeout: config={} event={event} matcher={matcher} command={command} repair={repair}",
+            display_home_path(hooks_path)
+        ));
+    }
+    for finding in &findings {
+        println!("{finding}");
+    }
+    if !findings.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn codex_stale_findings(data: &Value, config: &Path, repo_dir: Option<&Path>) -> Vec<String> {
+    codex_hook_records(data)
+        .into_iter()
+        .filter_map(|(event, matcher, hook)| {
+            let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+            if let Some(target) = codex_installed_hook_target(command) {
+                if target.exists() {
+                    return None;
+                }
+                return Some(format!(
+                    "stale Codex hook command: config={} event={event} matcher={matcher} command_path={} repair=bash setup.sh --yes",
+                    display_home_path(config),
+                    target.display()
+                ));
+            }
+            match codex_command_state(repo_dir, command) {
+                CodexCommandState::UnmanagedMissingTarget { target } => {
+                    let label = if codex_event_is_blocking(&event) {
+                        "repair-required unmanaged Codex blocking hook"
+                    } else {
+                        "stale unmanaged Codex hook"
+                    };
+                    Some(format!(
+                        "{label}: config={} event={event} matcher={matcher} command={command} command_path={} repair=bash setup.sh --yes --repair-stale-unmanaged-hooks",
+                        display_home_path(config),
+                        target.display()
+                    ))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn codex_prune_stale_unmanaged(
+    data: &mut Value,
+    repo_dir: &Path,
+    config: &Path,
+    events: &BTreeSet<String>,
+) -> Vec<String> {
+    let mut removed = Vec::new();
+    let Some(hooks) = data.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return removed;
+    };
+    for (event, entries) in hooks.iter_mut() {
+        if !events.contains(event) {
+            continue;
+        }
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        let mut next_entries = Vec::new();
+        for entry in std::mem::take(entries) {
+            let Some(entry_obj) = entry.as_object() else {
+                next_entries.push(entry);
+                continue;
+            };
+            let matcher = codex_entry_matcher(entry_obj);
+            let Some(hook_entries) = entry_obj.get("hooks").and_then(Value::as_array) else {
+                next_entries.push(entry);
+                continue;
+            };
+            let mut kept_hooks = Vec::new();
+            for hook in hook_entries {
+                let command = hook.get("command").and_then(Value::as_str).unwrap_or("");
+                match codex_command_state(Some(repo_dir), command) {
+                    CodexCommandState::UnmanagedMissingTarget { target } => {
+                        removed.push(format!(
+                            "removed stale unmanaged Codex hook: config={} event={event} matcher={matcher} command={command} command_path={}",
+                            display_home_path(config),
+                            target.display()
+                        ));
+                    }
+                    _ => kept_hooks.push(hook.clone()),
+                }
+            }
+            if kept_hooks.len() == hook_entries.len() {
+                next_entries.push(entry);
+            } else if !kept_hooks.is_empty() {
+                let mut next = entry_obj.clone();
+                next.insert("hooks".to_string(), Value::Array(kept_hooks));
+                next_entries.push(Value::Object(next));
+            }
+        }
+        *entries = next_entries;
+    }
+    hooks.retain(|_, value| value.as_array().is_some_and(|items| !items.is_empty()));
+    if hooks.is_empty() {
+        data.as_object_mut().expect("object").remove("hooks");
+    }
+    removed
+}
+
+fn codex_hook_records(data: &Value) -> Vec<(String, String, serde_json::Map<String, Value>)> {
+    let mut records = Vec::new();
+    let Some(hooks) = data.get("hooks").and_then(Value::as_object) else {
+        return records;
+    };
+    for (event, entries) in hooks {
+        let Some(entries) = entries.as_array() else {
+            continue;
+        };
+        for entry in entries {
+            let Some(entry_obj) = entry.as_object() else {
+                continue;
+            };
+            let matcher = codex_entry_matcher(entry_obj);
+            let Some(hook_entries) = entry_obj.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for hook in hook_entries {
+                if let Some(hook_obj) = hook.as_object() {
+                    records.push((event.clone(), matcher.clone(), hook_obj.clone()));
+                }
+            }
+        }
+    }
+    records
+}
+
+fn codex_entry_matcher(entry_obj: &serde_json::Map<String, Value>) -> String {
+    entry_obj
+        .get("matcher")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("<none>")
+        .to_string()
+}
+
+fn codex_event_is_blocking(event: &str) -> bool {
+    matches!(event, "PreToolUse" | "PermissionRequest")
+}
+
+fn codex_command_state(repo_dir: Option<&Path>, command: &str) -> CodexCommandState {
+    if repo_dir.is_some_and(|root| codex_command_is_managed(root, command)) {
+        return CodexCommandState::ManagedVibeguard;
+    }
+    let Some(target) = codex_unmanaged_command_target(command) else {
+        return CodexCommandState::UnmanagedUnresolved;
+    };
+    if target.exists() {
+        CodexCommandState::UnmanagedValid { target }
+    } else {
+        CodexCommandState::UnmanagedMissingTarget { target }
+    }
+}
+
+fn codex_unmanaged_command_target(command: &str) -> Option<PathBuf> {
+    let home = home_dir()?;
+    let parts = shell_split(command);
+    let start = codex_command_start_after_env(&parts)?;
+    let first = parts.get(start)?;
+    if let Some(path) = codex_expand_path(first, &home) {
+        return Some(path);
+    }
+    if !codex_token_is_interpreter(first) {
+        return None;
+    }
+    parts.iter().skip(start + 1).find_map(|token| {
+        if token.starts_with('-') || codex_token_is_env_assignment(token) {
+            None
+        } else {
+            codex_expand_path(token, &home)
+        }
+    })
+}
+
+fn codex_command_start_after_env(parts: &[String]) -> Option<usize> {
+    let mut idx = 0;
+    if parts.get(idx).is_some_and(|part| basename(part) == "env") {
+        idx += 1;
+    }
+    while parts
+        .get(idx)
+        .is_some_and(|part| codex_token_is_env_assignment(part))
+    {
+        idx += 1;
+    }
+    (idx < parts.len()).then_some(idx)
+}
+
+fn codex_token_is_env_assignment(token: &str) -> bool {
+    let Some((name, _)) = token.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn codex_token_is_interpreter(token: &str) -> bool {
+    matches!(
+        basename(token),
+        "node"
+            | "bash"
+            | "sh"
+            | "python"
+            | "python3"
+            | "python2"
+            | "ruby"
+            | "perl"
+            | "deno"
+            | "bun"
+    )
+}
+
+fn codex_installed_hook_target(command: &str) -> Option<PathBuf> {
+    let home = home_dir()?;
+    let parts = shell_split(command);
+    for (idx, token) in parts.iter().enumerate() {
+        let Some(path) = codex_expand_path(token, &home) else {
+            continue;
+        };
+        let path_text = path.to_string_lossy();
+        if path_text.contains("/.vibeguard/installed/hooks/") {
+            return Some(path);
+        }
+        if path_text.ends_with("/.vibeguard/run-hook-codex.sh") {
+            let script = parts.get(idx + 1)?;
+            if !script.contains('/') {
+                let installed = path.parent()?.join("installed/hooks").join(script);
+                if installed.parent().is_some_and(Path::exists) {
+                    return Some(installed);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_home() -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("vg-codex-health-{stamp}"));
+        fs::create_dir_all(&path).expect("temp home");
+        unsafe {
+            std::env::set_var("HOME", &path);
+        }
+        path
+    }
+
+    #[test]
+    fn unmanaged_target_detects_direct_interpreter_and_env_forms() {
+        let home = temp_home();
+        let existing = home.join("hook.sh");
+        fs::write(&existing, "#!/usr/bin/env bash\n").expect("write hook");
+
+        assert_eq!(
+            codex_command_state(None, &format!("bash {}", existing.display())),
+            CodexCommandState::UnmanagedValid { target: existing }
+        );
+        assert!(matches!(
+            codex_command_state(None, "env FOO=1 node /existing/non-vibeguard.js"),
+            CodexCommandState::UnmanagedMissingTarget { .. }
+        ));
+        assert_eq!(
+            codex_command_state(None, "node --eval 'console.log(1)'"),
+            CodexCommandState::UnmanagedUnresolved
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Refs #566.

- classify unmanaged Codex hook commands as valid, missing-target, unresolved, or VibeGuard-managed
- promote missing-target unmanaged `PreToolUse` / `PermissionRequest` hooks to strict repair-required diagnostics
- add explicit `setup.sh --yes --repair-stale-unmanaged-hooks` pruning that preserves valid third-party and managed hooks
- isolate setup fixtures so `/existing/non-vibeguard.js` is only used as a stale fixture, not a preserved valid hook
- document diagnosis and repair for Codex `PreToolUse hook (failed)`

## SpecRail

- Covered: SP566-T1, SP566-T2, SP566-T3, SP566-T4, SP566-T5
- Human gate remains: SP566-T6, because the repair path mutates `~/.codex/hooks.json`
- Merge note: do not merge until the opt-in deletion boundary is reviewed and accepted

## Verification

- `python3 -m py_compile scripts/lib/codex_hooks_json.py`
- `bash -n setup.sh scripts/setup/lib.sh scripts/setup/install.sh scripts/setup/targets/codex-home.sh tests/test_setup_check.sh tests/setup/install_flow_tests.sh tests/setup/profile_flow_tests.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_setup_check.sh`
- `bash tests/test_setup.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-no-personal-paths.sh`
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`
- `git diff --cached --check`