### PR TITLE
test: cover runtime policy and setup health paths

### DIFF
--- a/scripts/ci/self-application/check-u22-coverage.sh
+++ b/scripts/ci/self-application/check-u22-coverage.sh
@@ -6,7 +6,7 @@ REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 CARGO_BIN="${VIBEGUARD_U22_CARGO_BIN:-cargo}"
 CARGO_LLVM_COV_VERSION="0.8.7"
-LINE_COVERAGE_BASELINE="72"
+LINE_COVERAGE_BASELINE="76"
 LINE_COVERAGE_TARGET="80"
 
 if [[ ! -f "${RUNTIME_MANIFEST}" ]]; then

--- a/tests/test_u22_coverage.sh
+++ b/tests/test_u22_coverage.sh
@@ -67,10 +67,10 @@ run_gate() {
 
 success_out="$(run_gate bash "${CHECK}" "${REPO_DIR}")"
 assert_cmd "coverage gate accepts a successful measured run" test -n "${success_out}"
-assert_cmd "coverage output names the 72% blocking baseline" grep -Fq "blocking baseline=72%" <<< "${success_out}"
+assert_cmd "coverage output names the 76% blocking baseline" grep -Fq "blocking baseline=76%" <<< "${success_out}"
 assert_cmd "coverage output keeps the 80% target visible" grep -Fq "target=80% (target not yet enforced)" <<< "${success_out}"
 assert_cmd "coverage command uses the locked runtime manifest" grep -Fq \
-  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 72" \
+  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 76" \
   "${CALL_LOG}"
 
 assert_fails "missing cargo-llvm-cov fails closed" env \

--- a/vibeguard-runtime/tests/cli_codex.rs
+++ b/vibeguard-runtime/tests/cli_codex.rs
@@ -532,8 +532,8 @@ fn codex_hooks_health_missing_config_is_clean_or_explicit_skip() {
 fn codex_hooks_health_read_errors_are_visible_and_do_not_write() {
     let manifest = valid_codex_manifest(15);
     let (repo, hooks_file, _) = codex_setup_fixture("health-read-error", Some(&manifest));
-    fs::remove_file(&hooks_file).unwrap();
-    fs::create_dir(&hooks_file).unwrap();
+    let malformed = b"{not-json";
+    fs::write(&hooks_file, malformed).unwrap();
 
     for command in [
         "setup-codex-hooks-check-stale",
@@ -544,7 +544,7 @@ fn codex_hooks_health_read_errors_are_visible_and_do_not_write() {
         assert!(!output.status.success(), "{command} falsely succeeded");
         assert!(output.stdout.is_empty(), "{command}: {output:?}");
         assert!(!output.stderr.is_empty(), "{command} hid the read error");
-        assert!(hooks_file.is_dir(), "{command} replaced the directory");
+        assert_eq!(fs::read(&hooks_file).unwrap(), malformed, "{command} wrote");
     }
     fs::remove_dir_all(repo).unwrap();
 }

--- a/vibeguard-runtime/tests/cli_codex.rs
+++ b/vibeguard-runtime/tests/cli_codex.rs
@@ -423,11 +423,13 @@ fn codex_setup_validates_manifest_before_missing_hooks_file_short_circuits() {
 fn codex_hooks_prune_fails_before_output_or_writes_on_invalid_manifest() {
     let (repo, hooks_file, before) =
         codex_setup_fixture("prune-invalid-manifest", Some("{not-json"));
-    let output = run_codex_setup(
-        "setup-codex-hooks-prune-stale-unmanaged",
-        &repo,
-        &hooks_file,
-    );
+    let output = bin()
+        .arg("setup-codex-hooks-prune-stale-unmanaged")
+        .arg(&repo)
+        .arg(&hooks_file)
+        .arg("PreToolUse")
+        .output()
+        .unwrap();
 
     assert_manifest_failure(&output);
     assert_eq!(fs::read(&hooks_file).unwrap(), before);
@@ -468,6 +470,329 @@ fn codex_hooks_remove_preserves_third_party_hooks_with_valid_manifest() {
             .get("command")
             .and_then(serde_json::Value::as_str),
         Some("bash /missing/third-party.sh")
+    );
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_hooks_health_missing_config_is_clean_or_explicit_skip() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-missing", Some(&manifest));
+    fs::remove_file(&hooks_file).unwrap();
+
+    for command in [
+        "setup-codex-hooks-check-stale",
+        "setup-codex-hooks-check-timeouts",
+    ] {
+        let output = run_codex_setup(command, &repo, &hooks_file);
+        assert!(output.status.success(), "{command}: {output:?}");
+        assert!(output.stdout.is_empty(), "{command}");
+        assert!(output.stderr.is_empty(), "{command}");
+        assert!(!hooks_file.exists(), "{command} created the config");
+    }
+
+    let prune = run_codex_setup(
+        "setup-codex-hooks-prune-stale-unmanaged",
+        &repo,
+        &hooks_file,
+    );
+    assert!(prune.status.success(), "{prune:?}");
+    assert_eq!(String::from_utf8_lossy(&prune.stdout), "SKIP\n");
+    assert!(prune.stderr.is_empty());
+    assert!(!hooks_file.exists());
+
+    let one_arg = bin()
+        .arg("setup-codex-hooks-check-stale")
+        .arg(&hooks_file)
+        .output()
+        .unwrap();
+    assert!(one_arg.status.success(), "{one_arg:?}");
+    assert!(one_arg.stdout.is_empty());
+    assert!(one_arg.stderr.is_empty());
+
+    for config in [
+        "{}",
+        r#"{"hooks":{"PreToolUse":["bad",{}, {"hooks":"bad"}]}}"#,
+    ] {
+        fs::write(&hooks_file, config).unwrap();
+        for command in [
+            "setup-codex-hooks-check-stale",
+            "setup-codex-hooks-check-timeouts",
+        ] {
+            let output = run_codex_setup(command, &repo, &hooks_file);
+            assert!(output.status.success(), "{command}: {output:?}");
+            assert!(output.stdout.is_empty(), "{command}: {output:?}");
+            assert!(output.stderr.is_empty(), "{command}: {output:?}");
+        }
+    }
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_hooks_health_read_errors_are_visible_and_do_not_write() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-read-error", Some(&manifest));
+    fs::remove_file(&hooks_file).unwrap();
+    fs::create_dir(&hooks_file).unwrap();
+
+    for command in [
+        "setup-codex-hooks-check-stale",
+        "setup-codex-hooks-check-timeouts",
+        "setup-codex-hooks-prune-stale-unmanaged",
+    ] {
+        let output = run_codex_setup(command, &repo, &hooks_file);
+        assert!(!output.status.success(), "{command} falsely succeeded");
+        assert!(output.stdout.is_empty(), "{command}: {output:?}");
+        assert!(!output.stderr.is_empty(), "{command} hid the read error");
+        assert!(hooks_file.is_dir(), "{command} replaced the directory");
+    }
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_stale_check_reports_installed_and_unmanaged_missing_targets() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-stale", Some(&manifest));
+    let installed_dir = repo.join(".vibeguard/installed/hooks");
+    fs::create_dir_all(&installed_dir).unwrap();
+    let existing = repo.join("existing-third-party.sh");
+    fs::write(&existing, "#!/bin/sh\n").unwrap();
+    let missing_installed = installed_dir.join("missing-installed.sh");
+    let missing_blocking = repo.join("missing-blocking.sh");
+    let missing_nonblocking = repo.join("missing-nonblocking.js");
+    fs::write(
+        &hooks_file,
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"command": format!("bash {}", missing_installed.display()), "timeout": 15},
+                        {"command": missing_blocking.display().to_string(), "timeout": 15},
+                        {"command": format!("bash {}", existing.display()), "timeout": 15},
+                        {"command": "echo unresolved", "timeout": 15}
+                    ]
+                }],
+                "PostToolUse": [{
+                    "hooks": [{"command": format!("node {}", missing_nonblocking.display()), "timeout": 15}]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let output = run_codex_setup("setup-codex-hooks-check-stale", &repo, &hooks_file);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stale Codex hook command:"), "{stdout}");
+    assert!(stdout.contains(missing_installed.to_string_lossy().as_ref()));
+    assert!(
+        stdout.contains("repair-required unmanaged Codex blocking hook:"),
+        "{stdout}"
+    );
+    assert!(stdout.contains(missing_blocking.to_string_lossy().as_ref()));
+    assert!(stdout.contains("stale unmanaged Codex hook:"), "{stdout}");
+    assert!(stdout.contains(missing_nonblocking.to_string_lossy().as_ref()));
+    assert!(!stdout.contains(existing.to_string_lossy().as_ref()));
+    assert!(!stdout.contains("echo unresolved"));
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_stale_check_resolves_wrapper_script_targets() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-wrapper", Some(&manifest));
+    let vg_dir = repo.join(".vibeguard");
+    let installed_dir = vg_dir.join("installed/hooks");
+    fs::create_dir_all(&installed_dir).unwrap();
+    let wrapper = vg_dir.join("run-hook-codex.sh");
+    let present = installed_dir.join("present.sh");
+    fs::write(&present, "#!/bin/sh\n").unwrap();
+    fs::write(
+        &hooks_file,
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{"hooks": [
+                    {"command": format!("bash {} present.sh", wrapper.display()), "timeout": 15},
+                    {"command": format!("bash {} missing.sh", wrapper.display()), "timeout": 15},
+                    {"command": format!("bash {} nested/missing.sh", wrapper.display()), "timeout": 15}
+                ]}]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let output = run_codex_setup("setup-codex-hooks-check-stale", &repo, &hooks_file);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(&installed_dir.join("missing.sh").display().to_string()));
+    assert!(!stdout.contains("present.sh"), "{stdout}");
+    assert!(
+        stdout.contains("repair-required unmanaged Codex blocking hook:"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("nested/missing.sh"), "{stdout}");
+    assert!(
+        stdout.contains(wrapper.to_string_lossy().as_ref()),
+        "{stdout}"
+    );
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_prune_removes_only_selected_missing_unmanaged_hooks() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-prune", Some(&manifest));
+    let existing = repo.join("existing.sh");
+    let stale = repo.join("stale.sh");
+    let unselected = repo.join("unselected.sh");
+    fs::write(&existing, "#!/bin/sh\n").unwrap();
+    let managed = repo.join("vibeguard-pre-bash-guard.sh");
+    let original = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Bash", "hooks": [
+                    {"command": format!("bash {}", stale.display())},
+                    {"command": format!("bash {}", existing.display())},
+                    {"command": format!("bash {}", managed.display())},
+                    {"command": "echo unresolved"}
+                ]},
+                "malformed-entry",
+                {"matcher": "Read"}
+            ],
+            "PostToolUse": [{"hooks": [{"command": format!("bash {}", unselected.display())}]}],
+            "MalformedEvent": {"hooks": []}
+        }
+    });
+    fs::write(&hooks_file, original.to_string()).unwrap();
+
+    let output = bin()
+        .arg("setup-codex-hooks-prune-stale-unmanaged")
+        .arg(&repo)
+        .arg(&hooks_file)
+        .arg("PreToolUse")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("removed stale unmanaged Codex hook:"),
+        "{stdout}"
+    );
+    assert!(stdout.ends_with("CHANGED\n"), "{stdout}");
+
+    let updated: serde_json::Value =
+        serde_json::from_slice(&fs::read(&hooks_file).unwrap()).unwrap();
+    let text = updated.to_string();
+    assert!(!text.contains(stale.to_string_lossy().as_ref()));
+    assert!(text.contains(existing.to_string_lossy().as_ref()));
+    assert!(text.contains(managed.to_string_lossy().as_ref()));
+    assert!(text.contains("echo unresolved"));
+    assert!(text.contains(unselected.to_string_lossy().as_ref()));
+    assert!(text.contains("malformed-entry"));
+    assert!(updated["hooks"].get("MalformedEvent").is_none());
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_timeout_check_distinguishes_managed_and_unmanaged_repairs() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-timeout", Some(&manifest));
+    let managed = repo.join("vibeguard-pre-bash-guard.sh");
+    let unmanaged = repo.join("third-party.sh");
+    fs::write(
+        &hooks_file,
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{"matcher": "", "hooks": [
+                    {"command": format!("bash {}", managed.display())},
+                    {"command": format!("bash {}", unmanaged.display()), "timeout": 0},
+                    {"command": "bash /ignored-positive.sh", "timeout": 1},
+                    {"command": ""},
+                    "malformed"
+                ]}],
+                "MalformedEvent": "not-an-array"
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let output = run_codex_setup("setup-codex-hooks-check-timeouts", &repo, &hooks_file);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("managed Codex hook without timeout:"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("repair=bash setup.sh --yes"), "{stdout}");
+    assert!(
+        stdout.contains("unmanaged Codex hook without timeout:"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("repair=add timeout or consult hook owner"),
+        "{stdout}"
+    );
+    assert_eq!(stdout.matches("Codex hook without timeout:").count(), 2);
+    assert!(stdout.contains("matcher=<none>"));
+    fs::remove_dir_all(repo).unwrap();
+}
+
+#[test]
+fn codex_prune_handles_empty_malformed_kept_and_fully_removed_containers() {
+    let manifest = valid_codex_manifest(15);
+    let (repo, hooks_file, _) = codex_setup_fixture("health-prune-containers", Some(&manifest));
+
+    for data in [
+        serde_json::json!({}),
+        serde_json::json!({"hooks": {"PreToolUse": {"hooks": []}}}),
+        serde_json::json!({"hooks": {"PreToolUse": [{"hooks": [
+            {"command": "echo unresolved"}
+        ]}]}}),
+    ] {
+        fs::write(&hooks_file, data.to_string()).unwrap();
+        let output = run_codex_setup(
+            "setup-codex-hooks-prune-stale-unmanaged",
+            &repo,
+            &hooks_file,
+        );
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "SKIP\n");
+        assert!(output.stderr.is_empty());
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&fs::read(&hooks_file).unwrap()).unwrap(),
+            data
+        );
+    }
+
+    let stale = repo.join("only-stale.sh");
+    fs::write(
+        &hooks_file,
+        serde_json::json!({"hooks": {"PreToolUse": [{"hooks": [
+            {"command": format!("bash {}", stale.display())}
+        ]}]}})
+        .to_string(),
+    )
+    .unwrap();
+    let output = run_codex_setup(
+        "setup-codex-hooks-prune-stale-unmanaged",
+        &repo,
+        &hooks_file,
+    );
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).ends_with("CHANGED\n"),
+        "{output:?}"
+    );
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&fs::read(&hooks_file).unwrap()).unwrap(),
+        serde_json::json!({})
     );
     fs::remove_dir_all(repo).unwrap();
 }

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -354,6 +354,11 @@ fn runtime_policy_downgrade_output_preserves_non_json_text() {
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(String::from_utf8_lossy(&output.stdout), "not json\n");
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+    let scalar = run_runtime_with_stdin(&["runtime-policy-downgrade-output"], "42");
+    assert_eq!(scalar.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&scalar.stdout), "42\n");
+    assert_eq!(String::from_utf8_lossy(&scalar.stderr), "");
 }
 
 #[test]

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -591,6 +591,11 @@ fn runtime_policy_codex_error_outputs_event_specific_payloads() {
     let stop_value: serde_json::Value =
         serde_json::from_slice(&stop.stdout).expect("Stop payload should be JSON");
     assert_eq!(stop_value["stopReason"], "stop denied");
+
+    let unknown = run_runtime_with_stdin(&["runtime-policy-codex-error", "Unknown"], "visible");
+    let unknown_value: serde_json::Value =
+        serde_json::from_slice(&unknown.stdout).expect("fallback payload should be JSON");
+    assert_eq!(unknown_value["systemMessage"], "visible");
 }
 
 #[test]
