### PR TITLE
fix: add W-14 overlap cooldown

### DIFF
--- a/templates/vibeguard-config.README.md
+++ b/templates/vibeguard-config.README.md
@@ -23,6 +23,7 @@ weaken unrelated hook behavior.
 | `u16.limit` | `VG_U16_LIMIT` | `800` | Source-file line limit. Files over this trigger block on `Write`/`Edit` and warn after `PostToolUse`. Per-file `CLAUDE.md` exemptions (`U-16 exempt: \`pattern\` → N`) can raise it further per repo. |
 | `circuit_breaker.threshold` | `VG_CB_THRESHOLD` | `3` | Consecutive blocks before the hook circuit trips OPEN (silences batch advisories). |
 | `circuit_breaker.cooldown_seconds` | `VG_CB_COOLDOWN` | `300` | Seconds an OPEN circuit waits before HALF-OPEN. |
+| `w14.cooldown_seconds` | `VIBEGUARD_W14_COOLDOWN_SECONDS` | `3600` | Suppresses repeated W-14 reports for the same directed session pair and file; `0` disables suppression. |
 | `paralysis.threshold` | `VG_PARALYSIS_THRESHOLD` | `7` | W-13 read-only-action streak before paralysis warning. |
 | `write_mode` | `VIBEGUARD_WRITE_MODE` | `warn` | `warn` = advisory; `block` = hard reject new source files without prior search. |
 

--- a/templates/vibeguard-config.json.example
+++ b/templates/vibeguard-config.json.example
@@ -8,6 +8,9 @@
     "threshold": 3,
     "cooldown_seconds": 300
   },
+  "w14": {
+    "cooldown_seconds": 3600
+  },
   "paralysis": {
     "threshold": 7
   },

