### PR TITLE
test(learn): keep snooze fixture relative to now

### DIFF
--- a/tests/hooks/test_skills_loader.sh
+++ b/tests/hooks/test_skills_loader.sh
@@ -63,8 +63,7 @@ for index in 1 2 3 4 5; do
       HOME="$loader_home" python3 "$REPO_DIR/scripts/learn/triage_state.py" skip "lrn_pending_0${index}" --reason "not useful" >/dev/null
       ;;
     5)
-      HOME="$loader_home" _VIBEGUARD_TEST_NOW="2026-06-24T00:00:00Z" \
-        python3 "$REPO_DIR/scripts/learn/triage_state.py" snooze "lrn_pending_05" --days 14 --reason "later" >/dev/null
+      HOME="$loader_home" python3 "$REPO_DIR/scripts/learn/triage_state.py" snooze "lrn_pending_05" --days 14 --reason "later" >/dev/null
       ;;
   esac
 done


### PR DESCRIPTION
## 摘要

修复 `tests/hooks/test_skills_loader.sh` 的日期过期失败：不再把 snooze 当前时间固定在 `2026-06-24`，改为使用 `triage_state.py` 的真实 UTC 时钟生成 `now + 14 days`。

## 根因

旧 fixture 在 2026-07-08 后自然过期；loader 按生产语义正确地重新显示信号，但测试仍断言隐藏，导致 Linux/macOS Hook regression tests 从该日期起稳定失败。

## 范围

- 只修改测试 fixture。
- 不修改生产 snooze 逻辑。
- 保留“未过期 snooze 必须隐藏”的原断言。

## 验证

- `bash -n tests/hooks/test_skills_loader.sh`
- focused test 连续 5 次通过（每次 13/13）
- `bash tests/test_hooks.sh`（all shards passed）
- test-integrity / test-weakening guards 通过
- `git diff --check`
- 独立 reviewer lane：无 findings

Closes #578