@@ -622,5 +627,164 @@ fn runtime_policy_diag_appends_jsonl_event() {
     assert_eq!(value["event"], "PreToolUse");
     assert_eq!(value["kind"], "policy_error");
     assert_eq!(value["reason"], "runtime missing");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_check_runs_strict_only_hook_for_strict_profile() {
+    let repo = unique_temp_dir("strict_profile");
+    write_policy(&repo, r#"{"profile":"strict"}"#);
+
+    let output = run_runtime_policy(&repo, "count_active_constraints.sh");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    let value = policy_json(&output);
+    assert_eq!(value["decision"], "run");
+    assert_eq!(value["profile"], "strict");
+    assert_eq!(value["enforcement"], "block");
+    assert!(value["reason"].is_null());
+
+    let alias_output = bin()
+        .args([
+            "runtime-policy-check",
+            "--project-root",
+            repo.to_str().expect("repo path should be utf8"),
+            "--",
+            "count_active_constraints.sh",
+        ])
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env_remove("VIBEGUARD_USER_CONFIG_FILE")
+        .output()
+        .expect("runtime policy command should run");
+    assert_eq!(alias_output.status.code(), Some(0));
+    assert_eq!(policy_json(&alias_output)["profile"], "strict");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[test]
+fn runtime_policy_argument_errors_are_visible() {
+    let cases: &[(&[&str], &str)] = &[
+        (
+            &["runtime-policy-supports", "extra"],
+            "runtime-policy-supports",
+        ),
+        (&["runtime-policy-check"], "runtime-policy-check"),
+        (&["runtime-policy-check", "--cwd"], "runtime-policy-check"),
+        (
+            &["runtime-policy-check", "--cwd", "", "hook.sh"],
+            "runtime-policy-check",
+        ),
+        (
+            &["runtime-policy-check", "--unknown", "hook.sh"],
+            "runtime-policy-check",
+        ),
+        (&["runtime-policy-check", "--"], "runtime-policy-check"),
+        (
+            &["runtime-policy-check", "--", "one.sh", "two.sh"],
+            "runtime-policy-check",
+        ),
+        (
+            &["runtime-policy-check", "one.sh", "two.sh"],
+            "runtime-policy-check",
+        ),
+        (
+            &["runtime-policy-downgrade-output", "--cwd"],
+            "runtime-policy-downgrade-output",
+        ),
+        (
+            &["runtime-policy-downgrade-output", "--payload"],
+            "runtime-policy-downgrade-output",
+        ),
+        (
+            &["runtime-policy-downgrade-output", "--unknown"],
+            "runtime-policy-downgrade-output",
+        ),
+        (
+            &[
+                "runtime-policy-downgrade-output",
+                "--cwd",
+                "one",
+                "--cwd",
+                "two",
+            ],
+            "runtime-policy-downgrade-output",
+        ),
+        (
+            &[
+                "runtime-policy-downgrade-output",
+                "--payload",
+                "{}",
+                "--payload",
+                "{}",
+            ],
+            "runtime-policy-downgrade-output",
+        ),
+        (
+            &["runtime-policy-downgrade-output", "one.sh", "two.sh"],
+            "runtime-policy-downgrade-output",
+        ),
+        (
+            &["runtime-policy-codex-error"],
+            "runtime-policy-codex-error",
+        ),
+        (&["runtime-policy-diag"], "runtime-policy-diag"),
+    ];
+
+    for (args, command) in cases {
+        let output = bin()
+            .args(*args)
+            .output()
+            .expect("runtime helper should run");
+        assert!(!output.status.success(), "{args:?} falsely succeeded");
+        assert!(output.stdout.is_empty(), "{args:?}: {output:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("Usage:"), "{args:?}: {stderr}");
+        assert!(stderr.contains(command), "{args:?}: {stderr}");
+    }
+
+    let supports = bin()
+        .arg("runtime-policy-supports")
+        .output()
+        .expect("runtime helper should run");
+    assert!(supports.status.success());
+    assert!(supports.stdout.is_empty());
+    assert!(supports.stderr.is_empty());
+}
+
+#[test]
+fn runtime_policy_diag_open_error_is_visible() {
+    let repo = unique_temp_dir("diag_open_error");
+    fs::create_dir_all(&repo).expect("diag directory should be created");
+
+    let output = run_runtime_with_stdin(
+        &[
+            "runtime-policy-diag",
+            repo.to_str().expect("diag path should be utf8"),
+            "pre-bash-guard.sh",
+            "PreToolUse",
+            "policy_error",
+            "run-hook-codex.sh",
+        ],
+        "runtime missing",
+    );
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty());
+    assert!(repo.is_dir());
+
+    let invalid_payload = run_runtime_with_stdin(
+        &[
+            "runtime-policy-downgrade-output",
+            "--payload",
+            "not-json",
+            "post-edit-guard.sh",
+        ],
+        r#"{"decision":"block"}"#,
+    );
+    assert!(!invalid_payload.status.success());
+    assert!(invalid_payload.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&invalid_payload.stderr).contains("payload invalid JSON"));
     let _ = fs::remove_dir_all(repo);
 }

--- a/vibeguard-runtime/tests/runtime_policy_diag_io_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_diag_io_cli.rs
@@ -1,0 +1,51 @@
+mod common;
+
+use common::{run_runtime_with_stdin, unique_temp_dir};
+use std::fs;
+
+#[test]
+fn runtime_policy_diag_parent_create_error_is_visible() {
+    let repo = unique_temp_dir("policy-diag-parent-error");
+    fs::create_dir_all(&repo).expect("temporary directory should be created");
+    let blocked_parent = repo.join("not-a-directory");
+    fs::write(&blocked_parent, "unchanged").expect("blocking file should be written");
+    let diag_file = blocked_parent.join("policy.jsonl");
+
+    let output = run_runtime_with_stdin(
+        &[
+            "runtime-policy-diag",
+            diag_file.to_str().expect("diagnostic path should be UTF-8"),
+            "pre-bash-guard.sh",
+            "PreToolUse",
+            "policy_error",
+            "run-hook-codex.sh",
+        ],
+        "runtime missing",
+    );
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty());
+    assert_eq!(fs::read_to_string(&blocked_parent).unwrap(), "unchanged");
+    let _ = fs::remove_dir_all(repo);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn runtime_policy_diag_write_error_is_visible() {
+    let output = run_runtime_with_stdin(
+        &[
+            "runtime-policy-diag",
+            "/dev/full",
+            "pre-bash-guard.sh",
+            "PreToolUse",
+            "policy_error",
+            "run-hook-codex.sh",
+        ],
+        "runtime missing",
+    );
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty());
+}

--- a/vibeguard-runtime/tests/setup_install_state_cli.rs
+++ b/vibeguard-runtime/tests/setup_install_state_cli.rs
@@ -1,0 +1,733 @@
+mod common;
+
+use common::{bin, unique_temp_dir};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    bin()
+        .args(args)
+        .env("HOME", root.join("home"))
+        .current_dir(root)
+        .output()
+        .expect("vibeguard-runtime command should run")
+}
+
+fn assert_output(output: &Output, code: i32, stdout: &str, stderr: &str) {
+    assert_eq!(output.status.code(), Some(code));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), stdout);
+    assert_eq!(String::from_utf8_lossy(&output.stderr), stderr);
+}
+
+fn assert_io_error(output: &Output) {
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.starts_with("vibeguard-runtime error: "));
+    assert!(stderr.trim().len() > "vibeguard-runtime error:".len());
+}
+
+fn write_json(path: &Path, value: &Value) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("JSON parent should be created");
+    }
+    fs::write(
+        path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(value).expect("fixture should serialize")
+        ),
+    )
+    .expect("JSON fixture should be written");
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_slice(&fs::read(path).expect("state file should be readable"))
+        .expect("state file should contain JSON")
+}
+
+fn path_text(path: &Path) -> String {
+    path.to_str()
+        .expect("temporary paths should be UTF-8")
+        .to_string()
+}
+
+#[test]
+fn setup_state_commands_reject_invalid_arity_with_exact_usage() {
+    let root = unique_temp_dir("install_state_arity");
+    fs::create_dir_all(root.join("home")).expect("temp root should be created");
+    let cases = [
+        (
+            "setup-state-init",
+            "Usage: vibeguard-runtime setup-state-init <state-file> <profile> <languages>",
+        ),
+        (
+            "setup-state-record-file",
+            "Usage: vibeguard-runtime setup-state-record-file <state-file> <dest> <source> <type>",
+        ),
+        (
+            "setup-state-record-project-hook",
+            "Usage: vibeguard-runtime setup-state-record-project-hook <state-file> <repo-dir> <hook-path> <hook-name>",
+        ),
+        (
+            "setup-state-check-drift",
+            "Usage: vibeguard-runtime setup-state-check-drift <state-file>",
+        ),
+        (
+            "setup-state-list",
+            "Usage: vibeguard-runtime setup-state-list <state-file>",
+        ),
+        (
+            "setup-state-list-symlinks-under",
+            "Usage: vibeguard-runtime setup-state-list-symlinks-under <state-file> <dest-dir>",
+        ),
+        (
+            "setup-state-list-project-hooks",
+            "Usage: vibeguard-runtime setup-state-list-project-hooks <state-file>",
+        ),
+    ];
+
+    for (command, usage) in cases {
+        let output = run(&root, &[command]);
+        assert_output(
+            &output,
+            1,
+            "",
+            &format!("vibeguard-runtime error: {usage}\n"),
+        );
+    }
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn init_and_record_commands_persist_expected_schema() {
+    let root = unique_temp_dir("install_state_record");
+    let home = root.join("home");
+    let state = root.join("install-state.json");
+    fs::create_dir_all(home.join(".vibeguard")).expect("home state dir should be created");
+    fs::write(home.join(".vibeguard/repo-path"), " /repo/source \n")
+        .expect("repo path should be written");
+
+    let output = run(
+        &root,
+        &[
+            "setup-state-init",
+            &path_text(&state),
+            "full",
+            "rust,python",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+    let initialized = read_json(&state);
+    assert_eq!(initialized["version"], 1);
+    assert_eq!(initialized["profile"], "full");
+    assert_eq!(initialized["languages"], json!(["rust", "python"]));
+    assert_eq!(initialized["repo_dir"], "/repo/source");
+    assert_eq!(initialized["files"], json!({}));
+    let installed_at = initialized["installed_at"]
+        .as_str()
+        .expect("installed_at should be a string");
+    assert!(installed_at.len() >= 10);
+    assert!(installed_at.chars().all(|ch| ch.is_ascii_digit()));
+    assert_eq!(initialized.as_object().unwrap().len(), 6);
+
+    let no_home_state = root.join("no-home-state.json");
+    let no_home = bin()
+        .args(["setup-state-init", &path_text(&no_home_state), "core", ""])
+        .env_remove("HOME")
+        .env_remove("USERPROFILE")
+        .current_dir(&root)
+        .output()
+        .expect("no-home setup-state-init should run");
+    assert_output(&no_home, 0, "", "");
+    assert_eq!(read_json(&no_home_state)["repo_dir"], "");
+
+    let empty_state = root.join("empty-install-state.json");
+    let output = run(
+        &root,
+        &["setup-state-init", &path_text(&empty_state), "core", ""],
+    );
+    assert_output(&output, 0, "", "");
+    let empty_initialized = read_json(&empty_state);
+    assert_eq!(empty_initialized["languages"], json!([]));
+    assert_eq!(empty_initialized["repo_dir"], "/repo/source");
+
+    let regular = root.join("regular.txt");
+    fs::write(&regular, "hello").expect("regular fixture should be written");
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&state),
+            &path_text(&regular),
+            "generated/regular.txt",
+            "copy",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    let link = root.join("linked.txt");
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&state),
+            &path_text(&link),
+            "generated/linked.txt",
+            "symlink",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    let missing = root.join("missing.txt");
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&state),
+            &path_text(&missing),
+            "generated/missing.txt",
+            "copy",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    let repo = root.join("project");
+    let hook = repo.join(".git/hooks/pre-commit");
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-project-hook",
+            &path_text(&state),
+            &path_text(&repo),
+            &path_text(&hook),
+            "pre-commit",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    let recorded = read_json(&state);
+    assert_eq!(
+        recorded["files"][path_text(&regular)],
+        json!({
+            "source": "generated/regular.txt",
+            "type": "copy",
+            "checksum": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        })
+    );
+    assert_eq!(
+        recorded["files"][path_text(&link)],
+        json!({"source": "generated/linked.txt", "type": "symlink"})
+    );
+    assert_eq!(
+        recorded["files"][path_text(&missing)],
+        json!({"source": "generated/missing.txt", "type": "copy"})
+    );
+    assert_eq!(
+        recorded["project_hooks"][path_text(&hook)],
+        json!({"repo_dir": path_text(&repo), "hook_name": "pre-commit"})
+    );
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn record_commands_initialize_missing_state_and_reject_invalid_shapes() {
+    let root = unique_temp_dir("install_state_record_errors");
+    fs::create_dir_all(root.join("home")).expect("temp root should be created");
+    let state = root.join("missing-state.json");
+    let dest = root.join("not-created.txt");
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&state),
+            &path_text(&dest),
+            "source.txt",
+            "copy",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+    assert_eq!(read_json(&state)["version"], 1);
+    assert_eq!(read_json(&state)["files"].as_object().unwrap().len(), 1);
+
+    let hook_state = root.join("missing-hook-state.json");
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-project-hook",
+            &path_text(&hook_state),
+            "/repo",
+            "/repo/.git/hooks/pre-commit",
+            "pre-commit",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+    assert_eq!(read_json(&hook_state)["version"], 1);
+    assert_eq!(
+        read_json(&hook_state)["project_hooks"]
+            .as_object()
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let bad_files = root.join("bad-files.json");
+    write_json(&bad_files, &json!({"version": 1, "files": []}));
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&bad_files),
+            &path_text(&dest),
+            "source.txt",
+            "copy",
+        ],
+    );
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: install-state files must be an object\n",
+    );
+
+    let bad_hooks = root.join("bad-hooks.json");
+    write_json(
+        &bad_hooks,
+        &json!({"version": 1, "files": {}, "project_hooks": []}),
+    );
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-project-hook",
+            &path_text(&bad_hooks),
+            "/repo",
+            "/repo/.git/hooks/pre-commit",
+            "pre-commit",
+        ],
+    );
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: install-state project_hooks must be an object\n",
+    );
+
+    let root_array = root.join("record-root-array.json");
+    write_json(&root_array, &json!([]));
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&root_array),
+            &path_text(&dest),
+            "source.txt",
+            "copy",
+        ],
+    );
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: install-state root must be an object\n",
+    );
+
+    let unsupported = root.join("record-unsupported.json");
+    write_json(&unsupported, &json!({"version": 7, "files": {}}));
+    let output = run(
+        &root,
+        &[
+            "setup-state-record-file",
+            &path_text(&unsupported),
+            &path_text(&dest),
+            "source.txt",
+            "copy",
+        ],
+    );
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: Unsupported install-state version: 7 (expected 1)\n",
+    );
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn strict_state_readers_surface_missing_invalid_and_io_states() {
+    let root = unique_temp_dir("install_state_strict_read");
+    fs::create_dir_all(root.join("home")).expect("temp root should be created");
+    let missing = root.join("missing.json");
+    let output = run(&root, &["setup-state-list", &path_text(&missing)]);
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: No install state found. Run setup.sh first.\n",
+    );
+
+    let malformed = root.join("malformed.json");
+    fs::write(&malformed, "{").expect("malformed state should be written");
+    let output = run(&root, &["setup-state-list", &path_text(&malformed)]);
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: EOF while parsing an object at line 1 column 1\n",
+    );
+
+    let root_array = root.join("root-array.json");
+    write_json(&root_array, &json!([]));
+    let output = run(&root, &["setup-state-check-drift", &path_text(&root_array)]);
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: install-state root must be an object\n",
+    );
+
+    let unsupported = root.join("unsupported.json");
+    write_json(&unsupported, &json!({"version": 2, "files": {}}));
+    let output = run(&root, &["setup-state-list", &path_text(&unsupported)]);
+    assert_output(
+        &output,
+        1,
+        "",
+        "vibeguard-runtime error: Unsupported install-state version: 2 (expected 1)\n",
+    );
+
+    let state_directory = root.join("state-directory");
+    fs::create_dir_all(&state_directory).expect("state directory should be created");
+    let output = run(
+        &root,
+        &["setup-state-check-drift", &path_text(&state_directory)],
+    );
+    assert_io_error(&output);
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn drift_reports_exact_clean_missing_checksum_and_symlink_counts() {
+    let root = unique_temp_dir("install_state_drift");
+    fs::create_dir_all(root.join("home")).expect("temp root should be created");
+    let state = root.join("state.json");
+    let output = run(&root, &["setup-state-check-drift", &path_text(&state)]);
+    assert_output(&output, 0, "NO_STATE\n", "");
+
+    write_json(&state, &json!({"version": 9, "files": {}}));
+    let output = run(&root, &["setup-state-check-drift", &path_text(&state)]);
+    assert_output(
+        &output,
+        0,
+        "UNSUPPORTED_STATE_VERSION: 9 (expected 1)\n",
+        "",
+    );
+
+    let clean = root.join("a-clean.txt");
+    let checksum_drift = root.join("b-checksum-drift.txt");
+    let missing = root.join("c-missing.txt");
+    let regular_instead_of_link = root.join("d-was-symlink.txt");
+    let missing_link = root.join("e-missing-link.txt");
+    fs::write(&clean, "hello").expect("clean fixture should be written");
+    fs::write(&checksum_drift, "changed").expect("drift fixture should be written");
+    fs::write(&regular_instead_of_link, "regular").expect("regular fixture should be written");
+
+    let mut files = serde_json::Map::new();
+    files.insert(
+        path_text(&clean),
+        json!({"type":"copy", "checksum":"sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"}),
+    );
+    files.insert(
+        path_text(&checksum_drift),
+        json!({"type":"copy", "checksum":"sha256:0000"}),
+    );
+    files.insert(path_text(&missing), json!({"type":"copy"}));
+    files.insert(
+        path_text(&regular_instead_of_link),
+        json!({"type":"symlink"}),
+    );
+    files.insert(path_text(&missing_link), json!({"type":"symlink"}));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        let clean_link = root.join("f-clean-link.txt");
+        symlink(&clean, &clean_link).expect("symlink fixture should be created");
+        files.insert(path_text(&clean_link), json!({"type":"symlink"}));
+    }
+
+    write_json(
+        &state,
+        &Value::Object(serde_json::Map::from_iter([
+            ("version".to_string(), json!(1)),
+            ("files".to_string(), Value::Object(files)),
+        ])),
+    );
+    let output = run(&root, &["setup-state-check-drift", &path_text(&state)]);
+    let tracked = if cfg!(unix) { 6 } else { 5 };
+    assert_output(
+        &output,
+        0,
+        &format!(
+            "DRIFT: {} (checksum mismatch)\nMISSING: {}\nDRIFT: {} (was symlink, now regular file)\nMISSING: {}\n---\nTotal tracked: {tracked}, Missing: 2, Drifted: 2\nSTATUS: DRIFT (2 drifted, 2 missing)\n",
+            checksum_drift.display(),
+            missing.display(),
+            regular_instead_of_link.display(),
+            missing_link.display()
+        ),
+        "",
+    );
+
+    let clean_state = root.join("clean-state.json");
+    write_json(
+        &clean_state,
+        &json!({
+            "version": 1,
+            "files": {
+                path_text(&clean): {
+                    "type": "copy",
+                    "checksum": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+                }
+            }
+        }),
+    );
+    let output = run(
+        &root,
+        &["setup-state-check-drift", &path_text(&clean_state)],
+    );
+    assert_output(
+        &output,
+        0,
+        "---\nTotal tracked: 1, Missing: 0, Drifted: 0\nSTATUS: CLEAN\n",
+        "",
+    );
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn list_renders_default_and_populated_state_exactly() {
+    let root = unique_temp_dir("install_state_list");
+    fs::create_dir_all(root.join("home")).expect("temp root should be created");
+    let state = root.join("state.json");
+    write_json(&state, &json!({}));
+    let output = run(&root, &["setup-state-list", &path_text(&state)]);
+    assert_output(
+        &output,
+        0,
+        "Profile: unknown\nInstalled: unknown\nTracked files: 0\n\n",
+        "",
+    );
+
+    write_json(
+        &state,
+        &json!({
+            "version": 1,
+            "profile": "strict",
+            "installed_at": "1700000000",
+            "languages": ["rust", 7, "go"],
+            "files": {
+                "/a-copy": {"type": "copy"},
+                "/b-link": {"type": "symlink"},
+                "/c-unknown": {}
+            }
+        }),
+    );
+    let output = run(&root, &["setup-state-list", &path_text(&state)]);
+    assert_output(
+        &output,
+        0,
+        "Profile: strict\nInstalled: 1700000000\nLanguages: rust, go\nTracked files: 3\n\n  [copy   ] /a-copy\n  [symlink] /b-link\n  [?      ] /c-unknown\n",
+        "",
+    );
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn symlink_cleanup_listing_handles_bad_state_and_filters_paths() {
+    let root = unique_temp_dir("install_state_symlink_list");
+    let home = root.join("home");
+    fs::create_dir_all(&home).expect("temp root should be created");
+    let canonical_root = fs::canonicalize(&root).expect("child cwd should canonicalize");
+    let state = root.join("state.json");
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            "links",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    fs::write(&state, "{").expect("corrupt state should be written");
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            "links",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    write_json(&state, &json!({"version": 1, "files": []}));
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            "links",
+        ],
+    );
+    assert_output(&output, 0, "", "");
+
+    write_json(&state, &json!({"version": 4, "files": {}}));
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            "links",
+        ],
+    );
+    assert_output(
+        &output,
+        0,
+        "",
+        "WARN: unsupported install-state version; skipping tracked symlink cleanup\n",
+    );
+
+    let absolute_dir = root.join("absolute-links");
+    let absolute_child = absolute_dir.join("child");
+    let outside = root.join("absolute-links-other/child");
+    write_json(
+        &state,
+        &json!({
+            "version": 1,
+            "files": {
+                path_text(&absolute_child): {"type": "symlink"},
+                path_text(&absolute_dir): {"type": "symlink"},
+                path_text(&outside): {"type": "symlink"},
+                "links/child": {"type": "symlink"},
+                "links/regular": {"type": "copy"},
+                "other/child": {"type": "symlink"},
+                "~/home-links/child": {"type": "symlink"}
+            }
+        }),
+    );
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            &path_text(&absolute_dir),
+        ],
+    );
+    assert_output(
+        &output,
+        0,
+        &format!("{}\n{}\n", absolute_dir.display(), absolute_child.display()),
+        "",
+    );
+
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            "links",
+        ],
+    );
+    assert_output(
+        &output,
+        0,
+        &format!("{}\n", canonical_root.join("links/child").display()),
+        "",
+    );
+
+    let output = run(
+        &root,
+        &[
+            "setup-state-list-symlinks-under",
+            &path_text(&state),
+            "~/home-links",
+        ],
+    );
+    assert_output(
+        &output,
+        0,
+        &format!("{}\n", home.join("home-links/child").display()),
+        "",
+    );
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn project_hook_cleanup_listing_handles_bad_state_and_filters_rows() {
+    let root = unique_temp_dir("install_state_project_hooks");
+    let home = root.join("home");
+    fs::create_dir_all(&home).expect("temp root should be created");
+    let state = root.join("state.json");
+    let output = run(
+        &root,
+        &["setup-state-list-project-hooks", &path_text(&state)],
+    );
+    assert_output(&output, 0, "", "");
+
+    fs::write(&state, "{").expect("corrupt state should be written");
+    let output = run(
+        &root,
+        &["setup-state-list-project-hooks", &path_text(&state)],
+    );
+    assert_output(&output, 0, "", "");
+
+    write_json(&state, &json!({"version": 1, "project_hooks": []}));
+    let output = run(
+        &root,
+        &["setup-state-list-project-hooks", &path_text(&state)],
+    );
+    assert_output(&output, 0, "", "");
+
+    write_json(&state, &json!({"version": 3, "project_hooks": {}}));
+    let output = run(
+        &root,
+        &["setup-state-list-project-hooks", &path_text(&state)],
+    );
+    assert_output(
+        &output,
+        0,
+        "",
+        "WARN: unsupported install-state version; skipping project hook cleanup\n",
+    );
+
+    let absolute_hook = root.join("project/.git/hooks/pre-push");
+    write_json(
+        &state,
+        &json!({
+            "version": 1,
+            "project_hooks": {
+                "": {"repo_dir": "/ignored", "hook_name": "pre-commit"},
+                "/missing-name": {"repo_dir": "/ignored"},
+                path_text(&absolute_hook): {"repo_dir": path_text(&root.join("project")), "hook_name": "pre-push"},
+                "~/project/.git/hooks/pre-commit": {"repo_dir": "~/project", "hook_name": "pre-commit"}
+            }
+        }),
+    );
+    let output = run(
+        &root,
+        &["setup-state-list-project-hooks", &path_text(&state)],
+    );
+    assert_output(
+        &output,
+        0,
+        &format!(
+            "{}\tpre-push\t{}\n{}\tpre-commit\t~/project\n",
+            absolute_hook.display(),
+            root.join("project").display(),
+            home.join("project/.git/hooks/pre-commit").display()
+        ),
+        "",
+    );
+    fs::remove_dir_all(root).expect("temp root should be removed");
+}