--- a/tests/hooks/test_post_edit_w14.sh
+++ b/tests/hooks/test_post_edit_w14.sh
@@ -16,6 +16,79 @@ _w14_project_hash=$(printf '%s' "$REPO_DIR" | shasum -a 256 2>/dev/null | cut -c
 _w14_log_file="$VIBEGUARD_LOG_DIR/projects/${_w14_project_hash}/events.jsonl"
 mkdir -p "$(dirname "$_w14_log_file")"
 
+_w14_timestamp_ago() {
+  python3 - "$1" <<'PY'
+from datetime import datetime, timedelta, timezone
+import sys
+
+seconds = int(sys.argv[1])
+print((datetime.now(timezone.utc) - timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+}
+
+_w14_key() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import hashlib
+import os
+import sys
+
+current, peer, path = sys.argv[1:]
+normalized = os.path.realpath(path)
+raw = f"{len(current)}:{current}{len(peer)}:{peer}{len(normalized)}:{normalized}"
+print(hashlib.sha256(raw.encode()).hexdigest())
+PY
+}
+
+_w14_seed_history() {
+  local target=$1
+  local peer=$2
+  local shown_key=${3:--}
+  local shown_age=${4:-0}
+  python3 - "$_w14_log_file" "$target" "$peer" "$shown_key" "$shown_age" <<'PY'
+from datetime import datetime, timedelta, timezone
+import json
+import sys
+
+log_file, target, peer, shown_key, shown_age = sys.argv[1:]
+now = datetime.now(timezone.utc)
+candidate = {
+    "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "hook": "post-write-guard",
+    "tool": "Write",
+    "decision": "pass",
+    "agent": "peer-agent",
+    "detail": target,
+}
+if peer != "__missing__":
+    candidate["session"] = peer
+events = [candidate]
+if shown_key != "-":
+    events.append({
+        "ts": (now - timedelta(seconds=int(shown_age))).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "session": "current-session",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "status": "warn",
+        "agent": "codex",
+        "reason": "[W-14] overlap shown session peer agent codex",
+        "detail": f"{target}||w14_key={shown_key}",
+    })
+with open(log_file, "w", encoding="utf-8") as handle:
+    for event in events:
+        handle.write(json.dumps(event, separators=(",", ":")) + "\n")
+PY
+}
+
+_w14_run() {
+  local target=$1
+  shift
+  printf '{"tool_input":{"file_path":"%s","new_string":"value = 9\\n"}}' "$target" \
+    | env VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" \
+      VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_AGENT_TYPE="codex" \
+      "$@" bash hooks/post-edit-guard.sh
+}
+
 cat > "$_w14_log_file" <<EOF
 {"ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","session":"other-session","hook":"post-write-guard","tool":"Write","decision":"pass","detail":"$_w14_file"}
 EOF
@@ -67,6 +140,75 @@ _w14_disabled=$(
     | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_W14_COOLDOWN_SECONDS=0 bash hooks/post-edit-guard.sh
 )
 assert_contains "$_w14_disabled" "[W-14]" "W-14 cooldown value zero restores visible warnings"
+
+printf 'value = 1\n' > "$_w14_file"
+_w14_boundary_key=$(_w14_key "current-session" "boundary-peer" "$_w14_file")
+_w14_seed_history "$_w14_file" "boundary-peer" "$_w14_boundary_key" 3600
+_w14_boundary=$(_w14_run "$_w14_file")
+assert_contains "$_w14_boundary" "[W-14]" "W-14 exact cooldown boundary fails open to a visible warning"
+
+_w14_other_file="$_w14_dir/other.py"
+printf 'value = 1\n' > "$_w14_other_file"
+_w14_wrong_file_key=$(_w14_key "current-session" "other-session" "$_w14_file")
+_w14_seed_history "$_w14_other_file" "other-session" "$_w14_wrong_file_key" 0
+_w14_other_file_result=$(_w14_run "$_w14_other_file")
+assert_contains "$_w14_other_file_result" "[W-14]" "W-14 does not share cooldown across normalized files"
+
+_w14_wrong_peer_key=$(_w14_key "current-session" "first-peer" "$_w14_file")
+_w14_seed_history "$_w14_file" "second-peer" "$_w14_wrong_peer_key" 0
+_w14_other_peer=$(_w14_run "$_w14_file")
+assert_contains "$_w14_other_peer" "[W-14]" "W-14 does not share cooldown across peer sessions"
+
+_w14_reverse_key=$(_w14_key "reverse-peer" "current-session" "$_w14_file")
+_w14_seed_history "$_w14_file" "reverse-peer" "$_w14_reverse_key" 0
+_w14_reverse=$(_w14_run "$_w14_file")
+assert_contains "$_w14_reverse" "[W-14]" "W-14 keeps current and peer session order directed"
+
+_w14_seed_history "$_w14_file" "unknown"
+_w14_unknown=$(_w14_run "$_w14_file")
+assert_contains "$_w14_unknown" "[W-14]" "W-14 unknown peer session fails open"
+
+_w14_seed_history "$_w14_file" "__missing__"
+_w14_missing=$(_w14_run "$_w14_file")
+assert_contains "$_w14_missing" "[W-14]" "W-14 missing peer session fails open"
+
+_w14_seed_history "$_w14_file" "bad-history-peer"
+printf 'not-json\n' >> "$_w14_log_file"
+_w14_bad_history=$(_w14_run "$_w14_file")
+assert_contains "$_w14_bad_history" "[W-14]" "W-14 malformed history fails open"
+
+_w14_long_dir="$_w14_dir/$(printf 'x%.0s' {1..140})"
+mkdir -p "$_w14_long_dir"
+_w14_long_file="$_w14_long_dir/long.py"
+printf 'value = 1\n' > "$_w14_long_file"
+_w14_seed_history "$_w14_long_file" "long-path-peer"
+_w14_long_result=$(_w14_run "$_w14_long_file")
+assert_contains "$_w14_long_result" "[W-14]" "W-14 long-path candidate remains visible"
+assert_exit_zero "W-14 shown evidence preserves a long file path and complete key" python3 - "$_w14_log_file" "$_w14_long_file" <<'PY'
+import json
+import re
+import sys
+
+events = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+shown = [event for event in events if event.get("reason", "").startswith("[W-14] overlap shown")]
+detail = shown[-1].get("detail", "") if shown else ""
+path, separator, key = detail.partition("||w14_key=")
+raise SystemExit(0 if path == sys.argv[2] and separator and re.fullmatch(r"[0-9a-f]{64}", key) else 1)
+PY
+
+_w14_append_key=$(_w14_key "current-session" "append-peer" "$_w14_file")
+_w14_seed_history "$_w14_file" "append-peer" "$_w14_append_key" 0
+mkdir -p "${_w14_log_file}.lock.d"
+printf 'held\n' > "${_w14_log_file}.lock.d/owner"
+_w14_append_failure=$(_w14_run "$_w14_file" \
+  VIBEGUARD_LOG_LOCK_ATTEMPTS=1 \
+  VIBEGUARD_LOG_LOCK_SLEEP_SECONDS=0 \
+  VIBEGUARD_LOG_LOCK_STALE_SECONDS=3600 2>&1)
+rm -rf "${_w14_log_file}.lock.d"
+assert_contains "$_w14_append_failure" "[W-14]" "W-14 telemetry append failure preserves the visible warning"
+assert_contains "$_w14_append_failure" "W-14 suppressed telemetry append failed" "W-14 telemetry append failure reports its root cause"
+assert_contains "$_w14_append_failure" "VG-INTERNAL-LOG-APPEND" "W-14 final event append failure reports hook diagnostics"
+
 rm -rf "$_w14_dir"
 
 hook_test_finish

--- a/tests/hooks/test_post_edit_w14.sh
+++ b/tests/hooks/test_post_edit_w14.sh
@@ -24,9 +24,49 @@ _w14_result=$(
   printf '{"tool_input":{"file_path":"%s","new_string":"value = 2\\n"}}' "$_w14_rel" \
     | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
 )
-rm -rf "$_w14_dir"
 assert_contains "$_w14_result" "[W-14]" "W-14 detects relative/absolute matches for the same file"
 assert_contains "$_w14_result" 'BASE=${VIBEGUARD_WORKTREE_BASE:-${REPO}.wt}' "W-14 worktree hint reads configured base"
 assert_contains "$_w14_result" 'case \"$BASE\" in /*)' "W-14 worktree hint resolves relative base against repo root"
+_w14_shown_event=$(python3 -c '
+import json, sys
+events = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+matches = [event for event in events if event.get("reason", "").startswith("[W-14] overlap shown")]
+print(json.dumps(matches[-1], sort_keys=True) if matches else "")
+' "$_w14_log_file")
+assert_contains "$_w14_shown_event" '"decision": "warn"' "First W-14 records dedicated shown evidence"
+
+_w14_repeat=$(
+  printf '{"tool_input":{"file_path":"%s","new_string":"value = 3\\n"}}' "$_w14_rel" \
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
+)
+assert_not_contains "$_w14_repeat" "[W-14]" "W-14 suppresses the same directed pair and file inside cooldown"
+_w14_suppressed_event=$(python3 -c '
+import json, sys
+events = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+matches = [event for event in events if event.get("reason", "").startswith("[W-14] overlap suppressed cooldown")]
+print(json.dumps(matches[-1], sort_keys=True) if matches else "")
+' "$_w14_log_file")
+assert_contains "$_w14_suppressed_event" '"decision": "pass"' "W-14 cooldown records pass telemetry"
+assert_contains "$_w14_suppressed_event" '"status": "skipped"' "W-14 cooldown records skipped status"
+assert_exit_zero "W-14 cooldown records a complete opaque key" python3 -c '
+import json, re, sys
+event = json.loads(sys.argv[1])
+raise SystemExit(0 if re.search(r"\\|\\|w14_key=[0-9a-f]{64}$", event.get("detail", "")) else 1)
+' "$_w14_suppressed_event"
+
+for _ in {1..801}; do printf 'value = 1\n'; done > "$_w14_file"
+_w14_mixed=$(
+  printf '{"tool_input":{"file_path":"%s","new_string":"value = 4\\n"}}' "$_w14_rel" \
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
+)
+assert_not_contains "$_w14_mixed" "[W-14]" "W-14 cooldown does not renew from suppressed telemetry"
+assert_contains "$_w14_mixed" "[U-16]" "W-14 cooldown preserves other post-edit warnings"
+
+_w14_disabled=$(
+  printf '{"tool_input":{"file_path":"%s","new_string":"value = 5\\n"}}' "$_w14_rel" \
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_W14_COOLDOWN_SECONDS=0 bash hooks/post-edit-guard.sh
+)
+assert_contains "$_w14_disabled" "[W-14]" "W-14 cooldown value zero restores visible warnings"
+rm -rf "$_w14_dir"
 
 hook_test_finish

--- a/tests/hooks/test_post_edit_w14.sh
+++ b/tests/hooks/test_post_edit_w14.sh
@@ -109,10 +109,10 @@ print(json.dumps(matches[-1], sort_keys=True) if matches else "")
 assert_contains "$_w14_shown_event" '"decision": "warn"' "First W-14 records dedicated shown evidence"
 
 _w14_repeat=$(
-  printf '{"tool_input":{"file_path":"%s","new_string":"value = 3\\n"}}' "$_w14_rel" \
+  printf '{"tool_input":{"file_path":"%s","new_string":"value = 3\\n"}}' "$_w14_file" \
     | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
 )
-assert_not_contains "$_w14_repeat" "[W-14]" "W-14 suppresses the same directed pair and file inside cooldown"
+assert_not_contains "$_w14_repeat" "[W-14]" "W-14 reuses cooldown across relative and absolute forms of the same file"
 _w14_suppressed_event=$(python3 -c '
 import json, sys
 events = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
@@ -177,7 +177,10 @@ printf 'not-json\n' >> "$_w14_log_file"
 _w14_bad_history=$(_w14_run "$_w14_file")
 assert_contains "$_w14_bad_history" "[W-14]" "W-14 malformed history fails open"
 
-_w14_long_dir="$_w14_dir/$(printf 'x%.0s' {1..140})"
+_w14_long_dir="$_w14_dir"
+for _w14_component_index in {1..8}; do
+  _w14_long_dir="$_w14_long_dir/$(printf 'x%.0s' {1..100})$_w14_component_index"
+done
 mkdir -p "$_w14_long_dir"
 _w14_long_file="$_w14_long_dir/long.py"
 printf 'value = 1\n' > "$_w14_long_file"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -116,6 +116,7 @@ checks = [
     data.get("u16", {}).get("limit") == 800,
     data.get("circuit_breaker", {}).get("threshold") == 3,
     data.get("circuit_breaker", {}).get("cooldown_seconds") == 300,
+    data.get("w14", {}).get("cooldown_seconds") == 3600,
     data.get("paralysis", {}).get("threshold") == 7,
 ]
 raise SystemExit(0 if all(checks) else 1)

--- a/vibeguard-runtime/src/hook_checks_history.rs
+++ b/vibeguard-runtime/src/hook_checks_history.rs
@@ -30,6 +30,7 @@ pub(crate) struct OverlapSignal {
     pub(crate) agent: String,
     pub(crate) hook: String,
     pub(crate) tool: String,
+    pub(crate) normalized_file: String,
 }
 
 pub(crate) fn post_edit_history_signals(
@@ -171,6 +172,7 @@ pub(crate) fn recent_overlap(
                 .and_then(Value::as_str)
                 .unwrap_or("?")
                 .to_string(),
+            normalized_file: normalized_file.clone(),
         });
     }
     last
@@ -388,21 +390,20 @@ mod tests {
             consecutive_post_edit_count(&events, "current", "src/main.rs"),
             2
         );
-        assert!(
-            recent_overlap(
-                &[serde_json::json!({
-                    "ts": format_unix_secs_utc(now_unix_secs()),
-                    "session": "other",
-                    "agent": "codex",
-                    "tool": "Edit",
-                    "detail": "/tmp/main.rs"
-                })],
-                "current",
-                "codex",
-                "/tmp/main.rs"
-            )
-            .is_some()
-        );
+        let overlap = recent_overlap(
+            &[serde_json::json!({
+                "ts": format_unix_secs_utc(now_unix_secs()),
+                "session": "other",
+                "agent": "codex",
+                "tool": "Edit",
+                "detail": "/tmp/main.rs"
+            })],
+            "current",
+            "codex",
+            "/tmp/main.rs",
+        )
+        .expect("matching file should produce an overlap");
+        assert_eq!(overlap.normalized_file, "/tmp/main.rs");
     }
 
     #[test]

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -376,7 +376,7 @@ fn run_source_new(
                         ctx,
                         "pre-write-guard",
                         "circuit-breaker",
-                        decision::WARN,
+                        (decision::WARN, None),
                         &reason,
                         "",
                         elapsed_ms(start),
@@ -406,7 +406,7 @@ fn run_source_new(
                 ctx,
                 "pre-write-guard",
                 "circuit-breaker",
-                decision::PASS,
+                (decision::PASS, None),
                 &reason,
                 "",
                 elapsed_ms(start),
@@ -568,7 +568,27 @@ pub(crate) fn append_hook_event(
         ctx,
         kind.hook_name(),
         kind.tool_name(),
-        decision_value,
+        (decision_value, None),
+        reason,
+        detail,
+        duration_ms,
+    )
+}
+
+pub(crate) fn append_hook_event_with_status(
+    ctx: &RuntimeContext,
+    kind: HookKind,
+    decision_value: &str,
+    status_value: &str,
+    reason: &str,
+    detail: &str,
+    duration_ms: u64,
+) -> Result {
+    append_event(
+        ctx,
+        kind.hook_name(),
+        kind.tool_name(),
+        (decision_value, Some(status_value)),
         reason,
         detail,
         duration_ms,
@@ -579,12 +599,14 @@ fn append_event(
     ctx: &RuntimeContext,
     hook_name: &str,
     tool_name: &str,
-    decision_value: &str,
+    outcome: (&str, Option<&str>),
     reason: &str,
     detail: &str,
     duration_ms: u64,
 ) -> Result {
+    let (decision_value, status_value) = outcome;
     let (decision_value, reason) = log_policy_decision(decision_value, reason);
+    let status_value = status_value.unwrap_or(&decision_value);
     let mut event = json!({
         "schema_version": 1,
         field::TS: format_unix_secs_utc(now_unix_secs()),
@@ -592,7 +614,7 @@ fn append_event(
         field::HOOK: hook_name,
         field::TOOL: tool_name,
         field::DECISION: decision_value,
-        field::STATUS: decision_value,
+        field::STATUS: status_value,
         field::REASON: reason,
         field::DETAIL: truncate_chars(detail, 200),
         field::DURATION_MS: duration_ms,

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -14,6 +14,8 @@ use crate::wrapper_env::env_nonempty;
 
 pub(crate) type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+const EVENT_DETAIL_MAX_CHARS: usize = 200;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HookKind {
     PreWrite,
@@ -378,7 +380,7 @@ fn run_source_new(
                         "circuit-breaker",
                         (decision::WARN, None),
                         &reason,
-                        "",
+                        ("", EVENT_DETAIL_MAX_CHARS),
                         elapsed_ms(start),
                     )?;
                 }
@@ -408,7 +410,7 @@ fn run_source_new(
                 "circuit-breaker",
                 (decision::PASS, None),
                 &reason,
-                "",
+                ("", EVENT_DETAIL_MAX_CHARS),
                 elapsed_ms(start),
             )?;
         }
@@ -570,7 +572,7 @@ pub(crate) fn append_hook_event(
         kind.tool_name(),
         (decision_value, None),
         reason,
-        detail,
+        (detail, EVENT_DETAIL_MAX_CHARS),
         duration_ms,
     )
 }
@@ -581,7 +583,7 @@ pub(crate) fn append_hook_event_with_status(
     decision_value: &str,
     status_value: &str,
     reason: &str,
-    detail: &str,
+    detail: (&str, usize),
     duration_ms: u64,
 ) -> Result {
     append_event(
@@ -601,10 +603,11 @@ fn append_event(
     tool_name: &str,
     outcome: (&str, Option<&str>),
     reason: &str,
-    detail: &str,
+    detail: (&str, usize),
     duration_ms: u64,
 ) -> Result {
     let (decision_value, status_value) = outcome;
+    let (detail, detail_max_chars) = detail;
     let (decision_value, reason) = log_policy_decision(decision_value, reason);
     let status_value = status_value.unwrap_or(&decision_value);
     let mut event = json!({
@@ -616,7 +619,7 @@ fn append_event(
         field::DECISION: decision_value,
         field::STATUS: status_value,
         field::REASON: reason,
-        field::DETAIL: truncate_chars(detail, 200),
+        field::DETAIL: truncate_chars(detail, detail_max_chars),
         field::DURATION_MS: duration_ms,
         field::CLI: ctx.cli,
         field::CLIENT: ctx.client,

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
@@ -80,6 +80,11 @@ pub(crate) fn run(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
         );
     }
 
+    let prefix = if decision_value == decision::ESCALATE {
+        "VIBEGUARD upgrade warning"
+    } else {
+        "VIBEGUARD quality warning"
+    };
     if let Err(err) = append_hook_event(
         ctx,
         HookKind::PostEdit,
@@ -89,15 +94,13 @@ pub(crate) fn run(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
         &detail,
         elapsed_ms(start),
     ) {
-        print_context(&internal_context(ctx, "allow", &err.to_string()))?;
+        print_context(&format!(
+            "{}\n---\n{prefix}：{reason}",
+            internal_context(ctx, "allow", &err.to_string())
+        ))?;
         return Ok(());
     }
 
-    let prefix = if decision_value == decision::ESCALATE {
-        "VIBEGUARD upgrade warning"
-    } else {
-        "VIBEGUARD quality warning"
-    };
     print_context(&format!("{prefix}：{reason}"))?;
     Ok(())
 }

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
@@ -18,7 +18,7 @@ use crate::time_utils::{now_unix_secs, parse_iso_ts};
 
 const POST_EDIT_HISTORY_LINES: usize = 500;
 const W14_COOLDOWN_DEFAULT_SECONDS: &str = "3600";
-const EVENT_DETAIL_MAX_CHARS: usize = 200;
+const W14_EVENT_DETAIL_MAX_CHARS: usize = 4096;
 const W14_SHOWN_REASON_PREFIX: &str = "[W-14] overlap shown";
 const W14_SUPPRESSED_REASON_PREFIX: &str = "[W-14] overlap suppressed cooldown";
 
@@ -147,18 +147,25 @@ fn detect_w14_at(
     if let Some(key) = key.as_deref() {
         let eligible = cooldown_seconds > 0
             && has_recent_w14_shown(events, &ctx.session_id, key, now, cooldown_seconds);
-        if suppress_after_audit(eligible, || {
+        match suppress_after_audit(eligible, || {
             append_hook_event_with_status(
                 ctx,
                 HookKind::PostEdit,
                 decision::PASS,
                 status::SKIPPED,
                 W14_SUPPRESSED_REASON_PREFIX,
-                &w14_event_detail(file_path, key),
+                (
+                    &w14_event_detail(file_path, key),
+                    W14_EVENT_DETAIL_MAX_CHARS,
+                ),
                 elapsed_ms(start),
             )
         }) {
-            return;
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(err) => {
+                eprintln!("VIBEGUARD: W-14 suppressed telemetry append failed: {err}");
+            }
         }
     }
     warnings.push(format!("[W-14] [review] [this-file] OBSERVATION: another session or agent recently touched {} ({} via {}, session {}, agent {})\nFIX: Isolate via a dedicated worktree before continuing. Copy-paste:\n  REPO=$(git rev-parse --show-toplevel) && SID=${{VIBEGUARD_SESSION_ID:-$(date +%s)}}\n  BASE=${{VIBEGUARD_WORKTREE_BASE:-${{REPO}}.wt}}\n  case \"$BASE\" in /*) ;; *) BASE=\"${{REPO}}/${{BASE}}\" ;; esac\n  BASE=${{BASE%/}}\n  git worktree add \"$BASE/$SID\" -b \"vg/$SID\" HEAD\n  cd \"$BASE/$SID\"\nDO NOT: Continue parallel/background edits to this file without an isolated worktree", post_edit_history_file_name(file_path), overlap.tool, overlap.hook, overlap.session, if overlap.agent.is_empty() { "unknown" } else { &overlap.agent }));
@@ -180,7 +187,7 @@ fn detect_w14_at(
                 &overlap.agent
             }
         ),
-        &detail,
+        (&detail, W14_EVENT_DETAIL_MAX_CHARS),
         elapsed_ms(start),
     ) {
         eprintln!("VIBEGUARD: W-14 shown evidence append failed: {err}");
@@ -209,10 +216,7 @@ fn known_w14_session(session: &str) -> bool {
 }
 
 fn w14_event_detail(file_path: &str, key: &str) -> String {
-    let suffix = format!("||w14_key={key}");
-    let path_limit = EVENT_DETAIL_MAX_CHARS.saturating_sub(suffix.chars().count());
-    let display_path = file_path.chars().take(path_limit).collect::<String>();
-    format!("{display_path}{suffix}")
+    format!("{file_path}||w14_key={key}")
 }
 
 fn has_recent_w14_shown(
@@ -261,8 +265,14 @@ fn w14_key_from_detail(detail: &str) -> Option<&str> {
         .filter(|key| key.len() == 64 && key.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
-fn suppress_after_audit<E>(eligible: bool, append: impl FnOnce() -> Result<(), E>) -> bool {
-    eligible && append().is_ok()
+fn suppress_after_audit<E>(
+    eligible: bool,
+    append: impl FnOnce() -> Result<(), E>,
+) -> Result<bool, E> {
+    if !eligible {
+        return Ok(false);
+    }
+    append().map(|()| true)
 }
 
 #[expect(
@@ -512,9 +522,11 @@ mod tests {
     #[test]
     fn w14_detail_keeps_the_full_key_within_the_event_limit() {
         let key = "a".repeat(64);
-        let detail = w14_event_detail(&"x".repeat(300), &key);
+        let path = "x".repeat(300);
+        let detail = w14_event_detail(&path, &key);
 
-        assert_eq!(detail.chars().count(), EVENT_DETAIL_MAX_CHARS);
+        assert!(detail.chars().count() < W14_EVENT_DETAIL_MAX_CHARS);
+        assert_eq!(first_detail_path(&json!({"detail": detail})), path);
         assert!(detail.ends_with(&format!("||w14_key={key}")));
         assert_eq!(w14_key_from_detail(&detail), Some(key.as_str()));
     }
@@ -603,13 +615,19 @@ mod tests {
     #[test]
     fn suppression_requires_successful_audit_append() {
         let called = std::cell::Cell::new(false);
-        assert!(!suppress_after_audit(false, || {
-            called.set(true);
-            Ok::<(), ()>(())
-        }));
+        assert_eq!(
+            suppress_after_audit(false, || {
+                called.set(true);
+                Ok::<(), ()>(())
+            }),
+            Ok(false)
+        );
         assert!(!called.get());
-        assert!(suppress_after_audit(true, || Ok::<(), ()>(())));
-        assert!(!suppress_after_audit(true, || Err::<(), _>("locked")));
+        assert_eq!(suppress_after_audit(true, || Ok::<(), ()>(())), Ok(true));
+        assert_eq!(
+            suppress_after_audit(true, || Err::<(), _>("locked")),
+            Err("locked")
+        );
     }
 
     #[test]

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
@@ -18,7 +18,6 @@ use crate::time_utils::{now_unix_secs, parse_iso_ts};
 
 const POST_EDIT_HISTORY_LINES: usize = 500;
 const W14_COOLDOWN_DEFAULT_SECONDS: &str = "3600";
-const W14_EVENT_DETAIL_MAX_CHARS: usize = 4096;
 const W14_SHOWN_REASON_PREFIX: &str = "[W-14] overlap shown";
 const W14_SUPPRESSED_REASON_PREFIX: &str = "[W-14] overlap suppressed cooldown";
 
@@ -148,16 +147,15 @@ fn detect_w14_at(
         let eligible = cooldown_seconds > 0
             && has_recent_w14_shown(events, &ctx.session_id, key, now, cooldown_seconds);
         match suppress_after_audit(eligible, || {
+            let detail = w14_event_detail(file_path, key);
+            let detail_limit = detail.chars().count();
             append_hook_event_with_status(
                 ctx,
                 HookKind::PostEdit,
                 decision::PASS,
                 status::SKIPPED,
                 W14_SUPPRESSED_REASON_PREFIX,
-                (
-                    &w14_event_detail(file_path, key),
-                    W14_EVENT_DETAIL_MAX_CHARS,
-                ),
+                (&detail, detail_limit),
                 elapsed_ms(start),
             )
         }) {
@@ -173,6 +171,7 @@ fn detect_w14_at(
         .as_deref()
         .map(|key| w14_event_detail(file_path, key))
         .unwrap_or_else(|| file_path.to_string());
+    let detail_limit = detail.chars().count();
     if let Err(err) = append_hook_event_with_status(
         ctx,
         HookKind::PostEdit,
@@ -187,7 +186,7 @@ fn detect_w14_at(
                 &overlap.agent
             }
         ),
-        (&detail, W14_EVENT_DETAIL_MAX_CHARS),
+        (&detail, detail_limit),
         elapsed_ms(start),
     ) {
         eprintln!("VIBEGUARD: W-14 shown evidence append failed: {err}");
@@ -520,12 +519,13 @@ mod tests {
     }
 
     #[test]
-    fn w14_detail_keeps_the_full_key_within_the_event_limit() {
+    fn w14_detail_keeps_the_full_path_and_key_at_platform_scale() {
         let key = "a".repeat(64);
-        let path = "x".repeat(300);
+        let path = "x".repeat(8192);
         let detail = w14_event_detail(&path, &key);
+        let detail_limit = detail.chars().count();
 
-        assert!(detail.chars().count() < W14_EVENT_DETAIL_MAX_CHARS);
+        assert_eq!(detail_limit, path.chars().count() + 10 + key.len());
         assert_eq!(first_detail_path(&json!({"detail": detail})), path);
         assert!(detail.ends_with(&format!("||w14_key={key}")));
         assert_eq!(w14_key_from_detail(&detail), Some(key.as_str()));

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
@@ -7,11 +7,20 @@ use crate::event_schema::{decision, field, hook, status, tool};
 use crate::git_root::current_git_root_by_marker;
 use crate::hook_checks_common::first_detail_path;
 use crate::hook_checks_history::{read_tail_lines, recent_overlap};
-use crate::hook_orchestrator::{HookKind, append_hook_event, elapsed_ms};
+use crate::hook_orchestrator::{
+    HookKind, append_hook_event, append_hook_event_with_status, elapsed_ms,
+};
 use crate::hook_orchestrator_context::RuntimeContext;
 use crate::log_query::count_build_fail_events;
+use crate::runtime_config::runtime_config_int_value;
+use crate::setup_support::sha256_text;
+use crate::time_utils::{now_unix_secs, parse_iso_ts};
 
 const POST_EDIT_HISTORY_LINES: usize = 500;
+const W14_COOLDOWN_DEFAULT_SECONDS: &str = "3600";
+const EVENT_DETAIL_MAX_CHARS: usize = 200;
+const W14_SHOWN_REASON_PREFIX: &str = "[W-14] overlap shown";
+const W14_SUPPRESSED_REASON_PREFIX: &str = "[W-14] overlap suppressed cooldown";
 
 pub(crate) fn detect_history_warnings(
     ctx: &RuntimeContext,
@@ -105,17 +114,65 @@ fn detect_w14(
     events: &[Value],
     warnings: &mut Vec<String>,
 ) {
+    let cooldown_seconds = runtime_config_int_value(
+        "VIBEGUARD_W14_COOLDOWN_SECONDS",
+        "w14.cooldown_seconds",
+        W14_COOLDOWN_DEFAULT_SECONDS,
+    );
+    detect_w14_at(
+        ctx,
+        start,
+        file_path,
+        events,
+        warnings,
+        now_unix_secs(),
+        cooldown_seconds,
+    );
+}
+
+fn detect_w14_at(
+    ctx: &RuntimeContext,
+    start: Instant,
+    file_path: &str,
+    events: &[Value],
+    warnings: &mut Vec<String>,
+    now: u64,
+    cooldown_seconds: u64,
+) {
     let agent = env::var("VIBEGUARD_AGENT_TYPE").unwrap_or_default();
     let Some(overlap) = recent_overlap(events, &ctx.session_id, &agent, file_path) else {
         return;
     };
+    let key = w14_key(&ctx.session_id, &overlap.session, &overlap.normalized_file);
+    if let Some(key) = key.as_deref() {
+        let eligible = cooldown_seconds > 0
+            && has_recent_w14_shown(events, &ctx.session_id, key, now, cooldown_seconds);
+        if suppress_after_audit(eligible, || {
+            append_hook_event_with_status(
+                ctx,
+                HookKind::PostEdit,
+                decision::PASS,
+                status::SKIPPED,
+                W14_SUPPRESSED_REASON_PREFIX,
+                &w14_event_detail(file_path, key),
+                elapsed_ms(start),
+            )
+        }) {
+            return;
+        }
+    }
     warnings.push(format!("[W-14] [review] [this-file] OBSERVATION: another session or agent recently touched {} ({} via {}, session {}, agent {})\nFIX: Isolate via a dedicated worktree before continuing. Copy-paste:\n  REPO=$(git rev-parse --show-toplevel) && SID=${{VIBEGUARD_SESSION_ID:-$(date +%s)}}\n  BASE=${{VIBEGUARD_WORKTREE_BASE:-${{REPO}}.wt}}\n  case \"$BASE\" in /*) ;; *) BASE=\"${{REPO}}/${{BASE}}\" ;; esac\n  BASE=${{BASE%/}}\n  git worktree add \"$BASE/$SID\" -b \"vg/$SID\" HEAD\n  cd \"$BASE/$SID\"\nDO NOT: Continue parallel/background edits to this file without an isolated worktree", post_edit_history_file_name(file_path), overlap.tool, overlap.hook, overlap.session, if overlap.agent.is_empty() { "unknown" } else { &overlap.agent }));
-    append_history_event(
+    let detail = key
+        .as_deref()
+        .map(|key| w14_event_detail(file_path, key))
+        .unwrap_or_else(|| file_path.to_string());
+    if let Err(err) = append_hook_event_with_status(
         ctx,
-        start,
+        HookKind::PostEdit,
         decision::WARN,
+        status::WARN,
         &format!(
-            "w14 overlap recent session {} agent {}",
+            "{W14_SHOWN_REASON_PREFIX} session {} agent {}",
             overlap.session,
             if overlap.agent.is_empty() {
                 "unknown"
@@ -123,8 +180,89 @@ fn detect_w14(
                 &overlap.agent
             }
         ),
-        file_path,
+        &detail,
+        elapsed_ms(start),
+    ) {
+        eprintln!("VIBEGUARD: W-14 shown evidence append failed: {err}");
+    }
+}
+
+fn w14_key(current_session: &str, peer_session: &str, normalized_file: &str) -> Option<String> {
+    if !known_w14_session(current_session)
+        || !known_w14_session(peer_session)
+        || normalized_file.is_empty()
+    {
+        return None;
+    }
+    let tuple = format!(
+        "{}:{current_session}{}:{peer_session}{}:{normalized_file}",
+        current_session.len(),
+        peer_session.len(),
+        normalized_file.len()
     );
+    Some(sha256_text(&tuple))
+}
+
+fn known_w14_session(session: &str) -> bool {
+    let session = session.trim();
+    !session.is_empty() && session != "?" && !session.eq_ignore_ascii_case("unknown")
+}
+
+fn w14_event_detail(file_path: &str, key: &str) -> String {
+    let suffix = format!("||w14_key={key}");
+    let path_limit = EVENT_DETAIL_MAX_CHARS.saturating_sub(suffix.chars().count());
+    let display_path = file_path.chars().take(path_limit).collect::<String>();
+    format!("{display_path}{suffix}")
+}
+
+fn has_recent_w14_shown(
+    events: &[Value],
+    current_session: &str,
+    key: &str,
+    now: u64,
+    cooldown_seconds: u64,
+) -> bool {
+    if cooldown_seconds == 0 || !known_w14_session(current_session) {
+        return false;
+    }
+    events
+        .iter()
+        .rev()
+        .take(POST_EDIT_HISTORY_LINES)
+        .any(|event| {
+            event.get(field::SESSION).and_then(Value::as_str) == Some(current_session)
+                && event.get(field::HOOK).and_then(Value::as_str) == Some(hook::POST_EDIT_GUARD)
+                && event.get(field::TOOL).and_then(Value::as_str) == Some(tool::EDIT)
+                && event.get(field::DECISION).and_then(Value::as_str) == Some(decision::WARN)
+                && event.get(field::STATUS).and_then(Value::as_str) == Some(status::WARN)
+                && event
+                    .get(field::REASON)
+                    .and_then(Value::as_str)
+                    .is_some_and(|reason| reason.starts_with(W14_SHOWN_REASON_PREFIX))
+                && event
+                    .get(field::DETAIL)
+                    .and_then(Value::as_str)
+                    .and_then(w14_key_from_detail)
+                    == Some(key)
+                && event
+                    .get(field::TS)
+                    .and_then(Value::as_str)
+                    .and_then(parse_iso_ts)
+                    .and_then(|timestamp| now.checked_sub(timestamp))
+                    .is_some_and(|age| age < cooldown_seconds)
+        })
+}
+
+fn w14_key_from_detail(detail: &str) -> Option<&str> {
+    detail
+        .split("||")
+        .skip(1)
+        .find_map(|part| part.strip_prefix("w14_key="))
+        .filter(|key| key.len() == 64 && key.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}
+
+fn suppress_after_audit<E>(eligible: bool, append: impl FnOnce() -> Result<(), E>) -> bool {
+    eligible && append().is_ok()
 }
 
 #[expect(
@@ -197,15 +335,23 @@ fn same_file_edit_trail(events: &[Value], session: &str, file_path: &str) -> W15
 }
 
 pub(crate) fn count_prior_warn_events(ctx: &RuntimeContext, file_path: &str) -> usize {
-    read_post_edit_history_events(ctx)
-        .into_iter()
+    count_prior_warn_events_in(
+        &read_post_edit_history_events(ctx),
+        &ctx.session_id,
+        file_path,
+    )
+}
+
+fn count_prior_warn_events_in(events: &[Value], session: &str, file_path: &str) -> usize {
+    events
+        .iter()
         .filter(|event| {
             let reason = event
                 .get(field::REASON)
                 .and_then(Value::as_str)
                 .unwrap_or("");
             let churn_only = reason.contains("[CHURN") && !reason.contains("\n---\n");
-            event.get(field::SESSION).and_then(Value::as_str) == Some(ctx.session_id.as_str())
+            event.get(field::SESSION).and_then(Value::as_str) == Some(session)
                 && event.get(field::HOOK).and_then(Value::as_str) == Some(hook::POST_EDIT_GUARD)
                 && event.get(field::DECISION).and_then(Value::as_str) == Some(decision::WARN)
                 && !churn_only
@@ -301,6 +447,19 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn w14_shown_event(session: &str, key: &str, timestamp: u64) -> Value {
+        json!({
+            "ts": crate::time_utils::format_unix_secs_utc(timestamp),
+            "session": session,
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "warn",
+            "status": "warn",
+            "reason": "[W-14] overlap shown session peer agent codex",
+            "detail": format!("src/main.rs||w14_key={key}"),
+        })
+    }
+
     #[test]
     fn delta_metadata_is_read_from_post_edit_detail() {
         assert_eq!(
@@ -328,5 +487,150 @@ mod tests {
     fn history_file_helpers_match_common_paths() {
         assert_eq!(post_edit_history_file_name("src/main.rs"), "main.rs");
         assert_eq!(post_edit_history_extension("docs/guide.md"), "md");
+    }
+
+    #[test]
+    fn w14_key_is_directed_and_rejects_unknown_sessions() {
+        let Some(forward) = w14_key("current", "peer", "/repo/src/main.rs") else {
+            panic!("known sessions and file should produce a key");
+        };
+        let Some(reverse) = w14_key("peer", "current", "/repo/src/main.rs") else {
+            panic!("reversed known sessions should produce a key");
+        };
+        let Some(other_file) = w14_key("current", "peer", "/repo/src/lib.rs") else {
+            panic!("a different known file should produce a key");
+        };
+
+        assert_eq!(forward.len(), 64);
+        assert!(forward.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert_ne!(forward, reverse);
+        assert_ne!(forward, other_file);
+        assert_eq!(w14_key("unknown", "peer", "/repo/src/main.rs"), None);
+        assert_eq!(w14_key("current", "?", "/repo/src/main.rs"), None);
+    }
+
+    #[test]
+    fn w14_detail_keeps_the_full_key_within_the_event_limit() {
+        let key = "a".repeat(64);
+        let detail = w14_event_detail(&"x".repeat(300), &key);
+
+        assert_eq!(detail.chars().count(), EVENT_DETAIL_MAX_CHARS);
+        assert!(detail.ends_with(&format!("||w14_key={key}")));
+        assert_eq!(w14_key_from_detail(&detail), Some(key.as_str()));
+    }
+
+    #[test]
+    fn shown_evidence_obeys_time_key_and_bounded_history_contract() {
+        let now = 1_800_000_000;
+        let key = "b".repeat(64);
+        let shown = w14_shown_event("current", &key, now - 59);
+        assert!(has_recent_w14_shown(
+            std::slice::from_ref(&shown),
+            "current",
+            &key,
+            now,
+            60
+        ));
+
+        let exact_boundary = w14_shown_event("current", &key, now - 60);
+        assert!(!has_recent_w14_shown(
+            &[exact_boundary],
+            "current",
+            &key,
+            now,
+            60
+        ));
+        let future = w14_shown_event("current", &key, now + 1);
+        assert!(!has_recent_w14_shown(&[future], "current", &key, now, 60));
+        let mut invalid_timestamp = shown.clone();
+        invalid_timestamp[field::TS] = json!("not-a-timestamp");
+        assert!(!has_recent_w14_shown(
+            &[invalid_timestamp],
+            "current",
+            &key,
+            now,
+            60
+        ));
+        assert!(!has_recent_w14_shown(
+            std::slice::from_ref(&shown),
+            "other-current",
+            &key,
+            now,
+            60
+        ));
+        assert!(!has_recent_w14_shown(
+            std::slice::from_ref(&shown),
+            "current",
+            &"c".repeat(64),
+            now,
+            60
+        ));
+
+        let suppressed = json!({
+            "ts": crate::time_utils::format_unix_secs_utc(now - 1),
+            "session": "current",
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "pass",
+            "status": "skipped",
+            "reason": "[W-14] overlap suppressed cooldown",
+            "detail": format!("src/main.rs||w14_key={key}"),
+        });
+        assert!(!has_recent_w14_shown(
+            &[suppressed],
+            "current",
+            &key,
+            now,
+            60
+        ));
+
+        let mut beyond_tail = vec![shown];
+        beyond_tail.extend((0..POST_EDIT_HISTORY_LINES).map(|index| {
+            json!({
+                "ts": crate::time_utils::format_unix_secs_utc(now - 1),
+                "session": format!("filler-{index}"),
+            })
+        }));
+        assert!(!has_recent_w14_shown(
+            &beyond_tail,
+            "current",
+            &key,
+            now,
+            60
+        ));
+    }
+
+    #[test]
+    fn suppression_requires_successful_audit_append() {
+        let called = std::cell::Cell::new(false);
+        assert!(!suppress_after_audit(false, || {
+            called.set(true);
+            Ok::<(), ()>(())
+        }));
+        assert!(!called.get());
+        assert!(suppress_after_audit(true, || Ok::<(), ()>(())));
+        assert!(!suppress_after_audit(true, || Err::<(), _>("locked")));
+    }
+
+    #[test]
+    fn suppressed_w14_does_not_increase_prior_warn_count() {
+        let key = "d".repeat(64);
+        let events = vec![
+            w14_shown_event("current", &key, 1_800_000_000),
+            json!({
+                "session": "current",
+                "hook": "post-edit-guard",
+                "tool": "Edit",
+                "decision": "pass",
+                "status": "skipped",
+                "reason": "[W-14] overlap suppressed cooldown",
+                "detail": format!("src/main.rs||w14_key={key}"),
+            }),
+        ];
+
+        assert_eq!(
+            count_prior_warn_events_in(&events, "current", "src/main.rs"),
+            1
+        );
     }
 }

--- a/vibeguard-runtime/src/observe/aggregate.rs
+++ b/vibeguard-runtime/src/observe/aggregate.rs
@@ -377,4 +377,28 @@ mod tests {
             status::UNKNOWN
         );
     }
+
+    #[test]
+    fn suppressed_w14_is_counted_without_attention_or_warn_inflation() {
+        let event = json!({
+            "ts":"2026-06-01T00:00:09Z",
+            "session":"s1",
+            "hook":"post-edit-guard",
+            "tool":"Edit",
+            "decision":"pass",
+            "status":"skipped",
+            "reason":"[W-14] overlap suppressed cooldown",
+            "detail":"src/main.rs||w14_key=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+
+        let aggregate = aggregate_events(std::slice::from_ref(&event), 2_000);
+        let rendered = observe_event_json(&event, 2_000);
+
+        assert_eq!(aggregate.attention_count, 0);
+        assert_eq!(aggregate.decision_counts.get("pass"), Some(&1));
+        assert_eq!(aggregate.decision_counts.get("warn"), None);
+        assert_eq!(aggregate.rule_ids.get("W-14"), Some(&1));
+        assert_eq!(rendered[field::STATUS], status::SKIPPED);
+        assert_eq!(rendered[field::MODEL_CONTEXT], false);
+    }
 }

--- a/vibeguard-runtime/tests/runtime_config_cli.rs
+++ b/vibeguard-runtime/tests/runtime_config_cli.rs
@@ -118,6 +118,48 @@ fn runtime_config_get_int_defaults_for_parse_errors_and_wrong_types() {
 }
 
 #[test]
+fn runtime_config_get_int_resolves_w14_cooldown_contract() {
+    let dir = runtime_config_temp_dir("w14_cooldown");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let config = dir.join("config.json");
+    fs::write(&config, r#"{"w14":{"cooldown_seconds":1800}}"#)
+        .expect("runtime config should be written");
+
+    let resolve = |env_value: Option<&str>| {
+        let mut command = bin();
+        command
+            .arg("runtime-config-get-int")
+            .arg("VIBEGUARD_W14_COOLDOWN_SECONDS")
+            .arg("w14.cooldown_seconds")
+            .arg("3600")
+            .env("VIBEGUARD_CONFIG_FILE", &config);
+        match env_value {
+            Some(value) => command.env("VIBEGUARD_W14_COOLDOWN_SECONDS", value),
+            None => command.env_remove("VIBEGUARD_W14_COOLDOWN_SECONDS"),
+        };
+        let output = command.output().expect("runtime config command should run");
+        assert_eq!(output.status.code(), Some(0));
+        String::from_utf8(output.stdout).expect("runtime config output should be UTF-8")
+    };
+
+    assert_eq!(resolve(None).trim(), "1800");
+    assert_eq!(resolve(Some("7200")).trim(), "7200");
+    assert_eq!(resolve(Some("0")).trim(), "0");
+    assert_eq!(resolve(Some("not-a-number")).trim(), "1800");
+
+    for body in [
+        r#"{"w14":{}}"#,
+        r#"{"w14":{"cooldown_seconds":"3600"}}"#,
+        r#"{"w14":{"cooldown_seconds":-1}}"#,
+    ] {
+        fs::write(&config, body).expect("runtime config should be rewritten");
+        assert_eq!(resolve(None).trim(), "3600");
+    }
+
+    fs::remove_dir_all(dir).expect("temp dir should be removed");
+}
+
+#[test]
 fn runtime_config_get_str_preserves_env_json_default_order() {
     let dir = runtime_config_temp_dir("str");
     fs::create_dir_all(&dir).expect("temp dir should be created");


### PR DESCRIPTION
Closes #590

## Summary

- key W-14 cooldown by directed current session, peer session, and normalized file
- suppress repeated overlap warnings only after successful skipped telemetry append
- preserve visible warnings on invalid evidence, cooldown boundaries, append failures, and mixed warning output
- document and test env/config/default cooldown precedence with zero as rollback

## Verification

- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check
- cargo clippy --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/hooks/test_post_edit_w14.sh (23/23)
- bash tests/test_hooks.sh
- bash tests/test_setup.sh (499/499)
- bash scripts/local-contract-check.sh --quick
- hook, manifest, docs, workflow validators

## Review

Independent native reviewer PASS at immutable head 8c65351bea133322edbe704cd0a3fcd7eafb7e8d; zero P0/P1/P2 findings.