### PR TITLE
perf(hooks): migrate stop and pre-bash to runtime orchestrator

### DIFF
--- a/hooks/pre-bash-guard.sh
+++ b/hooks/pre-bash-guard.sh
@@ -1,126 +1,44 @@
 #!/usr/bin/env bash
 # VibeGuard PreToolUse(Bash) Hook
 #
-# Rust classifies Bash input; this shell wrapper preserves hook logging,
-# package-tool availability checks, and the git-commit pre-commit bridge.
-# Runtime malformed input contract: invalid Bash hook input JSON; fail-closed.
+# Thin compatibility entry point. The hot path lives in vibeguard-runtime so
+# Bash hooks avoid sourcing the shared bash logging and breaker stack.
 
 set -euo pipefail
 
-source "$(dirname "$0")/log.sh"
-vg_start_timer
+_VG_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_VIBEGUARD_RUNTIME=""
 
-INPUT=$(cat)
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-VIBEGUARD_ROOT="${VIBEGUARD_DIR:-$(cd "$HOOK_DIR/.." && pwd)}"
-
-fail_closed_runtime() {
-  local reason="$1"
-  local detail="${2:-}"
-  vg_log "pre-bash-guard" "Bash" "block" "$reason" "$detail"
-  vg_json_output_kv decision block reason "VIBEGUARD interception: ${reason}"
-  exit 0
+_vg_prebash_installed_context() {
+  local installed_hooks="${HOME:-}/.vibeguard/installed/hooks"
+  [[ -n "${HOME:-}" && ( "${_VG_HOOK_DIR}" == "${installed_hooks}" || "${_VG_HOOK_DIR}" == "${installed_hooks}/"* ) ]]
 }
 
-pre_bash_required_field() {
-  local field="$1"
-  printf '%s' "$PRE_BASH_BODY" | vg_json_field_strict "$field"
-}
-
-runtime_err=$(mktemp "${TMPDIR:-/tmp}/vibeguard-pre-bash.XXXXXX") || \
-  fail_closed_runtime "pre-bash-check stderr capture could not be created" ""
-if PRE_BASH_RESULT=$(printf '%s' "$INPUT" | "$_VIBEGUARD_RUNTIME" pre-bash-check "$VIBEGUARD_ROOT" 2>"$runtime_err"); then
-  runtime_status=0
-else
-  runtime_status=$?
-fi
-if ! runtime_stderr=$(cat "$runtime_err"); then
-  if ! rm -f "$runtime_err"; then
-    printf 'VIBEGUARD ERROR: failed to remove pre-bash stderr capture: %s\n' "$runtime_err" >&2
+_vg_prebash_runtime_candidates() {
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if _vg_prebash_installed_context; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
   fi
-  fail_closed_runtime "pre-bash-check stderr capture could not be read" ""
-fi
-if ! rm -f "$runtime_err"; then
-  fail_closed_runtime "pre-bash-check stderr capture could not be removed" ""
-fi
-if [[ "$runtime_status" -ne 0 ]]; then
-  fail_closed_runtime "pre-bash-check runtime failed: ${runtime_stderr:-exit $runtime_status}" ""
-fi
-if [[ -n "$runtime_stderr" ]]; then
-  fail_closed_runtime "pre-bash-check runtime wrote stderr: $runtime_stderr" ""
+}
+
+while IFS= read -r _candidate; do
+  if [[ -n "$_candidate" && -f "$_candidate" && -x "$_candidate" ]]; then
+    _VIBEGUARD_RUNTIME="$_candidate"
+    break
+  fi
+done < <(_vg_prebash_runtime_candidates)
+
+if [[ -z "$_VIBEGUARD_RUNTIME" ]]; then
+  printf '%s\n' "VIBEGUARD ERROR: vibeguard-runtime not found. Run setup.sh or cargo build --release --manifest-path vibeguard-runtime/Cargo.toml." >&2
+  exit 2
 fi
 
-PRE_BASH_TOKEN="${PRE_BASH_RESULT%%$'\n'*}"
-PRE_BASH_BODY="${PRE_BASH_RESULT#*$'\n'}"
-[[ "$PRE_BASH_BODY" == "$PRE_BASH_RESULT" ]] && PRE_BASH_BODY="{}"
-
-case "$PRE_BASH_TOKEN" in
-  EMPTY)
-    exit 0
-    ;;
-  BLOCK)
-    if ! LOG_REASON=$(pre_bash_required_field log_reason) \
-        || ! DETAIL=$(pre_bash_required_field detail) \
-        || ! HOOK_OUTPUT=$(pre_bash_required_field output); then
-      fail_closed_runtime "pre-bash-check emitted invalid BLOCK payload" ""
-    fi
-    vg_log "pre-bash-guard" "Bash" "block" "$LOG_REASON" "$DETAIL"
-    printf '%s\n' "$HOOK_OUTPUT"
-    exit 0
-    ;;
-  WARN)
-    if ! LOG_REASON=$(pre_bash_required_field log_reason) \
-        || ! DETAIL=$(pre_bash_required_field detail) \
-        || ! HOOK_OUTPUT=$(pre_bash_required_field output); then
-      fail_closed_runtime "pre-bash-check emitted invalid WARN payload" ""
-    fi
-    vg_log "pre-bash-guard" "Bash" "warn" "$LOG_REASON" "$DETAIL"
-    printf '%s\n' "$HOOK_OUTPUT"
-    exit 0
-    ;;
-  CORRECTION)
-    if ! COMMAND=$(pre_bash_required_field command) \
-        || ! CORRECTED=$(pre_bash_required_field corrected) \
-        || ! HOOK_OUTPUT=$(pre_bash_required_field output); then
-      fail_closed_runtime "pre-bash-check emitted invalid CORRECTION payload" ""
-    fi
-    target_tool="${CORRECTED%% *}"
-    if ! command -v "$target_tool" &>/dev/null; then
-      vg_log "pre-bash-guard" "Bash" "pass" "pkg-rewrite skipped (${target_tool} not found)" "${COMMAND:0:120}"
-      exit 0
-    fi
-    if [[ "$CORRECTED" == uv\ pip\ install* ]] \
-        && [[ -z "${VIRTUAL_ENV:-}" ]] && [[ ! -d ".venv" ]]; then
-      vg_log "pre-bash-guard" "Bash" "pass" "pkg-rewrite skipped (no active venv for uv pip)" "${COMMAND:0:120}"
-      exit 0
-    fi
-    vg_log "pre-bash-guard" "Bash" "correction" "package manager auto-rewrite" "${COMMAND:0:120} → $CORRECTED"
-    printf '%s\n' "$HOOK_OUTPUT"
-    exit 0
-    ;;
-  PASS)
-    if ! COMMAND=$(pre_bash_required_field command) \
-        || ! PRECOMMIT=$(pre_bash_required_field precommit); then
-      fail_closed_runtime "pre-bash-check emitted invalid PASS payload" ""
-    fi
-    if [[ "$PRECOMMIT" == "true" ]]; then
-      PRECOMMIT_SCRIPT="${HOOK_DIR}/pre-commit-guard.sh"
-      if [[ -f "$PRECOMMIT_SCRIPT" ]]; then
-        PRECOMMIT_EXIT=0
-        PRECOMMIT_OUTPUT=$(VIBEGUARD_DIR="$VIBEGUARD_ROOT" bash "$PRECOMMIT_SCRIPT" 2>&1) || PRECOMMIT_EXIT=$?
-        if [[ $PRECOMMIT_EXIT -ne 0 ]]; then
-          vg_log "pre-bash-guard" "Bash" "block" "pre-commit check failed" "$COMMAND"
-          vg_json_output_kv decision block reason "VIBEGUARD Pre-Commit 检查失败。请根据上方错误信息修复问题后重新提交。禁止使用环境变量绕过。
-
-$PRECOMMIT_OUTPUT"
-          exit 0
-        fi
-      fi
-    fi
-    vg_log "pre-bash-guard" "Bash" "pass" "" "$COMMAND"
-    exit 0
-    ;;
-  *)
-    fail_closed_runtime "pre-bash-check emitted unexpected token: $PRE_BASH_TOKEN" ""
-    ;;
-esac
+VIBEGUARD_HOOK_DIR="${VIBEGUARD_HOOK_DIR:-$_VG_HOOK_DIR}" exec "$_VIBEGUARD_RUNTIME" hook pre-bash

