### PR TITLE
fix(guard): scope slop self-scan suppressions

### DIFF
--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -116,17 +116,16 @@ DEBUG_CODE=$(grep --null -rn "${EXCLUDE_ARGS[@]}" \
 if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
   TARGET_RUNTIME_SRC="${TARGET_DIR%/}/vibeguard-runtime/src/"
   DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | TARGET_RUNTIME_SRC="$TARGET_RUNTIME_SRC" awk '
-    function has_dbg_macro(text, i, ch, in_string, in_char, escaped) {
+    function has_dbg_macro(text, i, ch, in_string, escaped) {
       for (i = 1; i <= length(text); i++) {
         ch = substr(text, i, 1)
-        if (in_string || in_char) {
+        if (in_string) {
           if (escaped) {
             escaped = 0
           } else if (ch == "\\") {
             escaped = 1
-          } else if ((in_string && ch == "\"") || (in_char && ch == "\047")) {
+          } else if (ch == "\"") {
             in_string = 0
-            in_char = 0
           }
           continue
         }
@@ -135,9 +134,8 @@ if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
         }
         if (ch == "\"") {
           in_string = 1
-        } else if (ch == "\047") {
-          in_char = 1
-        } else if (substr(text, i, 5) == "dbg!(") {
+        } else if (substr(text, i, 4) == "dbg!" \
+            && (i == 1 || substr(text, i - 1, 1) !~ /[[:alnum:]_]/)) {
           return 1
         }
       }

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -116,9 +116,64 @@ DEBUG_CODE=$(grep --null -rn "${EXCLUDE_ARGS[@]}" \
 if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
   TARGET_RUNTIME_SRC="${TARGET_DIR%/}/vibeguard-runtime/src/"
   DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | TARGET_RUNTIME_SRC="$TARGET_RUNTIME_SRC" awk '
-    function has_dbg_macro(text, i, ch, in_string, escaped) {
+    function repeat_hashes(count, result, position) {
+      result = ""
+      for (position = 0; position < count; position++) {
+        result = result "#"
+      }
+      return result
+    }
+    function raw_string_hashes(text, start, prefix_length, position, count) {
+      prefix_length = 0
+      if (substr(text, start, 1) == "r") {
+        prefix_length = 1
+      } else if (substr(text, start, 2) ~ /^(br|cr)$/) {
+        prefix_length = 2
+      } else {
+        return -1
+      }
+      if (start > 1 && substr(text, start - 1, 1) ~ /[[:alnum:]_]/) {
+        return -1
+      }
+      position = start + prefix_length
+      count = 0
+      while (substr(text, position, 1) == "#") {
+        count++
+        position++
+      }
+      if (substr(text, position, 1) != "\"") {
+        return -1
+      }
+      return count
+    }
+    function char_literal_end(text, start, position, ch, escaped) {
+      ch = substr(text, start + 1, 1)
+      if (ch ~ /[[:alpha:]_]/ && substr(text, start + 2, 1) != "\047") {
+        return 0
+      }
+      escaped = 0
+      for (position = start + 1; position <= length(text); position++) {
+        ch = substr(text, position, 1)
+        if (escaped) {
+          escaped = 0
+        } else if (ch == "\\") {
+          escaped = 1
+        } else if (ch == "\047") {
+          return position
+        }
+      }
+      return 0
+    }
+    function has_dbg_macro(text, i, ch, in_string, escaped, raw_hashes, raw_prefix_length, raw_quote, raw_close, char_end) {
       for (i = 1; i <= length(text); i++) {
         ch = substr(text, i, 1)
+        if (raw_close != "") {
+          if (substr(text, i, length(raw_close)) == raw_close) {
+            i += length(raw_close) - 1
+            raw_close = ""
+          }
+          continue
+        }
         if (in_string) {
           if (escaped) {
             escaped = 0
@@ -132,7 +187,18 @@ if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
         if (substr(text, i, 2) == "//") {
           return 0
         }
-        if (ch == "\"") {
+        raw_hashes = raw_string_hashes(text, i)
+        if (raw_hashes >= 0) {
+          raw_prefix_length = substr(text, i, 1) == "r" ? 1 : 2
+          raw_quote = i + raw_prefix_length + raw_hashes
+          raw_close = "\"" repeat_hashes(raw_hashes)
+          i = raw_quote
+        } else if (ch == "\047") {
+          char_end = char_literal_end(text, i)
+          if (char_end > 0) {
+            i = char_end
+          }
+        } else if (ch == "\"") {
           in_string = 1
         } else if (substr(text, i, 4) == "dbg!" \
             && (i == 1 || substr(text, i - 1, 1) !~ /[[:alnum:]_]/)) {

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -115,11 +115,12 @@ DEBUG_CODE=$(grep -rn "${EXCLUDE_ARGS[@]}" \
   2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || true
 if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
   TARGET_RUNTIME_SRC="${TARGET_DIR%/}/vibeguard-runtime/src/"
-  DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | awk -v prefix="$TARGET_RUNTIME_SRC" '
+  DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | TARGET_RUNTIME_SRC="$TARGET_RUNTIME_SRC" awk '
+    BEGIN { prefix = ENVIRON["TARGET_RUNTIME_SRC"] }
     index($0, prefix) == 1 {
       matched = substr($0, length(prefix) + 1)
-      sub(/^[^:]*:[0-9]+:/, "", matched)
-      if (matched ~ /^[[:space:]]*println!\(/) {
+      sub(/^.*\.rs:[0-9]+:/, "", matched)
+      if (matched ~ /^[[:space:]]*println!\(/ && matched !~ /dbg!\(/) {
         next
       }
     }

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -109,23 +109,59 @@ fi
 
 # 2. Legacy debugging code
 echo "Check legacy debugging code..."
-DEBUG_CODE=$(grep -rn "${EXCLUDE_ARGS[@]}" \
+DEBUG_CODE=$(grep --null -rn "${EXCLUDE_ARGS[@]}" \
   -E '^\s*(console\.(log|debug|info)\(|print\(|println!\(|dbg!\(|puts |p |pp )' \
   "$TARGET_DIR" --include='*.py' --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' --include='*.rs' --include='*.rb' --include='*.go' \
-  2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || true
+  2>/dev/null | tr '\000' '\034' | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || true
 if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
   TARGET_RUNTIME_SRC="${TARGET_DIR%/}/vibeguard-runtime/src/"
   DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | TARGET_RUNTIME_SRC="$TARGET_RUNTIME_SRC" awk '
-    BEGIN { prefix = ENVIRON["TARGET_RUNTIME_SRC"] }
-    index($0, prefix) == 1 {
-      matched = substr($0, length(prefix) + 1)
-      sub(/^.*\.rs:[0-9]+:/, "", matched)
-      if (matched ~ /^[[:space:]]*println!\(/ && matched !~ /dbg!\(/) {
+    function has_dbg_macro(text, i, ch, in_string, in_char, escaped) {
+      for (i = 1; i <= length(text); i++) {
+        ch = substr(text, i, 1)
+        if (in_string || in_char) {
+          if (escaped) {
+            escaped = 0
+          } else if (ch == "\\") {
+            escaped = 1
+          } else if ((in_string && ch == "\"") || (in_char && ch == "\047")) {
+            in_string = 0
+            in_char = 0
+          }
+          continue
+        }
+        if (substr(text, i, 2) == "//") {
+          return 0
+        }
+        if (ch == "\"") {
+          in_string = 1
+        } else if (ch == "\047") {
+          in_char = 1
+        } else if (substr(text, i, 5) == "dbg!(") {
+          return 1
+        }
+      }
+      return 0
+    }
+    BEGIN {
+      prefix = ENVIRON["TARGET_RUNTIME_SRC"]
+      separator = sprintf("%c", 28)
+    }
+    {
+      separator_index = index($0, separator)
+      finding_path = substr($0, 1, separator_index - 1)
+      matched = substr($0, separator_index + 1)
+      sub(/^[0-9]+:/, "", matched)
+      if (separator_index > 0 && index(finding_path, prefix) == 1 \
+          && matched ~ /^[[:space:]]*println!\(/ && !has_dbg_macro(matched)) {
         next
       }
     }
     { print }
   ')
+fi
+if [[ -n "$DEBUG_CODE" ]]; then
+  DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | tr '\034' ':')
 fi
 if [[ -n "$DEBUG_CODE" ]]; then
   COUNT=$(echo "$DEBUG_CODE" | wc -l | tr -d ' ')

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -164,7 +164,7 @@ if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
       }
       return 0
     }
-    function has_dbg_macro(text, i, ch, in_string, escaped, raw_hashes, raw_prefix_length, raw_quote, raw_close, char_end) {
+    function has_dbg_macro(text, i, ch, in_string, escaped, raw_hashes, raw_prefix_length, raw_quote, raw_close, char_end, block_depth) {
       for (i = 1; i <= length(text); i++) {
         ch = substr(text, i, 1)
         if (raw_close != "") {
@@ -184,8 +184,23 @@ if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
           }
           continue
         }
+        if (block_depth > 0) {
+          if (substr(text, i, 2) == "/*") {
+            block_depth++
+            i++
+          } else if (substr(text, i, 2) == "*/") {
+            block_depth--
+            i++
+          }
+          continue
+        }
         if (substr(text, i, 2) == "//") {
           return 0
+        }
+        if (substr(text, i, 2) == "/*") {
+          block_depth = 1
+          i++
+          continue
         }
         raw_hashes = raw_string_hashes(text, i)
         if (raw_hashes >= 0) {

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -115,7 +115,7 @@ DEBUG_CODE=$(grep --null -rn "${EXCLUDE_ARGS[@]}" \
   2>/dev/null | tr '\000' '\034' | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || true
 if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
   TARGET_RUNTIME_SRC="${TARGET_DIR%/}/vibeguard-runtime/src/"
-  DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | TARGET_RUNTIME_SRC="$TARGET_RUNTIME_SRC" awk '
+  DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | LC_ALL=C TARGET_RUNTIME_SRC="$TARGET_RUNTIME_SRC" awk '
     function repeat_hashes(count, result, position) {
       result = ""
       for (position = 0; position < count; position++) {
@@ -164,63 +164,83 @@ if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
       }
       return 0
     }
-    function has_dbg_macro(text, i, ch, in_string, escaped, raw_hashes, raw_prefix_length, raw_quote, raw_close, char_end, block_depth) {
-      for (i = 1; i <= length(text); i++) {
-        ch = substr(text, i, 1)
-        if (raw_close != "") {
-          if (substr(text, i, length(raw_close)) == raw_close) {
-            i += length(raw_close) - 1
-            raw_close = ""
+    function scan_rust_file(path, text, line_number, read_status, i, ch, in_string, escaped, raw_hashes, raw_prefix_length, raw_quote, raw_close, char_end, block_depth, key) {
+      line_number = 0
+      while ((read_status = (getline text < path)) > 0) {
+        line_number++
+        escaped = 0
+        for (i = 1; i <= length(text); i++) {
+          ch = substr(text, i, 1)
+          if (raw_close != "") {
+            if (substr(text, i, length(raw_close)) == raw_close) {
+              i += length(raw_close) - 1
+              raw_close = ""
+            }
+            continue
           }
-          continue
-        }
-        if (in_string) {
-          if (escaped) {
-            escaped = 0
-          } else if (ch == "\\") {
-            escaped = 1
-          } else if (ch == "\"") {
-            in_string = 0
+          if (in_string) {
+            if (escaped) {
+              escaped = 0
+            } else if (ch == "\\") {
+              escaped = 1
+            } else if (ch == "\"") {
+              in_string = 0
+            }
+            continue
           }
-          continue
-        }
-        if (block_depth > 0) {
+          if (block_depth > 0) {
+            if (substr(text, i, 2) == "/*") {
+              block_depth++
+              i++
+            } else if (substr(text, i, 2) == "*/") {
+              block_depth--
+              i++
+            }
+            continue
+          }
+          if (substr(text, i, 2) == "//") {
+            break
+          }
           if (substr(text, i, 2) == "/*") {
-            block_depth++
+            block_depth = 1
             i++
-          } else if (substr(text, i, 2) == "*/") {
-            block_depth--
-            i++
+            continue
           }
-          continue
-        }
-        if (substr(text, i, 2) == "//") {
-          return 0
-        }
-        if (substr(text, i, 2) == "/*") {
-          block_depth = 1
-          i++
-          continue
-        }
-        raw_hashes = raw_string_hashes(text, i)
-        if (raw_hashes >= 0) {
-          raw_prefix_length = substr(text, i, 1) == "r" ? 1 : 2
-          raw_quote = i + raw_prefix_length + raw_hashes
-          raw_close = "\"" repeat_hashes(raw_hashes)
-          i = raw_quote
-        } else if (ch == "\047") {
-          char_end = char_literal_end(text, i)
-          if (char_end > 0) {
-            i = char_end
+          raw_hashes = raw_string_hashes(text, i)
+          if (raw_hashes >= 0) {
+            raw_prefix_length = substr(text, i, 1) == "r" ? 1 : 2
+            raw_quote = i + raw_prefix_length + raw_hashes
+            raw_close = "\"" repeat_hashes(raw_hashes)
+            i = raw_quote
+          } else if (ch == "\047") {
+            char_end = char_literal_end(text, i)
+            if (char_end > 0) {
+              i = char_end
+            }
+          } else if (ch == "\"") {
+            in_string = 1
+          } else if (substr(text, i, 4) == "dbg!" \
+              && (i == 1 || substr(text, i - 1, 1) !~ /[[:alnum:]_]/)) {
+            key = path SUBSEP line_number
+            dbg_lines[key] = 1
           }
-        } else if (ch == "\"") {
-          in_string = 1
-        } else if (substr(text, i, 4) == "dbg!" \
-            && (i == 1 || substr(text, i - 1, 1) !~ /[[:alnum:]_]/)) {
-          return 1
         }
       }
-      return 0
+      close(path)
+      scanned[path] = 1
+      if (read_status < 0) {
+        scan_failed[path] = 1
+      }
+    }
+    function file_line_has_dbg(path, line_number, key) {
+      if (!(path in scanned)) {
+        scan_rust_file(path)
+      }
+      if (path in scan_failed) {
+        return 1
+      }
+      key = path SUBSEP line_number
+      return key in dbg_lines
     }
     BEGIN {
       prefix = ENVIRON["TARGET_RUNTIME_SRC"]
@@ -230,9 +250,12 @@ if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
       separator_index = index($0, separator)
       finding_path = substr($0, 1, separator_index - 1)
       matched = substr($0, separator_index + 1)
+      line_number = matched
+      sub(/:.*/, "", line_number)
       sub(/^[0-9]+:/, "", matched)
       if (separator_index > 0 && index(finding_path, prefix) == 1 \
-          && matched ~ /^[[:space:]]*println!\(/ && !has_dbg_macro(matched)) {
+          && matched ~ /^[[:space:]]*println!\(/ \
+          && !file_line_has_dbg(finding_path, line_number + 0)) {
         next
       }
     }

--- a/guards/universal/check_code_slop.sh
+++ b/guards/universal/check_code_slop.sh
@@ -38,6 +38,7 @@ EOF
 
 INCLUDE_FIXTURES=false
 STRICT_REPO=false
+VIBEGUARD_SELF_SCAN=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --include-fixtures)
@@ -80,6 +81,7 @@ fi
 # test data, workflow YAML with shell snippets).  Use --strict-repo to disable.
 if [[ "$STRICT_REPO" != true ]] && [[ -f "${TARGET_DIR%/}/.vibeguard-doc-paths-allowlist" ]] \
   && [[ -d "${TARGET_DIR%/}/guards" ]] && [[ -d "${TARGET_DIR%/}/hooks" ]]; then
+  VIBEGUARD_SELF_SCAN=true
   EXCLUDE_DIRS+=(workflows data scripts eval)
 fi
 
@@ -111,6 +113,19 @@ DEBUG_CODE=$(grep -rn "${EXCLUDE_ARGS[@]}" \
   -E '^\s*(console\.(log|debug|info)\(|print\(|println!\(|dbg!\(|puts |p |pp )' \
   "$TARGET_DIR" --include='*.py' --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' --include='*.rs' --include='*.rb' --include='*.go' \
   2>/dev/null | grep -v '// keep' | grep -v '# keep' | grep -v 'logger\.') || true
+if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEBUG_CODE" ]]; then
+  TARGET_RUNTIME_SRC="${TARGET_DIR%/}/vibeguard-runtime/src/"
+  DEBUG_CODE=$(printf '%s\n' "$DEBUG_CODE" | awk -v prefix="$TARGET_RUNTIME_SRC" '
+    index($0, prefix) == 1 {
+      matched = substr($0, length(prefix) + 1)
+      sub(/^[^:]*:[0-9]+:/, "", matched)
+      if (matched ~ /^[[:space:]]*println!\(/) {
+        next
+      }
+    }
+    { print }
+  ')
+fi
 if [[ -n "$DEBUG_CODE" ]]; then
   COUNT=$(echo "$DEBUG_CODE" | wc -l | tr -d ' ')
   yellow "Legacy debug code: ${COUNT}"
@@ -159,6 +174,17 @@ DEAD_CODE=$(grep -rn "${EXCLUDE_ARGS[@]}" \
   -E '(unreachable!|todo!|unimplemented!|#\[allow\(dead_code\)\]|// @ts-ignore|# type: ignore|# noqa)' \
   "$TARGET_DIR" --include='*.py' --include='*.ts' --include='*.js' --include='*.rs' \
   2>/dev/null || true)
+if [[ "$VIBEGUARD_SELF_SCAN" == true && -n "$DEAD_CODE" ]]; then
+  DEAD_CODE=$(printf '%s\n' "$DEAD_CODE" | awk '
+    {
+      matched = $0
+      sub(/^[^:]*:[0-9]+:/, "", matched)
+      if (matched !~ /\/\/[[:space:]]*slop-pattern-source([[:space:]]|$)/) {
+        print
+      }
+    }
+  ')
+fi
 if [[ -n "$DEAD_CODE" ]]; then
   COUNT=$(echo "$DEAD_CODE" | wc -l | tr -d ' ')
   yellow "Dead code/suppression flag: ${COUNT}"

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -156,10 +156,10 @@ cat > "${proj_self_scan}/vibeguard-runtime/src/main.rs" <<'EOF'
 fn main() {
     println!("cli product output");
     dbg!("runtime diagnostic");
-    println!("cli output"); dbg!("same-line diagnostic");
-    println!("{}", dbg!("nested diagnostic"));
+    println!("cli output"); dbg!("same-line diagnostic"); println!("{}", dbg!("nested diagnostic"));
     println!("dbg!( is product text, not a macro");
     dbg!("trace.rs:12: println!(\"x\")");
+    println!("cli output"); let value: &'static str = dbg!("lifetime diagnostic"); dbg! ("spaced diagnostic");
 }
 EOF
 cat > "${proj_self_scan}/vibeguard-runtime/src/hook_checks_common.rs" <<'EOF'
@@ -168,11 +168,6 @@ const DETECTOR_PATTERN: &str = "todo!("; // slop-pattern-source
 const ADJACENT_PATTERN: &str = "unimplemented!(";
 fn unfinished() {
     todo!();
-}
-EOF
-cat > "${proj_self_scan}/other/cli.rs" <<'EOF'
-fn probe() {
-    println!("outside runtime output");
 }
 EOF
 cat > "${proj_self_scan}/other/client.ts" <<'EOF'
@@ -186,6 +181,8 @@ assert_output_contains "self-scan retains dbg after same-line println" 'dbg!("sa
 assert_output_contains "self-scan retains dbg nested in println" 'dbg!("nested diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan ignores dbg text inside println string" 'dbg!( is product text' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains leading dbg containing line-like text" 'trace.rs:12: println!' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains dbg after Rust lifetime" 'dbg!("lifetime diagnostic")' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains dbg with spaced delimiter" 'dbg! ("spaced diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan suppresses same-line detector marker" 'const DETECTOR_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "adjacent marker does not suppress dead-code finding" 'const ADJACENT_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "unmarked real stub remains visible" 'todo!();' bash "$GUARD" "$proj_self_scan"

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -222,6 +222,16 @@ make_runtime_self_scan_project "$proj_raw_dbg"
 printf '%s\n' '    println!(r#"quote " inside"#); dbg!(value);' > "${proj_raw_dbg}/vibeguard-runtime/src/main.rs"
 assert_output_contains "self-scan retains dbg after Rust raw string" 'dbg!(value)' bash "$GUARD" "$proj_raw_dbg"
 
+proj_block_comment_dbg="${tmpdir}/self_scan_block_comment_dbg"
+make_runtime_self_scan_project "$proj_block_comment_dbg"
+printf '%s\n' '    println!("out"); /* " */ dbg!(value);' > "${proj_block_comment_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg after Rust block comment" 'dbg!(value)' bash "$GUARD" "$proj_block_comment_dbg"
+
+proj_commented_dbg="${tmpdir}/self_scan_commented_dbg"
+make_runtime_self_scan_project "$proj_commented_dbg"
+printf '%s\n' '    println!("out"); /* dbg!(commented) */' > "${proj_commented_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_not_contains "self-scan ignores dbg inside Rust block comment" 'dbg!(commented)' bash "$GUARD" "$proj_commented_dbg"
+
 # Keep the outside-runtime assertion isolated from the guard's five-line
 # display cap so additional retained runtime diagnostics cannot mask it.
 proj_outside_debug="${tmpdir}/outside_runtime_debug"

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -232,6 +232,16 @@ make_runtime_self_scan_project "$proj_commented_dbg"
 printf '%s\n' '    println!("out"); /* dbg!(commented) */' > "${proj_commented_dbg}/vibeguard-runtime/src/main.rs"
 assert_output_not_contains "self-scan ignores dbg inside Rust block comment" 'dbg!(commented)' bash "$GUARD" "$proj_commented_dbg"
 
+proj_multiline_comment_dbg="${tmpdir}/self_scan_multiline_comment_dbg"
+make_runtime_self_scan_project "$proj_multiline_comment_dbg"
+printf '%s\n' '/*' '    println!("commented"); " */ dbg!(value);' > "${proj_multiline_comment_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg after multiline Rust block comment" 'dbg!(value)' bash "$GUARD" "$proj_multiline_comment_dbg"
+
+proj_multiline_commented_dbg="${tmpdir}/self_scan_multiline_commented_dbg"
+make_runtime_self_scan_project "$proj_multiline_commented_dbg"
+printf '%s\n' '/*' '    println!("commented"); dbg!(commented);' '*/' > "${proj_multiline_commented_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_not_contains "self-scan ignores dbg inside multiline Rust block comment" 'dbg!(commented)' bash "$GUARD" "$proj_multiline_commented_dbg"
+
 # Keep the outside-runtime assertion isolated from the guard's five-line
 # display cap so additional retained runtime diagnostics cannot mask it.
 proj_outside_debug="${tmpdir}/outside_runtime_debug"

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -29,6 +29,16 @@ assert_output_contains() {
   else red "$desc (missing: $expected)"; FAIL=$((FAIL+1)); fi
 }
 
+assert_output_not_contains() {
+  local desc="$1" unexpected="$2"; shift 2; TOTAL=$((TOTAL+1))
+  local out; out=$("$@" 2>&1 || true)
+  if printf '%s\n' "$out" | grep -qF "$unexpected"; then
+    red "$desc (unexpected: $unexpected)"; FAIL=$((FAIL+1))
+  else
+    green "$desc"; PASS=$((PASS+1))
+  fi
+}
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -133,6 +143,64 @@ EOF
 assert_ok "tests/fixtures debug code is ignored by default" bash "$GUARD" "$proj_fixtures"
 assert_fail "tests/fixtures debug code is scanned with --include-fixtures" bash "$GUARD" --include-fixtures "$proj_fixtures"
 assert_fail "tests/fixtures debug code is scanned with --strict-repo" bash "$GUARD" --strict-repo "$proj_fixtures"
+
+# --- VibeGuard self-scan precision: repo-local, category-local, line-scoped ---
+proj_self_scan="${tmpdir}/vibeguard_self_scan"
+mkdir -p \
+  "${proj_self_scan}/guards" \
+  "${proj_self_scan}/hooks" \
+  "${proj_self_scan}/vibeguard-runtime/src" \
+  "${proj_self_scan}/other"
+: > "${proj_self_scan}/.vibeguard-doc-paths-allowlist"
+cat > "${proj_self_scan}/vibeguard-runtime/src/main.rs" <<'EOF'
+fn main() {
+    println!("cli product output");
+    dbg!("runtime diagnostic");
+}
+EOF
+cat > "${proj_self_scan}/vibeguard-runtime/src/hook_checks_common.rs" <<'EOF'
+const DETECTOR_PATTERN: &str = "todo!("; // slop-pattern-source
+// slop-pattern-source
+const ADJACENT_PATTERN: &str = "unimplemented!(";
+fn unfinished() {
+    todo!();
+}
+EOF
+cat > "${proj_self_scan}/other/cli.rs" <<'EOF'
+fn probe() {
+    println!("outside runtime output");
+}
+EOF
+cat > "${proj_self_scan}/other/client.ts" <<'EOF'
+console.log("other category remains visible"); // slop-pattern-source
+EOF
+
+assert_fail "self-scan retains unsuppressed findings" bash "$GUARD" "$proj_self_scan"
+assert_output_not_contains "self-scan suppresses runtime CLI println" 'println!("cli product output")' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains runtime dbg" 'dbg!("runtime diagnostic")' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains println outside runtime src" 'println!("outside runtime output")' bash "$GUARD" "$proj_self_scan"
+assert_output_not_contains "self-scan suppresses same-line detector marker" 'const DETECTOR_PATTERN' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "adjacent marker does not suppress dead-code finding" 'const ADJACENT_PATTERN' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "unmarked real stub remains visible" 'todo!();' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "marker does not suppress another category" 'console.log("other category remains visible")' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "strict self-scan restores runtime println" 'println!("cli product output")' bash "$GUARD" --strict-repo "$proj_self_scan"
+assert_output_contains "strict self-scan restores marked detector line" 'const DETECTOR_PATTERN' bash "$GUARD" --strict-repo "$proj_self_scan"
+
+# A target with only two self-scan markers is an ordinary repo.  Neither the
+# runtime path nor marker text is a general-purpose suppression contract.
+proj_partial_marker="${tmpdir}/partial_self_markers"
+mkdir -p \
+  "${proj_partial_marker}/guards" \
+  "${proj_partial_marker}/hooks" \
+  "${proj_partial_marker}/vibeguard-runtime/src"
+cat > "${proj_partial_marker}/vibeguard-runtime/src/main.rs" <<'EOF'
+fn main() {
+    println!("ordinary repo output");
+}
+const PATTERN: &str = "todo!("; // slop-pattern-source
+EOF
+assert_output_contains "partial-marker repo retains runtime println" 'println!("ordinary repo output")' bash "$GUARD" "$proj_partial_marker"
+assert_output_contains "partial-marker repo retains marked dead-code line" 'const PATTERN' bash "$GUARD" "$proj_partial_marker"
 
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -156,6 +156,8 @@ cat > "${proj_self_scan}/vibeguard-runtime/src/main.rs" <<'EOF'
 fn main() {
     println!("cli product output");
     dbg!("runtime diagnostic");
+    println!("cli output"); dbg!("same-line diagnostic");
+    println!("{}", dbg!("nested diagnostic"));
 }
 EOF
 cat > "${proj_self_scan}/vibeguard-runtime/src/hook_checks_common.rs" <<'EOF'
@@ -178,6 +180,8 @@ EOF
 assert_fail "self-scan retains unsuppressed findings" bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan suppresses runtime CLI println" 'println!("cli product output")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains runtime dbg" 'dbg!("runtime diagnostic")' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains dbg after same-line println" 'dbg!("same-line diagnostic")' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains dbg nested in println" 'dbg!("nested diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains println outside runtime src" 'println!("outside runtime output")' bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan suppresses same-line detector marker" 'const DETECTOR_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "adjacent marker does not suppress dead-code finding" 'const ADJACENT_PATTERN' bash "$GUARD" "$proj_self_scan"
@@ -201,6 +205,20 @@ const PATTERN: &str = "todo!("; // slop-pattern-source
 EOF
 assert_output_contains "partial-marker repo retains runtime println" 'println!("ordinary repo output")' bash "$GUARD" "$proj_partial_marker"
 assert_output_contains "partial-marker repo retains marked dead-code line" 'const PATTERN' bash "$GUARD" "$proj_partial_marker"
+
+# Grep renders findings as path:line:content.  Qualified self-scan filtering
+# must preserve literal path characters instead of interpreting them as awk
+# escapes or treating a colon in a Rust filename as the line delimiter.
+proj_escaped_path="${tmpdir}/vibeguard\\self_scan"
+mkdir -p \
+  "${proj_escaped_path}/guards" \
+  "${proj_escaped_path}/hooks" \
+  "${proj_escaped_path}/vibeguard-runtime/src"
+: > "${proj_escaped_path}/.vibeguard-doc-paths-allowlist"
+cat > "${proj_escaped_path}/vibeguard-runtime/src/cli:main.rs" <<'EOF'
+fn main() { println!("escaped path product output"); }
+EOF
+assert_ok "self-scan handles backslash target and colon Rust filename" bash "$GUARD" "$proj_escaped_path"
 
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' "$TOTAL" "$PASS" "$FAIL"

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -156,10 +156,9 @@ cat > "${proj_self_scan}/vibeguard-runtime/src/main.rs" <<'EOF'
 fn main() {
     println!("cli product output");
     dbg!("runtime diagnostic");
-    println!("cli output"); dbg!("same-line diagnostic"); println!("{}", dbg!("nested diagnostic"));
+    println!("cli output"); dbg!("same-line diagnostic");
     println!("dbg!( is product text, not a macro");
     dbg!("trace.rs:12: println!(\"x\")");
-    println!("cli output"); let value: &'static str = dbg!("lifetime diagnostic"); dbg! ("spaced diagnostic");
 }
 EOF
 cat > "${proj_self_scan}/vibeguard-runtime/src/hook_checks_common.rs" <<'EOF'
@@ -178,17 +177,50 @@ assert_fail "self-scan retains unsuppressed findings" bash "$GUARD" "$proj_self_
 assert_output_not_contains "self-scan suppresses runtime CLI println" 'println!("cli product output")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains runtime dbg" 'dbg!("runtime diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains dbg after same-line println" 'dbg!("same-line diagnostic")' bash "$GUARD" "$proj_self_scan"
-assert_output_contains "self-scan retains dbg nested in println" 'dbg!("nested diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan ignores dbg text inside println string" 'dbg!( is product text' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains leading dbg containing line-like text" 'trace.rs:12: println!' bash "$GUARD" "$proj_self_scan"
-assert_output_contains "self-scan retains dbg after Rust lifetime" 'dbg!("lifetime diagnostic")' bash "$GUARD" "$proj_self_scan"
-assert_output_contains "self-scan retains dbg with spaced delimiter" 'dbg! ("spaced diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan suppresses same-line detector marker" 'const DETECTOR_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "adjacent marker does not suppress dead-code finding" 'const ADJACENT_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "unmarked real stub remains visible" 'todo!();' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "marker does not suppress another category" 'console.log("other category remains visible")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "strict self-scan restores runtime println" 'println!("cli product output")' bash "$GUARD" --strict-repo "$proj_self_scan"
 assert_output_contains "strict self-scan restores marked detector line" 'const DETECTOR_PATTERN' bash "$GUARD" --strict-repo "$proj_self_scan"
+
+# Keep lexer edge cases in separate projects so each assertion proves its own
+# finding instead of inheriting visibility from another dbg! on the same line.
+make_runtime_self_scan_project() {
+  local project_dir="$1"
+  mkdir -p \
+    "${project_dir}/guards" \
+    "${project_dir}/hooks" \
+    "${project_dir}/vibeguard-runtime/src"
+  : > "${project_dir}/.vibeguard-doc-paths-allowlist"
+}
+
+proj_nested_dbg="${tmpdir}/self_scan_nested_dbg"
+make_runtime_self_scan_project "$proj_nested_dbg"
+printf '%s\n' '    println!("{}", dbg!("nested diagnostic"));' > "${proj_nested_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg nested in println" 'dbg!("nested diagnostic")' bash "$GUARD" "$proj_nested_dbg"
+
+proj_lifetime_dbg="${tmpdir}/self_scan_lifetime_dbg"
+make_runtime_self_scan_project "$proj_lifetime_dbg"
+printf '%s\n' "    println!(\"cli output\"); let value: &'static str = dbg!(\"lifetime diagnostic\");" > "${proj_lifetime_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg after Rust lifetime" 'dbg!("lifetime diagnostic")' bash "$GUARD" "$proj_lifetime_dbg"
+
+proj_spaced_dbg="${tmpdir}/self_scan_spaced_dbg"
+make_runtime_self_scan_project "$proj_spaced_dbg"
+printf '%s\n' '    println!("cli output"); dbg! ("spaced diagnostic");' > "${proj_spaced_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg with spaced delimiter" 'dbg! ("spaced diagnostic")' bash "$GUARD" "$proj_spaced_dbg"
+
+proj_char_dbg="${tmpdir}/self_scan_char_dbg"
+make_runtime_self_scan_project "$proj_char_dbg"
+printf '%s\n' '    println!("out"); let quote = '\''"'\''; dbg!(quote);' > "${proj_char_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg after Rust char literal" 'dbg!(quote)' bash "$GUARD" "$proj_char_dbg"
+
+proj_raw_dbg="${tmpdir}/self_scan_raw_dbg"
+make_runtime_self_scan_project "$proj_raw_dbg"
+printf '%s\n' '    println!(r#"quote " inside"#); dbg!(value);' > "${proj_raw_dbg}/vibeguard-runtime/src/main.rs"
+assert_output_contains "self-scan retains dbg after Rust raw string" 'dbg!(value)' bash "$GUARD" "$proj_raw_dbg"
 
 # Keep the outside-runtime assertion isolated from the guard's five-line
 # display cap so additional retained runtime diagnostics cannot mask it.

--- a/tests/unit/test_universal_check_code_slop.sh
+++ b/tests/unit/test_universal_check_code_slop.sh
@@ -158,6 +158,8 @@ fn main() {
     dbg!("runtime diagnostic");
     println!("cli output"); dbg!("same-line diagnostic");
     println!("{}", dbg!("nested diagnostic"));
+    println!("dbg!( is product text, not a macro");
+    dbg!("trace.rs:12: println!(\"x\")");
 }
 EOF
 cat > "${proj_self_scan}/vibeguard-runtime/src/hook_checks_common.rs" <<'EOF'
@@ -182,13 +184,27 @@ assert_output_not_contains "self-scan suppresses runtime CLI println" 'println!(
 assert_output_contains "self-scan retains runtime dbg" 'dbg!("runtime diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains dbg after same-line println" 'dbg!("same-line diagnostic")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "self-scan retains dbg nested in println" 'dbg!("nested diagnostic")' bash "$GUARD" "$proj_self_scan"
-assert_output_contains "self-scan retains println outside runtime src" 'println!("outside runtime output")' bash "$GUARD" "$proj_self_scan"
+assert_output_not_contains "self-scan ignores dbg text inside println string" 'dbg!( is product text' bash "$GUARD" "$proj_self_scan"
+assert_output_contains "self-scan retains leading dbg containing line-like text" 'trace.rs:12: println!' bash "$GUARD" "$proj_self_scan"
 assert_output_not_contains "self-scan suppresses same-line detector marker" 'const DETECTOR_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "adjacent marker does not suppress dead-code finding" 'const ADJACENT_PATTERN' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "unmarked real stub remains visible" 'todo!();' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "marker does not suppress another category" 'console.log("other category remains visible")' bash "$GUARD" "$proj_self_scan"
 assert_output_contains "strict self-scan restores runtime println" 'println!("cli product output")' bash "$GUARD" --strict-repo "$proj_self_scan"
 assert_output_contains "strict self-scan restores marked detector line" 'const DETECTOR_PATTERN' bash "$GUARD" --strict-repo "$proj_self_scan"
+
+# Keep the outside-runtime assertion isolated from the guard's five-line
+# display cap so additional retained runtime diagnostics cannot mask it.
+proj_outside_debug="${tmpdir}/outside_runtime_debug"
+mkdir -p \
+  "${proj_outside_debug}/guards" \
+  "${proj_outside_debug}/hooks" \
+  "${proj_outside_debug}/vibeguard-runtime/src" \
+  "${proj_outside_debug}/other"
+: > "${proj_outside_debug}/.vibeguard-doc-paths-allowlist"
+printf '%s\n' '    println!("inside product output");' > "${proj_outside_debug}/vibeguard-runtime/src/main.rs"
+printf '%s\n' '    println!("outside runtime output");' > "${proj_outside_debug}/other/main.rs"
+assert_output_contains "self-scan retains println outside runtime src" 'println!("outside runtime output")' bash "$GUARD" "$proj_outside_debug"
 
 # A target with only two self-scan markers is an ordinary repo.  Neither the
 # runtime path nor marker text is a general-purpose suppression contract.
@@ -216,7 +232,9 @@ mkdir -p \
   "${proj_escaped_path}/vibeguard-runtime/src"
 : > "${proj_escaped_path}/.vibeguard-doc-paths-allowlist"
 cat > "${proj_escaped_path}/vibeguard-runtime/src/cli:main.rs" <<'EOF'
-fn main() { println!("escaped path product output"); }
+fn main() {
+    println!("escaped path product output");
+}
 EOF
 assert_ok "self-scan handles backslash target and colon Rust filename" bash "$GUARD" "$proj_escaped_path"
 

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -159,8 +159,8 @@ pub(crate) fn is_clean_rust_fast_path(
         || has_let_underscore_assign(new_string)
         || new_string.contains(".db\"")
         || new_string.contains(".sqlite\"")
-        || new_string.contains("todo!(")
-        || new_string.contains("unimplemented!(")
+        || new_string.contains("todo!(") // slop-pattern-source
+        || new_string.contains("unimplemented!(") // slop-pattern-source
         || new_string.contains("panic!(\"not implemented")
     {
         return false;
@@ -187,8 +187,8 @@ pub(crate) fn is_clean_rust_write_fast_path(
     if count_lines(content) > base_limit {
         return false;
     }
-    if content.contains("todo!(")
-        || content.contains("unimplemented!(")
+    if content.contains("todo!(") // slop-pattern-source
+        || content.contains("unimplemented!(") // slop-pattern-source
         || content.contains("panic!(\"not implemented")
     {
         return false;
@@ -714,7 +714,7 @@ mod tests {
         ));
         assert!(!is_clean_rust_write_fast_path(
             "src/lib.rs",
-            "todo!()\n",
+            "todo!()\n", // slop-pattern-source
             800
         ));
         assert!(!is_clean_rust_write_fast_path(

--- a/vibeguard-runtime/src/hook_checks_write.rs
+++ b/vibeguard-runtime/src/hook_checks_write.rs
@@ -186,19 +186,19 @@ pub(crate) fn evaluate_post_write(
 fn stub_warning(file_path: &str, content: &str) -> Option<String> {
     let (patterns, lang_desc) = match extension(file_path).as_str() {
         "rs" => {
-            if !(content.contains("todo!(")
-                || content.contains("unimplemented!(")
+            if !(content.contains("todo!(") // slop-pattern-source
+                || content.contains("unimplemented!(") // slop-pattern-source
                 || content.contains("panic!(\"not implemented"))
             {
                 return None;
             }
             (
                 &[
-                    r"^\s*todo!\(",
-                    r"^\s*unimplemented!\(",
+                    r"^\s*todo!\(",          // slop-pattern-source
+                    r"^\s*unimplemented!\(", // slop-pattern-source
                     r#"^\s*panic!\("not implemented"#,
                 ][..],
-                "todo!/unimplemented!",
+                "todo!/unimplemented!", // slop-pattern-source
             )
         }
         "ts" | "tsx" | "js" | "jsx" => {

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
@@ -252,12 +252,12 @@ fn detect_stubs(file_path: &str, new_string: &str, warnings: &mut Vec<String>) {
     let (patterns, lang_desc) = match extension(file_path).as_str() {
         "rs" if has_any(
             new_string,
-            &["todo!(", "unimplemented!(", "panic!(\"not implemented"],
+            &["todo!(", "unimplemented!(", "panic!(\"not implemented"], // slop-pattern-source
         ) =>
         {
             (
-                vec![r#"^\s*(todo!\(|unimplemented!\(|panic!\("not implemented)"#],
-                "todo!/unimplemented!",
+                vec![r#"^\s*(todo!\(|unimplemented!\(|panic!\("not implemented)"#], // slop-pattern-source
+                "todo!/unimplemented!", // slop-pattern-source
             )
         }
         "ts" | "tsx" | "js" | "jsx"


### PR DESCRIPTION
## Summary

- reuse the existing VibeGuard self-scan qualification and keep `--strict-repo` as the opt-out
- suppress only `vibeguard-runtime/src/` `println!` findings in the legacy-debug category
- mark intentional detector literals line by line and suppress those markers only in the dead-code category
- add focused coverage for strict mode, partial markers, adjacent markers, file-aware Rust literal/comment `dbg!` retention, retained real stubs, and cross-category behavior

## Spec and gates

- Implements the merged packet in `docs/specs/GH589/` (spec PR #592)
- Covers B-001 through B-007 and SP589-T1 through SP589-T4
- Implementation and duplicate-work route gates were allowed; merge authorization remains a separate human gate

## Verification

- `bash -n guards/universal/check_code_slop.sh`
- `bash tests/unit/test_universal_check_code_slop.sh` (38/38)
- `bash scripts/ci/validate-guards.sh`
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash scripts/local-contract-check.sh --quick`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH589`
- `git diff --check`

Closes #589
