### PR TITLE
test: raise Rust coverage baseline to 68%

### DIFF
--- a/scripts/ci/self-application/check-u22-coverage.sh
+++ b/scripts/ci/self-application/check-u22-coverage.sh
@@ -6,7 +6,7 @@ REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 CARGO_BIN="${VIBEGUARD_U22_CARGO_BIN:-cargo}"
 CARGO_LLVM_COV_VERSION="0.8.7"
-LINE_COVERAGE_BASELINE="66"
+LINE_COVERAGE_BASELINE="68"
 LINE_COVERAGE_TARGET="80"
 
 if [[ ! -f "${RUNTIME_MANIFEST}" ]]; then

--- a/tests/test_u22_coverage.sh
+++ b/tests/test_u22_coverage.sh
@@ -67,10 +67,10 @@ run_gate() {
 
 success_out="$(run_gate bash "${CHECK}" "${REPO_DIR}")"
 assert_cmd "coverage gate accepts a successful measured run" test -n "${success_out}"
-assert_cmd "coverage output names the 66% blocking baseline" grep -Fq "blocking baseline=66%" <<< "${success_out}"
+assert_cmd "coverage output names the 68% blocking baseline" grep -Fq "blocking baseline=68%" <<< "${success_out}"
 assert_cmd "coverage output keeps the 80% target visible" grep -Fq "target=80% (target not yet enforced)" <<< "${success_out}"
 assert_cmd "coverage command uses the locked runtime manifest" grep -Fq \
-  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 66" \
+  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 68" \
   "${CALL_LOG}"
 
 assert_fails "missing cargo-llvm-cov fails closed" env \

--- a/vibeguard-runtime/tests/cli_hook_orchestrator.rs
+++ b/vibeguard-runtime/tests/cli_hook_orchestrator.rs
@@ -721,7 +721,6 @@ fn pre_bash_all_append_errors_propagate() {
     assert_pre_bash_log_failure("prebash-log-missing-tool", &correction, |command| {
         command.env_remove("PATH");
     });
-
     let tools = unique_temp_dir("prebash-log-tools");
     fs::create_dir_all(&tools).unwrap();
     write_executable(&tools.join("uv"), "#!/bin/sh\nexit 0\n");
@@ -771,6 +770,29 @@ fn pre_bash_empty_and_pass_preserve_behavior() {
 
     let input = pre_bash_input("echo ok");
     let (root, logs, out) = run_pre_bash_case("prebash-pass", &input, |_| {});
+    assert!(out.stdout.is_empty());
+    assert_eq!(first_project_event(&logs)["decision"], "pass");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn pre_bash_deleted_cwd_uses_defensive_fallbacks() {
+    let root = unique_temp_dir("prebash-deleted-cwd");
+    let (repo, logs) = (root.join("repo"), root.join("logs"));
+    fs::create_dir_all(repo.join(".git")).unwrap();
+    let mut command = hook_command(&repo, &logs);
+    command.args(["hook", "pre-bash"]).stdin(Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    fs::remove_dir_all(&repo).unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(pre_bash_input("git commit -m deleted-cwd").as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
     assert!(out.stdout.is_empty());
     assert_eq!(first_project_event(&logs)["decision"], "pass");
     let _ = fs::remove_dir_all(root);

--- a/vibeguard-runtime/tests/cli_hook_orchestrator.rs
+++ b/vibeguard-runtime/tests/cli_hook_orchestrator.rs
@@ -4,7 +4,9 @@ use common::{bin, unique_temp_dir};
 use serde_json::Value;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 fn run_hook(repo: &Path, log_root: &Path, hook: &str, input: &str) -> Output {
@@ -65,6 +67,65 @@ fn hook_command(repo: &Path, log_root: &Path) -> Command {
         .env("VIBEGUARD_SOURCE_CONFIG", "test-config")
         .env("VIBEGUARD_HOOK_PROTOCOL_VERSION", "1");
     command
+}
+
+fn run_pre_bash_with(
+    repo: &Path,
+    log_root: &Path,
+    input: &str,
+    configure: impl FnOnce(&mut Command),
+) -> Output {
+    let mut command = hook_command(repo, log_root);
+    configure(&mut command);
+    let mut child = command
+        .args(["hook", "pre-bash"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn pre_bash_input(command: &str) -> String {
+    serde_json::json!({"tool_input": {"command": command}}).to_string()
+}
+
+fn run_pre_bash_case(
+    label: &str,
+    input: &str,
+    configure: impl FnOnce(&mut Command),
+) -> (PathBuf, PathBuf, Output) {
+    let root = unique_temp_dir(label);
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+    let output = run_pre_bash_with(&repo, &log_root, input, configure);
+    (root, log_root, output)
+}
+
+fn first_project_event(log_root: &Path) -> Value {
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    read_first_json(&project_dir.join("events.jsonl"))
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
 }
 
 fn git(repo: &Path, args: &[&str]) {
@@ -498,5 +559,219 @@ fn hook_orchestrator_manual_session_without_cli_stays_unknown() {
     assert_eq!(event["client_variant"], "unknown");
     assert_eq!(event["caller_evidence"], "no-client-evidence");
 
+    let _ = fs::remove_dir_all(root);
+}
+
+fn assert_pre_bash_log_failure(label: &str, input: &str, configure: impl FnOnce(&mut Command)) {
+    let bad_log = unique_temp_dir(&format!("{label}-bad-log"));
+    let project_log = unique_temp_dir(&format!("{label}-project-log"));
+    fs::create_dir_all(&bad_log).unwrap();
+    let (root, _, out) = run_pre_bash_case(label, input, |command| {
+        configure(command);
+        command
+            .env("VIBEGUARD_PROJECT_LOG_DIR", &project_log)
+            .env("VIBEGUARD_LOG_FILE", &bad_log);
+    });
+    assert_eq!(out.status.code(), Some(1), "{label}");
+    assert!(out.stdout.is_empty(), "{label}");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("vibeguard-runtime error:"),
+        "{label}: {stderr}"
+    );
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(project_log);
+    let _ = fs::remove_dir_all(bad_log);
+}
+
+#[test]
+fn pre_bash_malformed_missing_warning_and_root_precedence() {
+    for (label, input) in [
+        ("prebash-malformed", "not-json"),
+        ("prebash-missing-command", r#"{"tool_input":{}}"#),
+    ] {
+        let (root, logs, out) = run_pre_bash_case(label, input, |_| {});
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
+        assert_eq!(first_project_event(&logs)["decision"], "block");
+        let _ = fs::remove_dir_all(root);
+    }
+    let input = pre_bash_input("printf x > notes.md");
+    let (root, logs, out) = run_pre_bash_case("prebash-warning", &input, |_| {});
+    assert!(String::from_utf8_lossy(&out.stdout).contains("non-standard .md file"));
+    assert_eq!(first_project_event(&logs)["decision"], "warn");
+    let _ = fs::remove_dir_all(root);
+
+    let input = pre_bash_input("git checkout .");
+    let (root, _, out) = run_pre_bash_case("prebash-root-precedence", &input, |command| {
+        command
+            .env("VIBEGUARD_DIR", "/explicit-vg-root")
+            .env("VIBEGUARD_HOOK_DIR", "/ignored-vg-root/hooks");
+    });
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("/explicit-vg-root/scripts/authorized-discard.py"));
+    assert!(!stdout.contains("/ignored-vg-root"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn pre_bash_correction_paths_preserve_behavior() {
+    let empty_path = unique_temp_dir("prebash-empty-path");
+    fs::create_dir_all(&empty_path).unwrap();
+    let input = pre_bash_input("npm install");
+    let (root, logs, out) = run_pre_bash_case("prebash-no-path", &input, |command| {
+        command.env("PATH", &empty_path);
+    });
+    assert!(out.stdout.is_empty());
+    assert_eq!(
+        first_project_event(&logs)["reason"],
+        "pkg-rewrite skipped (pnpm not found)"
+    );
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(empty_path);
+
+    let tools = unique_temp_dir("prebash-tools");
+    fs::create_dir_all(&tools).unwrap();
+    write_executable(&tools.join("uv"), "#!/bin/sh\nexit 0\n");
+    write_executable(&tools.join("pnpm"), "#!/bin/sh\nexit 0\n");
+    let input = pre_bash_input("pip install requests");
+    let (root, logs, out) = run_pre_bash_case("prebash-uv-skip", &input, |command| {
+        command.env("PATH", &tools).env_remove("VIRTUAL_ENV");
+    });
+    assert!(out.stdout.is_empty());
+    assert!(
+        first_project_event(&logs)["reason"]
+            .as_str()
+            .unwrap()
+            .contains("no active venv")
+    );
+    let _ = fs::remove_dir_all(root);
+
+    let input = pre_bash_input("npm install");
+    let (root, logs, out) = run_pre_bash_case("prebash-correction", &input, |command| {
+        command.env("PATH", &tools);
+    });
+    assert!(String::from_utf8_lossy(&out.stdout).contains("pnpm install"));
+    assert_eq!(first_project_event(&logs)["decision"], "correction");
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(tools);
+}
+
+#[cfg(unix)]
+#[test]
+fn pre_bash_precommit_outcomes_preserve_behavior() {
+    for (label, script) in [
+        ("prebash-precommit-ok", Some("echo checked\nexit 0\n")),
+        ("prebash-no-script", None),
+    ] {
+        let hooks = unique_temp_dir(label).join("hooks");
+        fs::create_dir_all(&hooks).unwrap();
+        if let Some(body) = script {
+            fs::write(hooks.join("pre-commit-guard.sh"), body).unwrap();
+        }
+        let input = pre_bash_input("git commit -m ok");
+        let (root, logs, out) = run_pre_bash_case(label, &input, |command| {
+            command.env("VIBEGUARD_HOOK_DIR", &hooks);
+        });
+        assert!(out.stdout.is_empty());
+        assert_eq!(first_project_event(&logs)["decision"], "pass");
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(hooks.parent().unwrap());
+    }
+
+    let hooks = unique_temp_dir("prebash-precommit-fail").join("hooks");
+    fs::create_dir_all(&hooks).unwrap();
+    fs::write(
+        hooks.join("pre-commit-guard.sh"),
+        "echo child-stdout\necho child-stderr >&2\nexit 7\n",
+    )
+    .unwrap();
+    let input = pre_bash_input("git commit -m fail");
+    let (root, logs, out) = run_pre_bash_case("prebash-precommit-fail", &input, |command| {
+        command.env("VIBEGUARD_HOOK_DIR", &hooks);
+    });
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("child-stdout") && stdout.contains("child-stderr"));
+    assert_eq!(first_project_event(&logs)["decision"], "block");
+    let _ = fs::remove_dir_all(root);
+
+    let empty_path = unique_temp_dir("prebash-spawn-empty-path");
+    fs::create_dir_all(&empty_path).unwrap();
+    let (root, logs, out) = run_pre_bash_case("prebash-spawn-fail", &input, |command| {
+        command
+            .env("VIBEGUARD_HOOK_DIR", &hooks)
+            .env("PATH", &empty_path);
+    });
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"decision\": \"block\"") && stdout.contains("Pre-Commit"));
+    assert_eq!(first_project_event(&logs)["decision"], "block");
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(empty_path);
+    let _ = fs::remove_dir_all(hooks.parent().unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn pre_bash_all_append_errors_propagate() {
+    assert_pre_bash_log_failure("prebash-log-block", "not-json", |_| {});
+    let warning = pre_bash_input("printf x > notes.md");
+    assert_pre_bash_log_failure("prebash-log-warn", &warning, |_| {});
+    let correction = pre_bash_input("npm install");
+    assert_pre_bash_log_failure("prebash-log-missing-tool", &correction, |command| {
+        command.env_remove("PATH");
+    });
+
+    let tools = unique_temp_dir("prebash-log-tools");
+    fs::create_dir_all(&tools).unwrap();
+    write_executable(&tools.join("uv"), "#!/bin/sh\nexit 0\n");
+    write_executable(&tools.join("pnpm"), "#!/bin/sh\nexit 0\n");
+    let uv = pre_bash_input("pip install requests");
+    assert_pre_bash_log_failure("prebash-log-uv-skip", &uv, |command| {
+        command.env("PATH", &tools).env_remove("VIRTUAL_ENV");
+    });
+    assert_pre_bash_log_failure("prebash-log-correction", &correction, |command| {
+        command.env("PATH", &tools);
+    });
+
+    let hooks = unique_temp_dir("prebash-log-hooks").join("hooks");
+    fs::create_dir_all(&hooks).unwrap();
+    fs::write(hooks.join("pre-commit-guard.sh"), "exit 9\n").unwrap();
+    let commit = pre_bash_input("git commit -m fail");
+    assert_pre_bash_log_failure("prebash-log-precommit", &commit, |command| {
+        command.env("VIBEGUARD_HOOK_DIR", &hooks);
+    });
+    let empty_path = unique_temp_dir("prebash-log-empty-path");
+    fs::create_dir_all(&empty_path).unwrap();
+    assert_pre_bash_log_failure("prebash-log-spawn", &commit, |command| {
+        command
+            .env("VIBEGUARD_HOOK_DIR", &hooks)
+            .env("PATH", &empty_path);
+    });
+    let pass = pre_bash_input("echo ok");
+    assert_pre_bash_log_failure("prebash-log-pass", &pass, |_| {});
+    let _ = fs::remove_dir_all(tools);
+    let _ = fs::remove_dir_all(hooks.parent().unwrap());
+    let _ = fs::remove_dir_all(empty_path);
+}
+
+#[test]
+fn pre_bash_empty_and_pass_preserve_behavior() {
+    let input = pre_bash_input("");
+    let (root, logs, out) = run_pre_bash_case("prebash-empty", &input, |_| {});
+    assert!(out.stdout.is_empty());
+    let project = fs::read_dir(logs.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    assert!(!project.join("events.jsonl").exists());
+    let _ = fs::remove_dir_all(root);
+
+    let input = pre_bash_input("echo ok");
+    let (root, logs, out) = run_pre_bash_case("prebash-pass", &input, |_| {});
+    assert!(out.stdout.is_empty());
+    assert_eq!(first_project_event(&logs)["decision"], "pass");
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
Refs #581

## Partial tranche

This PR implements SP581-T1 and SP581-T2 only. The issue remains open for later tranches that continue the ratchet to 80%.

## Coverage evidence

- canonical Linux before on main 866d5c2: 12,674 / 18,761 = 67.56%
- clean before JSON: 12,674 / 18,761 = 67.555034%
- clean post JSON: 12,809 / 18,761 = 68.274612%
- newly covered production lines: 135
- pre-bash target: 58 / 179 = 32.402234% to 177 / 179 = 98.882682%
- blocking baseline: 66% to 68%
- before JSON SHA-256: 42968aca01381f96c3ca04994958f8fa1b3ba529896e94e0c80dfb65d0e8240a
- post JSON SHA-256: 517be6892faf208f60a8520718a5a22f74aca1002b8b3474bdfe5e1a0079f58e

## Behavior coverage

- malformed and missing command fail closed
- destructive block and warning decisions remain visible and logged
- correction success plus missing-tool and no-venv skips
- pre-commit success, nonzero child output, and launcher spawn failure
- append failures across every decision propagate visibly without false output
- explicit root/PATH behavior, deleted-cwd defensive fallbacks, empty and ordinary pass

## Exception ledger

Independent reviewer accepted hook_orchestrator_pre_bash.rs:206-209 as a line-specific unsupported non-Unix runtime exception. Canonical Linux excludes it; Windows Rust runtime is not a supported production path. Revisit if Windows runtime support is introduced.

## Verification

- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check
- cargo clippy --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml --test cli_hook_orchestrator pre_bash (7/7)
- bash tests/test_u22_coverage.sh (8/8)
- bash scripts/ci/self-application/check-u22-coverage.sh
- bash scripts/ci/self-application/run-all.sh
- bash tests/test_self_application_ci.sh
- bash tests/test_release_workflow.sh
- bash scripts/local-contract-check.sh --quick
- git diff --check

Independent native reviewer PASS at immutable head 306ae415efec182e450e9a7d2d169b498816cd6a with no P0/P1/P2 findings.