--- a/hooks/stop-guard.sh
+++ b/hooks/stop-guard.sh
@@ -1,70 +1,44 @@
 #!/usr/bin/env bash
 # VibeGuard Stop Hook — Verify access control before completion
 #
-# Check if there are any uncommitted source code changes at the end of the AI session.
-# There are uncommitted changes → exit 0 (log only; exit 2 will trigger an infinite loop in the Stop context)
-# No changes or non-git repository → exit 0 (pass silently)
+# Thin compatibility entry point. The hot path lives in vibeguard-runtime so
+# Stop hooks avoid sourcing the shared bash logging stack.
 
 set -euo pipefail
 
-source "$(dirname "$0")/log.sh"
-vg_start_timer
+_VG_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_VIBEGUARD_RUNTIME=""
 
-vg_stop_is_ci() {
-  case "${CI:-}" in true|True|TRUE|1|yes|Yes|YES) return 0 ;; esac
-  case "${GITHUB_ACTIONS:-}" in true|True|TRUE|1|yes|Yes|YES) return 0 ;; esac
-  case "${TRAVIS:-}" in true|True|TRUE|1|yes|Yes|YES) return 0 ;; esac
-  case "${CIRCLECI:-}" in true|True|TRUE|1|yes|Yes|YES) return 0 ;; esac
-  [[ -n "${JENKINS_URL:-}" ]] && return 0
-  case "${GITLAB_CI:-}" in true|True|TRUE|1|yes|Yes|YES) return 0 ;; esac
-  case "${TF_BUILD:-}" in true|True|TRUE|1|yes|Yes|YES) return 0 ;; esac
-  return 1
+_vg_stop_installed_context() {
+  local installed_hooks="${HOME:-}/.vibeguard/installed/hooks"
+  [[ -n "${HOME:-}" && ( "${_VG_HOOK_DIR}" == "${installed_hooks}" || "${_VG_HOOK_DIR}" == "${installed_hooks}/"* ) ]]
 }
 
-vg_stop_hook_active_fast() {
-  local input="$1" active=""
-  active=$(printf '%s' "$input" | "$_VIBEGUARD_RUNTIME" json-field stop_hook_active 2>/dev/null || true)
-  [[ "$active" == "true" ]]
-}
-
-# CI guard: skip interactive hooks in CI environments
-vg_stop_is_ci && exit 0
-
-# Read stdin once (Stop hook receives JSON input)
-INPUT=$(cat 2>/dev/null || true)
-
-# stop_hook_active: platform sets this when a Stop hook triggered another Stop hook.
-# Checking it breaks the feedback → Stop hook → feedback → Stop hook infinite loop.
-vg_stop_hook_active_fast "$INPUT" && exit 0
-
-# PERF-OK: Stop hook skips source-change counting outside git; single cheap probe.
-if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-  exit 0
-fi
-
-# Check if there are any uncommitted source code changes (staged + unstaged)
-changed_source_files=""
-while IFS= read -r file; do
-  if [[ -n "$file" ]] && vg_is_source_file "$file"; then
-    changed_source_files="${changed_source_files}${file}"$'\n'
+_vg_stop_runtime_candidates() {
+  printf '%s\n' "${VIBEGUARD_RUNTIME:-}"
+  if _vg_stop_installed_context; then
+    printf '%s\n' "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+  else
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/release/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/../vibeguard-runtime/target/debug/vibeguard-runtime"
+    printf '%s\n' "${HOME:-}/.vibeguard/installed/bin/vibeguard-runtime"
+    printf '%s\n' "${_VG_HOOK_DIR}/vibeguard-runtime"
   fi
-done < <(
-  # PERF-OK: Stop hook only needs changed file names to count source edits.
-  git diff --name-only HEAD 2>/dev/null || git diff --name-only --cached 2>/dev/null
-)
+}
 
-# Remove duplicates
-if [[ -n "$changed_source_files" ]]; then
-  changed_source_files=$(echo "$changed_source_files" | sort -u)
-  count=$(echo "$changed_source_files" | grep -c . || true)
+while IFS= read -r _candidate; do
+  if [[ -n "$_candidate" && -f "$_candidate" && -x "$_candidate" ]]; then
+    _VIBEGUARD_RUNTIME="$_candidate"
+    break
+  fi
+done < <(_vg_stop_runtime_candidates)
 
-  vg_log "stop-guard" "Stop" "gate" "uncommitted source changes: ${count} files" "$(echo "$changed_source_files" | head -5 | tr '\n' ' ')"
-
-  # exit 0: log only, do not block — Claude cannot commit in Stop context,
-  # so exit 2 here causes an infinite loop (feedback → response → stop hooks → repeat).
-  # See GitHub issues #3573, #10205.
-  exit 0
+if [[ -z "$_VIBEGUARD_RUNTIME" ]]; then
+  printf '%s\n' "VIBEGUARD ERROR: vibeguard-runtime not found. Run setup.sh or cargo build --release --manifest-path vibeguard-runtime/Cargo.toml." >&2
+  exit 2
 fi
 
