### PR TITLE
test: raise Rust coverage baseline to 70%

### DIFF
--- a/scripts/ci/self-application/check-u22-coverage.sh
+++ b/scripts/ci/self-application/check-u22-coverage.sh
@@ -6,7 +6,7 @@ REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 CARGO_BIN="${VIBEGUARD_U22_CARGO_BIN:-cargo}"
 CARGO_LLVM_COV_VERSION="0.8.7"
-LINE_COVERAGE_BASELINE="68"
+LINE_COVERAGE_BASELINE="70"
 LINE_COVERAGE_TARGET="80"
 
 if [[ ! -f "${RUNTIME_MANIFEST}" ]]; then

--- a/tests/test_u22_coverage.sh
+++ b/tests/test_u22_coverage.sh
@@ -67,10 +67,10 @@ run_gate() {
 
 success_out="$(run_gate bash "${CHECK}" "${REPO_DIR}")"
 assert_cmd "coverage gate accepts a successful measured run" test -n "${success_out}"
-assert_cmd "coverage output names the 68% blocking baseline" grep -Fq "blocking baseline=68%" <<< "${success_out}"
+assert_cmd "coverage output names the 70% blocking baseline" grep -Fq "blocking baseline=70%" <<< "${success_out}"
 assert_cmd "coverage output keeps the 80% target visible" grep -Fq "target=80% (target not yet enforced)" <<< "${success_out}"
 assert_cmd "coverage command uses the locked runtime manifest" grep -Fq \
-  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 68" \
+  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 70" \
   "${CALL_LOG}"
 
 assert_fails "missing cargo-llvm-cov fails closed" env \

--- a/vibeguard-runtime/tests/cli_hook_checks.rs
+++ b/vibeguard-runtime/tests/cli_hook_checks.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{bin, run_runtime_with_stdin, unique_temp_dir};
+use common::{bin, unique_temp_dir};
 use std::fs;
 use std::io::Write;
 use std::process::Stdio;
@@ -31,21 +31,68 @@ fn run_post_write_check(input: &str, log_file: &std::path::Path) -> std::process
     child.wait_with_output().unwrap()
 }
 
