### PR TITLE
feat(health): add opt-in weekly report scheduler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,9 @@ jobs:
       - name: Health report regression tests
         if: runner.os != 'Windows'
         shell: bash
-        run: bash tests/test_health_report.sh
+        run: |
+          bash tests/test_health_report.sh
+          bash tests/test_health_report_scheduler.sh
 
       - name: Quality grader regression tests
         if: runner.os != 'Windows'

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
 # Runtime / scheduler
 bash ~/vibeguard/setup.sh --build-from-source          # Force local Cargo build
 bash ~/vibeguard/setup.sh --with-scheduler             # Opt in to launchd/systemd scheduled GC
+bash ~/vibeguard/scripts/install-health-report-scheduler.sh --dry-run
+bash ~/vibeguard/scripts/install-health-report-scheduler.sh --install  # Opt in to weekly health reports
 
 # Verify / Uninstall
 bash ~/vibeguard/setup.sh doctor                      # Human-friendly report, exits 0 for compatibility

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -305,6 +305,8 @@ bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
 # 运行时 / 调度器
 bash ~/vibeguard/setup.sh --build-from-source          # 强制使用 Cargo 本地构建
 bash ~/vibeguard/setup.sh --with-scheduler             # opt in 安装 launchd/systemd 定时 GC
+bash ~/vibeguard/scripts/install-health-report-scheduler.sh --dry-run
+bash ~/vibeguard/scripts/install-health-report-scheduler.sh --install  # opt in 安装每周健康报告
 
 # 检查 / 卸载
 bash ~/vibeguard/setup.sh doctor                 # 面向人的友好报告，兼容性退出 0

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -8,6 +8,8 @@ Reference notes for the utility scripts shipped with VibeGuard.
 |------|------|
 | `stats.sh` | Analyze `events.jsonl` and summarize hook activity, decision mix, and hot spots |
 | `health-report.py` | Aggregate observe summary/health, precision tracker, and Learn adoption into a weekly health report (markdown or JSON); reads existing sources only, never mutates the scorecard |
+| `health-report-scheduled.sh` | Write a dated weekly health report file under `~/.vibeguard/reports/health/`; does not install a scheduler |
+| `install-health-report-scheduler.sh` | Opt-in installer/remover for the weekly health report launchd/cron scheduler; default mode is dry-run |
 | `hook-health.sh` | Show recent hook health: risk rate, top noisy hooks, and recent risky events |
 | `quality-grader.sh` | Compute the current quality grade from runtime events |
 | `project-init.sh` | Bootstrap another repository with detected languages, recommended constraints, and git hook wiring |
@@ -60,6 +62,8 @@ Reference notes for the utility scripts shipped with VibeGuard.
 bash scripts/stats.sh
 python3 scripts/health-report.py --days 7 --format markdown
 python3 scripts/health-report.py --days 30 --scope global --format json --output report.json
+bash scripts/health-report-scheduled.sh --dry-run
+bash scripts/install-health-report-scheduler.sh --dry-run
 bash scripts/hook-health.sh 24
 bash scripts/quality-grader.sh
 python3 scripts/authorized-discard.py --plan