-vg_log "stop-guard" "Stop" "pass" "" ""
-exit 0
+VIBEGUARD_HOOK_DIR="${VIBEGUARD_HOOK_DIR:-$_VG_HOOK_DIR}" exec "$_VIBEGUARD_RUNTIME" hook stop

--- a/scripts/ci/self-application/check-pkg-correction-argv-only.sh
+++ b/scripts/ci/self-application/check-pkg-correction-argv-only.sh
@@ -5,13 +5,14 @@ set -euo pipefail
 REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 HOOK="${REPO_DIR}/hooks/pre-bash-guard.sh"
 
-python3 - <<'PY' "${HOOK}"
+python3 - <<'PY' "${REPO_DIR}" "${HOOK}"
 import re
 import shlex
 import sys
 from pathlib import Path
 
-path = Path(sys.argv[1])
+repo = Path(sys.argv[1])
+path = Path(sys.argv[2])
 errors: list[str] = []
 
 
@@ -131,10 +132,23 @@ if not path.exists():
 else:
     text = path.read_text(encoding="utf-8")
 
-    runtime_owned = "pre-bash-check" in text and "_PKG_CORRECTION" not in text
+    runtime_owned = (
+        ("pre-bash-check" in text or re.search(r"\bhook\s+pre-bash\b", text) is not None)
+        and "_PKG_CORRECTION" not in text
+    )
     taint_source_vars = {"_PKG_CORRECTION"}
     if runtime_owned:
         taint_source_vars.add("CORRECTED")
+        classifier = repo / "vibeguard-runtime/src/hook_checks_bash.rs"
+        orchestrator = repo / "vibeguard-runtime/src/hook_orchestrator_pre_bash.rs"
+        if classifier.exists():
+            classifier_text = classifier.read_text(encoding="utf-8")
+            if "updatedInput" not in classifier_text or '"command": corrected' not in classifier_text:
+                errors.append("runtime package correction must emit corrected command through updatedInput")
+        if orchestrator.exists():
+            orchestrator_text = orchestrator.read_text(encoding="utf-8")
+            if re.search(r"Command::new\(\"(?:bash|sh)\"\)\s*\.arg\(\"-c\"\)", orchestrator_text):
+                errors.append("runtime package correction must not flow corrected command through shell -c")
 
     if not runtime_owned:
         if "PKG-CORRECTION-ARGV-CONTRACT" not in text:

--- a/scripts/ci/self-application/check-u29-no-silent-degrade.sh
+++ b/scripts/ci/self-application/check-u29-no-silent-degrade.sh
@@ -72,10 +72,23 @@ if precommit.exists():
 prebash = repo / "hooks/pre-bash-guard.sh"
 if prebash.exists():
     text = prebash.read_text(encoding="utf-8")
