### PR TITLE
docs(specs): mark GH556 implemented

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,7 +7,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | Spec | Status | Use it for |
 |---|---|---|
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
-| `GH556/` | Draft | Weekly health report for rule trigger counts, precision risk, unclassified backlog, and idle asset detection |
+| `GH556/` | Implemented reference | Weekly health report for rule trigger counts, precision risk, unclassified backlog, idle asset detection, and opt-in scheduling |
 | `GH566/` | Draft | Codex unmanaged stale `PreToolUse` hook detection, explicit repair, and setup-test fixture isolation |
 | `install-friction-reduction.md` | Implemented reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
 | `learn-first-class-signal-inbox.md` | Draft | Learn signal inbox, signal classification, triage state, adoption compiler, and outcome evaluator planning |


### PR DESCRIPTION
## Summary

- mark `docs/specs/GH556/` as an implemented reference now that #562 and #572 have merged
- mention the opt-in scheduling surface in the spec index entry

## Verification

- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

Refs #556