--- a/scripts/health-report-scheduled.sh
+++ b/scripts/health-report-scheduled.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# VibeGuard scheduled health report wrapper.
+#
+# This script is safe to run manually. It writes one markdown or JSON report to
+# ~/.vibeguard/reports/health by default and never installs a scheduler.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+DAYS=30
+SCOPE="global"
+FORMAT="markdown"
+OUTPUT_DIR="${VIBEGUARD_HEALTH_REPORT_DIR:-${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}/reports/health}"
+PROJECT=""
+LOG_FILE=""
+TRIAGE_FILE=""
+SCORECARD_FILE=""
+ADOPTIONS_FILE=""
+REPORT_DATE="${VIBEGUARD_HEALTH_REPORT_DATE:-}"
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/health-report-scheduled.sh [options]
+
+Options:
+  --dry-run              Print the report path and command without writing
+  --scheduled            Accepted for launchd/cron callers; same behavior as default
+  --days N               Window size in days (default: 30)
+  --scope project|global Event log scope (default: global)
+  --project REF          Project reference for observe
+  --log-file PATH        Explicit event log path
+  --triage-file PATH     Explicit triage JSONL path
+  --scorecard-file PATH  Explicit scorecard JSON path
+  --adoptions-file PATH  Explicit Learn adoption JSONL path
+  --format markdown|json Output format (default: markdown)
+  --output-dir PATH      Directory for report files
+  --report-date DATE     Report date for deterministic tests (YYYY-MM-DD)
+  --help, -h             Show this help
+
+Default output:
+  ~/.vibeguard/reports/health/YYYY-MM-DD.md
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --scheduled) shift ;;
+    --days)
+      [[ $# -lt 2 ]] && { echo "ERROR: --days requires a value" >&2; exit 64; }
+      DAYS="$2"; shift 2 ;;
+    --scope)
+      [[ $# -lt 2 ]] && { echo "ERROR: --scope requires a value" >&2; exit 64; }
+      SCOPE="$2"; shift 2 ;;
+    --project)
+      [[ $# -lt 2 ]] && { echo "ERROR: --project requires a value" >&2; exit 64; }
+      PROJECT="$2"; shift 2 ;;
+    --log-file)
+      [[ $# -lt 2 ]] && { echo "ERROR: --log-file requires a value" >&2; exit 64; }
+      LOG_FILE="$2"; shift 2 ;;
+    --triage-file)
+      [[ $# -lt 2 ]] && { echo "ERROR: --triage-file requires a value" >&2; exit 64; }
+      TRIAGE_FILE="$2"; shift 2 ;;
+    --scorecard-file)
+      [[ $# -lt 2 ]] && { echo "ERROR: --scorecard-file requires a value" >&2; exit 64; }
+      SCORECARD_FILE="$2"; shift 2 ;;
+    --adoptions-file)
+      [[ $# -lt 2 ]] && { echo "ERROR: --adoptions-file requires a value" >&2; exit 64; }
+      ADOPTIONS_FILE="$2"; shift 2 ;;
+    --format)
+      [[ $# -lt 2 ]] && { echo "ERROR: --format requires a value" >&2; exit 64; }
+      FORMAT="$2"; shift 2 ;;
+    --output-dir)
+      [[ $# -lt 2 ]] && { echo "ERROR: --output-dir requires a value" >&2; exit 64; }
+      OUTPUT_DIR="$2"; shift 2 ;;
+    --report-date)
+      [[ $# -lt 2 ]] && { echo "ERROR: --report-date requires a value" >&2; exit 64; }
+      REPORT_DATE="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 64 ;;
+  esac
+done
+
+case "${SCOPE}" in
+  project|global) ;;
+  *) echo "ERROR: --scope must be project or global" >&2; exit 64 ;;
+esac
+
+case "${FORMAT}" in
+  markdown) EXT="md" ;;
+  json) EXT="json" ;;
+  *) echo "ERROR: --format must be markdown or json" >&2; exit 64 ;;
+esac
+
+if ! [[ "${DAYS}" =~ ^[0-9]+$ ]] || [[ "${DAYS}" -le 0 ]]; then
+  echo "ERROR: --days must be a positive integer" >&2
+  exit 64
+fi
+
+if [[ -z "${REPORT_DATE}" ]]; then
+  REPORT_DATE="$(date -u '+%Y-%m-%d')"
+fi
+if ! [[ "${REPORT_DATE}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "ERROR: --report-date must be YYYY-MM-DD" >&2
+  exit 64
+fi
+
+OUTPUT_PATH="${OUTPUT_DIR}/${REPORT_DATE}.${EXT}"
+CMD=(python3 "${SCRIPT_DIR}/health-report.py" --days "${DAYS}" --scope "${SCOPE}" --format "${FORMAT}" --output "${OUTPUT_PATH}")
+[[ -z "${PROJECT}" ]] || CMD+=(--project "${PROJECT}")
+[[ -z "${LOG_FILE}" ]] || CMD+=(--log-file "${LOG_FILE}")
+[[ -z "${TRIAGE_FILE}" ]] || CMD+=(--triage-file "${TRIAGE_FILE}")
+[[ -z "${SCORECARD_FILE}" ]] || CMD+=(--scorecard-file "${SCORECARD_FILE}")
+[[ -z "${ADOPTIONS_FILE}" ]] || CMD+=(--adoptions-file "${ADOPTIONS_FILE}")
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  printf 'Health report scheduler dry run\n'
+  printf 'Output: %s\n' "${OUTPUT_PATH}"
+  printf 'Command:'
+  printf ' %q' "${CMD[@]}"
+  printf '\n'
+  exit 0
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+"${CMD[@]}"

--- a/scripts/install-health-report-scheduler.sh
+++ b/scripts/install-health-report-scheduler.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Install the opt-in weekly VibeGuard health report scheduler.
+#
+# Default mode is a dry-run plan. Use --install to modify launchd or crontab.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MODE="plan"
+DAYS=30
+SCOPE="global"
+OUTPUT_DIR="${VIBEGUARD_HEALTH_REPORT_DIR:-${HOME}/.vibeguard/reports/health}"
+LAUNCHD_LABEL="com.vibeguard.health-report"
+PLIST_SRC="${SCRIPT_DIR}/setup/com.vibeguard.health-report.plist"
+PLIST_DEST="${HOME}/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+CRON_MARKER_BEGIN="# VibeGuard health report scheduler start"
+CRON_MARKER_END="# VibeGuard health report scheduler end"
+CRON_FILE="${VIBEGUARD_HEALTH_REPORT_TEST_CRONTAB:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/install-health-report-scheduler.sh [--install|--remove|--dry-run] [options]
+
+Options:
+  --install          Install the weekly launchd/cron scheduler
+  --remove           Remove the installed scheduler
+  --dry-run          Print the install plan without writing scheduler config
+  --days N           Report window size in days (default: 30)
+  --scope SCOPE      project or global (default: global)
+  --output-dir PATH  Report output directory (default: ~/.vibeguard/reports/health)
+  --repo-dir PATH    Override repo path for tests
+  --help, -h         Show this help
+
+Default behavior is --dry-run. No scheduler is installed unless --install is passed.
+USAGE
+}
+
+test_uname() {
+  if [[ -n "${VIBEGUARD_HEALTH_REPORT_TEST_UNAME:-}" ]]; then
+    printf '%s\n' "${VIBEGUARD_HEALTH_REPORT_TEST_UNAME}"
+  else
+    uname
+  fi
+}
+
+escape_sed() {
+  printf '%s\n' "$1" | sed 's/[\\&|]/\\&/g'
+}
+
+escape_xml() {
+  local value="$1"
+  value="${value//&/&amp;}"
+  value="${value//</&lt;}"
+  value="${value//>/&gt;}"
+  printf '%s\n' "${value}"
+}
+
+escape_sed_xml() {
+  escape_sed "$(escape_xml "$1")"
+}
+
+shell_quote() {
+  local value="$1"
+  printf "'%s'" "$(printf '%s' "${value}" | sed "s/'/'\\\\''/g")"
+}
+
+reject_multiline_value() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" == *$'\n'* || "${value}" == *$'\r'* ]]; then
+    echo "ERROR: ${name} must not contain newlines" >&2
+    exit 64
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install) MODE="install"; shift ;;
+    --remove) MODE="remove"; shift ;;
+    --dry-run) MODE="plan"; shift ;;
+    --days)
+      [[ $# -lt 2 ]] && { echo "ERROR: --days requires a value" >&2; exit 64; }
+      DAYS="$2"; shift 2 ;;
+    --scope)
+      [[ $# -lt 2 ]] && { echo "ERROR: --scope requires a value" >&2; exit 64; }
+      SCOPE="$2"; shift 2 ;;
+    --output-dir)
+      [[ $# -lt 2 ]] && { echo "ERROR: --output-dir requires a value" >&2; exit 64; }
+      OUTPUT_DIR="$2"; shift 2 ;;
+    --repo-dir)
+      [[ $# -lt 2 ]] && { echo "ERROR: --repo-dir requires a value" >&2; exit 64; }
+      REPO_DIR="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 64 ;;
+  esac
+done
+
+case "${SCOPE}" in
+  project|global) ;;
+  *) echo "ERROR: --scope must be project or global" >&2; exit 64 ;;
+esac
+
+if ! [[ "${DAYS}" =~ ^[0-9]+$ ]] || [[ "${DAYS}" -le 0 ]]; then
+  echo "ERROR: --days must be a positive integer" >&2
+  exit 64
+fi
+
+reject_multiline_value "--repo-dir" "${REPO_DIR}"
+reject_multiline_value "--output-dir" "${OUTPUT_DIR}"
+reject_multiline_value "HOME" "${HOME}"
+
+SCHEDULE_CMD="/bin/bash $(shell_quote "${REPO_DIR}/scripts/health-report-scheduled.sh") --scheduled --days $(shell_quote "${DAYS}") --scope $(shell_quote "${SCOPE}") --output-dir $(shell_quote "${OUTPUT_DIR}")"
+
+print_plan() {
+  local os_name="$1"
+  printf 'VibeGuard health report scheduler plan\n'
+  printf 'Mode: %s\n' "${MODE}"
+  printf 'OS: %s\n' "${os_name}"
+  printf 'Schedule: weekly Monday 09:00\n'
+  printf 'Reports: %s\n' "${OUTPUT_DIR}"
+  printf 'Command: %s\n' "${SCHEDULE_CMD}"
+  if [[ "${MODE}" != "install" ]]; then
+    printf 'No scheduler installed. Re-run with --install to opt in.\n'
+  fi
+}
+
+install_launchd() {
+  [[ -f "${PLIST_SRC}" ]] || { echo "ERROR: missing launchd template: ${PLIST_SRC}" >&2; exit 1; }
+  mkdir -p "$(dirname "${PLIST_DEST}")"
+  sed -e "s|__VIBEGUARD_DIR__|$(escape_sed_xml "${REPO_DIR}")|g" \
+      -e "s|__HOME__|$(escape_sed_xml "${HOME}")|g" \
+      -e "s|__DAYS__|$(escape_sed_xml "${DAYS}")|g" \
+      -e "s|__SCOPE__|$(escape_sed_xml "${SCOPE}")|g" \
+      -e "s|__OUTPUT_DIR__|$(escape_sed_xml "${OUTPUT_DIR}")|g" \
+      "${PLIST_SRC}" > "${PLIST_DEST}"
+  chmod 600 "${PLIST_DEST}"
+  if [[ "${VIBEGUARD_HEALTH_REPORT_TEST_SKIP_LAUNCHCTL:-0}" != "1" ]]; then
+    launchctl bootout "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "${PLIST_DEST}"
+  fi
+  printf 'Installed launchd scheduler: %s\n' "${PLIST_DEST}"
+}
+
+remove_launchd() {
+  if [[ "${VIBEGUARD_HEALTH_REPORT_TEST_SKIP_LAUNCHCTL:-0}" != "1" ]]; then
+    launchctl bootout "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
+  fi
+  rm -f "${PLIST_DEST}"
+  printf 'Removed launchd scheduler: %s\n' "${PLIST_DEST}"
+}
+
+cron_read() {
+  if [[ -n "${CRON_FILE}" ]]; then
+    [[ -f "${CRON_FILE}" ]] && cat "${CRON_FILE}"
+    return 0
+  else
+    crontab -l 2>/dev/null || true
+  fi
+}
+
+cron_write() {
+  if [[ -n "${CRON_FILE}" ]]; then
+    mkdir -p "$(dirname "${CRON_FILE}")"
+    cat > "${CRON_FILE}"
+  else
+    crontab -
+  fi
+}
+
+install_cron() {
+  local cron_tmp entry log_path
+  cron_tmp="$(mktemp)"
+  trap 'rm -f "${cron_tmp}"' RETURN
+  cron_read | awk -v start="${CRON_MARKER_BEGIN}" -v end="${CRON_MARKER_END}" '
+    $0 == start { skip = 1; next }
+    $0 == end { skip = 0; next }
+    skip != 1 { print }
+  ' > "${cron_tmp}"
+  log_path="${HOME}/.vibeguard/health-report-cron.log"
+  entry="0 9 * * 1 ${SCHEDULE_CMD} >> $(shell_quote "${log_path}") 2>&1"
+  {
+    if [[ -s "${cron_tmp}" ]]; then
+      cat "${cron_tmp}"
+      printf '\n'
+    fi
+    printf '%s\n' "${CRON_MARKER_BEGIN}"
+    printf '%s\n' "${entry}"
+    printf '%s\n' "${CRON_MARKER_END}"
+  } | cron_write
+  printf 'Installed cron scheduler for weekly health report\n'
+}
+
+remove_cron() {
+  cron_read | awk -v start="${CRON_MARKER_BEGIN}" -v end="${CRON_MARKER_END}" '
+    $0 == start { skip = 1; next }
+    $0 == end { skip = 0; next }
+    skip != 1 { print }
+  ' | cron_write
+  printf 'Removed cron scheduler for weekly health report\n'
+}
+
+OS_NAME="$(test_uname)"
+print_plan "${OS_NAME}"
+
+case "${MODE}:${OS_NAME}" in
+  plan:*) exit 0 ;;
+  install:Darwin) install_launchd ;;
+  remove:Darwin) remove_launchd ;;
+  install:*) install_cron ;;
+  remove:*) remove_cron ;;
+esac

--- a/scripts/setup/com.vibeguard.health-report.plist
+++ b/scripts/setup/com.vibeguard.health-report.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.vibeguard.health-report</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__VIBEGUARD_DIR__/scripts/health-report-scheduled.sh</string>
+        <string>--scheduled</string>
+        <string>--days</string>
+        <string>__DAYS__</string>
+        <string>--scope</string>
+        <string>__SCOPE__</string>
+        <string>--output-dir</string>
+        <string>__OUTPUT_DIR__</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>__HOME__/.vibeguard/health-report-launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.vibeguard/health-report-launchd.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -9,6 +9,9 @@ assert_cmd "launchd plist points to canonical GC script path" grep -q "__VIBEGUA
 assert_cmd "systemd service points to canonical GC script path" grep -q "__VIBEGUARD_DIR__/scripts/gc/gc-scheduled.sh" "${REPO_DIR}/scripts/systemd/vibeguard-gc.service"
 assert_cmd "systemd installer chmods canonical GC script path" grep -q 'scripts/gc/gc-scheduled.sh' "${REPO_DIR}/scripts/install-systemd.sh"
 assert_cmd "scheduled GC installers do not reference retired root path" bash -c "! grep -q 'scripts/gc-scheduled.sh' '${REPO_DIR}/scripts/setup/com.vibeguard.gc.plist' '${REPO_DIR}/scripts/systemd/vibeguard-gc.service' '${REPO_DIR}/scripts/install-systemd.sh'"
+assert_cmd "health report scheduled wrapper exists at canonical path" test -x "${REPO_DIR}/scripts/health-report-scheduled.sh"
+assert_cmd "health report scheduler installer exists at canonical path" test -x "${REPO_DIR}/scripts/install-health-report-scheduler.sh"
+assert_cmd "health report launchd plist points to canonical wrapper path" grep -q "__VIBEGUARD_DIR__/scripts/health-report-scheduled.sh" "${REPO_DIR}/scripts/setup/com.vibeguard.health-report.plist"
 
 header "seed existing config"
 mkdir -p "${HOME}/.claude" "${HOME}/.codex"
@@ -120,6 +123,7 @@ assert_cmd "--dry-run does not modify ~/.codex/hooks.json" test "${dry_run_codex
 assert_cmd "--dry-run does not modify ~/.codex/config.toml" test "${dry_run_codex_config_sha_before}" = "${dry_run_codex_config_sha_after}"
 assert_cmd "--dry-run does not create ~/.claude/CLAUDE.md" test ! -e "${HOME}/.claude/CLAUDE.md"
 assert_cmd "--dry-run does not create ~/.codex/AGENTS.md" test ! -e "${HOME}/.codex/AGENTS.md"
+assert_cmd "--dry-run does not install health report launchd scheduler" test ! -e "${HOME}/Library/LaunchAgents/com.vibeguard.health-report.plist"
 
 valid_project_config="${TMP_HOME}/valid-vibeguard.json"
 cat > "${valid_project_config}" <<'JSON'

--- a/tests/setup/syntax_manifest_tests.sh
+++ b/tests/setup/syntax_manifest_tests.sh
@@ -7,6 +7,8 @@ assert_cmd "scripts/setup/clean.sh syntax is correct" bash -n "${REPO_DIR}/scrip
 assert_cmd "scripts/setup/codex-status.sh syntax is correct" bash -n "${REPO_DIR}/scripts/setup/codex-status.sh"
 assert_cmd "scripts/codex-contract-check.sh syntax is correct" bash -n "${REPO_DIR}/scripts/codex-contract-check.sh"
 assert_cmd "scripts/project-init.sh syntax is correct" bash -n "${REPO_DIR}/scripts/project-init.sh"
+assert_cmd "scripts/health-report-scheduled.sh syntax is correct" bash -n "${REPO_DIR}/scripts/health-report-scheduled.sh"
+assert_cmd "scripts/install-health-report-scheduler.sh syntax is correct" bash -n "${REPO_DIR}/scripts/install-health-report-scheduler.sh"
 assert_cmd "scripts/install-systemd.sh syntax is correct" bash -n "${REPO_DIR}/scripts/install-systemd.sh"
 assert_cmd "scripts/lib/install-state.sh syntax is correct" bash -n "${REPO_DIR}/scripts/lib/install-state.sh"
 assert_cmd "scripts/lib/settings_json.py syntax is correct" python3 -m py_compile "${SETTINGS_HELPER}"

--- a/tests/test_health_report_scheduler.sh
+++ b/tests/test_health_report_scheduler.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# VibeGuard health report scheduler regression testing.
+#
+# Usage: bash tests/test_health_report_scheduler.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCHEDULED_SCRIPT="${REPO_DIR}/scripts/health-report-scheduled.sh"
+INSTALLER="${REPO_DIR}/scripts/install-health-report-scheduler.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qF -- "$expected" <<< "$output"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (exit code: $?)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+ORIG_HOME="${HOME}"
+cleanup() {
+  export HOME="${ORIG_HOME}"
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+header "fixtures"
+export HOME="${TMP_DIR}/home"
+mkdir -p "${HOME}"
+EVENTS="${TMP_DIR}/events.jsonl"
+TRIAGE="${TMP_DIR}/triage.jsonl"
+SCORECARD="${TMP_DIR}/scorecard.json"
+ADOPTIONS="${TMP_DIR}/adoptions.jsonl"
+REPORT_DIR="${TMP_DIR}/reports"
+cat > "${EVENTS}" <<'JSONL'
+{"ts":"2026-07-05T00:00:00Z","session":"s1","hook":"analysis-paralysis-guard","tool":"Read","decision":"warn","reason":"W-13 paralysis 7x","client":"claude"}
+JSONL
+cat > "${TRIAGE}" <<'JSONL'
+{"schema_version":1,"ts":"2026-07-05T00:00:00Z","rule":"W-13","verdict":"unclassified","decision":"warn","hook":"analysis-paralysis-guard","tool":"Read","context":"W-13 paralysis 7x","session":"s1"}
+JSONL
+cat > "${SCORECARD}" <<'JSON'
+{"rules":{"W-13":{"stage":"warn","precision":null,"samples":0,"tp":0,"fp":0,"acceptable":0,"last_fp_ts":null}}}
+JSON
+: > "${ADOPTIONS}"
+
+header "scheduled wrapper dry-run"
+dry_run_out="$(bash "${SCHEDULED_SCRIPT}" \
+  --dry-run \
+  --days 30 \
+  --scope global \
+  --log-file "${EVENTS}" \
+  --triage-file "${TRIAGE}" \
+  --scorecard-file "${SCORECARD}" \
+  --adoptions-file "${ADOPTIONS}" \
+  --output-dir "${REPORT_DIR}" \
+  --report-date 2026-07-06)"
+assert_contains "${dry_run_out}" "Health report scheduler dry run" "scheduled wrapper reports dry-run mode"
+assert_contains "${dry_run_out}" "${REPORT_DIR}/2026-07-06.md" "scheduled wrapper previews deterministic output path"
+assert_cmd "scheduled wrapper dry-run does not write report" test ! -e "${REPORT_DIR}/2026-07-06.md"
+
+header "scheduled wrapper writes report"
+write_out="$(bash "${SCHEDULED_SCRIPT}" \
+  --days 30 \
+  --scope global \
+  --log-file "${EVENTS}" \
+  --triage-file "${TRIAGE}" \
+  --scorecard-file "${SCORECARD}" \
+  --adoptions-file "${ADOPTIONS}" \
+  --output-dir "${REPORT_DIR}" \
+  --report-date 2026-07-06)"
+assert_contains "${write_out}" "Wrote markdown report to" "scheduled wrapper writes report through health-report.py"
+assert_cmd "scheduled wrapper created report file" test -f "${REPORT_DIR}/2026-07-06.md"
+report_text="$(cat "${REPORT_DIR}/2026-07-06.md")"
+assert_contains "${report_text}" "# VibeGuard Health Report" "scheduled report contains markdown header"
+assert_contains "${report_text}" "W-13" "scheduled report carries W-13 evidence"
+
+header "installer default is non-mutating"
+install_plan_out="$(VIBEGUARD_HEALTH_REPORT_TEST_UNAME=Darwin \
+  VIBEGUARD_HEALTH_REPORT_TEST_SKIP_LAUNCHCTL=1 \
+  bash "${INSTALLER}" --repo-dir "${REPO_DIR}" --output-dir "${REPORT_DIR}")"
+assert_contains "${install_plan_out}" "No scheduler installed" "installer default does not install"
+assert_cmd "installer default does not write launchd plist" test ! -e "${HOME}/Library/LaunchAgents/com.vibeguard.health-report.plist"
+
+header "manual opt-in launchd install"
+LAUNCHD_REPORT_DIR="${TMP_DIR}/reports & launchd"
+launchd_out="$(VIBEGUARD_HEALTH_REPORT_TEST_UNAME=Darwin \
+  VIBEGUARD_HEALTH_REPORT_TEST_SKIP_LAUNCHCTL=1 \
+  bash "${INSTALLER}" --install --repo-dir "${REPO_DIR}" --output-dir "${LAUNCHD_REPORT_DIR}")"
+assert_contains "${launchd_out}" "Installed launchd scheduler" "manual opt-in installs launchd plist"
+PLIST="${HOME}/Library/LaunchAgents/com.vibeguard.health-report.plist"
+assert_cmd "launchd plist was written" test -f "${PLIST}"
+plist_text="$(cat "${PLIST}")"
+assert_contains "${plist_text}" "scripts/health-report-scheduled.sh" "launchd plist points to scheduled health wrapper"
+assert_contains "${plist_text}" "reports &amp; launchd" "launchd plist XML-escapes output directory"
+
+header "manual opt-in cron install"
+CRONTAB_FILE="${TMP_DIR}/crontab"
+CRON_REPORT_DIR="${TMP_DIR}/reports quote ' cron"
+cron_out="$(VIBEGUARD_HEALTH_REPORT_TEST_UNAME=Linux \
+  VIBEGUARD_HEALTH_REPORT_TEST_CRONTAB="${CRONTAB_FILE}" \
+  bash "${INSTALLER}" --install --repo-dir "${REPO_DIR}" --output-dir "${CRON_REPORT_DIR}")"
+assert_contains "${cron_out}" "Installed cron scheduler" "manual opt-in installs cron entry"
+cron_text="$(cat "${CRONTAB_FILE}")"
+assert_contains "${cron_text}" "VibeGuard health report scheduler start" "cron install uses managed marker"
+assert_contains "${cron_text}" "scripts/health-report-scheduled.sh" "cron install points to scheduled health wrapper"
+assert_contains "${cron_text}" "'\\''" "cron install shell-quotes output directory"
+
+printf '\n\033[1m=== Summary ===\033[0m\n'
+printf 'Total: %d  Passed: %d  Failed: %d\n' "$TOTAL" "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add `scripts/health-report-scheduled.sh` to write dated markdown/json health reports without installing a scheduler
- add an explicit opt-in launchd/cron installer/remover with dry-run default, shell quoting, and XML escaping
- add scheduler regression coverage, CI wiring, setup syntax/path checks, and README usage notes
- T7 validation evidence was posted on GH556: https://github.com/majiayu000/vibeguard/issues/556#issuecomment-4886797353

## Verification

- `python3 -m py_compile scripts/health-report.py`
- `bash tests/test_health_report.sh` (24/24)
- `bash tests/test_health_report_scheduler.sh` (17/17)
- `bash -n scripts/health-report-scheduled.sh && bash -n scripts/install-health-report-scheduler.sh && bash -n tests/test_health_report_scheduler.sh`
- `shellcheck scripts/health-report-scheduled.sh scripts/install-health-report-scheduler.sh tests/test_health_report_scheduler.sh`
- `bash tests/test_setup.sh` (451/451; setup flow coverage run before final installer quote-hardening patch, which is covered by the focused scheduler test and shellcheck above)
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

Refs #556