-    if "pre-bash-check" not in text:
-        errors.append("hooks/pre-bash-guard.sh: Bash command extraction is not runtime fail-closed")
-    if "invalid Bash hook input JSON; fail-closed" not in text:
-        errors.append("hooks/pre-bash-guard.sh: missing fail-closed parse warning")
+    runtime_owned = re.search(r"\bhook\s+pre-bash\b", text) is not None
+    if runtime_owned:
+        classifier = repo / "vibeguard-runtime/src/hook_checks_bash.rs"
+        orchestrator = repo / "vibeguard-runtime/src/hook_orchestrator_pre_bash.rs"
+        classifier_text = classifier.read_text(encoding="utf-8") if classifier.exists() else ""
+        orchestrator_text = orchestrator.read_text(encoding="utf-8") if orchestrator.exists() else ""
+        if "evaluate_pre_bash_input" not in classifier_text:
+            errors.append("vibeguard-runtime/src/hook_checks_bash.rs: Bash command extraction is not runtime fail-closed")
+        if "invalid Bash hook input JSON; fail-closed" not in classifier_text:
+            errors.append("vibeguard-runtime/src/hook_checks_bash.rs: missing fail-closed parse warning")
+        if "evaluate_pre_bash_input(input, &vibeguard_root)" not in orchestrator_text:
+            errors.append("vibeguard-runtime/src/hook_orchestrator_pre_bash.rs: pre-bash hook does not use runtime classifier")
+    else:
+        if "pre-bash-check" not in text:
+            errors.append("hooks/pre-bash-guard.sh: Bash command extraction is not runtime fail-closed")
+        if "invalid Bash hook input JSON; fail-closed" not in text:
+            errors.append("hooks/pre-bash-guard.sh: missing fail-closed parse warning")
 
 runtime_python_fallbacks = {
     "hooks/pre-bash-guard.sh": "_lib/pkg_rewrite.py",

--- a/tests/hooks/test_pre_bash_guard.sh
+++ b/tests/hooks/test_pre_bash_guard.sh
@@ -5,57 +5,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
 hook_test_init
 
-run_pre_bash_with_fake_runtime() {
-  local fake_case="$1"
+run_pre_bash_without_runtime() {
   local tmp_dir
   tmp_dir=$(mktemp -d)
-  mkdir -p "${tmp_dir}/hooks/_lib" "${tmp_dir}/home" "${tmp_dir}/log"
-  cp hooks/pre-bash-guard.sh hooks/log.sh "${tmp_dir}/hooks/"
-  cp hooks/_lib/*.sh "${tmp_dir}/hooks/_lib/"
-  cat > "${tmp_dir}/hooks/vibeguard-runtime" <<'EOF'
-#!/usr/bin/env bash
-case "$1" in
-  pre-bash-check)
-    case "${VIBEGUARD_FAKE_PRE_BASH:-}" in
-      stderr)
-        printf 'runtime noise\n' >&2
-        printf 'PASS\n{"command":"npm run build","precommit":false}\n'
-        exit 0
-        ;;
-      nonzero)
-        printf 'runtime exploded\n' >&2
-        exit 1
-        ;;
-      token)
-        printf 'SURPRISE\n{}\n'
-        exit 0
-        ;;
-      bad_payload)
-        printf 'BLOCK\n{}\n'
-        exit 0
-        ;;
-    esac
-    ;;
-  append-jsonl)
-    printf 'Unknown command: append-jsonl\n' >&2
-    exit 2
-    ;;
-  json-field)
-    printf 'Unknown command: json-field\n' >&2
-    exit 2
-    ;;
-esac
-printf 'Unknown command: %s\n' "$1" >&2
-exit 2
-EOF
-  chmod +x "${tmp_dir}/hooks/vibeguard-runtime"
+  mkdir -p "${tmp_dir}/hooks" "${tmp_dir}/home"
+  cp hooks/pre-bash-guard.sh "${tmp_dir}/hooks/"
+  set +e
   HOME="${tmp_dir}/home" \
-    VIBEGUARD_FAKE_PRE_BASH="$fake_case" \
-    VIBEGUARD_LOG_DIR="${tmp_dir}/log" \
-    VIBEGUARD_RUNTIME="${tmp_dir}/hooks/vibeguard-runtime" \
+    VIBEGUARD_RUNTIME="" \
     bash "${tmp_dir}/hooks/pre-bash-guard.sh" \
     <<< '{"tool_input":{"command":"npm run build"}}' 2>&1
+  local status=$?
+  set -e
+  printf '\n__status=%s\n' "$status"
   rm -rf "$tmp_dir"
+}
+
+assert_status_line() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qF "__status=${expected}" <<< "$output"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected status ${expected})"
+    FAIL=$((FAIL + 1))
+  fi
 }
 
 header "pre-bash-guard.sh — Dangerous command interception"
@@ -175,21 +150,9 @@ assert_contains "$result" '"decision": "block"' "Missing Bash command field fail
 result=$(echo '{"tool_input":{"command":""}}' | bash hooks/pre-bash-guard.sh)
 assert_not_contains "$result" '"decision": "block"' "Empty Bash command string remains a no-op"
 
-runtime_stderr_result=$(run_pre_bash_with_fake_runtime stderr)
-assert_contains "$runtime_stderr_result" '"decision": "block"' "Runtime stderr fails closed"
-assert_contains "$runtime_stderr_result" "runtime wrote stderr" "Runtime stderr diagnostic is visible"
-
-runtime_nonzero_result=$(run_pre_bash_with_fake_runtime nonzero)
-assert_contains "$runtime_nonzero_result" '"decision": "block"' "Runtime nonzero exit fails closed"
-assert_contains "$runtime_nonzero_result" "runtime failed" "Runtime nonzero diagnostic is visible"
-
-runtime_token_result=$(run_pre_bash_with_fake_runtime token)
-assert_contains "$runtime_token_result" '"decision": "block"' "Runtime unexpected token fails closed"
-assert_contains "$runtime_token_result" "unexpected token" "Runtime unexpected token diagnostic is visible"
-
-runtime_payload_result=$(run_pre_bash_with_fake_runtime bad_payload)
-assert_contains "$runtime_payload_result" '"decision": "block"' "Runtime malformed payload fails closed"
-assert_contains "$runtime_payload_result" "invalid BLOCK payload" "Runtime malformed payload diagnostic is visible"
+missing_runtime_result=$(run_pre_bash_without_runtime)
+assert_contains "$missing_runtime_result" "vibeguard-runtime not found" "Missing runtime emits explicit diagnostic"
+assert_status_line "$missing_runtime_result" "2" "Missing runtime exits nonzero"
 
 # =========================================================
 header "pre-bash-guard.sh — Package manager transparent correction (updatedInput)"

--- a/tests/hooks/test_stop_guard.sh
+++ b/tests/hooks/test_stop_guard.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/hook_test_lib.sh"
+hook_test_init
+
+run_stop_no_ci() {
+  local repo_dir="$1" log_dir="$2" input="$3"
+  (
+    cd "$repo_dir"
+    env -u CI -u GITHUB_ACTIONS -u TRAVIS -u CIRCLECI -u JENKINS_URL -u GITLAB_CI -u TF_BUILD \
+      VIBEGUARD_LOG_DIR="$log_dir" \
+      bash "$REPO_DIR/hooks/stop-guard.sh" <<< "$input"
+  )
+}
+
+header "stop-guard.sh — missing runtime reports explicit failure"
+
+runtime_missing_dir=$(mktemp -d)
+mkdir -p "$runtime_missing_dir/home" "$runtime_missing_dir/hooks"
+cp hooks/stop-guard.sh "$runtime_missing_dir/hooks/"
+set +e
+runtime_missing_output=$(
+  env -u VIBEGUARD_RUNTIME HOME="$runtime_missing_dir/home" \
+    bash "$runtime_missing_dir/hooks/stop-guard.sh" <<< '{"hook_event_name":"Stop"}' 2>&1
+)
+runtime_missing_rc=$?
+set -e
+assert_contains "rc=$runtime_missing_rc" "rc=2" "missing runtime exits nonzero instead of silently passing"
+assert_contains "$runtime_missing_output" "vibeguard-runtime not found" "missing runtime reports explicit install/build error"
+rm -rf "$runtime_missing_dir"
+
+header "stop-guard.sh — Stop loop guard skips logging"
+
+stop_repo=$(mktemp -d)
+stop_log=$(mktemp -d)
+git -C "$stop_repo" init >/dev/null
+git -C "$stop_repo" config user.email test@example.com
+git -C "$stop_repo" config user.name "Test User"
+mkdir -p "$stop_repo/src"
+printf 'pub fn value() -> i32 { 1 }\n' > "$stop_repo/src/lib.rs"
+git -C "$stop_repo" add src/lib.rs
+git -C "$stop_repo" commit -m initial >/dev/null
+printf 'pub fn value() -> i32 { 2 }\n' > "$stop_repo/src/lib.rs"
+
+run_stop_no_ci "$stop_repo" "$stop_log" '{"hook_event_name":"Stop","stop_hook_active":true}' >/dev/null
+assert_exit_zero "stop_hook_active skip does not create a global event log" \
+  bash -c '[[ ! -e "$1/events.jsonl" ]]' _ "$stop_log"
+
+header "stop-guard.sh — uncommitted source changes are logged, not blocked"
+
+run_stop_no_ci "$stop_repo" "$stop_log" '{"hook_event_name":"Stop"}' >/tmp/vg-stop-out.txt
+stop_output="$(cat /tmp/vg-stop-out.txt)"
+assert_not_contains "$stop_output" '"decision": "block"' "Stop hook does not block when source changes exist"
+stop_events="$(cat "$stop_log/events.jsonl")"
+assert_contains "$stop_events" '"hook": "stop-guard"' "Stop hook writes an event"
+assert_contains "$stop_events" '"decision": "gate"' "Stop hook records gate decision"
+assert_contains "$stop_events" 'uncommitted source changes: 1 files' "Stop hook counts changed source files"
+assert_contains "$stop_events" 'src/lib.rs ' "Stop hook records changed source detail"
+
+rm -rf "$stop_repo" "$stop_log" /tmp/vg-stop-out.txt
+
+hook_test_finish

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -216,6 +216,94 @@ PY
     cat >/dev/null
     printf 'PASS\n'
     ;;
+  hook)
+    hook_name="${1:-}"
+    input="$(cat || true)"
+    case "$hook_name" in
+      pre-bash|pre-bash-guard)
+        event_hook="pre-bash-guard"
+        event_tool="Bash"
+        detail="$(RUNTIME_INPUT="$input" python3 - <<'PY'
+import json
+import os
+
+try:
+    print(json.loads(os.environ.get("RUNTIME_INPUT", "")).get("tool_input", {}).get("command", ""))
+except Exception:
+    print("")
+PY
+)"
+        ;;
+      stop|stop-guard)
+        event_hook="stop-guard"
+        event_tool="Stop"
+        detail=""
+        ;;
+      *)
+        event_hook="${hook_name:-unknown}"
+        event_tool="unknown"
+        detail=""
+        ;;
+    esac
+    log_dir="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}"
+    project_hash="${VIBEGUARD_PROJECT_HASH:-${VIBEGUARD_TEST_PROJECT_HASH:-abcdef12}}"
+    project_dir="${VIBEGUARD_PROJECT_LOG_DIR:-${log_dir}/projects/${project_hash}}"
+    log_file="${VIBEGUARD_LOG_FILE:-${project_dir}/events.jsonl}"
+    global_log="${log_dir}/events.jsonl"
+    mkdir -p "$(dirname "$log_file")" "$log_dir"
+    RUNTIME_HOOK="$event_hook" \
+    RUNTIME_TOOL="$event_tool" \
+    RUNTIME_DETAIL="$detail" \
+    RUNTIME_LOG_FILE="$log_file" \
+    RUNTIME_GLOBAL_LOG="$global_log" \
+    python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+cli = os.environ.get("VIBEGUARD_CLI", "unknown")
+client = os.environ.get("VIBEGUARD_CLIENT")
+if not client:
+    client = cli if cli in {"claude", "codex"} else "unknown"
+client_variant = os.environ.get("VIBEGUARD_CLIENT_VARIANT")
+if not client_variant:
+    client_variant = {
+        "claude": "claude-code-hooks",
+        "codex": "codex-cli-hooks",
+    }.get(client, "unknown")
+
+event = {
+    "schema_version": 1,
+    "ts": "2026-01-01T00:00:00Z",
+    "session": os.environ.get("VIBEGUARD_SESSION_ID", "stub-session"),
+    "hook": os.environ["RUNTIME_HOOK"],
+    "tool": os.environ["RUNTIME_TOOL"],
+    "decision": "pass",
+    "status": "pass",
+    "reason": "",
+    "detail": os.environ.get("RUNTIME_DETAIL", ""),
+    "duration_ms": 1,
+    "cli": cli,
+    "client": client,
+    "client_variant": client_variant,
+    "caller_evidence": os.environ.get("VIBEGUARD_CALLER_EVIDENCE", "stub"),
+}
+for env_name, key in [
+    ("VIBEGUARD_WRAPPER", "wrapper"),
+    ("VIBEGUARD_SOURCE_CONFIG", "source_config"),
+    ("VIBEGUARD_HOOK_PROTOCOL_VERSION", "hook_protocol_version"),
+]:
+    value = os.environ.get(env_name)
+    if value:
+        event[key] = value
+line = json.dumps(event)
+for name in ["RUNTIME_LOG_FILE", "RUNTIME_GLOBAL_LOG"]:
+    path = Path(os.environ[name])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+PY
+    ;;
   *)
     cat >/dev/null || true
     ;;

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -19,6 +19,7 @@ shards=(
   "tests/hooks/test_log_injection.sh"
   "tests/hooks/test_log_locking.sh"
   "tests/hooks/test_pre_bash_guard.sh"
+  "tests/hooks/test_stop_guard.sh"
   "tests/hooks/test_pre_push_guard.sh"
   "tests/hooks/test_pre_edit_guard.sh"
   "tests/hooks/test_pre_write_guard.sh"

--- a/tests/test_self_application_ci.sh
+++ b/tests/test_self_application_ci.sh
@@ -132,6 +132,26 @@ printf '%s\n' "$CORRECTED"
 EOF
 assert_cmd "runtime-owned package correction passes taint check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${good_runtime_pkg_correction}"
 
+good_hook_runtime_pkg_correction="${TMP_DIR}/good-hook-runtime-pkg-correction"
+mkdir -p "${good_hook_runtime_pkg_correction}/hooks" "${good_hook_runtime_pkg_correction}/vibeguard-runtime/src"
+cat > "${good_hook_runtime_pkg_correction}/hooks/pre-bash-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+exec "$_VIBEGUARD_RUNTIME" hook pre-bash
+EOF
+cat > "${good_hook_runtime_pkg_correction}/vibeguard-runtime/src/hook_checks_bash.rs" <<'EOF'
+json!({
+  "updatedInput": {
+    "command": corrected,
+  }
+})
+EOF
+cat > "${good_hook_runtime_pkg_correction}/vibeguard-runtime/src/hook_orchestrator_pre_bash.rs" <<'EOF'
+fn run() {
+    println!("{}", corrected);
+}
+EOF
+assert_cmd "runtime hook package correction passes taint check" bash "${SELF_DIR}/check-pkg-correction-argv-only.sh" "${good_hook_runtime_pkg_correction}"
+
 bad_runtime_pkg_eval="${TMP_DIR}/bad-runtime-pkg-eval"
 mkdir -p "${bad_runtime_pkg_eval}/hooks"
 cat > "${bad_runtime_pkg_eval}/hooks/pre-bash-guard.sh" <<'EOF'
@@ -529,6 +549,23 @@ def x():
     return {"skipped": True, "EVAL_MAX_API_FAILURES": 1}
 PY
 assert_fails "runtime Python fallback references fail U-29 check" bash "${SELF_DIR}/check-u29-no-silent-degrade.sh" "${bad_runtime_fallback}"
+
+bad_runtime_u29="${TMP_DIR}/bad-runtime-u29"
+mkdir -p "${bad_runtime_u29}/hooks" "${bad_runtime_u29}/vibeguard-runtime/src" "${bad_runtime_u29}/eval"
+cat > "${bad_runtime_u29}/hooks/pre-bash-guard.sh" <<'EOF'
+exec "$_VIBEGUARD_RUNTIME" hook pre-bash
+EOF
+cat > "${bad_runtime_u29}/vibeguard-runtime/src/hook_checks_bash.rs" <<'EOF'
+fn evaluate_pre_bash_input() {}
+EOF
+cat > "${bad_runtime_u29}/vibeguard-runtime/src/hook_orchestrator_pre_bash.rs" <<'EOF'
+fn run() {}
+EOF
+cat > "${bad_runtime_u29}/eval/run_eval.py" <<'PY'
+def x():
+    return {"skipped": True, "EVAL_MAX_API_FAILURES": 1}
+PY
+assert_fails "runtime pre-bash without fail-closed classifier fails U-29 check" bash "${SELF_DIR}/check-u29-no-silent-degrade.sh" "${bad_runtime_u29}"
 
 header "SEC-14 sentinel"
 bad_sec14="${TMP_DIR}/bad-sec14"

--- a/vibeguard-runtime/src/hook_checks_bash.rs
+++ b/vibeguard-runtime/src/hook_checks_bash.rs
@@ -12,7 +12,7 @@ const INVALID_INPUT_REASON: &str = "VIBEGUARD interception: invalid Bash hook in
 const DOC_WARNING_CONTEXT: &str = "VIBEGUARD Warning: Creation of non-standard .md file detected. Only README/CLAUDE/CONTRIBUTING/CHANGELOG/LICENSE/SKILL.md is allowed to be created. Please confirm the file purpose if necessary.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum BashDecision {
+pub(crate) enum BashDecision {
     Empty,
     Pass {
         command: String,
@@ -138,6 +138,10 @@ fn emit_decision(decision: &BashDecision) -> Result {
         }
     }
     Ok(())
+}
+
+pub(crate) fn evaluate_pre_bash_input(input: &str, vibeguard_root: &str) -> BashDecision {
+    classify_input(input, vibeguard_root)
 }
 
 fn classify_input(input: &str, vibeguard_root: &str) -> BashDecision {

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -12,10 +12,10 @@ use crate::runtime_config::{runtime_config_int_value, runtime_config_str_value};
 use crate::time_utils::{format_unix_secs_utc, now_unix_secs};
 use crate::wrapper_env::env_nonempty;
 
-type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub(crate) type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HookKind {
+pub(crate) enum HookKind {
     PreWrite,
     PreBash,
     PreEdit,
@@ -77,6 +77,21 @@ pub(crate) fn run(args: &[String]) -> Result {
             }
         };
         run_pre_write(&ctx, &input, start)?;
+        return Ok(());
+    }
+    if kind == HookKind::PreBash {
+        let ctx = match RuntimeContext::collect() {
+            Ok(ctx) => ctx,
+            Err(err) => {
+                emit_runtime_failure_block(kind, "collect runtime context", err)?;
+                return Ok(());
+            }
+        };
+        crate::hook_orchestrator_pre_bash::run(&ctx, &input, start)?;
+        return Ok(());
+    }
+    if kind == HookKind::Stop {
+        crate::hook_orchestrator_stop::run(&input, start)?;
         return Ok(());
     }
 
@@ -503,7 +518,7 @@ fn print_block(reason: &str) -> Result {
     Ok(())
 }
 
-fn append_hook_event(
+pub(crate) fn append_hook_event(
     ctx: &RuntimeContext,
     kind: HookKind,
     decision_value: &str,
@@ -559,7 +574,7 @@ fn append_event(
         field::HOOK_PROTOCOL_VERSION,
     );
 
-    let line = serde_json::to_string(&event)?;
+    let line = serde_json::to_string(&event)?.replace("\":", "\": ");
     append_jsonl(&ctx.log_file, &line)?;
     let global_log = ctx.log_root.join("events.jsonl");
     if global_log != ctx.log_file {
@@ -602,7 +617,7 @@ fn detail_for(kind: HookKind, data: &Value) -> String {
     path.unwrap_or_default()
 }
 
-fn elapsed_ms(start: Instant) -> u64 {
+pub(crate) fn elapsed_ms(start: Instant) -> u64 {
     start.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
 }
 
@@ -616,7 +631,7 @@ fn print_pretty_decision(decision_value: &str, reason: &str) {
     println!("}}");
 }
 
-fn print_policy_decision_kv(decision_value: &str, reason: &str) {
+pub(crate) fn print_policy_decision_kv(decision_value: &str, reason: &str) {
     let output_decision = if env_nonempty("VIBEGUARD_POLICY_ENFORCEMENT").as_deref() == Some("warn")
         && matches!(
             decision_value,

--- a/vibeguard-runtime/src/hook_orchestrator_pre_bash.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_pre_bash.rs
@@ -215,3 +215,16 @@ fn command_output_text(output: &std::process::Output) -> String {
     text.push_str(&String::from_utf8_lossy(&output.stderr));
     text
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_available_accepts_current_executable_path() {
+        let current_exe = env::current_exe().expect("current test executable path");
+
+        assert!(!command_available(""));
+        assert!(command_available(&current_exe.to_string_lossy()));
+    }
+}

--- a/vibeguard-runtime/src/hook_orchestrator_pre_bash.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_pre_bash.rs
@@ -1,0 +1,217 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use crate::event_schema::{decision, status};
+use crate::hook_checks_bash::{BashDecision, evaluate_pre_bash_input};
+use crate::hook_checks_common::truncate_chars;
+use crate::hook_orchestrator::{
+    HookKind, Result, append_hook_event, elapsed_ms, print_policy_decision_kv,
+};
+use crate::hook_orchestrator_context::RuntimeContext;
+use crate::wrapper_env::env_nonempty;
+
+pub(crate) fn run(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
+    let vibeguard_root = vibeguard_root();
+    match evaluate_pre_bash_input(input, &vibeguard_root) {
+        BashDecision::Empty => {}
+        BashDecision::Block {
+            log_reason,
+            detail,
+            output,
+        } => {
+            append_hook_event(
+                ctx,
+                HookKind::PreBash,
+                decision::BLOCK,
+                status::BLOCK,
+                &log_reason,
+                &detail,
+                elapsed_ms(start),
+            )?;
+            print!("{output}\n");
+        }
+        BashDecision::Warn {
+            log_reason,
+            detail,
+            output,
+        } => {
+            append_hook_event(
+                ctx,
+                HookKind::PreBash,
+                decision::WARN,
+                status::WARN,
+                &log_reason,
+                &detail,
+                elapsed_ms(start),
+            )?;
+            print!("{output}\n");
+        }
+        BashDecision::Correction {
+            command,
+            corrected,
+            output,
+            ..
+        } => {
+            let target_tool = corrected.split_whitespace().next().unwrap_or("");
+            if !command_available(target_tool) {
+                append_hook_event(
+                    ctx,
+                    HookKind::PreBash,
+                    decision::PASS,
+                    status::PASS,
+                    &format!("pkg-rewrite skipped ({target_tool} not found)"),
+                    &truncate_chars(&command, 120),
+                    elapsed_ms(start),
+                )?;
+                return Ok(());
+            }
+            if corrected.starts_with("uv pip install")
+                && env_nonempty("VIRTUAL_ENV").is_none()
+                && !Path::new(".venv").is_dir()
+            {
+                append_hook_event(
+                    ctx,
+                    HookKind::PreBash,
+                    decision::PASS,
+                    status::PASS,
+                    "pkg-rewrite skipped (no active venv for uv pip)",
+                    &truncate_chars(&command, 120),
+                    elapsed_ms(start),
+                )?;
+                return Ok(());
+            }
+            append_hook_event(
+                ctx,
+                HookKind::PreBash,
+                decision::CORRECTION,
+                status::CORRECTION,
+                "package manager auto-rewrite",
+                &format!("{} → {}", truncate_chars(&command, 120), corrected),
+                elapsed_ms(start),
+            )?;
+            print!("{output}\n");
+        }
+        BashDecision::Pass { command, precommit } => {
+            if precommit {
+                let precommit_script = hook_dir().join("pre-commit-guard.sh");
+                if precommit_script.is_file() {
+                    let output = Command::new("bash")
+                        .arg(&precommit_script)
+                        .env("VIBEGUARD_DIR", &vibeguard_root)
+                        .output();
+                    match output {
+                        Ok(output) if output.status.success() => {}
+                        Ok(output) => {
+                            append_hook_event(
+                                ctx,
+                                HookKind::PreBash,
+                                decision::BLOCK,
+                                status::BLOCK,
+                                "pre-commit check failed",
+                                &command,
+                                elapsed_ms(start),
+                            )?;
+                            let precommit_output = command_output_text(&output);
+                            print_policy_decision_kv(
+                                "block",
+                                &format!(
+                                    "VIBEGUARD Pre-Commit 检查失败。请根据上方错误信息修复问题后重新提交。禁止使用环境变量绕过。\n\n{precommit_output}"
+                                ),
+                            );
+                            return Ok(());
+                        }
+                        Err(err) => {
+                            append_hook_event(
+                                ctx,
+                                HookKind::PreBash,
+                                decision::BLOCK,
+                                status::BLOCK,
+                                "pre-commit check failed",
+                                &command,
+                                elapsed_ms(start),
+                            )?;
+                            print_policy_decision_kv(
+                                "block",
+                                &format!(
+                                    "VIBEGUARD Pre-Commit 检查失败。请根据上方错误信息修复问题后重新提交。禁止使用环境变量绕过。\n\n{err}"
+                                ),
+                            );
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+            append_hook_event(
+                ctx,
+                HookKind::PreBash,
+                decision::PASS,
+                status::PASS,
+                "",
+                &command,
+                elapsed_ms(start),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn vibeguard_root() -> String {
+    if let Some(root) = env_nonempty("VIBEGUARD_DIR") {
+        return root;
+    }
+    if let Some(hook_dir) = env_nonempty("VIBEGUARD_HOOK_DIR").map(PathBuf::from) {
+        if let Some(parent) = hook_dir.parent() {
+            return parent.to_string_lossy().to_string();
+        }
+    }
+    env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn hook_dir() -> PathBuf {
+    env_nonempty("VIBEGUARD_HOOK_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+fn command_available(tool: &str) -> bool {
+    if tool.is_empty() {
+        return false;
+    }
+    if tool.contains('/') || tool.contains('\\') {
+        return is_executable_file(Path::new(tool));
+    }
+    let Some(path_var) = env::var_os("PATH") else {
+        return false;
+    };
+    env::split_paths(&path_var).any(|dir| is_executable_file(&dir.join(tool)))
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn command_output_text(output: &std::process::Output) -> String {
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    text
+}

--- a/vibeguard-runtime/src/hook_orchestrator_stop.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_stop.rs
@@ -116,3 +116,31 @@ fn stop_changed_detail(files: &[String]) -> String {
     detail.push(' ');
     detail
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_hook_active_only_accepts_true_boolean() {
+        assert!(stop_hook_active(r#"{"stop_hook_active":true}"#));
+        assert!(!stop_hook_active(r#"{"stop_hook_active":false}"#));
+        assert!(!stop_hook_active(r#"{"stop_hook_active":"true"}"#));
+        assert!(!stop_hook_active("{"));
+    }
+
+    #[test]
+    fn stop_changed_detail_includes_first_five_files_with_trailing_space() {
+        let files = vec![
+            "a.rs".to_string(),
+            "b.rs".to_string(),
+            "c.rs".to_string(),
+            "d.rs".to_string(),
+            "e.rs".to_string(),
+            "f.rs".to_string(),
+        ];
+
+        assert_eq!(stop_changed_detail(&files), "a.rs b.rs c.rs d.rs e.rs ");
+        assert_eq!(stop_changed_detail(&[]), "");
+    }
+}

--- a/vibeguard-runtime/src/hook_orchestrator_stop.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_stop.rs
@@ -1,0 +1,118 @@
+use serde_json::Value;
+use std::env;
+use std::process::Command;
+use std::time::Instant;
+
+use crate::event_schema::{decision, status};
+use crate::git_root::current_git_root_by_marker;
+use crate::hook_checks_common::is_source_path;
+use crate::hook_orchestrator::{HookKind, Result, append_hook_event, elapsed_ms};
+use crate::hook_orchestrator_context::RuntimeContext;
+use crate::wrapper_env::env_nonempty;
+
+pub(crate) fn run(input: &str, start: Instant) -> Result {
+    if stop_is_ci() || stop_hook_active(input) || current_git_root_by_marker().is_none() {
+        return Ok(());
+    }
+
+    let changed_files = changed_source_files();
+    let ctx = match RuntimeContext::collect() {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            eprintln!("VIBEGUARD: failed to collect context for stop-guard event: {err}");
+            return Ok(());
+        }
+    };
+    if changed_files.is_empty() {
+        append_hook_event(
+            &ctx,
+            HookKind::Stop,
+            decision::PASS,
+            status::PASS,
+            "",
+            "",
+            elapsed_ms(start),
+        )?;
+        return Ok(());
+    }
+
+    let detail = stop_changed_detail(&changed_files);
+    append_hook_event(
+        &ctx,
+        HookKind::Stop,
+        decision::GATE,
+        status::GATE,
+        &format!("uncommitted source changes: {} files", changed_files.len()),
+        &detail,
+        elapsed_ms(start),
+    )?;
+    Ok(())
+}
+
+fn stop_is_ci() -> bool {
+    fn truthy_env(name: &str) -> bool {
+        matches!(
+            env::var(name).as_deref(),
+            Ok("true" | "True" | "TRUE" | "1" | "yes" | "Yes" | "YES")
+        )
+    }
+    truthy_env("CI")
+        || truthy_env("GITHUB_ACTIONS")
+        || truthy_env("TRAVIS")
+        || truthy_env("CIRCLECI")
+        || env_nonempty("JENKINS_URL").is_some()
+        || truthy_env("GITLAB_CI")
+        || truthy_env("TF_BUILD")
+}
+
+fn stop_hook_active(input: &str) -> bool {
+    serde_json::from_str::<Value>(input)
+        .ok()
+        .and_then(|data| data.get("stop_hook_active").and_then(Value::as_bool))
+        .unwrap_or(false)
+}
+
+fn changed_source_files() -> Vec<String> {
+    let names = git_diff_names(&["diff", "--name-only", "HEAD"])
+        .or_else(|| git_diff_names(&["diff", "--name-only", "--cached"]))
+        .unwrap_or_default();
+    let mut files = names
+        .into_iter()
+        .filter(|file| !file.is_empty() && is_source_path(file))
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn git_diff_names(args: &[&str]) -> Option<Vec<String>> {
+    let output = Command::new("git")
+        .args(args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn stop_changed_detail(files: &[String]) -> String {
+    if files.is_empty() {
+        return String::new();
+    }
+    let mut detail = files
+        .iter()
+        .take(5)
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(" ");
+    detail.push(' ');
+    detail
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -20,6 +20,8 @@ mod hook_checks_write;
 mod hook_checks_write_scan;
 mod hook_orchestrator;
 mod hook_orchestrator_context;
+mod hook_orchestrator_pre_bash;
+mod hook_orchestrator_stop;
 mod hook_output;
 mod hook_status;
 mod json_field;

--- a/vibeguard-runtime/tests/cli_hook_orchestrator.rs
+++ b/vibeguard-runtime/tests/cli_hook_orchestrator.rs
@@ -24,6 +24,35 @@ fn run_hook(repo: &Path, log_root: &Path, hook: &str, input: &str) -> Output {
     child.wait_with_output().unwrap()
 }
 
+fn run_hook_without_ci(repo: &Path, log_root: &Path, hook: &str, input: &str) -> Output {
+    let mut command = hook_command(repo, log_root);
+    for name in [
+        "CI",
+        "GITHUB_ACTIONS",
+        "TRAVIS",
+        "CIRCLECI",
+        "JENKINS_URL",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ] {
+        command.env_remove(name);
+    }
+    let mut child = command
+        .args(["hook", hook])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
 fn hook_command(repo: &Path, log_root: &Path) -> Command {
     let mut command = bin();
     command
@@ -36,6 +65,20 @@ fn hook_command(repo: &Path, log_root: &Path) -> Command {
         .env("VIBEGUARD_SOURCE_CONFIG", "test-config")
         .env("VIBEGUARD_HOOK_PROTOCOL_VERSION", "1");
     command
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn read_first_json(path: &Path) -> Value {
@@ -251,14 +294,110 @@ fn hook_orchestrator_pre_write_source_new_logs_attempt_and_reminder() {
         fs::read_to_string(&global_log).unwrap()
     );
     let events = fs::read_to_string(&project_log).unwrap();
+    let reasons = events
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .map(|event| event["reason"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
     assert!(
-        events.contains("\"reason\":\"New source file attempt\""),
-        "{events}"
+        reasons
+            .iter()
+            .any(|reason| reason == "New source file attempt"),
+        "{reasons:?}"
     );
     assert!(
-        events.contains("\"reason\":\"New source file reminder\""),
-        "{events}"
+        reasons
+            .iter()
+            .any(|reason| reason == "New source file reminder"),
+        "{reasons:?}"
     );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn hook_orchestrator_pre_bash_blocks_and_logs_reason() {
+    let root = unique_temp_dir("hook-orchestrator-prebash-block");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+
+    let input = serde_json::json!({
+        "tool_input": {
+            "command": "git checkout ."
+        }
+    })
+    .to_string();
+    let out = run_hook(&repo, &log_root, "pre-bash", &input);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
+    assert!(stdout.contains("authorized-discard.py"), "{stdout}");
+
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let event = read_first_json(&project_dir.join("events.jsonl"));
+    assert_eq!(event["hook"], "pre-bash-guard");
+    assert_eq!(event["tool"], "Bash");
+    assert_eq!(event["decision"], "block");
+    assert_eq!(event["status"], "block");
+    assert!(
+        event["reason"]
+            .as_str()
+            .unwrap()
+            .contains("Disable git checkout/restore"),
+        "{event}"
+    );
+    assert_eq!(event["detail"], "git checkout .");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn hook_orchestrator_stop_logs_uncommitted_source_changes() {
+    let root = unique_temp_dir("hook-orchestrator-stop-gate");
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join("src")).unwrap();
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "user.name", "Test User"]);
+    fs::write(repo.join("src/lib.rs"), "pub fn value() -> i32 { 1 }\n").unwrap();
+    git(&repo, &["add", "src/lib.rs"]);
+    git(&repo, &["commit", "-m", "initial"]);
+    fs::write(repo.join("src/lib.rs"), "pub fn value() -> i32 { 2 }\n").unwrap();
+
+    let out = run_hook_without_ci(&repo, &log_root, "stop", r#"{"hook_event_name":"Stop"}"#);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.stdout.is_empty());
+
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let event = read_first_json(&project_dir.join("events.jsonl"));
+    assert_eq!(event["hook"], "stop-guard");
+    assert_eq!(event["tool"], "Stop");
+    assert_eq!(event["decision"], "gate");
+    assert_eq!(event["status"], "gate");
+    assert_eq!(event["reason"], "uncommitted source changes: 1 files");
+    assert_eq!(event["detail"], "src/lib.rs ");
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
Refs #551

Implements the SP551-T5 tranche only: migrate `pre-bash-guard.sh` and `stop-guard.sh` to the Rust runtime hook orchestrator while keeping the existing shell wrappers as thin runtime launchers.

Scope notes:
- Does not implement GH551 T6/T7.
- Uses `Refs #551` intentionally so this partial tranche does not auto-close the issue.
- Keeps stop-guard non-blocking and preserves pre-bash dangerous-command/package-rewrite behavior.

Verification:
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test cli_hook_orchestrator`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash -n hooks/pre-bash-guard.sh hooks/stop-guard.sh tests/hooks/test_pre_bash_guard.sh tests/hooks/test_stop_guard.sh tests/test_hooks.sh`
- `VIBEGUARD_RUNTIME="$PWD/vibeguard-runtime/target/release/vibeguard-runtime" bash tests/hooks/test_pre_bash_guard.sh`
- `VIBEGUARD_RUNTIME="$PWD/vibeguard-runtime/target/release/vibeguard-runtime" bash tests/hooks/test_stop_guard.sh`
- `bash tests/test_hooks.sh`
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash tests/test_observability_schemas.sh`
- `bash tests/test_hook_perf_contract.sh`
- `bash tests/bench_hook_latency.sh`