### PR TITLE
perf(hooks): migrate pre-write guard to runtime orchestrator

### DIFF
--- a/hooks/pre-write-guard.sh
+++ b/hooks/pre-write-guard.sh
@@ -1,198 +1,44 @@
 #!/usr/bin/env bash
 # VibeGuard PreToolUse(Write) Hook
 #
-# Grading strategy:
-# - Edit existing file → Release
-# - New configuration/document/test file → Release
-# - Create a new source code file (.rs/.py/.ts/.js/.go/.jsx/.tsx) → intercept (requires searching first and then writing)
-#
-#Default warn mode: remind to search first and then write (L1 constraint is covered by PostToolUse repeated detection)
-# Set VIBEGUARD_WRITE_MODE=block to upgrade to hard blocking mode
+# Thin compatibility entry point. The hot path lives in vibeguard-runtime so
+# Write hooks avoid sourcing the shared bash logging and breaker stack.
 
 set -euo pipefail
 
-source "$(dirname "$0")/log.sh"
-source "$(dirname "$0")/circuit-breaker.sh"
-vg_start_timer
+_VG_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_VIBEGUARD_RUNTIME=""
 
-_pass_and_exit() {
-  if ! vg_cb_record_pass "pre-write-guard"; then
-    vg_log "pre-write-guard" "Write" "block" "Circuit breaker state error; fail-closed" ""
-    vg_json_output_kv decision block reason "VIBEGUARD interception: pre-write circuit breaker state could not be updated; fail-closed instead of silently continuing."
-  fi
-  exit 0
+_vg_prewrite_installed_context() {
+  local installed_hooks="${HOME:-}/.vibeguard/installed/hooks"
+  [[ -n "${HOME:-}" && ( "${_VG_HOOK_DIR}" == "${installed_hooks}" || "${_VG_HOOK_DIR}" == "${installed_hooks}/"* ) ]]
 }
 
-INPUT=$(cat)
-
-vg_config_get_int_result _U16_BASE_LIMIT VG_U16_LIMIT u16.limit 800
-vg_u16_warn_limit_result _U16_WARN_LIMIT "$_U16_BASE_LIMIT"
-if ! CHECK_RESULT=$(printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" pre-write-check "$_U16_BASE_LIMIT" "$_U16_WARN_LIMIT" 2>/dev/null); then
-  vg_log "pre-write-guard" "Write" "block" "vibeguard-runtime pre-write-check failed; fail-closed" ""
-  vg_json_output_kv decision block reason "VIBEGUARD interception: runtime pre-write-check failed; fail-closed."
-  exit 0
-fi
-
-CHECK_STATUS="${CHECK_RESULT%%$'\n'*}"
-_CHECK_REST="${CHECK_RESULT#*$'\n'}"
-FILE_PATH="${_CHECK_REST%%$'\n'*}"
-[[ "$FILE_PATH" == "$CHECK_RESULT" ]] && FILE_PATH=""
-
-if [[ "$CHECK_STATUS" == "MALFORMED" ]]; then
-  vg_log "pre-write-guard" "Write" "block" "Malformed hook input" ""
-  cat <<'EOF'
-{
-  "decision": "block",
-  "reason": "VIBEGUARD interception: malformed PreToolUse(Write) hook input. The write request could not be validated, so it was blocked instead of being treated as a safe skip."
-}
-EOF
-  exit 0
-fi
-
-if [[ "$CHECK_STATUS" == "PASS" || -z "$FILE_PATH" ]]; then
-  _pass_and_exit
-fi
-
-if [[ "$CHECK_STATUS" == "W12" ]]; then
-  vg_log "pre-write-guard" "Write" "block" "Test Infrastructure File Guard (W-12)" "$FILE_PATH"
-  cat <<'EOF'
-{
-  "decision": "block",
-  "reason": "[W-12] [block] [this-edit] OBSERVATION: writing to test infrastructure file blocked (conftest.py/jest.config/pytest.ini/.coveragerc/babel.config)\nFIX: Fix the production code that is failing — do not manipulate test framework configuration"
-}
-EOF
-  exit 0
-fi
-
-if [[ "$CHECK_STATUS" == "U16_BLOCK" ]]; then
-  _CHECK_REST="${_CHECK_REST#*$'\n'}"
-  _U16_LINES="${_CHECK_REST%%$'\n'*}"
-  _CHECK_REST="${_CHECK_REST#*$'\n'}"
-  _U16_LIM="${_CHECK_REST%%$'\n'*}"
-  vg_log "pre-write-guard" "Write" "block" "U-16 file size: ${_U16_LINES} > ${_U16_LIM}" "$FILE_PATH"
-  cat <<BLOCK_EOF
-{
-  "decision": "block",
-  "reason": "VIBEGUARD [U-16] block: writing ${FILE_PATH##*/} with ${_U16_LINES} lines exceeds the ${_U16_LIM}-line limit. Split into focused submodules first. Do NOT proceed with this write."
-}
-BLOCK_EOF
-  exit 0
-fi
-
-_U16_SOURCE_NEW_LINES=""
-_U16_SOURCE_NEW_WARN=""
-_U16_SOURCE_NEW_LIMIT=""
-
-if [[ "$CHECK_STATUS" == "U16_WARN" || "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]]; then
-  _CHECK_REST="${_CHECK_REST#*$'\n'}"
-  _U16_LINES="${_CHECK_REST%%$'\n'*}"
-  _CHECK_REST="${_CHECK_REST#*$'\n'}"
-  _U16_WARN="${_CHECK_REST%%$'\n'*}"
-  _CHECK_REST="${_CHECK_REST#*$'\n'}"
-  _U16_LIM="${_CHECK_REST%%$'\n'*}"
-  vg_log "pre-write-guard" "Write" "warn" "U-16 file size advisory: ${_U16_LINES} > ${_U16_WARN}" "$FILE_PATH"
-  if [[ "$CHECK_STATUS" == "U16_WARN_SOURCE_NEW" ]]; then
-    _U16_SOURCE_NEW_LINES="$_U16_LINES"
-    _U16_SOURCE_NEW_WARN="$_U16_WARN"
-    _U16_SOURCE_NEW_LIMIT="$_U16_LIM"
-    CHECK_STATUS="SOURCE_NEW"
+_vg_prewrite_runtime_candidates() {
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if _vg_prewrite_installed_context; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
   else
-    cat <<EOF | "$_VIBEGUARD_RUNTIME" hook-context PreToolUse
-VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: writing ${FILE_PATH##*/} with ${_U16_LINES} lines exceeds the ${_U16_WARN}-line typical range but stays under the ${_U16_LIM}-line hard limit
-SCOPE: keep the current change localized; plan a split if this file keeps growing
-ACTION: NONE — advisory only, continue without acknowledgement
-EOF
-    exit 0
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
   fi
-fi
-
-if [[ "$CHECK_STATUS" != "SOURCE_NEW" ]]; then
-  _pass_and_exit
-fi
-
-# --- Source code files: reminder to search first and then write ---
-# Default warn (reminder), set VIBEGUARD_WRITE_MODE=block to upgrade to hard interception.
-#
-# Circuit breaker (warn mode): after CB_THRESHOLD consecutive notices in the same
-# session the circuit OPENs and subsequent writes pass silently. This prevents
-# 6-file batch writes from injecting 6 redundant advisories. Block mode does not
-# use the circuit breaker so hard rejections are never silenced.
-vg_config_get_str_result MODE VIBEGUARD_WRITE_MODE write_mode warn
-case "$MODE" in
-  block|warn) ;;
-  *) MODE="warn" ;;
-esac
-
-if [[ "$MODE" == "block" ]]; then
-  vg_log "pre-write-guard" "Write" "block" "New source code file not searched" "$FILE_PATH"
-  cat <<'EOF'
-{
-  "decision": "block",
-  "reason": "VIBEGUARD [L1] [block] [this-edit] OBSERVATION: new source file creation blocked — search not performed before write\nSCOPE: search required before retry — use Grep for functions/classes/structs, Glob for same-named files\nACTION: REVIEW"
 }
-EOF
-else
-  # Escalation: count prior new-source attempts in this session. After N hits
-  # the agent has demonstrably ignored the warning, so the next attempt is
-  # blocked. Threshold is configurable; set to 0 to disable escalation.
-  vg_config_get_int_result ESCALATE_THRESHOLD VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD write_escalate_threshold 5
-  PRIOR_SOURCE_NEW_COUNT=0
-  if [[ "$ESCALATE_THRESHOLD" -gt 0 && -f "$VIBEGUARD_LOG_FILE" ]]; then
-    PRIOR_SOURCE_NEW_COUNT=$(tail -500 "$VIBEGUARD_LOG_FILE" \
-      | "$_VIBEGUARD_RUNTIME" reason-count "$VIBEGUARD_SESSION_ID" "pre-write-guard" "New source file attempt" \
-      2>/dev/null || echo 0)
-    PRIOR_SOURCE_NEW_COUNT="${PRIOR_SOURCE_NEW_COUNT:-0}"
-  fi
 
-  if [[ "$ESCALATE_THRESHOLD" -gt 0 && "$PRIOR_SOURCE_NEW_COUNT" -ge "$ESCALATE_THRESHOLD" ]]; then
-    vg_log "pre-write-guard" "Write" "escalate" "L1 escalation after ${PRIOR_SOURCE_NEW_COUNT} unheeded source-new attempts" "$FILE_PATH"
-    cat <<EOF
-{
-  "decision": "block",
-  "reason": "VIBEGUARD [L1] [block] [escalation] OBSERVATION: ${PRIOR_SOURCE_NEW_COUNT} new source file attempts in this session went unheeded\nSCOPE: pause new file creation — run Grep for similar function/class names and Glob for same-named files in this repo before any further Write\nACTION: REVIEW — confirm no duplicate exists; after manual verification start a new session, raise VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD, or export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0 to disable escalation for this session"
-}
-EOF
-    exit 0
+while IFS= read -r _candidate; do
+  if [[ -n "$_candidate" && -f "$_candidate" && -x "$_candidate" ]]; then
+    _VIBEGUARD_RUNTIME="$_candidate"
+    break
   fi
+done < <(_vg_prewrite_runtime_candidates)
 
-  vg_log "pre-write-guard" "Write" "warn" "New source file attempt" "$FILE_PATH"
-
-  CB_STATUS=0
-  if vg_cb_check "pre-write-guard"; then
-    CB_STATUS=0
-  else
-    CB_STATUS=$?
-  fi
-
-  if [[ "$CB_STATUS" -eq 0 ]]; then
-    vg_log "pre-write-guard" "Write" "warn" "New source file reminder" "$FILE_PATH"
-    if ! vg_cb_record_block "pre-write-guard"; then
-      vg_log "pre-write-guard" "Write" "block" "Circuit breaker state error; fail-closed" "$FILE_PATH"
-      vg_json_output_kv decision block reason "VIBEGUARD interception: pre-write circuit breaker state could not be persisted; fail-closed instead of silently continuing."
-      exit 0
-    fi
-    if [[ -n "$_U16_SOURCE_NEW_LINES" ]]; then
-      cat <<EOF | "$_VIBEGUARD_RUNTIME" hook-context PreToolUse
-VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: writing ${FILE_PATH##*/} with ${_U16_SOURCE_NEW_LINES} lines exceeds the ${_U16_SOURCE_NEW_WARN}-line typical range but stays under the ${_U16_SOURCE_NEW_LIMIT}-line hard limit
-SCOPE: keep the current change localized; plan a split if this file keeps growing
-ACTION: NONE — advisory only, continue without acknowledgement
----
-VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates
-SCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files
-ACTION: NONE — advisory only, continue without acknowledgement
-EOF
-    else
-      cat <<'EOF' | "$_VIBEGUARD_RUNTIME" hook-context PreToolUse
-VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates
-SCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files
-ACTION: NONE — advisory only, continue without acknowledgement
-EOF
-    fi
-  elif [[ "$CB_STATUS" -eq 1 ]]; then
-    : # Circuit OPEN: silent pass (vg_cb_check already logged the auto-pass).
-  else
-    vg_log "pre-write-guard" "Write" "block" "Circuit breaker state error; fail-closed" "$FILE_PATH"
-    vg_json_output_kv decision block reason "VIBEGUARD interception: pre-write circuit breaker state could not be read; fail-closed instead of silently auto-passing."
-    exit 0
-  fi
+if [[ -z "$_VIBEGUARD_RUNTIME" ]]; then
+  printf '%s\n' "VIBEGUARD ERROR: vibeguard-runtime not found. Run setup.sh or cargo build --release --manifest-path vibeguard-runtime/Cargo.toml." >&2
+  exit 2
 fi
+
+exec "$_VIBEGUARD_RUNTIME" hook pre-write

--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -27,6 +27,15 @@ header "pre-write-guard.sh — malformed input fails closed"
 result=$(printf '%s' '{"tool_input":' | bash hooks/pre-write-guard.sh)
 assert_contains "$result" '"decision": "block"' "Malformed Write hook JSON fails closed"
 assert_contains "$result" "malformed PreToolUse(Write)" "Malformed Write hook input explains validation failure"
+expected_malformed_output=$(cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "VIBEGUARD interception: malformed PreToolUse(Write) hook input. The write request could not be validated, so it was blocked instead of being treated as a safe skip."
+}
+EOF
+)
+assert_exit_zero "Malformed Write hook output matches legacy JSON shape" \
+  bash -c '[[ "$1" == "$2" ]]' _ "$result" "$expected_malformed_output"
 
 result=$(printf '%s' '{"tool_input":{}}' | bash hooks/pre-write-guard.sh)
 assert_contains "$result" '"decision": "block"' "Write hook payload missing file_path fails closed"
@@ -81,6 +90,15 @@ assert_not_contains "$result" "VIBEGUARD" "Source code files in the tests/ direc
 result=$(echo '{"tool_input":{"file_path":"/tmp/vg_nonexist_dir/conftest.py"}}' | bash hooks/pre-write-guard.sh)
 assert_contains "$result" '"decision": "block"' "W-12: Block writing to new conftest.py"
 assert_contains "$result" "W-12" "W-12: write guard error message contains rule number"
+expected_w12_output=$(cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "[W-12] [block] [this-edit] OBSERVATION: writing to test infrastructure file blocked (conftest.py/jest.config/pytest.ini/.coveragerc/babel.config)\nFIX: Fix the production code that is failing — do not manipulate test framework configuration"
+}
+EOF
+)
+assert_exit_zero "W-12 Write hook output matches legacy JSON shape" \
+  bash -c '[[ "$1" == "$2" ]]' _ "$result" "$expected_w12_output"
 
 # W-12: Writing to existing conftest.py paths (including directories) should also be blocked
 result=$(echo '{"tool_input":{"file_path":"/project/tests/conftest.py"}}' | bash hooks/pre-write-guard.sh)

--- a/vibeguard-runtime/src/circuit_breaker.rs
+++ b/vibeguard-runtime/src/circuit_breaker.rs
@@ -53,13 +53,63 @@ impl Default for CircuitState {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CircuitCheckOutcome {
+    Run,
+    AutoPass { reason: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CircuitRecordBlockOutcome {
+    Recorded,
+    Opened { reason: String },
+}
+
+pub(crate) fn check(
+    state_file: &Path,
+    lock_file: &Path,
+    cooldown: u64,
+    lock_timeout: u64,
+    session: &str,
+) -> Result<CircuitCheckOutcome> {
+    let _lock = CircuitLock::acquire(lock_file, lock_timeout)?;
+    let mut state = load_state(state_file)?;
+    let dirty = apply_session_reset(&mut state, session);
+    run_check(state_file, &mut state, session, cooldown, dirty)
+}
+
+pub(crate) fn record_block(
+    state_file: &Path,
+    lock_file: &Path,
+    threshold: u64,
+    cooldown: u64,
+    lock_timeout: u64,
+    session: &str,
+) -> Result<CircuitRecordBlockOutcome> {
+    let _lock = CircuitLock::acquire(lock_file, lock_timeout)?;
+    let mut state = load_state(state_file)?;
+    let _dirty = apply_session_reset(&mut state, session);
+    run_record_block(state_file, &mut state, session, threshold, cooldown)
+}
+
+pub(crate) fn record_pass(
+    state_file: &Path,
+    lock_file: &Path,
+    lock_timeout: u64,
+    session: &str,
+) -> Result {
+    let _lock = CircuitLock::acquire(lock_file, lock_timeout)?;
+    let mut state = load_state(state_file)?;
+    let dirty = apply_session_reset(&mut state, session);
+    run_record_pass(state_file, &mut state, session, dirty)
+}
+
 pub fn run(args: &[String]) -> Result {
     if args.len() != 7 {
         return Err("Usage: vibeguard-runtime circuit-breaker <check|record-block|record-pass> <hook> <state-file> <lock-file> <threshold> <cooldown-seconds> <lock-timeout-seconds>".into());
     }
 
     let action = args[0].as_str();
-    let hook = args[1].as_str();
     let state_file = Path::new(&args[2]);
     let lock_file = Path::new(&args[3]);
     let threshold = parse_u64(&args[4], "threshold")?;
@@ -67,16 +117,43 @@ pub fn run(args: &[String]) -> Result {
     let lock_timeout = parse_u64(&args[6], "lock-timeout-seconds")?;
     let session = std::env::var("VIBEGUARD_SESSION_ID").unwrap_or_default();
 
-    let _lock = CircuitLock::acquire(lock_file, lock_timeout)?;
-    let mut state = load_state(state_file)?;
-    let dirty = apply_session_reset(&mut state, &session);
-
     match action {
-        "check" => run_check(hook, state_file, &mut state, &session, cooldown, dirty),
+        "check" => match check(state_file, lock_file, cooldown, lock_timeout, &session)? {
+            CircuitCheckOutcome::Run => {
+                println!("RUN");
+                Ok(())
+            }
+            CircuitCheckOutcome::AutoPass { reason } => {
+                println!("AUTO_PASS");
+                println!("{reason}");
+                Ok(())
+            }
+        },
         "record-block" => {
-            run_record_block(hook, state_file, &mut state, &session, threshold, cooldown)
+            match record_block(
+                state_file,
+                lock_file,
+                threshold,
+                cooldown,
+                lock_timeout,
+                &session,
+            )? {
+                CircuitRecordBlockOutcome::Recorded => {
+                    println!("RECORDED");
+                    Ok(())
+                }
+                CircuitRecordBlockOutcome::Opened { reason } => {
+                    println!("OPENED");
+                    println!("{reason}");
+                    Ok(())
+                }
+            }
         }
-        "record-pass" => run_record_pass(state_file, &mut state, &session, dirty),
+        "record-pass" => {
+            record_pass(state_file, lock_file, lock_timeout, &session)?;
+            println!("RECORDED");
+            Ok(())
+        }
         _ => Err(format!("unknown circuit-breaker action: {action}").into()),
     }
 }
@@ -88,13 +165,12 @@ fn parse_u64(value: &str, name: &str) -> Result<u64> {
 }
 
 fn run_check(
-    _hook: &str,
     state_file: &Path,
     state: &mut CircuitState,
     session: &str,
     cooldown: u64,
     dirty: bool,
-) -> Result {
+) -> Result<CircuitCheckOutcome> {
     let now = now_unix_secs();
 
     match state.state {
@@ -102,7 +178,7 @@ fn run_check(
             if dirty {
                 save_state(state_file, state, session)?;
             }
-            println!("RUN");
+            Ok(CircuitCheckOutcome::Run)
         }
         CircuitStateName::Open => {
             let elapsed = now.saturating_sub(state.last_block);
@@ -110,53 +186,49 @@ fn run_check(
                 state.state = CircuitStateName::HalfOpen;
                 state.last_block = now;
                 save_state(state_file, state, session)?;
-                println!("RUN");
+                Ok(CircuitCheckOutcome::Run)
             } else {
                 let remaining = cooldown - elapsed;
-                println!("AUTO_PASS");
-                println!(
-                    "CB OPEN: auto-pass ({remaining}s remaining, {} consecutive blocks)",
-                    state.blocks
-                );
+                Ok(CircuitCheckOutcome::AutoPass {
+                    reason: format!(
+                        "CB OPEN: auto-pass ({remaining}s remaining, {} consecutive blocks)",
+                        state.blocks
+                    ),
+                })
             }
         }
-        CircuitStateName::HalfOpen => {
-            println!("AUTO_PASS");
-            println!(
+        CircuitStateName::HalfOpen => Ok(CircuitCheckOutcome::AutoPass {
+            reason: format!(
                 "CB HALF-OPEN: probe in-flight, auto-passing ({} prior blocks)",
                 state.blocks
-            );
-        }
+            ),
+        }),
     }
-
-    Ok(())
 }
 
 fn run_record_block(
-    _hook: &str,
     state_file: &Path,
     state: &mut CircuitState,
     session: &str,
     threshold: u64,
     cooldown: u64,
-) -> Result {
+) -> Result<CircuitRecordBlockOutcome> {
     state.blocks = state.blocks.saturating_add(1);
     state.last_block = now_unix_secs();
 
     if state.state == CircuitStateName::HalfOpen || state.blocks >= threshold {
         state.state = CircuitStateName::Open;
         save_state(state_file, state, session)?;
-        println!("OPENED");
-        println!(
-            "CB tripped OPEN: {} consecutive blocks, cooldown {cooldown}s",
-            state.blocks
-        );
+        Ok(CircuitRecordBlockOutcome::Opened {
+            reason: format!(
+                "CB tripped OPEN: {} consecutive blocks, cooldown {cooldown}s",
+                state.blocks
+            ),
+        })
     } else {
         save_state(state_file, state, session)?;
-        println!("RECORDED");
+        Ok(CircuitRecordBlockOutcome::Recorded)
     }
-
-    Ok(())
 }
 
 fn run_record_pass(
@@ -171,7 +243,6 @@ fn run_record_pass(
         state.last_block = 0;
         save_state(state_file, state, session)?;
     }
-    println!("RECORDED");
     Ok(())
 }
 

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -14,6 +14,40 @@ use crate::hook_checks_scan::{SameNameScan, find_project_dir, scan_same_name_dup
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PreWriteCheck {
+    Malformed,
+    Exists {
+        file_path: String,
+    },
+    Allow {
+        file_path: String,
+    },
+    SourceNew {
+        file_path: String,
+    },
+    W12 {
+        file_path: String,
+    },
+    U16Block {
+        file_path: String,
+        line_count: usize,
+        limit: usize,
+    },
+    U16Warn {
+        file_path: String,
+        line_count: usize,
+        warn_limit: usize,
+        limit: usize,
+    },
+    U16WarnSourceNew {
+        file_path: String,
+        line_count: usize,
+        warn_limit: usize,
+        limit: usize,
+    },
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum MissingFileCandidates {
     Found(Vec<String>),
@@ -31,24 +65,28 @@ pub fn pre_write_check(args: &[String]) -> Result {
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(400);
     let input = read_stdin()?;
-    let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
-        println!("MALFORMED");
-        return Ok(());
+    print_pre_write_check(&evaluate_pre_write_input(&input, base_limit, warn_limit));
+    Ok(())
+}
+
+pub(crate) fn evaluate_pre_write_input(
+    input: &str,
+    base_limit: usize,
+    warn_limit: usize,
+) -> PreWriteCheck {
+    let Ok(data) = serde_json::from_str::<serde_json::Value>(input) else {
+        return PreWriteCheck::Malformed;
     };
 
     let Some(file_path) = nested_str(&data, "tool_input.file_path") else {
-        println!("MALFORMED");
-        return Ok(());
+        return PreWriteCheck::Malformed;
     };
     if file_path.is_empty() {
-        println!("MALFORMED");
-        return Ok(());
+        return PreWriteCheck::Malformed;
     }
 
     if is_test_infra_path(&file_path) {
-        println!("W12");
-        println!("{file_path}");
-        return Ok(());
+        return PreWriteCheck::W12 { file_path };
     }
 
     let content = nested_str(&data, "tool_input.content").unwrap_or_default();
@@ -57,11 +95,11 @@ pub fn pre_write_check(args: &[String]) -> Result {
     if is_source_path(&file_path) && !is_test_path(&file_path) {
         let limit = project_u16_limit(&file_path, base_limit);
         if line_count > limit {
-            println!("U16_BLOCK");
-            println!("{file_path}");
-            println!("{line_count}");
-            println!("{limit}");
-            return Ok(());
+            return PreWriteCheck::U16Block {
+                file_path,
+                line_count,
+                limit,
+            };
         }
         let advisory_limit = u16_advisory_limit(base_limit, limit, warn_limit);
         if advisory_limit < limit && line_count > advisory_limit {
@@ -70,37 +108,89 @@ pub fn pre_write_check(args: &[String]) -> Result {
     }
 
     if Path::new(&file_path).exists() {
-        if let Some((line_count, advisory_limit, limit)) = u16_advisory {
-            println!("U16_WARN");
-            println!("{file_path}");
-            println!("{line_count}");
-            println!("{advisory_limit}");
-            println!("{limit}");
-            return Ok(());
+        if let Some((line_count, warn_limit, limit)) = u16_advisory {
+            return PreWriteCheck::U16Warn {
+                file_path,
+                line_count,
+                warn_limit,
+                limit,
+            };
         }
-        println!("EXISTS");
-        println!("{file_path}");
-        return Ok(());
+        return PreWriteCheck::Exists { file_path };
     }
 
     if is_allowed_new_file(&file_path) || !is_source_path(&file_path) {
-        println!("ALLOW");
-        println!("{file_path}");
-        return Ok(());
+        return PreWriteCheck::Allow { file_path };
     }
 
-    if let Some((line_count, advisory_limit, limit)) = u16_advisory {
-        println!("U16_WARN_SOURCE_NEW");
-        println!("{file_path}");
-        println!("{line_count}");
-        println!("{advisory_limit}");
-        println!("{limit}");
-        return Ok(());
+    if let Some((line_count, warn_limit, limit)) = u16_advisory {
+        return PreWriteCheck::U16WarnSourceNew {
+            file_path,
+            line_count,
+            warn_limit,
+            limit,
+        };
     }
 
-    println!("SOURCE_NEW");
-    println!("{file_path}");
-    Ok(())
+    PreWriteCheck::SourceNew { file_path }
+}
+
+fn print_pre_write_check(check: &PreWriteCheck) {
+    match check {
+        PreWriteCheck::Malformed => {
+            println!("MALFORMED");
+        }
+        PreWriteCheck::Exists { file_path } => {
+            println!("EXISTS");
+            println!("{file_path}");
+        }
+        PreWriteCheck::Allow { file_path } => {
+            println!("ALLOW");
+            println!("{file_path}");
+        }
+        PreWriteCheck::SourceNew { file_path } => {
+            println!("SOURCE_NEW");
+            println!("{file_path}");
+        }
+        PreWriteCheck::W12 { file_path } => {
+            println!("W12");
+            println!("{file_path}");
+        }
+        PreWriteCheck::U16Block {
+            file_path,
+            line_count,
+            limit,
+        } => {
+            println!("U16_BLOCK");
+            println!("{file_path}");
+            println!("{line_count}");
+            println!("{limit}");
+        }
+        PreWriteCheck::U16Warn {
+            file_path,
+            line_count,
+            warn_limit,
+            limit,
+        } => {
+            println!("U16_WARN");
+            println!("{file_path}");
+            println!("{line_count}");
+            println!("{warn_limit}");
+            println!("{limit}");
+        }
+        PreWriteCheck::U16WarnSourceNew {
+            file_path,
+            line_count,
+            warn_limit,
+            limit,
+        } => {
+            println!("U16_WARN_SOURCE_NEW");
+            println!("{file_path}");
+            println!("{line_count}");
+            println!("{warn_limit}");
+            println!("{limit}");
+        }
+    }
 }
 
 pub fn pre_edit_check(args: &[String]) -> Result {

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -1,9 +1,14 @@
 use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use crate::circuit_breaker::{self, CircuitCheckOutcome, CircuitRecordBlockOutcome};
 use crate::event_schema::{decision, field, status, tool};
+use crate::hook_checks::{PreWriteCheck, evaluate_pre_write_input};
 use crate::hook_checks_common::{append_jsonl, nested_str, read_stdin, truncate_chars};
 use crate::hook_orchestrator_context::RuntimeContext;
+use crate::runtime_config::{runtime_config_int_value, runtime_config_str_value};
 use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
 use crate::wrapper_env::env_nonempty;
 
@@ -63,6 +68,17 @@ pub(crate) fn run(args: &[String]) -> Result {
     let kind = HookKind::parse(&args[0]).ok_or_else(|| format!("unknown hook: {}", args[0]))?;
     let start = Instant::now();
     let input = read_stdin()?;
+    if kind == HookKind::PreWrite {
+        let ctx = match RuntimeContext::collect() {
+            Ok(ctx) => ctx,
+            Err(err) => {
+                emit_runtime_failure_block(kind, "collect runtime context", err)?;
+                return Ok(());
+            }
+        };
+        run_pre_write(&ctx, &input, start)?;
+        return Ok(());
+    }
 
     let parsed = serde_json::from_str::<Value>(&input);
     match parsed {
@@ -122,6 +138,345 @@ pub(crate) fn run(args: &[String]) -> Result {
     }
 }
 
+fn run_pre_write(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
+    let base_limit = runtime_config_int_value("VG_U16_LIMIT", "u16.limit", "800") as usize;
+    let warn_limit = u16_warn_limit(base_limit);
+    let check = evaluate_pre_write_input(input, base_limit, warn_limit);
+
+    match &check {
+        PreWriteCheck::Malformed => {
+            append_hook_event(
+                ctx,
+                HookKind::PreWrite,
+                decision::BLOCK,
+                status::BLOCK,
+                "Malformed hook input",
+                "",
+                elapsed_ms(start),
+            )?;
+            print_pretty_decision("block", MALFORMED_PRE_WRITE_REASON);
+        }
+        PreWriteCheck::Exists { .. } | PreWriteCheck::Allow { .. } => {
+            pass_and_exit(ctx, start)?;
+        }
+        PreWriteCheck::W12 { file_path } => {
+            append_hook_event(
+                ctx,
+                HookKind::PreWrite,
+                decision::BLOCK,
+                status::BLOCK,
+                "Test Infrastructure File Guard (W-12)",
+                file_path,
+                elapsed_ms(start),
+            )?;
+            print_pretty_decision("block", W12_PRE_WRITE_REASON);
+        }
+        PreWriteCheck::U16Block {
+            file_path,
+            line_count,
+            limit,
+        } => {
+            append_hook_event(
+                ctx,
+                HookKind::PreWrite,
+                decision::BLOCK,
+                status::BLOCK,
+                &format!("U-16 file size: {line_count} > {limit}"),
+                file_path,
+                elapsed_ms(start),
+            )?;
+            print_pretty_decision(
+                "block",
+                &format!(
+                    "VIBEGUARD [U-16] block: writing {} with {line_count} lines exceeds the {limit}-line limit. Split into focused submodules first. Do NOT proceed with this write.",
+                    file_name(file_path)
+                ),
+            );
+        }
+        PreWriteCheck::U16Warn {
+            file_path,
+            line_count,
+            warn_limit,
+            limit,
+        } => {
+            append_hook_event(
+                ctx,
+                HookKind::PreWrite,
+                decision::WARN,
+                status::WARN,
+                &format!("U-16 file size advisory: {line_count} > {warn_limit}"),
+                file_path,
+                elapsed_ms(start),
+            )?;
+            print_hook_context(&u16_advisory_context(
+                file_path,
+                *line_count,
+                *warn_limit,
+                *limit,
+                false,
+            ))?;
+        }
+        PreWriteCheck::U16WarnSourceNew { .. } => {
+            run_source_new(ctx, start, &check, true)?;
+        }
+        PreWriteCheck::SourceNew { .. } => {
+            run_source_new(ctx, start, &check, false)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn run_source_new(
+    ctx: &RuntimeContext,
+    start: Instant,
+    check: &PreWriteCheck,
+    has_u16_advisory: bool,
+) -> Result {
+    let file_path = match check {
+        PreWriteCheck::SourceNew { file_path }
+        | PreWriteCheck::U16WarnSourceNew { file_path, .. } => file_path,
+        _ => return pass_and_exit(ctx, start),
+    };
+    let mode = write_mode();
+    if mode == "block" {
+        append_hook_event(
+            ctx,
+            HookKind::PreWrite,
+            decision::BLOCK,
+            status::BLOCK,
+            "New source code file not searched",
+            file_path,
+            elapsed_ms(start),
+        )?;
+        print_pretty_decision("block", L1_BLOCK_REASON);
+        return Ok(());
+    }
+
+    let threshold = runtime_config_int_value(
+        "VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD",
+        "write_escalate_threshold",
+        "5",
+    );
+    let prior_count = if threshold > 0 {
+        count_recent_source_new_attempts(ctx).unwrap_or(0)
+    } else {
+        0
+    };
+    if threshold > 0 && prior_count >= threshold {
+        append_hook_event(
+            ctx,
+            HookKind::PreWrite,
+            decision::ESCALATE,
+            status::ESCALATE,
+            &format!("L1 escalation after {prior_count} unheeded source-new attempts"),
+            file_path,
+            elapsed_ms(start),
+        )?;
+        print_pretty_decision(
+            "block",
+            &format!(
+                "VIBEGUARD [L1] [block] [escalation] OBSERVATION: {prior_count} new source file attempts in this session went unheeded\nSCOPE: pause new file creation — run Grep for similar function/class names and Glob for same-named files in this repo before any further Write\nACTION: REVIEW — confirm no duplicate exists; after manual verification start a new session, raise VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD, or export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0 to disable escalation for this session"
+            ),
+        );
+        return Ok(());
+    }
+
+    append_hook_event(
+        ctx,
+        HookKind::PreWrite,
+        decision::WARN,
+        status::WARN,
+        "New source file attempt",
+        file_path,
+        elapsed_ms(start),
+    )?;
+
+    let breaker = breaker_config(ctx, "pre-write-guard");
+    match circuit_breaker::check(
+        &breaker.state_file,
+        &breaker.lock_file,
+        breaker.cooldown,
+        breaker.lock_timeout,
+        &ctx.session_id,
+    ) {
+        Ok(CircuitCheckOutcome::Run) => {
+            append_hook_event(
+                ctx,
+                HookKind::PreWrite,
+                decision::WARN,
+                status::WARN,
+                "New source file reminder",
+                file_path,
+                elapsed_ms(start),
+            )?;
+            match circuit_breaker::record_block(
+                &breaker.state_file,
+                &breaker.lock_file,
+                breaker.threshold,
+                breaker.cooldown,
+                breaker.lock_timeout,
+                &ctx.session_id,
+            ) {
+                Ok(CircuitRecordBlockOutcome::Recorded) => {}
+                Ok(CircuitRecordBlockOutcome::Opened { reason }) => {
+                    append_event(
+                        ctx,
+                        "pre-write-guard",
+                        "circuit-breaker",
+                        decision::WARN,
+                        &reason,
+                        "",
+                        elapsed_ms(start),
+                    )?;
+                }
+                Err(_) => {
+                    append_hook_event(
+                        ctx,
+                        HookKind::PreWrite,
+                        decision::BLOCK,
+                        status::BLOCK,
+                        "Circuit breaker state error; fail-closed",
+                        file_path,
+                        elapsed_ms(start),
+                    )?;
+                    print_policy_decision_kv(
+                        "block",
+                        "VIBEGUARD interception: pre-write circuit breaker state could not be persisted; fail-closed instead of silently continuing.",
+                    );
+                    return Ok(());
+                }
+            }
+            print_hook_context(&source_new_context(check, has_u16_advisory))?;
+        }
+        Ok(CircuitCheckOutcome::AutoPass { reason }) => {
+            append_event(
+                ctx,
+                "pre-write-guard",
+                "circuit-breaker",
+                decision::PASS,
+                &reason,
+                "",
+                elapsed_ms(start),
+            )?;
+        }
+        Err(_) => {
+            append_hook_event(
+                ctx,
+                HookKind::PreWrite,
+                decision::BLOCK,
+                status::BLOCK,
+                "Circuit breaker state error; fail-closed",
+                file_path,
+                elapsed_ms(start),
+            )?;
+            print_policy_decision_kv(
+                "block",
+                "VIBEGUARD interception: pre-write circuit breaker state could not be read; fail-closed instead of silently auto-passing.",
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn pass_and_exit(ctx: &RuntimeContext, start: Instant) -> Result {
+    let breaker = breaker_config(ctx, "pre-write-guard");
+    if circuit_breaker::record_pass(
+        &breaker.state_file,
+        &breaker.lock_file,
+        breaker.lock_timeout,
+        &ctx.session_id,
+    )
+    .is_err()
+    {
+        append_hook_event(
+            ctx,
+            HookKind::PreWrite,
+            decision::BLOCK,
+            status::BLOCK,
+            "Circuit breaker state error; fail-closed",
+            "",
+            elapsed_ms(start),
+        )?;
+        print_policy_decision_kv(
+            "block",
+            "VIBEGUARD interception: pre-write circuit breaker state could not be updated; fail-closed instead of silently continuing.",
+        );
+    }
+    Ok(())
+}
+
+fn u16_warn_limit(base_limit: usize) -> usize {
+    let configured =
+        runtime_config_int_value("VG_U16_WARN_LIMIT", "u16.warn_limit", "400") as usize;
+    configured.min(base_limit)
+}
+
+fn write_mode() -> String {
+    match runtime_config_str_value("VIBEGUARD_WRITE_MODE", "write_mode", "warn").as_str() {
+        "block" => "block".to_string(),
+        _ => "warn".to_string(),
+    }
+}
+
+struct BreakerConfig {
+    state_file: PathBuf,
+    lock_file: PathBuf,
+    threshold: u64,
+    cooldown: u64,
+    lock_timeout: u64,
+}
+
+fn breaker_config(ctx: &RuntimeContext, hook: &str) -> BreakerConfig {
+    let state_file = ctx
+        .log_root
+        .join("circuit-breaker")
+        .join(&ctx.project_hash)
+        .join(format!("{hook}.cb"));
+    let lock_file = PathBuf::from(format!("{}.lock", state_file.display()));
+    BreakerConfig {
+        state_file,
+        lock_file,
+        threshold: runtime_config_int_value("VG_CB_THRESHOLD", "circuit_breaker.threshold", "3"),
+        cooldown: runtime_config_int_value(
+            "VG_CB_COOLDOWN",
+            "circuit_breaker.cooldown_seconds",
+            "300",
+        ),
+        lock_timeout: runtime_config_int_value(
+            "VG_CB_LOCK_TIMEOUT_SECONDS",
+            "circuit_breaker.lock_timeout_seconds",
+            "5",
+        ),
+    }
+}
+
+fn count_recent_source_new_attempts(ctx: &RuntimeContext) -> Result<u64> {
+    let text = match fs::read_to_string(&ctx.log_file) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(err) => return Err(err.into()),
+    };
+    let count = text
+        .lines()
+        .rev()
+        .take(500)
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| {
+            event.get(field::SESSION).and_then(Value::as_str) == Some(ctx.session_id.as_str())
+                && event.get(field::HOOK).and_then(Value::as_str) == Some("pre-write-guard")
+                && event.get(field::REASON).and_then(Value::as_str)
+                    == Some("New source file attempt")
+        })
+        .count();
+    Ok(count as u64)
+}
+
+const MALFORMED_PRE_WRITE_REASON: &str = "VIBEGUARD interception: malformed PreToolUse(Write) hook input. The write request could not be validated, so it was blocked instead of being treated as a safe skip.";
+const W12_PRE_WRITE_REASON: &str = "[W-12] [block] [this-edit] OBSERVATION: writing to test infrastructure file blocked (conftest.py/jest.config/pytest.ini/.coveragerc/babel.config)\nFIX: Fix the production code that is failing — do not manipulate test framework configuration";
+const L1_BLOCK_REASON: &str = "VIBEGUARD [L1] [block] [this-edit] OBSERVATION: new source file creation blocked — search not performed before write\nSCOPE: search required before retry — use Grep for functions/classes/structs, Glob for same-named files\nACTION: REVIEW";
+
 fn emit_runtime_failure_block(
     kind: HookKind,
     operation: &str,
@@ -152,19 +507,40 @@ fn append_hook_event(
     ctx: &RuntimeContext,
     kind: HookKind,
     decision_value: &str,
-    status_value: &str,
+    _status_value: &str,
     reason: &str,
     detail: &str,
     duration_ms: u64,
 ) -> Result {
+    append_event(
+        ctx,
+        kind.hook_name(),
+        kind.tool_name(),
+        decision_value,
+        reason,
+        detail,
+        duration_ms,
+    )
+}
+
+fn append_event(
+    ctx: &RuntimeContext,
+    hook_name: &str,
+    tool_name: &str,
+    decision_value: &str,
+    reason: &str,
+    detail: &str,
+    duration_ms: u64,
+) -> Result {
+    let (decision_value, reason) = log_policy_decision(decision_value, reason);
     let mut event = json!({
         "schema_version": 1,
         field::TS: format_unix_secs_utc(now_unix_secs()),
         field::SESSION: ctx.session_id,
-        field::HOOK: kind.hook_name(),
-        field::TOOL: kind.tool_name(),
+        field::HOOK: hook_name,
+        field::TOOL: tool_name,
         field::DECISION: decision_value,
-        field::STATUS: status_value,
+        field::STATUS: decision_value,
         field::REASON: reason,
         field::DETAIL: truncate_chars(detail, 200),
         field::DURATION_MS: duration_ms,
@@ -192,6 +568,22 @@ fn append_hook_event(
     Ok(())
 }
 
+fn log_policy_decision(decision_value: &str, reason: &str) -> (String, String) {
+    if env_nonempty("VIBEGUARD_POLICY_ENFORCEMENT").as_deref() == Some("warn")
+        && matches!(
+            decision_value,
+            decision::BLOCK | "gate" | decision::ESCALATE
+        )
+    {
+        (
+            decision::WARN.to_string(),
+            format!("warn-mode advisory: {reason}"),
+        )
+    } else {
+        (decision_value.to_string(), reason.to_string())
+    }
+}
+
 fn append_optional_env(event: &mut Value, env_name: &str, field_name: &str) {
     if let Some(value) = env_nonempty(env_name) {
         event[field_name] = Value::String(value);
@@ -213,6 +605,88 @@ fn detail_for(kind: HookKind, data: &Value) -> String {
 fn elapsed_ms(start: Instant) -> u64 {
     start.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
 }
+
+fn print_pretty_decision(decision_value: &str, reason: &str) {
+    println!("{{");
+    println!("  \"decision\": \"{decision_value}\",");
+    println!(
+        "  \"reason\": {}",
+        serde_json::to_string(reason).unwrap_or_else(|_| "\"\"".to_string())
+    );
+    println!("}}");
+}
+
+fn print_policy_decision_kv(decision_value: &str, reason: &str) {
+    let output_decision = if env_nonempty("VIBEGUARD_POLICY_ENFORCEMENT").as_deref() == Some("warn")
+        && matches!(
+            decision_value,
+            decision::BLOCK | "gate" | decision::ESCALATE
+        ) {
+        decision::WARN
+    } else {
+        decision_value
+    };
+    println!(
+        "{{ \"decision\": {}, \"reason\": {} }}",
+        serde_json::to_string(output_decision).unwrap_or_else(|_| "\"block\"".to_string()),
+        serde_json::to_string(reason).unwrap_or_else(|_| "\"\"".to_string())
+    );
+}
+
+fn print_hook_context(context: &str) -> Result {
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": context,
+            }
+        }))?
+    );
+    Ok(())
+}
+
+fn source_new_context(check: &PreWriteCheck, has_u16_advisory: bool) -> String {
+    if has_u16_advisory {
+        if let PreWriteCheck::U16WarnSourceNew {
+            file_path,
+            line_count,
+            warn_limit,
+            limit,
+        } = check
+        {
+            return u16_advisory_context(file_path, *line_count, *warn_limit, *limit, true);
+        }
+    }
+    L1_ADVISORY_CONTEXT.to_string()
+}
+
+fn u16_advisory_context(
+    file_path: &str,
+    line_count: usize,
+    warn_limit: usize,
+    limit: usize,
+    include_search: bool,
+) -> String {
+    let mut context = format!(
+        "VIBEGUARD [U-16] [advisory] [this-file] OBSERVATION: writing {} with {line_count} lines exceeds the {warn_limit}-line typical range but stays under the {limit}-line hard limit\nSCOPE: keep the current change localized; plan a split if this file keeps growing\nACTION: NONE — advisory only, continue without acknowledgement",
+        file_name(file_path)
+    );
+    if include_search {
+        context.push_str("\n---\n");
+        context.push_str(L1_ADVISORY_CONTEXT);
+    }
+    context
+}
+
+fn file_name(path: &str) -> &str {
+    Path::new(path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(path)
+}
+
+const L1_ADVISORY_CONTEXT: &str = "VIBEGUARD [L1] [advisory] [this-edit] OBSERVATION: new source file detected — search for similar implementation before adding duplicates\nSCOPE: if not yet checked, consider Grep for functions/classes/structs and Glob for same-named files\nACTION: NONE — advisory only, continue without acknowledgement";
 
 #[cfg(test)]
 mod tests {

--- a/vibeguard-runtime/src/runtime_config.rs
+++ b/vibeguard-runtime/src/runtime_config.rs
@@ -71,22 +71,10 @@ pub fn runtime_config_get_int(args: &[String]) -> HandlerResult {
     let json_path = &args[1];
     let default_value = &args[2];
 
-    if let Some(value) = std::env::var(env_name)
-        .ok()
-        .filter(|value| is_nonnegative_digits(value))
-    {
-        println!("{value}");
-        return Ok(());
-    }
-
-    if let Some(value) = load_runtime_config_value(json_path) {
-        if let Some(number) = value.as_u64() {
-            println!("{number}");
-            return Ok(());
-        }
-    }
-
-    println!("{default_value}");
+    println!(
+        "{}",
+        runtime_config_int_value(env_name, json_path, default_value)
+    );
     Ok(())
 }
 
@@ -102,23 +90,53 @@ pub fn runtime_config_get_str(args: &[String]) -> HandlerResult {
     let json_path = &args[1];
     let default_value = &args[2];
 
+    println!(
+        "{}",
+        runtime_config_str_value(env_name, json_path, default_value)
+    );
+    Ok(())
+}
+
+pub(crate) fn runtime_config_int_value(
+    env_name: &str,
+    json_path: &str,
+    default_value: &str,
+) -> u64 {
+    if let Some(value) = std::env::var(env_name)
+        .ok()
+        .filter(|value| is_nonnegative_digits(value))
+        .and_then(|value| value.parse::<u64>().ok())
+    {
+        return value;
+    }
+
+    if let Some(value) = load_runtime_config_value(json_path).and_then(|value| value.as_u64()) {
+        return value;
+    }
+
+    default_value.parse::<u64>().unwrap_or(0)
+}
+
+pub(crate) fn runtime_config_str_value(
+    env_name: &str,
+    json_path: &str,
+    default_value: &str,
+) -> String {
     if let Some(value) = std::env::var(env_name)
         .ok()
         .filter(|value| !value.is_empty())
     {
-        println!("{value}");
-        return Ok(());
+        return value;
     }
 
-    if let Some(value) = load_runtime_config_value(json_path) {
-        if let Some(text) = value.as_str().filter(|text| !text.is_empty()) {
-            println!("{text}");
-            return Ok(());
-        }
+    if let Some(text) = load_runtime_config_value(json_path)
+        .and_then(|value| value.as_str().map(str::to_string))
+        .filter(|text| !text.is_empty())
+    {
+        return text;
     }
 
-    println!("{default_value}");
-    Ok(())
+    default_value.to_string()
 }
 
 fn load_runtime_config_value(json_path: &str) -> Option<Value> {

--- a/vibeguard-runtime/tests/cli_hook_orchestrator.rs
+++ b/vibeguard-runtime/tests/cli_hook_orchestrator.rs
@@ -54,12 +54,11 @@ fn hook_orchestrator_writes_project_and_global_events() {
 
     let input = serde_json::json!({
         "tool_input": {
-            "file_path": "src/lib.rs",
-            "content": "fn main() {}"
+            "command": "git status"
         }
     })
     .to_string();
-    let out = run_hook(&repo, &log_root, "pre-write", &input);
+    let out = run_hook(&repo, &log_root, "pre-bash", &input);
     assert_eq!(
         out.status.code(),
         Some(0),
@@ -84,8 +83,8 @@ fn hook_orchestrator_writes_project_and_global_events() {
     );
 
     let event = read_first_json(&project_log);
-    assert_eq!(event["hook"], "pre-write-guard");
-    assert_eq!(event["tool"], "Write");
+    assert_eq!(event["hook"], "pre-bash-guard");
+    assert_eq!(event["tool"], "Bash");
     assert_eq!(event["decision"], "pass");
     assert_eq!(event["status"], "pass");
     assert_eq!(event["session"], "session-test");
@@ -96,7 +95,7 @@ fn hook_orchestrator_writes_project_and_global_events() {
     assert_eq!(event["wrapper"], "test-wrapper");
     assert_eq!(event["source_config"], "test-config");
     assert_eq!(event["hook_protocol_version"], "1");
-    assert_eq!(event["detail"], "src/lib.rs");
+    assert_eq!(event["detail"], "git status");
     assert!(event["duration_ms"].as_u64().is_some(), "{event}");
     assert_eq!(event["project_hash"].as_str().unwrap().len(), 8);
 
@@ -151,9 +150,9 @@ fn hook_orchestrator_malformed_input_fails_closed() {
     let out = run_hook(&repo, &log_root, "pre-write-guard", "not-json");
     assert_eq!(out.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("\"decision\":\"block\""), "{stdout}");
+    assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
     assert!(
-        stdout.contains("invalid pre-write-guard hook input JSON; fail-closed"),
+        stdout.contains("malformed PreToolUse(Write) hook input"),
         "{stdout}"
     );
 
@@ -202,13 +201,63 @@ fn hook_orchestrator_malformed_input_blocks_even_when_context_collection_fails()
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("\"decision\":\"block\""), "{stdout}");
     assert!(
-        stdout.contains("invalid pre-write-guard hook input JSON; fail-closed"),
+        stdout.contains("runtime orchestrator failed to collect runtime context"),
         "{stdout}"
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("failed to collect context for fail-closed pre-write-guard event"),
+        stderr.contains("runtime orchestrator failed to collect runtime context"),
         "{stderr}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn hook_orchestrator_pre_write_source_new_logs_attempt_and_reminder() {
+    let root = unique_temp_dir("hook-orchestrator-prewrite-source-new");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": repo.join("src/new_file.rs"),
+            "content": "fn new_file() {}\n"
+        }
+    })
+    .to_string();
+    let out = run_hook(&repo, &log_root, "pre-write", &input);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("hookSpecificOutput"), "{stdout}");
+    assert!(stdout.contains("new source file detected"), "{stdout}");
+
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let project_log = project_dir.join("events.jsonl");
+    let global_log = log_root.join("events.jsonl");
+    assert_eq!(
+        fs::read_to_string(&project_log).unwrap(),
+        fs::read_to_string(&global_log).unwrap()
+    );
+    let events = fs::read_to_string(&project_log).unwrap();
+    assert!(
+        events.contains("\"reason\":\"New source file attempt\""),
+        "{events}"
+    );
+    assert!(
+        events.contains("\"reason\":\"New source file reminder\""),
+        "{events}"
     );
 
     let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
Refs #551

## 范围

实现 `SP551-T4` 的 bounded tranche：
- 将 `hooks/pre-write-guard.sh` 收缩为 thin wrapper，只负责解析 `vibeguard-runtime` 并执行 `vibeguard-runtime hook pre-write`。
- 将 PreToolUse(Write) 的 W-12、U-16、L1、escalation、circuit-breaker 语义迁入 runtime orchestrator。
- 保留当前 hook 注册面、stdout 决策文案、缺 runtime fail-closed 报错、env > JSON config > default 配置优先级。
- 保留 `SP551-T5/T6/T7` 不做：不迁移 stop/pre-bash/其他 hook，不收紧预算 gate，不关闭 issue。

## 验证

- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test cli_hook_orchestrator`
- `bash -n hooks/pre-write-guard.sh tests/hooks/test_pre_write_guard.sh`
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash tests/hooks/test_pre_write_guard.sh` (47/47)
- `bash tests/hooks/test_u16_config.sh` (48/48)
- `bash tests/test_hooks.sh`
- `bash tests/test_observability_schemas.sh` (7/7)
- `bash tests/test_hook_perf_contract.sh` (86/86)
- `bash tests/bench_hook_latency.sh` — `pre-write-guard` P95 30ms, budget 500ms
- `bash scripts/local-contract-check.sh --quick`（临时移开 untracked local artifacts 后）
- `git diff --check`

## 门禁

这是 #551 的 partial implementation PR，使用 `Refs #551`。最终预算收紧和 issue closure 仍受 `SP551-T7` human review gate 约束。