+fn run_post_edit_fast_check(input: &str, log_file: &std::path::Path) -> std::process::Output {
+    let mut child = bin()
+        .args([
+            "post-edit-fast-check",
+            "800",
+            "test-session",
+            "codex",
+            log_file.to_string_lossy().as_ref(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn run_pre_edit_check(input: &str, log_file: &std::path::Path) -> std::process::Output {
+    run_pre_edit_check_with(input, log_file, |_| {})
+}
+
+fn run_pre_edit_check_with(
+    input: &str,
+    log_file: &std::path::Path,
+    configure: impl FnOnce(&mut std::process::Command),
+) -> std::process::Output {
+    let mut command = bin();
+    command
+        .args([
+            "pre-edit-check",
+            "800",
+            "400",
+            log_file.to_string_lossy().as_ref(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("VIBEGUARD_PROJECT_HASH", "test-project")
+        .env("VIBEGUARD_SESSION_ID", "test-session");
+    configure(&mut command);
+    let mut child = command.spawn().unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
 #[test]
 fn post_edit_fast_check_reports_malformed_json() {
     let root = unique_temp_dir("post-edit-malformed");
     fs::create_dir_all(&root).unwrap();
     let log_file = root.join("events.jsonl");
-    let out = run_runtime_with_stdin(
-        &[
-            "post-edit-fast-check",
-            "400",
-            "test-session",
-            "codex",
-            log_file.to_string_lossy().as_ref(),
-        ],
-        "not-json",
-    );
+    let out = run_post_edit_fast_check("not-json", &log_file);
 
     assert_eq!(out.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -55,6 +102,237 @@ fn post_edit_fast_check_reports_malformed_json() {
     let log_text = fs::read_to_string(&log_file).unwrap();
     assert!(log_text.contains("Malformed hook input"), "{log_text}");
     assert!(log_text.contains("\"decision\":\"warn\""), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_keeps_malformed_warning_visible_when_log_fails() {
+    let root = unique_temp_dir("post-edit-malformed-log-failure");
+    fs::create_dir_all(&root).unwrap();
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks log parent creation").unwrap();
+    let log_file = blocking_parent.join("events.jsonl");
+
+    let out = run_post_edit_fast_check("not-json", &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stdout.contains("FAST_OUTPUT"), "{stdout}");
+    assert!(stdout.contains("malformed PostToolUse(Edit)"), "{stdout}");
+    assert!(
+        stderr.contains("post-edit malformed input log failed"),
+        "{stderr}"
+    );
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_skips_missing_required_fields() {
+    let root = unique_temp_dir("post-edit-missing-fields");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+
+    for input in [
+        r#"{"tool_input":{"new_string":"fn clean() {}"}}"#,
+        r#"{"tool_input":{"file_path":"src/lib.rs"}}"#,
+    ] {
+        let out = run_post_edit_fast_check(input, &log_file);
+        assert_eq!(out.status.code(), Some(0));
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "SKIP\n");
+        assert!(out.stderr.is_empty());
+    }
+    assert!(!log_file.exists(), "skip must not fabricate a pass log");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_exposes_non_clean_edit_fallback() {
+    let root = unique_temp_dir("post-edit-fallback");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "safe_call()?",
+            "new_string": "unsafe_call().unwrap()"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "FALLBACK\n");
+    assert!(out.stderr.is_empty());
+    assert!(!log_file.exists(), "fallback must defer the final decision");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_logs_pass_when_history_file_is_missing() {
+    let root = unique_temp_dir("post-edit-missing-history");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "FAST_LOGGED\n");
+    assert!(out.stderr.is_empty());
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("\"decision\":\"pass\""), "{log_text}");
+    assert!(log_text.contains("src/lib.rs||delta=2"), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_exposes_pass_log_failure() {
+    let root = unique_temp_dir("post-edit-log-failure");
+    fs::create_dir_all(&root).unwrap();
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks log parent creation").unwrap();
+    let log_file = blocking_parent.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout, "FAST_PASS\nsrc/lib.rs\n");
+    assert!(out.stderr.is_empty());
+    assert!(
+        !log_file.exists(),
+        "failed logging must not claim persistence"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn pre_edit_check_blocks_missing_file_with_lookup_failure_visible() {
+    let root = unique_temp_dir("pre-edit-missing-file");
+    fs::create_dir_all(&root).unwrap();
+    let file_path = root.join("src").join("missing_service.rs");
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": "old",
+            "new_string": "new"
+        }
+    })
+    .to_string();
+
+    let out = run_pre_edit_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("FAST_OUTPUT\n"), "{stdout}");
+    assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
+    assert!(stdout.contains("File does not exist"), "{stdout}");
+    assert!(stdout.contains("no git project root found"), "{stdout}");
+    assert!(out.stderr.is_empty());
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("\"decision\":\"block\""), "{log_text}");
+    assert!(log_text.contains("File does not exist"), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn pre_edit_check_exposes_missing_git_dependency() {
+    let root = unique_temp_dir("pre-edit-missing-git");
+    fs::create_dir_all(root.join(".git")).unwrap();
+    let file_path = root.join("src").join("missing_service.rs");
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": "old",
+            "new_string": "new"
+        }
+    })
+    .to_string();
+
+    let out = run_pre_edit_check_with(&input, &log_file, |command| {
+        command.env("PATH", "");
+    });
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("FAST_OUTPUT\n"), "{stdout}");
+    assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
+    assert!(stdout.contains("git ls-files could not run"), "{stdout}");
+    assert!(out.stderr.is_empty());
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("File does not exist"), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn pre_edit_check_blocks_stale_old_string() {
+    let root = unique_temp_dir("pre-edit-stale-old-string");
+    fs::create_dir_all(&root).unwrap();
+    let file_path = root.join("lib.rs");
+    fs::write(&file_path, "fn current() {}\n").unwrap();
+    let log_file = root.join("events.jsonl");
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": "fn stale() {}",
+            "new_string": "fn replacement() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_pre_edit_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("FAST_OUTPUT\n"), "{stdout}");
+    assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
+    assert!(stdout.contains("old_string does not exist"), "{stdout}");
+    assert!(stdout.contains("use the Read tool"), "{stdout}");
+    assert!(out.stderr.is_empty());
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("old_string does not exist"), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn pre_edit_check_keeps_block_visible_when_log_append_fails() {
+    let root = unique_temp_dir("pre-edit-block-log-failure");
+    fs::create_dir_all(&root).unwrap();
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks log parent creation").unwrap();
+    let log_file = blocking_parent.join("events.jsonl");
+
+    let out = run_pre_edit_check("not-json", &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stdout.starts_with("FAST_OUTPUT\n"), "{stdout}");
+    assert!(stdout.contains("\"decision\": \"block\""), "{stdout}");
+    assert!(stdout.contains("VG-INTERNAL-LOG-APPEND"), "{stdout}");
+    assert!(stdout.contains("failure_kind=runtime"), "{stdout}");
+    assert!(stdout.contains("project=test-project"), "{stdout}");
+    assert!(stdout.contains("session=test-session"), "{stdout}");
+    assert!(
+        stderr.contains("pre-edit block log append failed"),
+        "{stderr}"
+    );
+    assert!(
+        !log_file.exists(),
+        "failed logging must not claim persistence"
+    );
     let _ = fs::remove_dir_all(root);
 }
 

--- a/vibeguard-runtime/tests/cli_hook_post_edit.rs
+++ b/vibeguard-runtime/tests/cli_hook_post_edit.rs
@@ -1,0 +1,213 @@
+mod common;
+
+use common::{bin, unique_temp_dir};
+use serde_json::{Value, json};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn post_edit_command(repo: &Path, log_root: &Path, log_file: &Path) -> Command {
+    let mut command = bin();
+    let project_log_dir = log_root.join("projects").join("post-edit-project");
+    command
+        .current_dir(repo)
+        .env("VIBEGUARD_LOG_DIR", log_root)
+        .env("VIBEGUARD_PROJECT_LOG_DIR", project_log_dir)
+        .env("VIBEGUARD_LOG_FILE", log_file)
+        .env("VIBEGUARD_PROJECT_HASH", "post-edit-project")
+        .env("VIBEGUARD_CLI", "codex")
+        .env("VIBEGUARD_CLIENT", "codex")
+        .env("VIBEGUARD_SESSION_ID", "post-edit-session")
+        .env("VIBEGUARD_CALLER_EVIDENCE", "explicit-test")
+        .env("VIBEGUARD_AGENT_TYPE", "codex");
+    command
+}
+
+fn run_post_edit(repo: &Path, log_root: &Path, log_file: &Path, input: &str) -> Output {
+    let mut child = post_edit_command(repo, log_root, log_file)
+        .args(["hook", "post-edit"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn case_paths(label: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let root = unique_temp_dir(label);
+    let repo = root.join("repo");
+    let log_root = root.join("logs");
+    let project_log_dir = log_root.join("projects").join("post-edit-project");
+    let log_file = project_log_dir.join("events.jsonl");
+    fs::create_dir_all(repo.join(".git")).unwrap();
+    fs::create_dir_all(&project_log_dir).unwrap();
+    (root, repo, log_root, log_file)
+}
+
+fn edit_input(file_path: &str, old_string: &str, new_string: &str) -> String {
+    json!({
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string
+        }
+    })
+    .to_string()
+}
+
+fn parse_test_event_log(path: &Path) -> Vec<Value> {
+    fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn post_edit_malformed_input_warns_visibly_and_logs() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-malformed");
+    let out = run_post_edit(&repo, &log_root, &log_file, "not-json");
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("PostToolUse"), "{stdout}");
+    assert!(stdout.contains("malformed PostToolUse(Edit)"), "{stdout}");
+    let events = parse_test_event_log(&log_file);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["decision"], "warn");
+    assert_eq!(events[0]["reason"], "Malformed hook input");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_missing_fields_stay_silent_without_pass_log() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-missing-fields");
+
+    for input in [
+        r#"{"tool_input":{"new_string":"fn clean() {}"}}"#,
+        r#"{"tool_input":{"file_path":"src/lib.rs"}}"#,
+    ] {
+        let out = run_post_edit(&repo, &log_root, &log_file, input);
+        assert_eq!(out.status.code(), Some(0));
+        assert!(out.stdout.is_empty());
+        assert!(out.stderr.is_empty());
+    }
+    assert!(!log_file.exists(), "skip must not fabricate a pass event");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_clean_edit_logs_pass_and_delta() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-pass");
+    let input = edit_input("src/lib.rs", "fn old() {}", "fn clean() {}");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.is_empty());
+    let events = parse_test_event_log(&log_file);
+    let event = events.last().unwrap();
+    assert_eq!(event["decision"], "pass");
+    assert_eq!(event["status"], "pass");
+    assert_eq!(event["detail"], "src/lib.rs||delta=2");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_rust_warning_is_visible_and_logged() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-warning");
+    let input = edit_input("src/lib.rs", "safe_call()?", "unsafe_call().unwrap()");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VIBEGUARD quality warning"), "{stdout}");
+    assert!(stdout.contains("[RS-03]"), "{stdout}");
+    assert!(stdout.contains("unwrap()/expect()"), "{stdout}");
+    let events = parse_test_event_log(&log_file);
+    let event = events.last().unwrap();
+    assert_eq!(event["decision"], "warn");
+    assert!(event["reason"].as_str().unwrap().contains("[RS-03]"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_prior_warnings_escalate_current_warning() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-escalate");
+    let prior = (0..3)
+        .map(|index| {
+            json!({
+                "schema_version": 1,
+                "ts": format!("2026-07-15T19:00:0{index}Z"),
+                "session": "post-edit-session",
+                "hook": "post-edit-guard",
+                "tool": "Edit",
+                "decision": "warn",
+                "status": "warn",
+                "reason": "[RS-03] prior warning",
+                "detail": "src/lib.rs||delta=4"
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&log_file, format!("{prior}\n")).unwrap();
+
+    let input = edit_input("src/lib.rs", "safe_call()?", "unsafe_call().unwrap()");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VIBEGUARD upgrade warning"), "{stdout}");
+    assert!(stdout.contains("triggered 3 warnings"), "{stdout}");
+    assert!(stdout.contains("[RS-03]"), "{stdout}");
+    let events = parse_test_event_log(&log_file);
+    let event = events.last().unwrap();
+    assert_eq!(event["decision"], "escalate");
+    assert!(event["reason"].as_str().unwrap().contains("[ESCALATE]"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_pass_log_failure_is_reported_visibly() {
+    let (root, repo, log_root, _) = case_paths("post-edit-pass-log-failure");
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks log parent creation").unwrap();
+    let log_file = blocking_parent.join("events.jsonl");
+    let input = edit_input("src/lib.rs", "fn old() {}", "fn clean() {}");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VG-INTERNAL-LOG-APPEND"), "{stdout}");
+    assert!(stdout.contains("mode=allow"), "{stdout}");
+    assert!(stdout.contains("project=post-edit-project"), "{stdout}");
+    assert!(stdout.contains("session=post-edit-session"), "{stdout}");
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_warning_survives_log_failure_with_internal_error() {
+    let (root, repo, log_root, _) = case_paths("post-edit-warn-log-failure");
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks log parent creation").unwrap();
+    let log_file = blocking_parent.join("events.jsonl");
+    let input = edit_input("src/lib.rs", "safe_call()?", "unsafe_call().unwrap()");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VG-INTERNAL-LOG-APPEND"), "{stdout}");
+    assert!(stdout.contains("VIBEGUARD quality warning"), "{stdout}");
+    assert!(stdout.contains("[RS-03]"), "{stdout}");
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
Refs #581

## Partial tranche

This PR advances the GH581 hook-check and post-edit/history risk surface without marking SP581-T3 complete. The issue remains open for the pending silent-history, W-14, U-16 and long-tail coverage work.

## Coverage evidence

- before head: 0f2779463ed12a292fa698877d27cbed2a842c9f
- PR head: b3163d8b4d3e894f88f9beaaec8dadd685187b4c
- before: 12,809 / 18,761 = 68.274612%
- post: 13,233 / 18,761 = 70.534620%
- newly covered production lines: 424
- blocking baseline: 68% to 70%
- before JSON SHA-256: 438bced640d71016162fa1db54eb48a4823e2fbc26988fbb742e45b5fdf0db91
- post JSON SHA-256: 6cc63ba4fb06e493daa9c67519fffb5115ddac06398bcb450c7fbd1cdbd9f224

## Behavior coverage

- post-edit fast malformed, missing-field, fallback, pass and log-failure behavior
- pre-edit missing file, missing git dependency, stale old_string and block-log failure
- full post-edit malformed, silent skip, clean pass, Rust warning and three-warning escalation
- pass and warning append failures preserve visible internal-error and warning context
- all PATH/environment/cwd changes are child-process scoped

## Pending T3 gaps

The review inventory keeps the following as pending work rather than accepted exceptions: malformed-event append visibility, fast/full history read and malformed-line visibility, churn thresholds, W-14 shown/suppression, W-15 shrinking-radius, U-16 file read/threshold paths, pre-edit read errors and clean-pass log fallback.

## Verification

- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check
- cargo clippy --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- cargo test --manifest-path vibeguard-runtime/Cargo.toml --test cli_hook_checks --test cli_hook_post_edit
- bash tests/test_u22_coverage.sh (8/8)
- bash scripts/ci/self-application/check-u22-coverage.sh
- bash scripts/ci/self-application/run-all.sh
- bash tests/test_self_application_ci.sh
- bash tests/test_release_workflow.sh
- bash scripts/local-contract-check.sh --quick
- git diff --check
- W-20 runtime drift check

Independent native reviewer PASS at immutable head b3163d8b4d3e894f88f9beaaec8dadd685187b4c with no P0/P1/P2 findings. It explicitly requires the pending gaps to remain in later tranches.