### PR TITLE
fix: surface post-edit history failures

### DIFF
--- a/scripts/ci/self-application/check-u22-coverage.sh
+++ b/scripts/ci/self-application/check-u22-coverage.sh
@@ -6,7 +6,7 @@ REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 CARGO_BIN="${VIBEGUARD_U22_CARGO_BIN:-cargo}"
 CARGO_LLVM_COV_VERSION="0.8.7"
-LINE_COVERAGE_BASELINE="70"
+LINE_COVERAGE_BASELINE="71"
 LINE_COVERAGE_TARGET="80"
 
 if [[ ! -f "${RUNTIME_MANIFEST}" ]]; then

--- a/tests/hooks/test_post_edit_w14.sh
+++ b/tests/hooks/test_post_edit_w14.sh
@@ -175,7 +175,9 @@ assert_contains "$_w14_missing" "[W-14]" "W-14 missing peer session fails open"
 _w14_seed_history "$_w14_file" "bad-history-peer"
 printf 'not-json\n' >> "$_w14_log_file"
 _w14_bad_history=$(_w14_run "$_w14_file")
-assert_contains "$_w14_bad_history" "[W-14]" "W-14 malformed history fails open"
+assert_contains "$_w14_bad_history" "VG-INTERNAL-HISTORY-READ" "Malformed history reports the history read failure"
+assert_contains "$_w14_bad_history" "malformed post-edit history JSONL at line 2" "Malformed history preserves the parse failure detail"
+assert_not_contains "$_w14_bad_history" "[W-14]" "Malformed history does not fabricate a W-14 finding"
 
 _w14_long_dir="$_w14_dir"
 for _w14_component_index in {1..8}; do

--- a/tests/test_u22_coverage.sh
+++ b/tests/test_u22_coverage.sh
@@ -67,10 +67,10 @@ run_gate() {
 
 success_out="$(run_gate bash "${CHECK}" "${REPO_DIR}")"
 assert_cmd "coverage gate accepts a successful measured run" test -n "${success_out}"
-assert_cmd "coverage output names the 70% blocking baseline" grep -Fq "blocking baseline=70%" <<< "${success_out}"
+assert_cmd "coverage output names the 71% blocking baseline" grep -Fq "blocking baseline=71%" <<< "${success_out}"
 assert_cmd "coverage output keeps the 80% target visible" grep -Fq "target=80% (target not yet enforced)" <<< "${success_out}"
 assert_cmd "coverage command uses the locked runtime manifest" grep -Fq \
-  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 70" \
+  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 71" \
   "${CALL_LOG}"
 
 assert_fails "missing cargo-llvm-cov fails closed" env \

--- a/vibeguard-runtime/src/hook_checks.rs
+++ b/vibeguard-runtime/src/hook_checks.rs
@@ -564,7 +564,7 @@ pub fn post_edit_fast_check(args: &[String]) -> Result {
     let log_file = &args[3];
     let input = read_stdin()?;
     let Ok(data) = serde_json::from_str::<serde_json::Value>(&input) else {
-        let context = "VIBEGUARD ERROR: malformed PostToolUse(Edit) hook input. The edit result could not be inspected, so this warning is reported visibly instead of silently passing.";
+        let mut context = "VIBEGUARD ERROR: malformed PostToolUse(Edit) hook input. The edit result could not be inspected, so this warning is reported visibly instead of silently passing.".to_string();
         if let Err(exc) = write_log_event(
             log_file,
             "post-edit-guard",
@@ -574,9 +574,16 @@ pub fn post_edit_fast_check(args: &[String]) -> Result {
             "",
         ) {
             eprintln!("post-edit malformed input log failed: {exc}");
+            let project =
+                std::env::var("VIBEGUARD_PROJECT_HASH").unwrap_or_else(|_| "unknown".to_string());
+            let session =
+                std::env::var("VIBEGUARD_SESSION_ID").unwrap_or_else(|_| "unknown".to_string());
+            context.push_str(&format!(
+                "\n---\nVIBEGUARD internal error [VG-INTERNAL-LOG-APPEND]: hook=post-edit-guard tool=Edit failure_kind=runtime mode=allow project={project} session={session} log_path={log_file} recovery=bash scripts/hook-health.sh 24 detail=post-edit malformed input log append failed: {exc}"
+            ));
         }
         println!("FAST_OUTPUT");
-        println!("{}", hook_context_json("PostToolUse", context));
+        println!("{}", hook_context_json("PostToolUse", &context));
         return Ok(());
     };
 
@@ -594,7 +601,14 @@ pub fn post_edit_fast_check(args: &[String]) -> Result {
         return Ok(());
     }
 
-    let history = post_edit_history_signals(log_file, session, agent, &file_path);
+    let history = match post_edit_history_signals(log_file, session, agent, &file_path) {
+        Ok(history) => history,
+        Err(err) => {
+            eprintln!("VIBEGUARD ERROR: post-edit history read failed: {err}");
+            println!("FALLBACK");
+            return Ok(());
+        }
+    };
     if history
         .as_ref()
         .is_some_and(|signals| signals.needs_shell_w15_check())
@@ -723,122 +737,5 @@ pub fn post_write_fast_check(args: &[String]) -> Result {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
-
-    fn temp_project(name: &str) -> PathBuf {
-        let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-        std::env::temp_dir().join(format!(
-            "vibeguard_runtime_hook_checks_{name}_{}_{}",
-            std::process::id(),
-            unique
-        ))
-    }
-
-    fn init_git_repo(root: &Path) -> io::Result<()> {
-        fs::create_dir_all(root)?;
-        let output = std::process::Command::new("git")
-            .arg("-C")
-            .arg(root)
-            .arg("init")
-            .arg("-q")
-            .output()?;
-        assert!(
-            output.status.success(),
-            "git init failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn decision_block_json_escapes_reason_text() {
-        let output = decision_block_json("old_string \"missing\"\nread first");
-        let value: serde_json::Value =
-            serde_json::from_str(&output).expect("decision output should be valid JSON");
-
-        assert_eq!(value["decision"], "block");
-        assert_eq!(value["reason"], "old_string \"missing\"\nread first");
-    }
-
-    #[test]
-    fn missing_required_args_return_usage_errors_before_stdin() {
-        let pre_edit = pre_edit_check(&[]).expect_err("pre-edit args should be required");
-        let post_edit = post_edit_fast_check(&[]).expect_err("post-edit args should be required");
-        let post_write =
-            post_write_fast_check(&[]).expect_err("post-write args should be required");
-
-        assert!(pre_edit.to_string().contains("pre-edit-check"));
-        assert!(post_edit.to_string().contains("post-edit-fast-check"));
-        assert!(post_write.to_string().contains("post-write-fast-check"));
-    }
-
-    #[test]
-    fn missing_file_candidates_distinguishes_empty_from_lookup_failure() -> TestResult {
-        let root = temp_project("empty");
-        init_git_repo(&root)?;
-        let src_dir = root.join("src");
-        fs::create_dir_all(&src_dir)?;
-        let tracked = src_dir.join("lib.rs");
-        fs::write(&tracked, "pub fn lib() {}\n")?;
-        let add_output = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&root)
-            .arg("add")
-            .arg("src/lib.rs")
-            .output()?;
-        assert!(
-            add_output.status.success(),
-            "git add failed: {}",
-            String::from_utf8_lossy(&add_output.stderr)
-        );
-
-        let missing = root.join("src").join("missing_name.rs");
-        assert_eq!(
-            missing_file_candidates(missing.to_string_lossy().as_ref(), "missing_name"),
-            MissingFileCandidates::Empty
-        );
-
-        fs::remove_dir_all(root)?;
-        Ok(())
-    }
-
-    #[test]
-    fn missing_file_candidates_reports_git_lookup_failure() -> TestResult {
-        let root = temp_project("bad_git");
-        fs::create_dir_all(root.join(".git"))?;
-        fs::create_dir_all(root.join("src"))?;
-        let missing = root.join("src").join("lib.rs");
-
-        let result = missing_file_candidates(missing.to_string_lossy().as_ref(), "lib");
-        assert!(
-            matches!(
-                result,
-                MissingFileCandidates::LookupFailed(ref detail)
-                    if detail.contains("git ls-files")
-            ),
-            "expected lookup failure that names git ls-files, got {result:?}"
-        );
-
-        fs::remove_dir_all(root)?;
-        Ok(())
-    }
-
-    #[test]
-    fn post_edit_log_detail_preserves_delta_metadata() {
-        assert_eq!(
-            post_edit_log_detail("src/lib.rs", "old", "newer"),
-            "src/lib.rs||delta=2"
-        );
-        assert_eq!(
-            post_edit_log_detail("src/lib.rs", "abcdef", "xy"),
-            "src/lib.rs||delta=-4"
-        );
-    }
-}
+#[path = "hook_checks_tests.rs"]
+mod tests;

--- a/vibeguard-runtime/src/hook_checks_history.rs
+++ b/vibeguard-runtime/src/hook_checks_history.rs
@@ -38,16 +38,31 @@ pub(crate) fn post_edit_history_signals(
     session: &str,
     agent: &str,
     file_path: &str,
-) -> Option<PostEditHistorySignals> {
-    let Ok(lines) = read_tail_lines(log_file, POST_EDIT_HISTORY_LINES) else {
-        return None;
+) -> io::Result<Option<PostEditHistorySignals>> {
+    let lines = match read_tail_lines(log_file, POST_EDIT_HISTORY_LINES) {
+        Ok(lines) => lines,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
     };
-    let events = lines
-        .lines()
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .collect::<Vec<_>>();
+    let mut events = Vec::new();
+    for (index, line) in lines.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str::<Value>(line).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "malformed post-edit history JSONL at line {}: {err}",
+                    index + 1
+                ),
+            )
+        })?;
+        events.push(event);
+    }
     if events.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let churn_count = events