--- a/vibeguard-runtime/tests/setup_manifest_cli.rs
+++ b/vibeguard-runtime/tests/setup_manifest_cli.rs
@@ -1,0 +1,366 @@
+use serde_json::{Value, json};
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_REPO_ID: AtomicU64 = AtomicU64::new(0);
+
+struct TestRepo {
+    path: PathBuf,
+}
+
+impl TestRepo {
+    fn new(label: &str) -> Self {
+        let id = NEXT_REPO_ID.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "vibeguard-runtime-manifest-{label}-{}-{id}",
+            std::process::id()
+        ));
+        fs::create_dir_all(path.join("schemas")).expect("temporary repo should be created");
+        Self { path }
+    }
+
+    fn write_manifest(&self, value: &Value) {
+        let text = serde_json::to_string(value).expect("test manifest should serialize");
+        self.write_manifest_raw(&text);
+    }
+
+    fn write_manifest_raw(&self, text: &str) {
+        fs::write(self.path.join("schemas/install-modules.json"), text)
+            .expect("test manifest should be written");
+    }
+
+    fn write_rule(&self, relative_path: &str) {
+        let path = self.path.join(relative_path);
+        fs::create_dir_all(path.parent().expect("rule should have a parent directory"))
+            .expect("rule parent should be created");
+        fs::write(path, "# test rule\n").expect("test rule should be written");
+    }
+
+    fn cleanup(self) {
+        fs::remove_dir_all(self.path).expect("temporary repo should be removed");
+    }
+}
+
+fn run(repo: &TestRepo, command: &str, extra_args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+        .arg(command)
+        .arg(&repo.path)
+        .args(extra_args)
+        .current_dir(&repo.path)
+        .output()
+        .expect("manifest CLI command should run")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout should be UTF-8")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr should be UTF-8")
+}
+
+fn assert_success(output: &Output, expected_stdout: &str) {
+    assert_eq!(output.status.code(), Some(0), "stderr={}", stderr(output));
+    assert_eq!(stdout(output), expected_stdout);
+    assert_eq!(stderr(output), "");
+}
+
+fn assert_failure(output: &Output, expected_error: &str) {
+    assert_eq!(output.status.code(), Some(1), "stdout={}", stdout(output));
+    assert_eq!(stdout(output), "");
+    let error = stderr(output);
+    assert!(
+        error.starts_with("vibeguard-runtime error: "),
+        "unexpected stderr: {error}"
+    );
+    assert!(
+        error.contains(expected_error),
+        "stderr did not contain {expected_error:?}: {error}"
+    );
+}
+
+fn one_module(module: Value) -> Value {
+    json!({ "modules": [module] })
+}
+
+fn rule_module(paths: Value) -> Value {
+    json!({
+        "id": "bad-rule-module",
+        "kind": "rules",
+        "languages": [],
+        "paths": paths
+    })
+}
+
+#[test]
+fn manifest_commands_emit_ordered_filtered_and_deduplicated_links() {
+    let repo = TestRepo::new("success");
+    for rule in [
+        "rules/claude-rules/common/zeta.md",
+        "rules/claude-rules/common/alpha.md",
+        "rules/claude-rules/common/shared.md",
+        "rules/claude-rules/rust/quality.md",
+        "rules/claude-rules/golang/quality.md",
+        "rules/claude-rules/python/quality.md",
+    ] {
+        repo.write_rule(rule);
+    }
+    repo.write_manifest(&json!({
+        "modules": [
+            {
+                "id": "skills-codex",
+                "kind": "skills",
+                "target": "~/.codex/skills/",
+                "paths": ["skills/zeta/", "workflows/alpha/"]
+            },
+            {
+                "id": "skills-other-target",
+                "kind": "skills",
+                "target": "~/.claude/skills/",
+                "paths": ["skills/not-selected/"]
+            },
+            {
+                "id": "common-first",
+                "kind": "rules",
+                "paths": [
+                    "rules/claude-rules/common/zeta.md",
+                    "rules/claude-rules/common/alpha.md"
+                ]
+            },
+            {
+                "id": "common-second",
+                "kind": "rules",
+                "languages": [],
+                "paths": ["rules/claude-rules/common/shared.md"]
+            },
+            {
+                "id": "rust",
+                "kind": "rules",
+                "languages": ["rust", "RUST", ""],
+                "paths": ["rules/claude-rules/rust/quality.md"]
+            },
+            {
+                "id": "go",
+                "kind": "rules",
+                "languages": ["go"],
+                "paths": ["rules/claude-rules/golang/quality.md"]
+            },
+            {
+                "id": "python",
+                "kind": "rules",
+                "languages": ["python"],
+                "paths": ["rules/claude-rules/python/quality.md"]
+            }
+        ]
+    }));
+
+    let skills = run(&repo, "setup-manifest-skill-links", &["~/.codex/skills/"]);
+    assert_success(&skills, "skills/zeta\tzeta\nworkflows/alpha\talpha\n");
+
+    let links = run(
+        &repo,
+        "setup-manifest-rule-links",
+        &[" RUST, golang,rust, "],
+    );
+    assert_success(
+        &links,
+        concat!(
+            "rules/claude-rules/common/zeta.md\tcommon/zeta.md\tcommon\n",
+            "rules/claude-rules/common/alpha.md\tcommon/alpha.md\tcommon\n",
+            "rules/claude-rules/common/shared.md\tcommon/shared.md\tcommon\n",
+            "rules/claude-rules/rust/quality.md\trust/quality.md\trust\n",
+            "rules/claude-rules/golang/quality.md\tgolang/quality.md\tgolang\n"
+        ),
+    );
+
+    let labels = run(&repo, "setup-manifest-rule-labels", &["rust,golang"]);
+    assert_success(&labels, "common\nrust\ngolang\n");
+    repo.cleanup();
+}
+
+#[test]
+fn missing_manifest_and_missing_cli_arguments_fail_visibly() {
+    let repo = TestRepo::new("missing");
+    for command in [
+        "setup-manifest-skill-links",
+        "setup-manifest-rule-links",
+        "setup-manifest-rule-labels",
+    ] {
+        let extra_args: &[&str] = if command == "setup-manifest-skill-links" {
+            &["~/.codex/skills/"]
+        } else {
+            &[]
+        };
+        let output = run(&repo, command, extra_args);
+        assert_failure(&output, "vibeguard-runtime error:");
+    }
+
+    let missing_repo_argument = Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+        .arg("setup-manifest-rule-links")
+        .output()
+        .expect("manifest CLI command should run");
+    assert_failure(
+        &missing_repo_argument,
+        "Usage: vibeguard-runtime setup-manifest-rule-links",
+    );
+    repo.cleanup();
+}
+
+#[test]
+fn malformed_json_and_non_object_roots_fail_visibly() {
+    let repo = TestRepo::new("parse-root");
+    for (manifest, expected_error) in [
+        ("{]", "line 1 column"),
+        ("[]", "manifest root must be an object"),
+        ("null", "manifest root must be an object"),
+    ] {
+        repo.write_manifest_raw(manifest);
+        let output = run(&repo, "setup-manifest-rule-links", &[]);
+        assert_failure(&output, expected_error);
+    }
+    repo.cleanup();
+}
+
+#[test]
+fn invalid_modules_shapes_fail_visibly() {
+    let repo = TestRepo::new("modules");
+    for (manifest, expected_error) in [
+        (json!({}), "manifest modules must be a list"),
+        (
+            json!({ "modules": { "kind": "rules" } }),
+            "manifest modules must be a list",
+        ),
+        (
+            json!({ "modules": [17] }),
+            "manifest module entry is not an object",
+        ),
+    ] {
+        repo.write_manifest(&manifest);
+        let output = run(&repo, "setup-manifest-rule-links", &[]);
+        assert_failure(&output, expected_error);
+    }
+    repo.write_manifest(&json!({"modules": [17]}));
+    let skills = run(&repo, "setup-manifest-skill-links", &["~/.codex/skills/"]);
+    assert_failure(&skills, "manifest module entry is not an object");
+    repo.cleanup();
+}
+
+#[test]
+fn invalid_skill_path_shapes_fail_visibly() {
+    let repo = TestRepo::new("skill-paths");
+    let cases = [
+        (json!("skills/vibeguard/"), "paths must be a list"),
+        (json!([7]), "non-string path entry"),
+        (json!([""]), "skill path must be repo-relative"),
+        (
+            json!(["/skills/vibeguard"]),
+            "skill path must be repo-relative",
+        ),
+        (
+            json!(["skills\\vibeguard"]),
+            "skill path must be repo-relative",
+        ),
+        (
+            json!(["skills/../vibeguard"]),
+            "skill path must not contain '..'",
+        ),
+        (json!(["."]), "skill path must name a skill directory"),
+    ];
+    for (paths, expected_error) in cases {
+        repo.write_manifest(&one_module(json!({
+            "id": "bad-skill-module",
+            "kind": "skills",
+            "target": "~/.codex/skills/",
+            "paths": paths
+        })));
+        let output = run(&repo, "setup-manifest-skill-links", &["~/.codex/skills/"]);
+        assert_failure(&output, expected_error);
+    }
+    repo.cleanup();
+}
+
+#[test]
+fn invalid_language_shapes_fail_visibly() {
+    let repo = TestRepo::new("languages");
+    for (languages, expected_error) in [
+        (json!("rust"), "languages must be a list"),
+        (json!(["rust", 7]), "non-string language entry"),
+    ] {
+        repo.write_manifest(&one_module(json!({
+            "id": "bad-languages",
+            "kind": "rules",
+            "languages": languages,
+            "paths": []
+        })));
+        let output = run(&repo, "setup-manifest-rule-links", &["rust"]);
+        assert_failure(&output, expected_error);
+    }
+    repo.cleanup();
+}
+
+#[test]
+fn invalid_rule_path_shapes_and_missing_files_fail_visibly() {
+    let repo = TestRepo::new("rule-paths");
+    let cases = [
+        (
+            json!("rules/claude-rules/common/x.md"),
+            "paths must be a list",
+        ),
+        (json!([7]), "non-string rule path"),
+        (json!([""]), "rule path must be repo-relative"),
+        (json!(["/rules/x.md"]), "rule path must be repo-relative"),
+        (json!(["rules\\x.md"]), "rule path must be repo-relative"),
+        (
+            json!(["rules/claude-rules/../x.md"]),
+            "rule path must not contain '..'",
+        ),
+        (json!(["rules/claude-rules/common/x.txt"]), "Markdown file"),
+        (
+            json!(["docs/rules/common/x.md"]),
+            "must live under rules/claude-rules/",
+        ),
+        (
+            json!(["rules/claude-rules//x.md"]),
+            "must include a rule subdirectory",
+        ),
+        (
+            json!(["rules/claude-rules/common/missing.md"]),
+            "missing rule path rules/claude-rules/common/missing.md",
+        ),
+    ];
+    for (paths, expected_error) in cases {
+        repo.write_manifest(&one_module(rule_module(paths)));
+        let output = run(&repo, "setup-manifest-rule-links", &[]);
+        assert_failure(&output, expected_error);
+    }
+    repo.cleanup();
+}
+
+#[test]
+fn irrelevant_modules_are_filtered_before_invalid_optional_fields() {
+    let repo = TestRepo::new("filter-before-validate");
+    repo.write_manifest(&json!({
+        "modules": [
+            {
+                "id": "other-skill-target",
+                "kind": "skills",
+                "target": "~/.claude/skills/",
+                "paths": "invalid-but-unselected"
+            },
+            {
+                "id": "unrelated-kind",
+                "kind": "hook",
+                "languages": "invalid-but-unrelated",
+                "paths": "invalid-but-unrelated"
+            }
+        ]
+    }));
+
+    let skills = run(&repo, "setup-manifest-skill-links", &["~/.codex/skills/"]);
+    assert_success(&skills, "");
+    let rules = run(&repo, "setup-manifest-rule-links", &["rust"]);
+    assert_success(&rules, "");
+    repo.cleanup();
+}


### PR DESCRIPTION
## Summary

- cover runtime policy invalid config, strict verdict, argument, payload, and diagnostic I/O paths
- cover Codex hook health stale, prune, timeout, missing config, and read-error behavior
- cover setup manifest and install-state success/error/platform paths with real CLI integration tests
- ratchet the blocking Rust line-coverage baseline from 72% to 76%

## Verification

- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo clippy --locked --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings`
- `cargo check --locked --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --locked --manifest-path vibeguard-runtime/Cargo.toml`
- clean llvm-cov: 14,385 / 18,921 = 76.02663706992232%
- `bash scripts/ci/self-application/check-u22-coverage.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_self_application_ci.sh`
- `bash tests/test_release_workflow.sh`
- `bash scripts/local-contract-check.sh --quick`

Refs #581