@@ -74,13 +89,13 @@ pub(crate) fn post_edit_history_signals(
         0
     };
 
-    Some(PostEditHistorySignals {
+    Ok(Some(PostEditHistorySignals {
         churn_count,
         build_fail_count,
         warn_count,
         w15_count: consecutive_post_edit_count(&events, session, file_path),
         overlap: recent_overlap(&events, session, agent, file_path),
-    })
+    }))
 }
 
 fn count_session_build_fail_events(events: &[Value], session: &str, project: &str) -> u32 {
@@ -407,6 +422,56 @@ mod tests {
     }
 
     #[test]
+    fn history_signals_distinguish_no_history_from_malformed_history() {
+        let root =
+            std::env::temp_dir().join(format!("vibeguard-history-result-{}", std::process::id()));
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+        std::fs::create_dir_all(&root).unwrap();
+        let log_file = root.join("events.jsonl");
+        let log_path = log_file.to_string_lossy();
+
+        assert!(
+            post_edit_history_signals(&log_path, "s", "", "src/lib.rs")
+                .unwrap()
+                .is_none()
+        );
+        std::fs::write(&log_file, "\n").unwrap();
+        assert!(
+            post_edit_history_signals(&log_path, "s", "", "src/lib.rs")
+                .unwrap()
+                .is_none()
+        );
+        std::fs::write(&log_file, "not-json\n").unwrap();
+        let err = post_edit_history_signals(&log_path, "s", "", "src/lib.rs")
+            .err()
+            .expect("malformed non-empty history must fail");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string()
+                .contains("malformed post-edit history JSONL")
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn bounded_history_reader_returns_only_requested_tail() {
+        let log_file = std::env::temp_dir().join(format!(
+            "vibeguard-history-tail-{}.jsonl",
+            std::process::id()
+        ));
+        std::fs::write(&log_file, "first\nsecond\nthird\nfourth\n").unwrap();
+
+        assert_eq!(
+            read_tail_lines(log_file.to_string_lossy().as_ref(), 2).unwrap(),
+            "third\nfourth\n"
+        );
+        assert_eq!(normalize_path(""), "");
+        std::fs::remove_file(log_file).unwrap();
+    }
+
+    #[test]
     fn w15_candidate_requires_shell_delta_check() {
         let signals = PostEditHistorySignals {
             churn_count: 0,
@@ -504,7 +569,9 @@ mod tests {
             .join("\n");
         std::fs::write(&log_file, format!("{text}\n")).unwrap();
 
-        let signals = post_edit_history_signals(&log_path, "s", "", "src/lib.rs").unwrap();
+        let signals = post_edit_history_signals(&log_path, "s", "", "src/lib.rs")
+            .unwrap()
+            .unwrap();
         assert_eq!(signals.warn_count, 2);
 
         let _ = std::fs::remove_file(log_file);
@@ -586,7 +653,9 @@ mod tests {
             .join("\n");
         std::fs::write(&log_file, format!("{text}\n")).unwrap();
 
-        let signals = post_edit_history_signals(&log_path, "current", "", "src/lib.rs").unwrap();
+        let signals = post_edit_history_signals(&log_path, "current", "", "src/lib.rs")
+            .unwrap()
+            .unwrap();
         assert_eq!(signals.churn_count, 20);
         assert_eq!(signals.build_fail_count, 0);
 
@@ -606,7 +675,9 @@ mod tests {
             .join("\n");
         std::fs::write(&log_file, format!("{text}\n")).unwrap();
 
-        let signals = post_edit_history_signals(&log_path, "current", "", "src/lib.rs").unwrap();
+        let signals = post_edit_history_signals(&log_path, "current", "", "src/lib.rs")
+            .unwrap()
+            .unwrap();
         assert_eq!(signals.build_fail_count, 5);
 
         let _ = std::fs::remove_file(log_file);

--- a/vibeguard-runtime/src/hook_checks_tests.rs
+++ b/vibeguard-runtime/src/hook_checks_tests.rs
@@ -1,0 +1,115 @@
+use super::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+fn temp_project(name: &str) -> PathBuf {
+    let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "vibeguard_runtime_hook_checks_{name}_{}_{}",
+        std::process::id(),
+        unique
+    ))
+}
+
+fn init_git_repo(root: &Path) -> io::Result<()> {
+    fs::create_dir_all(root)?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("init")
+        .arg("-q")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+#[test]
+fn decision_block_json_escapes_reason_text() {
+    let output = decision_block_json("old_string \"missing\"\nread first");
+    let value: serde_json::Value =
+        serde_json::from_str(&output).expect("decision output should be valid JSON");
+
+    assert_eq!(value["decision"], "block");
+    assert_eq!(value["reason"], "old_string \"missing\"\nread first");
+}
+
+#[test]
+fn missing_required_args_return_usage_errors_before_stdin() {
+    let pre_edit = pre_edit_check(&[]).expect_err("pre-edit args should be required");
+    let post_edit = post_edit_fast_check(&[]).expect_err("post-edit args should be required");
+    let post_write = post_write_fast_check(&[]).expect_err("post-write args should be required");
+
+    assert!(pre_edit.to_string().contains("pre-edit-check"));
+    assert!(post_edit.to_string().contains("post-edit-fast-check"));
+    assert!(post_write.to_string().contains("post-write-fast-check"));
+}
+
+#[test]
+fn missing_file_candidates_distinguishes_empty_from_lookup_failure() -> TestResult {
+    let root = temp_project("empty");
+    init_git_repo(&root)?;
+    let src_dir = root.join("src");
+    fs::create_dir_all(&src_dir)?;
+    let tracked = src_dir.join("lib.rs");
+    fs::write(&tracked, "pub fn lib() {}\n")?;
+    let add_output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&root)
+        .arg("add")
+        .arg("src/lib.rs")
+        .output()?;
+    assert!(
+        add_output.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let missing = root.join("src").join("missing_name.rs");
+    assert_eq!(
+        missing_file_candidates(missing.to_string_lossy().as_ref(), "missing_name"),
+        MissingFileCandidates::Empty
+    );
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn missing_file_candidates_reports_git_lookup_failure() -> TestResult {
+    let root = temp_project("bad_git");
+    fs::create_dir_all(root.join(".git"))?;
+    fs::create_dir_all(root.join("src"))?;
+    let missing = root.join("src").join("lib.rs");
+
+    let result = missing_file_candidates(missing.to_string_lossy().as_ref(), "lib");
+    assert!(
+        matches!(
+            result,
+            MissingFileCandidates::LookupFailed(ref detail) if detail.contains("git ls-files")
+        ),
+        "expected lookup failure that names git ls-files, got {result:?}"
+    );
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn post_edit_log_detail_preserves_delta_metadata() {
+    assert_eq!(
+        post_edit_log_detail("src/lib.rs", "old", "newer"),
+        "src/lib.rs||delta=2"
+    );
+    assert_eq!(
+        post_edit_log_detail("src/lib.rs", "abcdef", "xy"),
+        "src/lib.rs||delta=-4"
+    );
+}

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
@@ -12,7 +12,7 @@ use crate::hook_checks_common::{
 use crate::hook_orchestrator::{HookKind, Result, append_hook_event, elapsed_ms};
 use crate::hook_orchestrator_context::RuntimeContext;
 use crate::hook_orchestrator_post_edit_history::{
-    count_prior_warn_events, detect_history_warnings,
+    count_prior_warn_events, detect_history_warnings, read_post_edit_history_events,
 };
 use crate::runtime_config::runtime_config_int_value;
 
@@ -21,7 +21,7 @@ pub(crate) fn run(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
         Ok(data) => data,
         Err(_) => {
             let context = "VIBEGUARD ERROR: malformed PostToolUse(Edit) hook input. The edit result could not be inspected, so this warning is reported visibly instead of silently passing.";
-            let _ = append_hook_event(
+            let visible_context = match append_hook_event(
                 ctx,
                 HookKind::PostEdit,
                 decision::WARN,
@@ -29,8 +29,14 @@ pub(crate) fn run(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
                 "Malformed hook input",
                 "",
                 elapsed_ms(start),
-            );
-            print_context(context)?;
+            ) {
+                Ok(()) => context.to_string(),
+                Err(err) => format!(
+                    "{context}\n---\n{}",
+                    internal_context(ctx, "allow", &err.to_string())
+                ),
+            };
+            print_context(&visible_context)?;
             return Ok(());
         }
     };
@@ -43,36 +49,46 @@ pub(crate) fn run(ctx: &RuntimeContext, input: &str, start: Instant) -> Result {
     let old_string = nested_str(&data, "tool_input.old_string").unwrap_or_default();
     let detail = post_edit_log_detail(&file_path, &old_string, &new_string);
     let mut warnings = Vec::new();
+    let history_events = match read_post_edit_history_events(ctx) {
+        Ok(events) => events,
+        Err(err) => {
+            warnings.push(history_read_context(ctx, &err.to_string()));
+            Vec::new()
+        }
+    };
 
     detect_stateless_warnings(&file_path, &new_string, &mut warnings);
     detect_history_warnings(
         ctx,
         start,
         &file_path,
-        &detail,
         &old_string,
         &new_string,
+        &history_events,
         &mut warnings,
     );
 
     if warnings.is_empty() {
-        if let Err(err) = append_hook_event(
+        return finish_clean_pass(
             ctx,
-            HookKind::PostEdit,
-            decision::PASS,
-            status::PASS,
-            "",
-            &detail,
-            elapsed_ms(start),
-        ) {
-            print_context(&internal_context(ctx, "allow", &err.to_string()))?;
-        }
-        return Ok(());
+            || {
+                append_hook_event(
+                    ctx,
+                    HookKind::PostEdit,
+                    decision::PASS,
+                    status::PASS,
+                    "",
+                    &detail,
+                    elapsed_ms(start),
+                )
+            },
+            print_context,
+        );
     }
 
     let mut decision_value = decision::WARN;
     let mut reason = warnings.join("\n---\n");
-    let prior_warn_count = count_prior_warn_events(ctx, &file_path);
+    let prior_warn_count = count_prior_warn_events(&history_events, &ctx.session_id, &file_path);
     if prior_warn_count >= 3 {
         decision_value = decision::ESCALATE;
         reason = format!(
@@ -468,6 +484,35 @@ fn internal_context(ctx: &RuntimeContext, mode: &str, detail: &str) -> String {
     )
 }
 
+fn clean_pass_append_failure<E: std::fmt::Display>(
+    ctx: &RuntimeContext,
+    append: impl FnOnce() -> std::result::Result<(), E>,
+) -> Option<String> {
+    append()
+        .err()
+        .map(|err| internal_context(ctx, "allow", &err.to_string()))
+}
+
+fn finish_clean_pass<E: std::fmt::Display>(
+    ctx: &RuntimeContext,
+    append: impl FnOnce() -> std::result::Result<(), E>,
+    emit: impl FnOnce(&str) -> Result,
+) -> Result {
+    if let Some(context) = clean_pass_append_failure(ctx, append) {
+        emit(&context)?;
+    }
+    Ok(())
+}
+
+fn history_read_context(ctx: &RuntimeContext, detail: &str) -> String {
+    format!(
+        "VIBEGUARD internal error [VG-INTERNAL-HISTORY-READ]: hook=post-edit-guard tool=Edit failure_kind=runtime mode=allow project={} session={} log_path={} recovery=bash scripts/hook-health.sh 24 detail=post-edit history read failed: {detail}",
+        ctx.project_hash,
+        ctx.session_id,
+        ctx.log_file.display()
+    )
+}
+
 fn extension(file_path: &str) -> String {
     Path::new(file_path)
         .extension()
@@ -479,6 +524,37 @@ fn extension(file_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_context() -> RuntimeContext {
+        RuntimeContext {
+            log_root: "/tmp/vg-clean-pass".into(),
+            log_file: "/tmp/vg-clean-pass/events.jsonl".into(),
+            project_hash: "test-project".into(),
+            session_id: "test-session".into(),
+            cli: "codex".into(),
+            client: "codex".into(),
+            client_variant: "codex-cli-hooks".into(),
+            caller_evidence: "explicit-test".into(),
+        }
+    }
+
+    #[test]
+    fn clean_pass_append_failure_emits_visible_internal_context() {
+        let mut visible = String::new();
+        finish_clean_pass(
+            &test_context(),
+            || Err::<(), _>(std::io::Error::other("injected clean-pass append failure")),
+            |context| {
+                visible = context.to_string();
+                Ok(())
+            },
+        )
+        .expect("append failure context must remain model-visible");
+
+        assert!(visible.contains("VG-INTERNAL-LOG-APPEND"));
+        assert!(visible.contains("mode=allow"));
+        assert!(visible.contains("injected clean-pass append failure"));
+    }
 
     #[test]
     fn post_edit_detail_records_character_delta() {

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
@@ -25,12 +25,11 @@ pub(crate) fn detect_history_warnings(
     ctx: &RuntimeContext,
     start: Instant,
     file_path: &str,
-    detail: &str,
     old_string: &str,
     new_string: &str,
+    events: &[Value],
     warnings: &mut Vec<String>,
 ) {
-    let events = read_post_edit_history_events(ctx);
     let session_events = events
         .iter()
         .filter(|event| {
@@ -38,10 +37,10 @@ pub(crate) fn detect_history_warnings(
         })
         .cloned()
         .collect::<Vec<_>>();
-    detect_churn(ctx, start, file_path, &session_events, &events, warnings);
-    detect_w14(ctx, start, file_path, &events, warnings);
+    detect_churn(ctx, start, file_path, &session_events, events, warnings);
+    detect_w14(ctx, start, file_path, events, warnings);
     detect_w15(
-        ctx, start, file_path, detail, old_string, new_string, &events, warnings,
+        ctx, start, file_path, old_string, new_string, events, warnings,
     );
 }
 
@@ -67,42 +66,58 @@ fn detect_churn(
     if churn_count >= 20 {
         let build_fail_count = count_build_failures(events);
         if build_fail_count >= 5 {
-            warnings.push(format!("[CHURN CRITICAL] [review] [this-file] OBSERVATION: {basename} has been edited {churn_count} times and the project has {build_fail_count} consecutive build failures — possible edit->fail->fix loop\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify; if failed loop, stop and re-check root cause (W-02)\nDO NOT: Keep making equivalent fix attempts without fresh build output and a confirmed root cause"));
-            append_history_event(
-                ctx,
-                start,
-                decision::ESCALATE,
-                &format!("churn {churn_count}x critical build_fails {build_fail_count}x"),
-                file_path,
+            let warning = format!(
+                "[CHURN CRITICAL] [review] [this-file] OBSERVATION: {basename} has been edited {churn_count} times and the project has {build_fail_count} consecutive build failures — possible edit->fail->fix loop\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify; if failed loop, stop and re-check root cause (W-02)\nDO NOT: Keep making equivalent fix attempts without fresh build output and a confirmed root cause"
             );
+            preserve_warning_after_append(ctx, warnings, warning, || {
+                append_history_event(
+                    ctx,
+                    start,
+                    decision::ESCALATE,
+                    &format!("churn {churn_count}x critical build_fails {build_fail_count}x"),
+                    file_path,
+                )
+            });
         } else {
-            warnings.push(format!("[CHURN WARNING] [review] [this-file] OBSERVATION: {basename} has been edited {churn_count} times — high edit volume without repeated build-failure evidence\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify.\nDO NOT: Treat edit count alone as proof of W-02 failure-loop behavior"));
+            let warning = format!(
+                "[CHURN WARNING] [review] [this-file] OBSERVATION: {basename} has been edited {churn_count} times — high edit volume without repeated build-failure evidence\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify.\nDO NOT: Treat edit count alone as proof of W-02 failure-loop behavior"
+            );
+            preserve_warning_after_append(ctx, warnings, warning, || {
+                append_history_event(
+                    ctx,
+                    start,
+                    decision::CORRECTION,
+                    &format!("churn {churn_count}x volume"),
+                    file_path,
+                )
+            });
+        }
+    } else if churn_count >= 10 {
+        let warning = format!(
+            "[CHURN WARNING] [info] [this-file] OBSERVATION: {basename} has been edited {churn_count} times — high edit volume\nFIX: Run full build to see the complete picture, or classify whether this is a planned refactor before continuing\nDO NOT: Take any action — monitor and decide whether to continue"
+        );
+        preserve_warning_after_append(ctx, warnings, warning, || {
             append_history_event(
                 ctx,
                 start,
                 decision::CORRECTION,
-                &format!("churn {churn_count}x volume"),
+                &format!("churn {churn_count}x warning"),
                 file_path,
-            );
-        }
-    } else if churn_count >= 10 {
-        warnings.push(format!("[CHURN WARNING] [info] [this-file] OBSERVATION: {basename} has been edited {churn_count} times — high edit volume\nFIX: Run full build to see the complete picture, or classify whether this is a planned refactor before continuing\nDO NOT: Take any action — monitor and decide whether to continue"));
-        append_history_event(
-            ctx,
-            start,
-            decision::CORRECTION,
-            &format!("churn {churn_count}x warning"),
-            file_path,
-        );
+            )
+        });
     } else if churn_count >= 5 {
-        warnings.push(format!("[CHURN] [info] [this-file] OBSERVATION: {basename} has been edited {churn_count} times\nFIX: Check if you are in a correction loop before continuing\nDO NOT: Take any action — this is informational only"));
-        append_history_event(
-            ctx,
-            start,
-            decision::CORRECTION,
-            &format!("churn {churn_count}x"),
-            file_path,
+        let warning = format!(
+            "[CHURN] [info] [this-file] OBSERVATION: {basename} has been edited {churn_count} times\nFIX: Check if you are in a correction loop before continuing\nDO NOT: Take any action — this is informational only"
         );
+        preserve_warning_after_append(ctx, warnings, warning, || {
+            append_history_event(
+                ctx,
+                start,
+                decision::CORRECTION,
+                &format!("churn {churn_count}x"),
+                file_path,
+            )
+        });
     }
 }
 
@@ -274,15 +289,10 @@ fn suppress_after_audit<E>(
     append().map(|()| true)
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "W-15 detection consumes the complete edit and history context"
-)]
 fn detect_w15(
     ctx: &RuntimeContext,
     start: Instant,
     file_path: &str,
-    detail: &str,
     old_string: &str,
     new_string: &str,
     events: &[Value],
@@ -301,14 +311,20 @@ fn detect_w15(
     let cur = current_delta.unsigned_abs();
     if prev2 >= prev && prev >= cur && cur < 300 {
         let total = trail.consecutive + 1;
-        warnings.push(format!("[W-15] [review] [this-file] OBSERVATION: {total} consecutive edits to {} with shrinking change radius (|Δ| {prev2}→{prev}→{cur} chars; latest <300)\nFIX: Pause — are these {total} edits solving the same problem? If radius keeps shrinking, report a blocker instead of continuing to round {}\nDO NOT: Toggle between equivalent rewrites; do not continue same-direction micro-tuning without reporting\nESCAPE: set VIBEGUARD_SUPPRESS_W15=1 to suppress (e.g. for long-document writing)", post_edit_history_file_name(file_path), total + 1));
-        append_history_event(
-            ctx,
-            start,
-            decision::WARN,
-            &format!("w15 shrinking radius {prev2}>{prev}>{cur}"),
-            detail,
+        let warning = format!(
+            "[W-15] [review] [this-file] OBSERVATION: {total} consecutive edits to {} with shrinking change radius (|Δ| {prev2}→{prev}→{cur} chars; latest <300)\nFIX: Pause — are these {total} edits solving the same problem? If radius keeps shrinking, report a blocker instead of continuing to round {}\nDO NOT: Toggle between equivalent rewrites; do not continue same-direction micro-tuning without reporting\nESCAPE: set VIBEGUARD_SUPPRESS_W15=1 to suppress (e.g. for long-document writing)",
+            post_edit_history_file_name(file_path),
+            total + 1
         );
+        preserve_warning_after_append(ctx, warnings, warning, || {
+            append_history_event(
+                ctx,
+                start,
+                decision::WARN,
+                &format!("w15 shrinking radius {prev2}>{prev}>{cur}"),
+                &format!("{file_path}||delta={current_delta}"),
+            )
+        });
     }
 }
 
@@ -343,12 +359,8 @@ fn same_file_edit_trail(events: &[Value], session: &str, file_path: &str) -> W15
     }
 }
 
-pub(crate) fn count_prior_warn_events(ctx: &RuntimeContext, file_path: &str) -> usize {
-    count_prior_warn_events_in(
-        &read_post_edit_history_events(ctx),
-        &ctx.session_id,
-        file_path,
-    )
+pub(crate) fn count_prior_warn_events(events: &[Value], session: &str, file_path: &str) -> usize {
+    count_prior_warn_events_in(events, session, file_path)
 }
 
 fn count_prior_warn_events_in(events: &[Value], session: &str, file_path: &str) -> usize {
@@ -375,14 +387,14 @@ fn append_history_event(
     decision_value: &str,
     reason: &str,
     detail: &str,
-) {
+) -> crate::hook_orchestrator::Result {
     let status_value = match decision_value {
         decision::ESCALATE => status::ESCALATE,
         decision::CORRECTION => status::CORRECTION,
         decision::WARN => status::WARN,
         _ => decision_value,
     };
-    let _ = append_hook_event(
+    append_hook_event(
         ctx,
         HookKind::PostEdit,
         decision_value,
@@ -390,17 +402,51 @@ fn append_history_event(
         reason,
         detail,
         elapsed_ms(start),
-    );
+    )
 }
 
-fn read_post_edit_history_events(ctx: &RuntimeContext) -> Vec<Value> {
+fn preserve_warning_after_append<E: std::fmt::Display>(
+    ctx: &RuntimeContext,
+    warnings: &mut Vec<String>,
+    warning: String,
+    append: impl FnOnce() -> std::result::Result<(), E>,
+) {
+    warnings.push(warning);
+    if let Err(err) = append() {
+        warnings.push(format!(
+            "VIBEGUARD internal error [VG-INTERNAL-LOG-APPEND]: hook=post-edit-guard tool=Edit failure_kind=runtime mode=allow project={} session={} log_path={} recovery=bash scripts/hook-health.sh 24 detail=post-edit history telemetry append failed: {err}",
+            ctx.project_hash,
+            ctx.session_id,
+            ctx.log_file.display()
+        ));
+    }
+}
+
+pub(crate) fn read_post_edit_history_events(ctx: &RuntimeContext) -> std::io::Result<Vec<Value>> {
     let log_file = ctx.log_file.to_string_lossy();
-    let Ok(text) = read_tail_lines(&log_file, POST_EDIT_HISTORY_LINES) else {
-        return Vec::new();
+    let text = match read_tail_lines(&log_file, POST_EDIT_HISTORY_LINES) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
     };
-    text.lines()
-        .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
-        .collect()
+    let mut events = Vec::new();
+    for (index, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str::<Value>(line).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "malformed post-edit history JSONL at line {}: {err}",
+                    index + 1
+                ),
+            )
+        })?;
+        events.push(event);
+    }
+    Ok(events)
 }
 
 fn count_build_failures(events: &[Value]) -> u32 {
@@ -455,6 +501,19 @@ fn post_edit_history_extension(file_path: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn test_context(log_file: std::path::PathBuf) -> RuntimeContext {
+        RuntimeContext {
+            log_root: log_file.parent().unwrap().to_path_buf(),
+            log_file,
+            project_hash: "test-project".into(),
+            session_id: "current".into(),
+            cli: "codex".into(),
+            client: "codex".into(),
+            client_variant: "codex-cli-hooks".into(),
+            caller_evidence: "explicit-test".into(),
+        }
+    }
 
     fn w14_shown_event(session: &str, key: &str, timestamp: u64) -> Value {
         json!({
@@ -651,4 +710,45 @@ mod tests {
             1
         );
     }
+
+    #[test]
+    fn shared_history_snapshot_drives_warnings_and_prior_count() {
+        let root = std::env::temp_dir().join(format!("vg-history-snapshot-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let ctx = test_context(root.join("events.jsonl"));
+        let event = json!({
+            "session":"current", "hook":"post-edit-guard", "tool":"Edit",
+            "decision":"warn", "reason":"[RS-03] prior", "detail":"src/main.rs||delta=9"
+        });
+        std::fs::write(&ctx.log_file, format!("{event}\n")).unwrap();
+
+        let events = read_post_edit_history_events(&ctx).unwrap();
+        assert_eq!(
+            count_prior_warn_events(&events, "current", "src/main.rs"),
+            1
+        );
+        assert_eq!(
+            same_file_edit_trail(&events, "current", "src/main.rs").consecutive,
+            1
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn append_failure_preserves_churn_and_w15_warnings() {
+        let ctx = test_context(std::path::PathBuf::from("/not-written/events.jsonl"));
+        for label in ["[CHURN] original warning", "[W-15] original warning"] {
+            let mut warnings = Vec::new();
+            preserve_warning_after_append(&ctx, &mut warnings, label.to_string(), || {
+                Err::<(), _>(std::io::Error::other("injected append failure"))
+            });
+            assert_eq!(warnings[0], label);
+            assert!(warnings[1].contains("VG-INTERNAL-LOG-APPEND"));
+            assert!(warnings[1].contains("history telemetry append failed"));
+        }
+    }
 }
+
+#[cfg(test)]
+#[path = "hook_orchestrator_post_edit_history_tests.rs"]
+mod review_tests;

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history_tests.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history_tests.rs
@@ -1,0 +1,285 @@
+use super::*;
+use serde_json::{Value, json};
+use std::fs;
+
+fn temp_root(label: &str) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "vg-post-history-review-{label}-{}",
+        std::process::id()
+    ));
+    if root.exists() {
+        fs::remove_dir_all(&root).unwrap();
+    }
+    fs::create_dir_all(&root).unwrap();
+    root
+}
+
+fn review_context(log_file: std::path::PathBuf) -> RuntimeContext {
+    RuntimeContext {
+        log_root: log_file.parent().unwrap().to_path_buf(),
+        log_file,
+        project_hash: "test-project".into(),
+        session_id: "current".into(),
+        cli: "codex".into(),
+        client: "codex".into(),
+        client_variant: "codex-cli-hooks".into(),
+        caller_evidence: "explicit-test".into(),
+    }
+}
+
+fn read_test_events(path: &Path) -> Vec<Value> {
+    fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn edit_events(count: usize, file_path: &str) -> Vec<Value> {
+    (0..count)
+        .map(|_| {
+            json!({
+                "session": "current",
+                "hook": "post-edit-guard",
+                "tool": "Edit",
+                "decision": "pass",
+                "detail": format!("{file_path}||delta=1"),
+            })
+        })
+        .collect()
+}
+
+fn assert_churn_warning(root: &Path, count: usize, marker: &str, expected_reason: &str) {
+    let ctx = review_context(root.join(format!("churn-{count}.jsonl")));
+    let events = edit_events(count, "src/main.rs");
+    let mut warnings = Vec::new();
+    detect_churn(
+        &ctx,
+        Instant::now(),
+        "src/main.rs",
+        &events,
+        &events,
+        &mut warnings,
+    );
+
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains(marker));
+    let logged = read_test_events(&ctx.log_file);
+    assert_eq!(logged.len(), 1);
+    assert_eq!(logged[0][field::DECISION], decision::CORRECTION);
+    assert_eq!(logged[0][field::REASON], expected_reason);
+}
+
+#[test]
+fn churn_thresholds_and_w15_shrinking_radius_are_behavioral() {
+    let root = temp_root("churn");
+    let four_ctx = review_context(root.join("four.jsonl"));
+    let four = edit_events(4, "src/main.rs");
+    let mut warnings = Vec::new();
+    detect_churn(
+        &four_ctx,
+        Instant::now(),
+        "src/main.rs",
+        &four,
+        &four,
+        &mut warnings,
+    );
+    assert!(warnings.is_empty());
+    assert!(!four_ctx.log_file.exists());
+
+    assert_churn_warning(&root, 5, "[CHURN]", "churn 5x");
+    assert_churn_warning(&root, 10, "[CHURN WARNING]", "churn 10x warning");
+
+    let volume_ctx = review_context(root.join("volume.jsonl"));
+    let volume = edit_events(20, "src/main.rs");
+    detect_churn(
+        &volume_ctx,
+        Instant::now(),
+        "src/main.rs",
+        &volume,
+        &volume,
+        &mut warnings,
+    );
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("[CHURN WARNING]"));
+    assert!(warnings[0].contains("high edit volume"));
+    let volume_events = read_test_events(&volume_ctx.log_file);
+    assert_eq!(volume_events.len(), 1);
+    assert_eq!(volume_events[0][field::DECISION], decision::CORRECTION);
+    assert_eq!(volume_events[0][field::REASON], "churn 20x volume");
+
+    let critical_ctx = review_context(root.join("critical.jsonl"));
+    let mut critical = edit_events(20, "src/main.rs");
+    let project = current_git_root_by_marker().unwrap();
+    let failure_path = project.join("src/failing.rs").to_string_lossy().to_string();
+    critical.extend((0..5).map(|_| {
+        json!({
+            "session": "current",
+            "hook": "post-build-check",
+            "tool": "Bash",
+            "decision": "warn",
+            "detail": failure_path.clone(),
+        })
+    }));
+    let mut critical_warnings = Vec::new();
+    detect_churn(
+        &critical_ctx,
+        Instant::now(),
+        "src/main.rs",
+        &critical,
+        &critical,
+        &mut critical_warnings,
+    );
+    assert_eq!(critical_warnings.len(), 1);
+    assert!(critical_warnings[0].contains("[CHURN CRITICAL]"));
+    assert!(critical_warnings[0].contains("5 consecutive build failures"));
+    let critical_events = read_test_events(&critical_ctx.log_file);
+    assert_eq!(critical_events.len(), 1);
+    assert_eq!(critical_events[0][field::DECISION], decision::ESCALATE);
+    assert_eq!(
+        critical_events[0][field::REASON],
+        "churn 20x critical build_fails 5x"
+    );
+
+    let w15_ctx = review_context(root.join("w15.jsonl"));
+    let w15_events = vec![
+        json!({"session":"current","hook":"post-edit-guard","tool":"Edit","detail":"src/main.rs||delta=9"}),
+        json!({"session":"current","hook":"post-edit-guard","tool":"Edit","detail":"src/main.rs||delta=5"}),
+    ];
+    let mut w15_warnings = Vec::new();
+    detect_w15(
+        &w15_ctx,
+        Instant::now(),
+        "src/main.rs",
+        "",
+        "abc",
+        &w15_events,
+        &mut w15_warnings,
+    );
+    assert_eq!(w15_warnings.len(), 1);
+    assert!(w15_warnings[0].contains("[W-15]"));
+    assert!(w15_warnings[0].contains("9→5→3"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+fn overlap_event(file_path: &str, now: u64) -> Value {
+    json!({
+        "ts": crate::time_utils::format_unix_secs_utc(now),
+        "session": "peer",
+        "agent": "peer-agent",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": file_path,
+    })
+}
+
+fn shown_event(file_path: &str, key: &str, now: u64) -> Value {
+    let agent = std::env::var("VIBEGUARD_AGENT_TYPE").unwrap_or_default();
+    json!({
+        "ts": crate::time_utils::format_unix_secs_utc(now),
+        "session": "current",
+        "agent": agent,
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "status": "warn",
+        "reason": "[W-14] overlap shown session peer agent peer-agent",
+        "detail": w14_event_detail(file_path, key),
+    })
+}
+
+#[test]
+fn w14_main_path_records_show_suppresses_and_restores_on_append_failure() {
+    let root = temp_root("w14");
+    let file_path = root.join("src/main.rs").to_string_lossy().to_string();
+    let now = now_unix_secs();
+    let overlap = overlap_event(&file_path, now);
+
+    let shown_ctx = review_context(root.join("shown.jsonl"));
+    let mut shown_warnings = Vec::new();
+    detect_w14_at(
+        &shown_ctx,
+        Instant::now(),
+        &file_path,
+        std::slice::from_ref(&overlap),
+        &mut shown_warnings,
+        now,
+        60,
+    );
+    assert_eq!(shown_warnings.len(), 1);
+    assert!(shown_warnings[0].contains("[W-14]"));
+    assert!(shown_warnings[0].contains("session peer"));
+    let shown_events = read_test_events(&shown_ctx.log_file);
+    assert_eq!(shown_events.len(), 1);
+    assert_eq!(shown_events[0][field::DECISION], decision::WARN);
+    assert_eq!(shown_events[0][field::STATUS], status::WARN);
+    assert!(
+        shown_events[0][field::REASON]
+            .as_str()
+            .unwrap()
+            .starts_with(W14_SHOWN_REASON_PREFIX)
+    );
+
+    let current_agent = std::env::var("VIBEGUARD_AGENT_TYPE").unwrap_or_default();
+    let overlap_signal = recent_overlap(
+        std::slice::from_ref(&overlap),
+        "current",
+        &current_agent,
+        &file_path,
+    )
+    .unwrap();
+    let key = w14_key("current", "peer", &overlap_signal.normalized_file).unwrap();
+    let history = vec![overlap.clone(), shown_event(&file_path, &key, now)];
+    let suppressed_ctx = review_context(root.join("suppressed.jsonl"));
+    let mut suppressed_warnings = Vec::new();
+    detect_w14_at(
+        &suppressed_ctx,
+        Instant::now(),
+        &file_path,
+        &history,
+        &mut suppressed_warnings,
+        now,
+        60,
+    );
+    assert!(suppressed_warnings.is_empty());
+    let suppressed_events = read_test_events(&suppressed_ctx.log_file);
+    assert_eq!(suppressed_events.len(), 1);
+    assert_eq!(suppressed_events[0][field::DECISION], decision::PASS);
+    assert_eq!(suppressed_events[0][field::STATUS], status::SKIPPED);
+    assert_eq!(
+        suppressed_events[0][field::REASON],
+        W14_SUPPRESSED_REASON_PREFIX
+    );
+
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks append").unwrap();
+    let failed_ctx = review_context(blocking_parent.join("events.jsonl"));
+    let mut restored_warnings = Vec::new();
+    detect_w14_at(
+        &failed_ctx,
+        Instant::now(),
+        &file_path,
+        &history,
+        &mut restored_warnings,
+        now,
+        60,
+    );
+    assert_eq!(restored_warnings.len(), 1);
+    assert!(restored_warnings[0].contains("[W-14]"));
+    assert!(restored_warnings[0].contains("session peer"));
+    assert!(!failed_ctx.log_file.exists());
+    assert!(blocking_parent.is_file());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn full_history_reader_treats_whitespace_only_log_as_empty() {
+    let root = temp_root("empty-lines");
+    let ctx = review_context(root.join("events.jsonl"));
+    fs::write(&ctx.log_file, "\n   \n\t\n").unwrap();
+
+    let events = read_post_edit_history_events(&ctx).unwrap();
+    assert!(events.is_empty());
+    fs::remove_dir_all(root).unwrap();
+}

--- a/vibeguard-runtime/tests/cli_hook_checks.rs
+++ b/vibeguard-runtime/tests/cli_hook_checks.rs
@@ -119,6 +119,8 @@ fn post_edit_fast_check_keeps_malformed_warning_visible_when_log_fails() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stdout.contains("FAST_OUTPUT"), "{stdout}");
     assert!(stdout.contains("malformed PostToolUse(Edit)"), "{stdout}");
+    assert!(stdout.contains("VG-INTERNAL-LOG-APPEND"), "{stdout}");
+    assert!(stdout.contains("mode=allow"), "{stdout}");
     assert!(
         stderr.contains("post-edit malformed input log failed"),
         "{stderr}"
@@ -193,7 +195,156 @@ fn post_edit_fast_check_logs_pass_when_history_file_is_missing() {
 }
 
 #[test]
-fn post_edit_fast_check_exposes_pass_log_failure() {
+fn post_edit_fast_check_malformed_history_falls_back_visibly() {
+    let root = unique_temp_dir("post-edit-malformed-history");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    fs::write(&log_file, "not-json\n").unwrap();
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "FALLBACK\n");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("post-edit history read failed"), "{stderr}");
+    assert!(
+        stderr.contains("malformed post-edit history JSONL"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read_to_string(&log_file).unwrap(), "not-json\n");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_history_io_error_falls_back_visibly() {
+    let root = unique_temp_dir("post-edit-history-io-error");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events-as-directory");
+    fs::create_dir_all(&log_file).unwrap();
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "FALLBACK\n");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("post-edit history read failed"), "{stderr}");
+    assert!(
+        log_file.is_dir(),
+        "history I/O fixture must remain a directory"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_emits_churn_and_overlap_warning_from_history() {
+    let root = unique_temp_dir("post-edit-history-warning");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let mut events = (0..5)
+        .map(|_| {
+            serde_json::json!({
+                "ts": "2099-01-01T00:00:00Z",
+                "session": "test-session",
+                "agent": "codex",
+                "hook": "post-edit-guard",
+                "tool": "Edit",
+                "decision": "pass",
+                "detail": "src/lib.rs||delta=1"
+            })
+        })
+        .collect::<Vec<_>>();
+    events.push(serde_json::json!({
+        "ts": "2099-01-01T00:00:00Z",
+        "session": "test-session",
+        "agent": "codex",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": "src/other.rs||delta=1"
+    }));
+    events.push(serde_json::json!({
+        "ts": "2099-01-01T00:00:00Z",
+        "session": "peer-session",
+        "agent": "claude",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": "src/lib.rs||delta=1"
+    }));
+    let history = events
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&log_file, format!("{history}\n")).unwrap();
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.starts_with("FAST_OUTPUT\n"), "{stdout}");
+    assert!(stdout.contains("[CHURN]"), "{stdout}");
+    assert!(stdout.contains("[W-14]"), "{stdout}");
+    assert!(stdout.contains("peer-session"), "{stdout}");
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.contains("\"decision\":\"warn\""), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_defers_consecutive_history_to_shell_w15() {
+    let root = unique_temp_dir("post-edit-history-w15-fallback");
+    fs::create_dir_all(&root).unwrap();
+    let log_file = root.join("events.jsonl");
+    let event = serde_json::json!({
+        "session": "test-session",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": "src/lib.rs||delta=1"
+    });
+    fs::write(&log_file, format!("{event}\n{event}\n")).unwrap();
+    let before = fs::read_to_string(&log_file).unwrap();
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+
+    let out = run_post_edit_fast_check(&input, &log_file);
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "FALLBACK\n");
+    assert!(out.stderr.is_empty());
+    assert_eq!(fs::read_to_string(&log_file).unwrap(), before);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_check_exposes_history_read_failure_before_pass_log() {
     let root = unique_temp_dir("post-edit-log-failure");
     fs::create_dir_all(&root).unwrap();
     let blocking_parent = root.join("not-a-directory");
@@ -211,8 +362,9 @@ fn post_edit_fast_check_exposes_pass_log_failure() {
     let out = run_post_edit_fast_check(&input, &log_file);
     assert_eq!(out.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert_eq!(stdout, "FAST_PASS\nsrc/lib.rs\n");
-    assert!(out.stderr.is_empty());
+    assert_eq!(stdout, "FALLBACK\n");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("post-edit history read failed"), "{stderr}");
     assert!(
         !log_file.exists(),
         "failed logging must not claim persistence"

--- a/vibeguard-runtime/tests/cli_hook_post_edit.rs
+++ b/vibeguard-runtime/tests/cli_hook_post_edit.rs
@@ -88,6 +88,23 @@ fn post_edit_malformed_input_warns_visibly_and_logs() {
 }
 
 #[test]
+fn post_edit_malformed_input_keeps_warning_visible_when_log_fails() {
+    let (root, repo, log_root, _) = case_paths("post-edit-malformed-log-failure");
+    let blocking_parent = root.join("not-a-directory");
+    fs::write(&blocking_parent, "blocks log parent creation").unwrap();
+    let log_file = blocking_parent.join("events.jsonl");
+    let out = run_post_edit(&repo, &log_root, &log_file, "not-json");
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("malformed PostToolUse(Edit)"), "{stdout}");
+    assert!(stdout.contains("VG-INTERNAL-LOG-APPEND"), "{stdout}");
+    assert!(stdout.contains("mode=allow"), "{stdout}");
+    assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn post_edit_missing_fields_stay_silent_without_pass_log() {
     let (root, repo, log_root, log_file) = case_paths("post-edit-missing-fields");
 
@@ -172,6 +189,44 @@ fn post_edit_prior_warnings_escalate_current_warning() {
     let event = events.last().unwrap();
     assert_eq!(event["decision"], "escalate");
     assert!(event["reason"].as_str().unwrap().contains("[ESCALATE]"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_malformed_history_is_reported_visibly() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-malformed-history");
+    fs::write(&log_file, "not-json\n").unwrap();
+    let input = edit_input("src/lib.rs", "safe_call()?", "unsafe_call().unwrap()");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VG-INTERNAL-HISTORY-READ"), "{stdout}");
+    assert!(
+        stdout.contains("malformed post-edit history JSONL"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("[RS-03]"), "{stdout}");
+    let log_text = fs::read_to_string(&log_file).unwrap();
+    assert!(log_text.starts_with("not-json\n"), "{log_text}");
+    assert!(log_text.contains("VG-INTERNAL-HISTORY-READ"), "{log_text}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_history_read_failure_preserves_stateless_warning() {
+    let (root, repo, log_root, _) = case_paths("post-edit-history-read-failure");
+    let log_file = log_root.join("projects/post-edit-project/events-as-directory");
+    fs::create_dir_all(&log_file).unwrap();
+    let input = edit_input("src/lib.rs", "safe_call()?", "unsafe_call().unwrap()");
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VG-INTERNAL-HISTORY-READ"), "{stdout}");
+    assert!(stdout.contains("[RS-03]"), "{stdout}");
+    assert!(stdout.contains("VG-INTERNAL-LOG-APPEND"), "{stdout}");
+    assert!(log_file.is_dir());
     let _ = fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
Refs #581

## Summary
- make malformed-input and history read/parse failures model-visible instead of silently degrading
- use one strict history snapshot for post-edit warnings and escalation counting
- preserve churn and W-15 warnings when telemetry append fails
- cover churn thresholds, W-14 shown/suppressed/recovery paths, whitespace-only history, and clean-pass append failure
- split oversized inline test modules and raise the blocking Rust line-coverage baseline from 70% to 71%
- align the shell regression with strict malformed-history diagnostics: preserve the parse error and do not fabricate W-14 from corrupt data

## Coverage evidence
- before head: `1ee41714ef851b186b828a17835960a198a4470a`
- PR head: `4f6096573fd4c34ca68dd054f267b152d7b664de`
- before: `13233 / 18761 = 70.53461968978199%`
- post: `13508 / 18883 = 71.53524334057089%`
- before JSON SHA-256: `60fc128a7fa94d10e9c47525a2810205a607229dbc2d351b514d6f5ec8f4bfd5`
- post JSON SHA-256: `7b46aa6ef76ff56970865a267d03110c313a097dc697a1da774b32d9af119d85`
- critical-path inventory SHA-256: `a41e8dd738704dece3d56c13e2a3e538fc2fd6be49ec2f9c272426f43b95c937`
- independent review at exact head: PASS, P0/P1/P2 = 0/0/0

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo clippy --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- focused review tests: 3/3; clean-pass helper: 1/1; post-edit CLI: 10/10
- malformed-history shell regression: 25/25
- full `VIBEGUARD_TEST_UPDATED_INPUT=1 bash tests/test_hooks.sh`
- full `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_u22_coverage.sh`
- `bash scripts/ci/self-application/check-u22-coverage.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_self_application_ci.sh`
- `bash tests/test_release_workflow.sh`
- `bash scripts/local-contract-check.sh --quick`
- SpecRail workflow checks, W20 drift check, and `git diff --check`

This is a partial GH581 tranche. The final 80% gate and the deferred post-edit U-16 read-error path remain for later tranches.
