### PR TITLE
test: enforce final Rust coverage gate

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,7 +7,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | Spec | Status | Use it for |
 |---|---|---|
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
-| `GH581/` | Draft | Rust coverage ratchets from a latest-head clean measurement through risk-ordered, independently reviewed tranches to the enforced 80% gate |
+| `GH581/` | Implemented reference | Rust coverage ratchets from a latest-head clean measurement through risk-ordered, independently reviewed tranches to the enforced 80% gate |
 | `GH588/` | Draft | Scheduled GC execution freshness, platform-correct wrapper/internal log evidence, and preserved setup-check mode semantics |
 | `GH589/` | Draft | Repo-scoped code-slop self-scan precision for Rust CLI stdout and line-scoped detector pattern sources |
 | `GH590/` | Draft | Directed session-pair W-14 cooldown, fail-open bounded history, schema-valid suppression telemetry, and runtime config distribution |

--- a/scripts/ci/self-application/check-u22-coverage.sh
+++ b/scripts/ci/self-application/check-u22-coverage.sh
@@ -6,7 +6,7 @@ REPO_DIR="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml"
 CARGO_BIN="${VIBEGUARD_U22_CARGO_BIN:-cargo}"
 CARGO_LLVM_COV_VERSION="0.8.7"
-LINE_COVERAGE_BASELINE="76"
+LINE_COVERAGE_BASELINE="80"
 LINE_COVERAGE_TARGET="80"
 
 if [[ ! -f "${RUNTIME_MANIFEST}" ]]; then
@@ -26,7 +26,7 @@ if [[ "${version_output}" != "${expected_version}" ]]; then
   exit 1
 fi
 
-echo "U-22 Rust line coverage: blocking baseline=${LINE_COVERAGE_BASELINE}%, target=${LINE_COVERAGE_TARGET}% (target not yet enforced)"
+echo "U-22 Rust line coverage: blocking baseline=${LINE_COVERAGE_BASELINE}%, target=${LINE_COVERAGE_TARGET}%"
 set +e
 "${CARGO_BIN}" llvm-cov \
   --locked \

--- a/tests/test_u22_coverage.sh
+++ b/tests/test_u22_coverage.sh
@@ -67,10 +67,11 @@ run_gate() {
 
 success_out="$(run_gate bash "${CHECK}" "${REPO_DIR}")"
 assert_cmd "coverage gate accepts a successful measured run" test -n "${success_out}"
-assert_cmd "coverage output names the 76% blocking baseline" grep -Fq "blocking baseline=76%" <<< "${success_out}"
-assert_cmd "coverage output keeps the 80% target visible" grep -Fq "target=80% (target not yet enforced)" <<< "${success_out}"
+assert_cmd "coverage output names the 80% blocking baseline" grep -Fq "blocking baseline=80%" <<< "${success_out}"
+assert_cmd "coverage output enforces the 80% target" grep -Fq "target=80%" <<< "${success_out}"
+assert_fails "coverage output removes the unenforced-target caveat" grep -Fq "target not yet enforced" <<< "${success_out}"
 assert_cmd "coverage command uses the locked runtime manifest" grep -Fq \
-  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 76" \
+  "llvm-cov --locked --manifest-path ${REPO_DIR}/vibeguard-runtime/Cargo.toml --summary-only --fail-under-lines 80" \
   "${CALL_LOG}"
 
 assert_fails "missing cargo-llvm-cov fails closed" env \

--- a/vibeguard-runtime/tests/cli_hook_checks.rs
+++ b/vibeguard-runtime/tests/cli_hook_checks.rs
@@ -279,6 +279,99 @@ fn post_edit_fast_check_emits_churn_and_overlap_warning_from_history() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn post_edit_fast_check_falls_back_when_warning_log_append_fails() {
+    use std::fs::OpenOptions;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let root = unique_temp_dir("post-edit-warning-log-failure");
+    fs::create_dir_all(&root).unwrap();
+    let history_file = root.join("read-only-history.jsonl");
+    let mut events = (0..5)
+        .map(|_| {
+            serde_json::json!({
+                "ts": "2099-01-01T00:00:00Z",
+                "session": "test-session",
+                "agent": "codex",
+                "hook": "post-edit-guard",
+                "tool": "Edit",
+                "decision": "pass",
+                "detail": "src/lib.rs||delta=1"
+            })
+        })
+        .collect::<Vec<_>>();
+    events.push(serde_json::json!({
+        "ts": "2099-01-01T00:00:00Z",
+        "session": "test-session",
+        "agent": "codex",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": "src/other.rs||delta=1"
+    }));
+    events.push(serde_json::json!({
+        "ts": "2099-01-01T00:00:00Z",
+        "session": "peer-session",
+        "agent": "claude",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": "src/lib.rs||delta=1"
+    }));
+    let history = events
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    let mut history_writer = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o400)
+        .open(&history_file)
+        .unwrap();
+    history_writer.write_all(history.as_bytes()).unwrap();
+    drop(history_writer);
+
+    let history_reader = fs::File::open(&history_file).unwrap();
+    let input = serde_json::json!({
+        "tool_input": {
+            "file_path": "src/lib.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn clean() {}"
+        }
+    })
+    .to_string();
+    let mut child = bin()
+        .args([
+            "post-edit-fast-check",
+            "800",
+            "test-session",
+            "codex",
+            "/dev/fd/2",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(history_reader))
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout, "FAST_PASS\nsrc/lib.rs\n");
+    assert!(!stdout.contains("FAST_OUTPUT"), "{stdout}");
+    assert_eq!(fs::read_to_string(&history_file).unwrap(), history);
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn post_edit_fast_check_defers_consecutive_history_to_shell_w15() {
     let root = unique_temp_dir("post-edit-history-w15-fallback");

--- a/vibeguard-runtime/tests/cli_hook_post_edit.rs
+++ b/vibeguard-runtime/tests/cli_hook_post_edit.rs
@@ -179,6 +179,59 @@ fn post_edit_rust_warning_is_visible_and_logged() {
 }
 
 #[test]
+fn post_edit_rs10_warning_is_visible_logged_and_rule_scoped() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-rs10-warning");
+    let new_string = concat!(
+        "// vibeguard-disable-next-line RS-10 -- intentional discard\n",
+        "let _ = intentionally_ignored();\n",
+        "let _ = must_be_reviewed();\n",
+        "let value = fallible_call().unwrap();\n"
+    );
+    let input = edit_input("src/lib.rs", "fn old() {}", new_string);
+    let out = run_post_edit(&repo, &log_root, &log_file, &input);
+
+    assert_eq!(out.status.code(), Some(0));
+    assert!(out.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("VIBEGUARD quality warning"), "{stdout}");
+    assert!(stdout.contains("[RS-10]"), "{stdout}");
+    assert!(
+        stdout.contains("1 new let _ = silent discard(s) added"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("2 new let _ = silent discard(s) added"));
+    assert!(stdout.contains("[RS-03]"), "{stdout}");
+    assert!(
+        stdout.contains("1 new unwrap()/expect() call(s) added"),
+        "{stdout}"
+    );
+
+    let events = parse_test_event_log(&log_file);
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(event["decision"], "warn");
+    assert_eq!(event["status"], "warn");
+    let reason = event["reason"].as_str().unwrap();
+    assert!(reason.contains("[RS-10]"), "{reason}");
+    assert!(
+        reason.contains("1 new let _ = silent discard(s) added"),
+        "{reason}"
+    );
+    assert!(reason.contains("[RS-03]"), "{reason}");
+    assert!(
+        reason.contains("1 new unwrap()/expect() call(s) added"),
+        "{reason}"
+    );
+    assert!(
+        event["detail"]
+            .as_str()
+            .unwrap()
+            .starts_with("src/lib.rs||delta=")
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn post_edit_prior_warnings_escalate_current_warning() {
     let (root, repo, log_root, log_file) = case_paths("post-edit-escalate");
     let prior = (0..3)

--- a/vibeguard-runtime/tests/hook_status_cli.rs
+++ b/vibeguard-runtime/tests/hook_status_cli.rs
@@ -1,0 +1,607 @@
+mod common;
+
+use common::{bin, unique_temp_dir};
+use serde_json::{Value, json};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn fixture_root(label: &str) -> PathBuf {
+    let root = unique_temp_dir(label);
+    fs::create_dir_all(root.join("home")).expect("fixture root should be created");
+    root
+}
+
+fn command(root: &Path) -> Command {
+    let mut command = bin();
+    command
+        .current_dir(root)
+        .env("HOME", root.join("home"))
+        .env_remove("VIBEGUARD_CODEX_DIAG_FILE")
+        .env_remove("VIBEGUARD_LOG_DIR")
+        .stdin(Stdio::null());
+    command
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    command(root)
+        .args(args)
+        .output()
+        .expect("hook-status command should run")
+}
+
+fn run_with_stdin(root: &Path, args: &[&str], input: &str) -> Output {
+    let mut child = command(root)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("hook-status command should spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(input.as_bytes())
+        .expect("stdin fixture should be written");
+    child
+        .wait_with_output()
+        .expect("hook-status command should finish")
+}
+
+fn write_jsonl(path: &Path, values: &[Value]) {
+    let text = values
+        .iter()
+        .map(Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    fs::write(path, text).expect("JSONL fixture should be written");
+}
+
+fn output_text(output: &Output) -> (String, String) {
+    (
+        String::from_utf8(output.stdout.clone()).expect("stdout should be UTF-8"),
+        String::from_utf8(output.stderr.clone()).expect("stderr should be UTF-8"),
+    )
+}
+
+fn json_output(output: &Output) -> Value {
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+    serde_json::from_slice(&output.stdout).expect("hook-status stdout should be JSON")
+}
+
+fn entry_by_detail<'a>(payload: &'a Value, detail: &str) -> &'a Value {
+    payload["entries"]
+        .as_array()
+        .expect("entries should be an array")
+        .iter()
+        .find(|entry| entry["detail"] == detail)
+        .unwrap_or_else(|| panic!("missing entry detail {detail:?}: {payload}"))
+}
+
+#[test]
+fn argument_contract_rejects_invalid_mode_limit_slow_scope_and_filters() {
+    let root = fixture_root("hook-status-args");
+    let cases = [
+        (&["hook-status", "--mode"][..], "--mode requires"),
+        (
+            &["hook-status", "--mode", "wide"][..],
+            "mode must be one of",
+        ),
+        (&["hook-status", "--limit"][..], "--limit requires"),
+        (&["hook-status", "--limit", "0"][..], "greater than 0"),
+        (&["hook-status", "--limit", "x"][..], "invalid digit"),
+        (&["hook-status", "--slow-ms"][..], "--slow-ms requires"),
+        (&["hook-status", "--slow-ms", "x"][..], "invalid digit"),
+        (&["hook-status", "--scope"][..], "--scope requires"),
+        (
+            &["hook-status", "--scope", "team"][..],
+            "scope must be one of: project, global",
+        ),
+        (&["hook-status", "--project"][..], "--project requires"),
+        (&["hook-status", "--log-file"][..], "--log-file requires"),
+        (&["hook-status", "--diag-file"][..], "--diag-file requires"),
+        (&["hook-status", "--session"][..], "--session requires"),
+        (&["hook-status", "--event"][..], "--event requires"),
+        (
+            &["hook-status", "--unknown"][..],
+            "unknown hook-status argument",
+        ),
+        (
+            &["hook-status", "--help"][..],
+            "Usage: vibeguard-runtime hook-status",
+        ),
+    ];
+    for (args, expected) in cases {
+        let output = run(&root, args);
+        let (stdout, stderr) = output_text(&output);
+        assert!(!output.status.success(), "{args:?} falsely succeeded");
+        assert!(stdout.is_empty(), "{args:?}: {stdout}");
+        assert!(stderr.contains(expected), "{args:?}: {stderr}");
+    }
+    fs::remove_dir_all(root).expect("fixture should be removed");
+}
+
+#[test]
+fn reads_explicit_files_stdin_implicit_no_data_and_bounded_tail() {
+    let root = fixture_root("hook-status-read");
+    let missing = root.join("missing.jsonl");
+    let diag = root.join("missing-diag.jsonl");
+    let missing_output = run(
+        &root,
+        &[
+            "hook-status",
+            "--log-file",
+            missing.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    );
+    assert!(!missing_output.status.success());
+    assert!(missing_output.stdout.is_empty());
+    assert!(!missing_output.stderr.is_empty());
+
+    let directory = root.join("events-dir");
+    fs::create_dir(&directory).expect("directory fixture should be created");
+    let directory_output = run(
+        &root,
+        &[
+            "hook-status",
+            "--log-file",
+            directory.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    );
+    assert!(!directory_output.status.success());
+    assert!(!directory_output.stderr.is_empty());
+
+    let empty_log = root.join("empty-events.jsonl");
+    fs::write(&empty_log, "").expect("empty event log should be written");
+    let diag_directory = root.join("diag-dir");
+    fs::create_dir(&diag_directory).expect("diagnostic directory should be created");
+    let diag_directory_output = run(
+        &root,
+        &[
+            "hook-status",
+            "--log-file",
+            empty_log.to_str().unwrap(),
+            "--diag-file",
+            diag_directory.to_str().unwrap(),
+        ],
+    );
+    assert!(!diag_directory_output.status.success());
+    assert!(diag_directory_output.stdout.is_empty());
+    assert!(!diag_directory_output.stderr.is_empty());
+
+    let log_root = root.join("logs");
+    fs::create_dir(&log_root).expect("log root should be created");
+    let implicit = command(&root)
+        .args([
+            "hook-status",
+            "--scope",
+            "global",
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ])
+        .env("VIBEGUARD_LOG_DIR", &log_root)
+        .output()
+        .expect("implicit no-data command should run");
+    let (implicit_stdout, implicit_stderr) = output_text(&implicit);
+    assert!(implicit.status.success(), "{implicit:?}");
+    assert!(implicit_stderr.is_empty());
+    assert!(implicit_stdout.contains("No hook status events found in"));
+    assert!(implicit_stdout.contains("events.jsonl"));
+
+    let project_log = log_root.join("projects/abc12345/events.jsonl");
+    fs::create_dir_all(project_log.parent().unwrap()).expect("project log dir should be created");
+    write_jsonl(
+        &project_log,
+        &[
+            json!({"ts":"2026-06-01T00:00:00Z","hook":"project-hook","decision":"pass","detail":"project-data"}),
+        ],
+    );
+    let project = command(&root)
+        .args([
+            "hook-status",
+            "--json",
+            "--project",
+            "abc12345",
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ])
+        .env("VIBEGUARD_LOG_DIR", &log_root)
+        .output()
+        .expect("project-scope command should run");
+    assert_eq!(
+        json_output(&project)["entries"][0]["detail"],
+        "project-data"
+    );
+
+    let stdin = run_with_stdin(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--mode",
+            "minimal",
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+        "not-json\n{\"ts\":\"2026-06-01T00:00:00Z\",\"hook\":\"pre-bash-guard\",\"tool\":\"Bash\",\"decision\":\"pass\",\"detail\":\"stdin-valid\"}\n",
+    );
+    let stdin_json = json_output(&stdin);
+    assert_eq!(stdin_json["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(stdin_json["entries"][0]["log_path"], "stdin");
+
+    let tail = root.join("tail.jsonl");
+    let mut text = String::from(
+        "{\"ts\":\"2026-06-01T00:00:00Z\",\"session\":\"old\",\"hook\":\"old-hook\",\"detail\":\"old-target\"}\nmalformed\n",
+    );
+    for index in 0..205 {
+        text.push_str(&format!(
+            "{{\"ts\":\"2026-06-01T00:01:{:02}Z\",\"session\":\"recent\",\"hook\":\"recent-hook\",\"decision\":\"pass\",\"detail\":\"recent-{index}\"}}\n",
+            index % 60
+        ));
+    }
+    fs::write(&tail, text).expect("tail fixture should be written");
+    let recent = json_output(&run(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--limit",
+            "1",
+            "--log-file",
+            tail.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(recent["entries"].as_array().unwrap().len(), 1);
+    assert!(
+        recent["entries"][0]["detail"]
+            .as_str()
+            .unwrap()
+            .starts_with("recent-")
+    );
+    let old = json_output(&run(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--limit",
+            "1",
+            "--session",
+            "old",
+            "--log-file",
+            tail.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(old["entries"][0]["detail"], "old-target");
+    fs::remove_dir_all(root).expect("fixture should be removed");
+}
+
+#[test]
+fn normalizes_hook_and_diag_fields_statuses_reasons_and_model_context() {
+    let root = fixture_root("hook-status-normalize");
+    let log = root.join("events.jsonl");
+    let diag = root.join("diag.jsonl");
+    write_jsonl(
+        &log,
+        &[
+            json!({"ts":"2026-06-01T00:00:01Z","session":"s1","hook":"vibeguard-pre-bash-guard.sh","tool":"Bash","decision":"pass","detail":"pass","duration_ms":"18"}),
+            json!({"ts":"2026-06-01T00:00:02Z","session":"s1","hook":"post-write-guard","tool":"Write","decision":"pass","detail":"slow","duration_ms":2500}),
+            json!({"ts":"2026-06-01T00:00:03Z","session":"s1","hook":"post-edit-guard","tool":"Edit","decision":"warn","reason":"unwrap found","detail":"warn","elapsed_ms":44}),
+            json!({"ts":"2026-06-01T00:00:04Z","session":"s1","hook":"pre-write-guard","hookEventName":"PermissionRequest","matcher":"Write","status":"block","reason":"blocked","detail":"block","timeout_ms":"30000"}),
+            json!({"ts":"2026-06-01T00:00:05Z","session":"s1","hook":"post-build-check","tool":"PostToolUse","decision":"pass","reason":"skip: missing file_path","detail":"skip","duration_ms":28}),
+            json!({"ts":"2026-06-01T00:00:06Z","session":"s1","hook":"post-build-check","event":"PostToolUse","decision":"warn","reason":"hook timeout after 30s","detail":"timeout","duration_ms":30000}),
+        ],
+    );
+    write_jsonl(
+        &diag,
+        &[
+            json!({"ts":"2026-06-01T00:00:07Z","session":"d1","hook":"diag-explicit","event":"Stop","matcher":"","status":"correction","decision":"correction","reason":"fix","detail":"diag-explicit","duration_ms":"1500","elapsed_ms":"1600","timeout_ms":"5000"}),
+            json!({"ts":"2026-06-01T00:00:08Z","hook":"diag-adapter","event":"PostToolUse","reason":"missing-runner","detail":"diag-adapter"}),
+            json!({"ts":"2026-06-01T00:00:09Z","hook":"diag-hook-error","event":"PostToolUse","reason":"unexpected","detail":"diag-hook-error"}),
+        ],
+    );
+    let payload = json_output(&run(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--mode",
+            "full",
+            "--slow-ms",
+            "2000",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(payload["schema_version"], 1);
+    assert_eq!(payload["mode"], "full");
+    let pass = entry_by_detail(&payload, "pass");
+    assert_eq!(pass["event"], "PreToolUse");
+    assert_eq!(pass["matcher"], "Bash");
+    assert_eq!(pass["status"], "pass");
+    assert_eq!(pass["duration_ms"], 18);
+    assert_eq!(pass["model_context"], false);
+    assert_eq!(entry_by_detail(&payload, "slow")["status"], "slow");
+    let warn = entry_by_detail(&payload, "warn");
+    assert_eq!(warn["event"], "PostToolUse");
+    assert_eq!(warn["matcher"], "Edit");
+    assert_eq!(warn["elapsed_ms"], 44);
+    assert_eq!(warn["model_context"], true);
+    let block = entry_by_detail(&payload, "block");
+    assert_eq!(block["event"], "PermissionRequest");
+    assert_eq!(block["timeout_ms"], 30000);
+    assert_eq!(block["model_context"], true);
+    let skipped = entry_by_detail(&payload, "skip");
+    assert_eq!(skipped["status"], "skipped");
+    assert_eq!(skipped["reason"], "missing file_path");
+    assert_eq!(entry_by_detail(&payload, "timeout")["status"], "timeout");
+    let explicit = entry_by_detail(&payload, "diag-explicit");
+    assert_eq!(explicit["source"], "codex_diag");
+    assert_eq!(explicit["matcher"], "<none>");
+    assert_eq!(explicit["elapsed_ms"], 1600);
+    assert_eq!(explicit["model_context"], true);
+    assert_eq!(
+        entry_by_detail(&payload, "diag-adapter")["status"],
+        "adapter_error"
+    );
+    assert_eq!(
+        entry_by_detail(&payload, "diag-hook-error")["status"],
+        "hook_error"
+    );
+    fs::remove_dir_all(root).expect("fixture should be removed");
+}
+
+#[test]
+fn filters_limits_orders_and_drops_stale_running_by_canonical_hook() {
+    let root = fixture_root("hook-status-filter-order");
+    let log = root.join("events.jsonl");
+    let diag = root.join("diag.jsonl");
+    write_jsonl(
+        &log,
+        &[
+            json!({"ts":"2026-06-01T00:00:01Z","session":"s1","hook":"pre-bash-guard","event":"PreToolUse","decision":"pass","detail":"first"}),
+            json!({"ts":"2026-06-01T00:00:02Z","session":"s2","hook":"post-build-check","event":"PostToolUse","decision":"warn","detail":"filtered-session"}),
+            json!({"ts":"2026-06-01T00:00:03Z","session":"s1","hook":"vibeguard-post-build-check.sh","event":"PostToolUse","decision":"pass","detail":"completed"}),
+            json!({"ts":"2026-06-01T00:00:04Z","session":"s1","hook":"last-hook","event":"Stop","decision":"complete","detail":"last"}),
+        ],
+    );
+    write_jsonl(
+        &diag,
+        &[
+            json!({"ts":"2026-06-01T00:00:03Z","hook":"post-build-check","event":"PostToolUse","status":"running","detail":"stale-running","elapsed_ms":12000,"timeout_ms":30000}),
+        ],
+    );
+    let filtered = json_output(&run(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--limit",
+            "2",
+            "--session",
+            "s1",
+            "--event",
+            "PostToolUse",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    ));
+    let entries = filtered["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["detail"], "completed");
+
+    let latest = json_output(&run(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--limit",
+            "2",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(latest["entries"].as_array().unwrap().len(), 2);
+    assert_eq!(latest["entries"][0]["detail"], "completed");
+    assert_eq!(latest["entries"][1]["detail"], "last");
+    assert!(
+        latest.to_string().find("completed").unwrap() < latest.to_string().find("last").unwrap()
+    );
+    assert!(!latest.to_string().contains("stale-running"));
+    fs::remove_dir_all(root).expect("fixture should be removed");
+}
+
+#[test]
+fn renders_minimal_focused_full_and_json_no_data_deterministically() {
+    let root = fixture_root("hook-status-render");
+    let log = root.join("events.jsonl");
+    let diag = root.join("missing-diag.jsonl");
+    write_jsonl(
+        &log,
+        &[
+            json!({"ts":"2026-06-01T00:00:01Z","hook":"post-edit-guard","event":"PostToolUse","matcher":"Edit","decision":"warn","reason":"review","detail":"src/lib.rs","duration_ms":500}),
+            json!({"ts":"2026-06-01T00:00:02Z","hook":"post-write-guard","event":"PostToolUse","matcher":"Write","decision":"pass","detail":"src/main.rs","duration_ms":2000}),
+            json!({"ts":"2026-06-01T00:00:03Z","hook":"post-build-check","event":"PostToolUse","matcher":"Bash","status":"timeout","reason":"timeout","detail":"cargo test","duration_ms":2500}),
+            json!({"ts":"2026-06-01T00:00:04Z","hook":"quick-pass","event":"PostToolUse","status":"pass","detail":"pass action","duration_ms":100}),
+            json!({"ts":"2026-06-01T00:00:05Z","hook":"explicit-skip","event":"PostToolUse","status":"skipped","reason":"skipped: not needed","detail":"skip action"}),
+            json!({"ts":"2026-06-01T00:00:06Z","hook":"explicit-block","event":"PostToolUse","status":"block","reason":"denied","detail":"block action"}),
+            json!({"ts":"2026-06-01T00:00:07Z","hook":"hook-failure","event":"PostToolUse","status":"hook_error","reason":"failed","detail":"error action"}),
+            json!({"ts":"2026-06-01T00:00:08Z","hook":"still-running","event":"PostToolUse","status":"running","reason":"checking","detail":"running action","elapsed_ms":1200,"timeout_ms":5000}),
+            json!({"ts":"2026-06-01T00:00:09Z","hook":"gate-hook","event":"PostToolUse","status":"gate","detail":"gate action"}),
+            json!({"ts":"2026-06-01T00:00:10Z","hook":"escalate-hook","event":"PostToolUse","status":"escalate","detail":"escalate action"}),
+            json!({"ts":"2026-06-01T00:00:11Z","hook":"correction-hook","event":"PostToolUse","status":"correction","detail":"correction action"}),
+            json!({"ts":"2026-06-01T00:00:12Z","hook":"complete-hook","event":"PostToolUse","status":"complete","detail":"complete action"}),
+            json!({"ts":"2026-06-01T00:00:13Z","hook":"unknown-hook","event":"PostToolUse","status":"unknown","detail":"unknown action"}),
+        ],
+    );
+    let base = [
+        "--log-file",
+        log.to_str().unwrap(),
+        "--diag-file",
+        diag.to_str().unwrap(),
+    ];
+    let minimal = run(
+        &root,
+        &[
+            "hook-status",
+            "--mode",
+            "minimal",
+            base[0],
+            base[1],
+            base[2],
+            base[3],
+        ],
+    );
+    let (minimal_stdout, minimal_stderr) = output_text(&minimal);
+    assert!(minimal.status.success());
+    assert!(minimal_stderr.is_empty());
+    assert!(minimal_stdout.contains("PostToolUse hook timed out - post-build-check - 2.5s"));
+    assert!(minimal_stdout.contains("Last action: cargo test"));
+    assert!(minimal_stdout.contains("Safe to interrupt: yes"));
+    assert!(!minimal_stdout.contains("[warn]"));
+
+    let focused = run(
+        &root,
+        &[
+            "hook-status",
+            "--mode",
+            "focused",
+            base[0],
+            base[1],
+            base[2],
+            base[3],
+        ],
+    );
+    let (focused_stdout, _) = output_text(&focused);
+    assert!(
+        focused_stdout.contains("[warn] post-edit-guard PostToolUse(Edit) warn - review - 500ms")
+    );
+    assert!(focused_stdout.contains("[slow] post-write-guard PostToolUse(Write) slow - 2s"));
+    assert!(focused_stdout.contains("[timeout] post-build-check PostToolUse(Bash) timeout"));
+    assert!(focused_stdout.contains("[pass] quick-pass PostToolUse(<none>) pass - 100ms"));
+    assert!(
+        focused_stdout.contains("[skip] explicit-skip PostToolUse(<none>) skipped - not needed")
+    );
+    assert!(focused_stdout.contains("[block] explicit-block PostToolUse(<none>) block - denied"));
+    assert!(
+        focused_stdout.contains("[error] hook-failure PostToolUse(<none>) hook_error - failed")
+    );
+    assert!(
+        focused_stdout
+            .contains("[running] still-running PostToolUse(<none>) running - checking - 1.2s / 5s")
+    );
+    for status in ["gate", "escalate", "correction", "complete", "unknown"] {
+        assert!(
+            focused_stdout.contains(&format!(
+                "[info] {status}-hook PostToolUse(<none>) {status}"
+            )),
+            "missing info label for {status}: {focused_stdout}"
+        );
+    }
+    assert!(!focused_stdout.contains("model_context="));
+
+    let full = run(
+        &root,
+        &[
+            "hook-status",
+            "--mode",
+            "full",
+            base[0],
+            base[1],
+            base[2],
+            base[3],
+        ],
+    );
+    let (full_stdout, _) = output_text(&full);
+    assert!(full_stdout.contains("model_context=true"));
+    assert!(full_stdout.contains("model_context=false"));
+    assert!(full_stdout.contains("last_action=src/lib.rs"));
+    assert!(full_stdout.contains("last_action=running action"));
+    assert!(full_stdout.contains("last_action=unknown action"));
+    assert!(full_stdout.contains(log.to_str().unwrap()));
+
+    let adapter_main = root.join("adapter-main.jsonl");
+    let adapter_diag = root.join("adapter-diag.jsonl");
+    fs::write(&adapter_main, "").expect("adapter main log should be written");
+    write_jsonl(
+        &adapter_diag,
+        &[
+            json!({"ts":"2026-06-01T00:00:00Z","hook":"diag-adapter","event":"PostToolUse","reason":"missing-runner","detail":"adapter action"}),
+        ],
+    );
+    let adapter = run(
+        &root,
+        &[
+            "hook-status",
+            "--mode",
+            "minimal",
+            "--log-file",
+            adapter_main.to_str().unwrap(),
+            "--diag-file",
+            adapter_diag.to_str().unwrap(),
+        ],
+    );
+    let (adapter_stdout, adapter_stderr) = output_text(&adapter);
+    assert!(adapter.status.success());
+    assert!(adapter_stderr.is_empty());
+    assert!(adapter_stdout.contains(
+        "PostToolUse hook adapter_error - diag-adapter - missing-runner\nLast action: adapter action"
+    ));
+    assert!(adapter_stdout.contains(adapter_diag.to_str().unwrap()));
+
+    let empty = root.join("empty.jsonl");
+    fs::write(&empty, "").expect("empty fixture should be written");
+    let empty_human = run(
+        &root,
+        &[
+            "hook-status",
+            "--mode",
+            "full",
+            "--log-file",
+            empty.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    );
+    let (empty_stdout, empty_stderr) = output_text(&empty_human);
+    assert!(empty_human.status.success());
+    assert!(empty_stderr.is_empty());
+    assert!(empty_stdout.contains("No hook status events found in"));
+    let empty_json = json_output(&run(
+        &root,
+        &[
+            "hook-status",
+            "--json",
+            "--mode",
+            "focused",
+            "--log-file",
+            empty.to_str().unwrap(),
+            "--diag-file",
+            diag.to_str().unwrap(),
+        ],
+    ));
+    assert_eq!(empty_json["mode"], "focused");
+    assert_eq!(
+        empty_json["summary"],
+        json!({"event":"unknown","total":0,"complete":0,"running":0,"attention":0,"model_context_entries":0})
+    );
+    assert_eq!(empty_json["entries"], json!([]));
+    fs::remove_dir_all(root).expect("fixture should be removed");
+}

--- a/vibeguard-runtime/tests/observe_cli.rs
+++ b/vibeguard-runtime/tests/observe_cli.rs
@@ -1,0 +1,629 @@
+mod common;
+
+use common::{bin, unique_temp_dir};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn case_root(label: &str) -> PathBuf {
+    let root = unique_temp_dir(&format!("observe_{label}"));
+    fs::create_dir_all(root.join("home")).expect("test home should be created");
+    root
+}
+
+fn cli_for_case(root: &Path) -> Command {
+    let mut command = bin();
+    command
+        .env("HOME", root.join("home"))
+        .env("VIBEGUARD_LOG_DIR", root.join("logs"))
+        .env_remove("VIBEGUARD_LOG_FILE")
+        .current_dir(root);
+    command
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    cli_for_case(root)
+        .args(args)
+        .output()
+        .expect("observe command should run")
+}
+
+fn path_text(path: &Path) -> String {
+    path.to_str()
+        .expect("temporary paths should be UTF-8")
+        .to_string()
+}
+
+fn write_log(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("log parent should be created");
+    }
+    fs::write(path, content).expect("event log should be written");
+}
+
+fn assert_success(output: &Output) {
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stderr.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_visible_error(output: &Output) {
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).starts_with("vibeguard-runtime error: "));
+}
+
+fn output_json(output: &Output) -> Value {
+    assert_success(output);
+    serde_json::from_slice(&output.stdout).expect("observe output should be JSON")
+}
+
+fn assert_empty_observe_json(rendered: &Value, command: &str, log_path: &str) {
+    assert_eq!(rendered["command"], command);
+    assert_eq!(rendered["source"]["log_path"], log_path);
+    assert_eq!(rendered["event_count"], 0);
+    assert_eq!(rendered["decision_counts"], json!({}));
+    assert_eq!(rendered["hook_counts"], json!({}));
+    assert_eq!(rendered["client_distribution"], json!({}));
+    assert_eq!(rendered["attention"]["count"], 0);
+    assert_eq!(rendered["attention"]["rate"].as_f64(), Some(0.0));
+    assert_eq!(rendered["attention"]["percent"].as_f64(), Some(0.0));
+    assert_eq!(rendered["top_rule_ids"], json!([]));
+    assert_eq!(rendered["top_reason_codes"], json!([]));
+    assert_eq!(rendered["duration_stats"]["count"], 0);
+    assert_eq!(rendered["duration_stats"]["avg_ms"], 0);
+    assert_eq!(rendered["duration_stats"]["min_ms"], Value::Null);
+    assert_eq!(rendered["duration_stats"]["p95_ms"], Value::Null);
+    assert_eq!(rendered["duration_stats"]["max_ms"], Value::Null);
+    assert_eq!(rendered["duration_stats"]["slow_count"], 0);
+}
+
+#[test]
+fn summary_health_and_session_report_missing_and_empty_data() {
+    let root = case_root("no_data");
+    let implicit = root.join("logs/events.jsonl");
+
+    let health = run(&root, &["observe", "health", "--scope", "global"]);
+    assert_success(&health);
+    assert_eq!(
+        String::from_utf8_lossy(&health.stdout),
+        format!(
+            "No log data. Hooks will be automatically logged to {} after being triggered.\n",
+            implicit.display()
+        )
+    );
+
+    let missing_global_json = output_json(&run(
+        &root,
+        &["observe", "health", "--scope", "global", "--json"],
+    ));
+    assert_empty_observe_json(&missing_global_json, "health", &path_text(&implicit));
+    assert_eq!(missing_global_json["schema_version"], 1);
+    assert_eq!(missing_global_json["source"]["scope"], "global");
+    assert_eq!(missing_global_json["source"]["period"], "last 24 hours");
+    assert_eq!(missing_global_json["source"]["limit"], 5000);
+    assert_eq!(missing_global_json["time_range"]["first_ts"], "");
+    assert_eq!(missing_global_json["time_range"]["last_ts"], "");
+    assert_eq!(missing_global_json["duration_stats"]["slow_ms"], 2000);
+    assert_eq!(missing_global_json["attention_states"], json!([]));
+    assert_eq!(missing_global_json["diagnostics"], json!([]));
+
+    let summary = run(&root, &["observe", "summary", "--scope", "global"]);
+    assert_success(&summary);
+    assert_eq!(
+        String::from_utf8_lossy(&summary.stdout),
+        format!(
+            "No log data. Hooks will be automatically logged to {} after being triggered\n",
+            implicit.display()
+        )
+    );
+
+    let empty = root.join("empty.jsonl");
+    write_log(&empty, "\n");
+    let empty_text = path_text(&empty);
+    let health = run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--log-file",
+            &empty_text,
+            "--hours",
+            "3",
+        ],
+    );
+    assert_success(&health);
+    assert_eq!(
+        String::from_utf8_lossy(&health.stdout),
+        "No log data for the last 3 hours.\n"
+    );
+    let summary = run(
+        &root,
+        &[
+            "observe",
+            "summary",
+            "--log-file",
+            &empty_text,
+            "--days",
+            "2",
+        ],
+    );
+    assert_success(&summary);
+    assert_eq!(
+        String::from_utf8_lossy(&summary.stdout),
+        "No log data for the last 2 days.\n"
+    );
+    let health_days = run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--log-file",
+            &empty_text,
+            "--days",
+            "2",
+        ],
+    );
+    assert_success(&health_days);
+    assert_eq!(
+        String::from_utf8_lossy(&health_days.stdout),
+        "No log data for the last 2 days.\n"
+    );
+
+    let health_json = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--json",
+            "--log-file",
+            &empty_text,
+            "--hours",
+            "all",
+        ],
+    ));
+    assert_empty_observe_json(&health_json, "health", &empty_text);
+    assert_eq!(health_json["attention_states"], json!([]));
+    assert_eq!(health_json["diagnostics"], json!([]));
+
+    let summary_json = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "summary",
+            "--json",
+            "--log-file",
+            &empty_text,
+            "--days",
+            "all",
+        ],
+    ));
+    assert_empty_observe_json(&summary_json, "summary", &empty_text);
+
+    let health_all = run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--log-file",
+            &empty_text,
+            "--hours",
+            "all",
+        ],
+    );
+    assert_success(&health_all);
+    assert_eq!(
+        String::from_utf8_lossy(&health_all.stdout),
+        "No log data.\n"
+    );
+
+    let old = root.join("old.jsonl");
+    write_log(
+        &old,
+        "{\"ts\":\"2000-01-01T00:00:00Z\",\"hook\":\"old-hook\",\"decision\":\"warn\"}\n",
+    );
+    let old_window = run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--log-file",
+            &path_text(&old),
+            "--hours",
+            "1",
+        ],
+    );
+    assert_success(&old_window);
+    assert_eq!(
+        String::from_utf8_lossy(&old_window.stdout),
+        "No log data for the last 1 hours.\n"
+    );
+
+    let home_log = root.join("home/.vibeguard/events.jsonl");
+    write_log(&home_log, "");
+    let session = run(
+        &root,
+        &[
+            "observe",
+            "session",
+            "missing-session",
+            "--log-file",
+            &path_text(&home_log),
+        ],
+    );
+    assert_success(&session);
+    assert_eq!(
+        String::from_utf8_lossy(&session.stdout),
+        "No observe events found for session missing-session in ~/.vibeguard/events.jsonl.\n"
+    );
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn explicit_missing_and_directory_inputs_fail_visibly() {
+    let root = case_root("input_errors");
+    let missing = root.join("missing.jsonl");
+    let missing_output = run(
+        &root,
+        &["observe", "health", "--log-file", &path_text(&missing)],
+    );
+    assert_visible_error(&missing_output);
+    let missing_stderr = String::from_utf8_lossy(&missing_output.stderr);
+    assert!(missing_stderr.contains("Log file does not exist:"));
+    assert!(missing_stderr.contains(&path_text(&missing)));
+
+    let directory = root.join("events-directory");
+    fs::create_dir_all(&directory).expect("input directory should be created");
+    let directory_output = run(
+        &root,
+        &["observe", "health", "--log-file", &path_text(&directory)],
+    );
+    assert_visible_error(&directory_output);
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn malformed_tail_window_and_session_filters_keep_stable_order() {
+    let root = case_root("filters");
+    let log = root.join("events.jsonl");
+    write_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2000-01-01T00:00:00Z\",\"session\":\"s1\",\"hook\":\"old-hook\",\"decision\":\"pass\"}\n",
+            "   \n",
+            "{\n",
+            "null\n",
+            "[]\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"z-hook\",\"decision\":\"pass\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s2\",\"hook\":\"middle-hook\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"a-hook\",\"decision\":\"pass\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"b-hook\",\"decision\":\"pass\"}\n"
+        ),
+    );
+    let log_text = path_text(&log);
+
+    let health = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--json",
+            "--log-file",
+            &log_text,
+            "--hours",
+            "1",
+            "--limit",
+            "all",
+        ],
+    ));
+    assert_eq!(health["event_count"], 4);
+    assert_eq!(health["hook_counts"]["old-hook"], Value::Null);
+    assert_eq!(health["time_range"]["first_ts"], "2099-01-01T00:00:01Z");
+    assert_eq!(health["time_range"]["last_ts"], "2099-01-01T00:00:02Z");
+
+    let session = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "session",
+            "s1",
+            "--json",
+            "--log-file",
+            &log_text,
+            "--hours",
+            "1",
+            "--limit",
+            "4",
+            "--top",
+            "10",
+        ],
+    ));
+    assert_eq!(session["event_count"], 3);
+    let recent = session["recent_events"].as_array().unwrap();
+    assert_eq!(recent.len(), 3);
+    assert_eq!(recent[0]["hook"], "b-hook");
+    assert_eq!(recent[1]["hook"], "a-hook");
+    assert_eq!(recent[2]["hook"], "z-hook");
+
+    let human = run(
+        &root,
+        &[
+            "observe",
+            "session",
+            "s1",
+            "--log-file",
+            &log_text,
+            "--hours",
+            "1",
+            "--limit",
+            "4",
+        ],
+    );
+    assert_success(&human);
+    assert_eq!(
+        String::from_utf8_lossy(&human.stdout),
+        "VibeGuard observe session s1\nTime range: 2099-01-01T00:00:01Z ~ 2099-01-01T00:00:02Z\nEvents: 3 | Attention: 0 (0.0%)\nTop hooks: a-hook=1, b-hook=1, z-hook=1\n"
+    );
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn summary_human_and_json_render_deterministic_counts_and_durations() {
+    let root = case_root("summary");
+    let log = root.join("events.jsonl");
+    write_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"pre-bash-guard\",\"cli\":\"codex\",\"client\":\"codex\",\"decision\":\"pass\",\"duration_ms\":10}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"cli\":\"claude\",\"decision\":\"warn\",\"reason\":\"U-16 file too large\",\"detail\":\"src/main.rs\",\"duration_ms\":20}\n",
+            "{\"ts\":\"2099-01-01T00:00:03Z\",\"session\":\"s2\",\"hook\":\"pre-bash-guard\",\"cli\":\"codex\",\"client\":\"cursor\",\"decision\":\"block\",\"reason\":\"force push denied\",\"duration_ms\":2500}\n"
+        ),
+    );
+    let log_text = path_text(&log);
+    let human = run(
+        &root,
+        &[
+            "observe",
+            "summary",
+            "--log-file",
+            &log_text,
+            "--days",
+            "all",
+        ],
+    );
+    assert_success(&human);
+    let human_text = String::from_utf8_lossy(&human.stdout);
+    for expected in [
+        "VibeGuard Statistics (all history)",
+        "Total triggers: 3 times",
+        "Interception (block): 1 times",
+        "Warning: 1 times",
+        "Pass (pass): 1 times",
+        "pre-bash-guard: 2 times",
+        "codex: 2 times",
+        "1x  force push denied",
+        "1x  U-16 file too large",
+    ] {
+        assert!(
+            human_text.contains(expected),
+            "missing {expected}:\n{human_text}"
+        );
+    }
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "summary",
+            "--json",
+            "--log-file",
+            &log_text,
+            "--days",
+            "all",
+            "--top",
+            "2",
+        ],
+    ));
+    assert_eq!(rendered["schema_version"], 1);
+    assert_eq!(rendered["command"], "summary");
+    assert_eq!(rendered["source"]["scope"], "project");
+    assert_eq!(rendered["event_count"], 3);
+    assert_eq!(
+        rendered["decision_counts"],
+        json!({"block":1,"pass":1,"warn":1})
+    );
+    assert_eq!(rendered["duration_stats"]["count"], 3);
+    assert_eq!(rendered["duration_stats"]["avg_ms"], 843);
+    assert_eq!(rendered["duration_stats"]["min_ms"], 10);
+    assert_eq!(rendered["duration_stats"]["p95_ms"], 2500);
+    assert_eq!(rendered["duration_stats"]["slow_count"], 1);
+    assert_eq!(
+        rendered["top_rule_ids"][0],
+        json!({"value":"U-16","count":1})
+    );
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn health_human_renders_risk_distributions_unknowns_and_truncation() {
+    let root = case_root("health_human");
+    let log = root.join("events.jsonl");
+    let long_reason = format!("U-16 {}\nsecret", "x".repeat(120));
+    let events = [
+        json!({"ts":"2099-01-01T00:00:01Z","session":"s1","hook":"alpha","cli":"codex","client":"codex","decision":"pass"}),
+        json!({"ts":"2099-01-01T00:00:02Z","session":"s1","hook":"beta","cli":"claude","decision":"warn","reason":long_reason,"detail":"first line\nsecond line"}),
+        json!({"ts":"2099-01-01T00:00:03Z","session":"s2","hook":"beta","client":"cursor","decision":"block","reason":"force push denied"}),
+        json!({"decision":"warn","reason":"missing metadata"}),
+    ];
+    write_log(
+        &log,
+        &events
+            .iter()
+            .map(|event| serde_json::to_string(event).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    let output = run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--log-file",
+            &path_text(&log),
+            "--hours",
+            "all",
+        ],
+    );
+    assert_success(&output);
+    let text = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "Total triggers: 4",
+        "Pass: 1",
+        "Risk (non-pass): 3",
+        "Risk rate: 75.0%",
+        "  block: 1",
+        "  warn: 2",
+        "  beta: 2",
+        "  unknown: 1",
+        "detail: first line second line",
+    ] {
+        assert!(text.contains(expected), "missing {expected}:\n{text}");
+    }
+    assert!(
+        text.contains(
+            "CLI distribution:\n  unknown: 2\n  claude: 1\n  codex: 1\nClient distribution:\n  claude: 1\n  codex: 1\n  cursor: 1\n  unknown: 1\n"
+        ),
+        "{text}"
+    );
+    assert!(
+        text.contains("Risk Hook Top 5:\n  beta: 2\n  unknown: 1\n"),
+        "{text}"
+    );
+    let cleaned = format!("U-16 {} secret", "x".repeat(120));
+    let expected_reason = format!("{}...", cleaned.chars().take(97).collect::<String>());
+    assert!(
+        text.contains(&format!("reason: {expected_reason}")),
+        "{text}"
+    );
+    assert!(
+        text.contains("1. 2099-01-01T00:00:03Z | beta | block"),
+        "{text}"
+    );
+    assert!(text.contains("3. ? | unknown | warn"), "{text}");
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn health_json_bounds_attention_diagnostics_and_session_events() {
+    let root = case_root("health_json");
+    let log = root.join("events.jsonl");
+    write_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"slow-hook\",\"decision\":\"pass\",\"duration_ms\":2500}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"warn-hook\",\"decision\":\"warn\",\"reason\":\"U-16 warning\",\"duration_ms\":20}\n",
+            "{\"ts\":\"2099-01-01T00:00:03Z\",\"session\":\"s1\",\"hook\":\"timeout-hook\",\"decision\":\"warn\",\"status\":\"timeout\",\"reason\":\"hook timeout\",\"duration_ms\":30000}\n",
+            "{\"ts\":\"2099-01-01T00:00:04Z\",\"session\":\"s1\",\"hook\":\"block-hook\",\"decision\":\"block\",\"duration_ms\":5}\n"
+        ),
+    );
+    let log_text = path_text(&log);
+    let health = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--json",
+            "--log-file",
+            &log_text,
+            "--hours",
+            "all",
+            "--top",
+            "1",
+        ],
+    ));
+    assert_eq!(health["command"], "health");
+    assert_eq!(health["event_count"], 4);
+    assert_eq!(health["attention"]["count"], 4);
+    assert_eq!(health["attention_states"].as_array().unwrap().len(), 1);
+    assert_eq!(health["attention_states"][0]["hook"], "block-hook");
+    assert_eq!(health["diagnostics"].as_array().unwrap().len(), 1);
+    assert_eq!(health["diagnostics"][0]["hook"], "timeout-hook");
+    assert_eq!(health["diagnostics"][0]["diagnostic"], "timeout");
+    assert_eq!(health["duration_stats"]["count"], 4);
+    assert_eq!(health["duration_stats"]["avg_ms"], 8131);
+    assert_eq!(health["duration_stats"]["slow_count"], 2);
+
+    let session = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "session",
+            "s1",
+            "--json",
+            "--log-file",
+            &log_text,
+            "--top",
+            "2",
+        ],
+    ));
+    assert_eq!(session["recent_events"].as_array().unwrap().len(), 2);
+    assert_eq!(session["recent_events"][0]["hook"], "timeout-hook");
+    assert_eq!(session["recent_events"][1]["hook"], "block-hook");
+    assert_eq!(session["attention_states"].as_array().unwrap().len(), 2);
+    assert_eq!(session["diagnostics"].as_array().unwrap().len(), 2);
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn prometheus_output_directory_and_parent_file_fail_visibly() {
+    let root = case_root("output_errors");
+    let input = root.join("events.jsonl");
+    write_log(
+        &input,
+        "{\"hook\":\"pre-bash-guard\",\"decision\":\"pass\"}\n",
+    );
+    let output_directory = root.join("metrics-directory");
+    fs::create_dir_all(&output_directory).expect("output directory should be created");
+
+    let directory_failure = run(
+        &root,
+        &[
+            "observe",
+            "export",
+            "prometheus",
+            "--since",
+            "all",
+            "--input-file",
+            &path_text(&input),
+            "--file",
+            &path_text(&output_directory),
+        ],
+    );
+    assert_visible_error(&directory_failure);
+    assert!(output_directory.is_dir());
+
+    let parent_file = root.join("parent-file");
+    fs::write(&parent_file, "not a directory").expect("parent file should be written");
+    let nested_output = parent_file.join("metrics.prom");
+    let parent_failure = run(
+        &root,
+        &[
+            "observe",
+            "export",
+            "prometheus",
+            "--since",
+            "all",
+            "--input-file",
+            &path_text(&input),
+            "--file",
+            &path_text(&nested_output),
+        ],
+    );
+    assert_visible_error(&parent_failure);
+    assert!(!nested_output.exists());
+    fs::remove_dir_all(root).expect("case root should be removed");
+}

--- a/vibeguard-runtime/tests/setup_markdown_cli.rs
+++ b/vibeguard-runtime/tests/setup_markdown_cli.rs
@@ -1,0 +1,303 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+struct Fixture {
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "vibeguard-setup-markdown-{label}-{}-{id}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("fixture root should be created");
+        Self { root }
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    fn write(&self, name: &str, text: &str) -> PathBuf {
+        let path = self.path(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("fixture parent should be created");
+        }
+        fs::write(&path, text).expect("fixture file should be written");
+        path
+    }
+
+    fn cleanup(self) {
+        fs::remove_dir_all(self.root).expect("fixture root should be removed");
+    }
+}
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+}
+
+fn run(fixture: &Fixture, command: &str, args: &[&Path], tail: &[&str]) -> Output {
+    bin()
+        .arg(command)
+        .args(args)
+        .args(tail)
+        .current_dir(&fixture.root)
+        .output()
+        .expect("setup Markdown command should run")
+}
+
+fn output_text(bytes: &[u8]) -> String {
+    String::from_utf8(bytes.to_vec()).expect("command output should be UTF-8")
+}
+
+fn assert_success(output: &Output, expected_stdout: &str) {
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        output_text(&output.stderr)
+    );
+    assert_eq!(output_text(&output.stdout), expected_stdout);
+    assert_eq!(output_text(&output.stderr), "");
+}
+
+fn assert_visible_failure(output: &Output, stable_message: Option<&str>) {
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output_text(&output.stdout), "");
+    let error = output_text(&output.stderr);
+    assert!(
+        error.starts_with("vibeguard-runtime error: "),
+        "unexpected stderr: {error}"
+    );
+    if let Some(message) = stable_message {
+        assert!(error.contains(message), "stderr={error}");
+    }
+}
+
+const RULES: &str = concat!(
+    "<!-- vibeguard-start -->\n",
+    "Repo: __VIBEGUARD_DIR__\n",
+    "Rules: __VIBEGUARD_RULE_COUNT__\n",
+    "<!-- vibeguard-end -->\n"
+);
+
+#[test]
+fn markdown_argument_and_missing_rules_errors_are_visible() {
+    let fixture = Fixture::new("errors");
+
+    for command in ["setup-md-diff-inject", "setup-md-inject", "setup-md-remove"] {
+        let output = bin()
+            .arg(command)
+            .current_dir(&fixture.root)
+            .output()
+            .expect("setup Markdown command should run");
+        assert_visible_failure(&output, Some("Usage: vibeguard-runtime setup-md-"));
+    }
+
+    let target = fixture.path("AGENTS.md");
+    let missing_rules = fixture.path("missing-rules.md");
+    let missing = run(
+        &fixture,
+        "setup-md-inject",
+        &[&target, &missing_rules],
+        &["/repo", "12"],
+    );
+    assert_visible_failure(&missing, None);
+    assert!(!target.exists());
+
+    let rules = fixture.write("rules.md", RULES);
+    let invalid_count = run(
+        &fixture,
+        "setup-md-diff-inject",
+        &[&target, &rules],
+        &["/repo", "twelve"],
+    );
+    assert_visible_failure(&invalid_count, Some("Invalid rule count: twelve"));
+    assert!(!target.exists());
+    fixture.cleanup();
+}
+
+#[test]
+fn diff_is_non_mutating_and_inject_is_exact_and_idempotent() {
+    let fixture = Fixture::new("inject");
+    let target = fixture.write("AGENTS.md", "Intro\n");
+    let rules = fixture.write("rules.md", RULES);
+    let rendered_rules = concat!(
+        "<!-- vibeguard-start -->\n",
+        "Repo: /workspace/repo\n",
+        "Rules: 126\n",
+        "<!-- vibeguard-end -->"
+    );
+    let managed_only = format!("{rendered_rules}\n");
+    let expected_content = format!("Intro\n\n{rendered_rules}\n");
+
+    let missing_target = fixture.path("missing-target.md");
+    assert_success(
+        &run(
+            &fixture,
+            "setup-md-inject",
+            &[&missing_target, &rules],
+            &["/workspace/repo", "126"],
+        ),
+        "APPENDED\n",
+    );
+    assert_eq!(fs::read_to_string(&missing_target).unwrap(), managed_only);
+
+    let empty_target = fixture.write("empty-target.md", "");
+    assert_success(
+        &run(
+            &fixture,
+            "setup-md-inject",
+            &[&empty_target, &rules],
+            &["/workspace/repo", "126"],
+        ),
+        "APPENDED\n",
+    );
+    assert_eq!(fs::read_to_string(&empty_target).unwrap(), managed_only);
+
+    let diff = run(
+        &fixture,
+        "setup-md-diff-inject",
+        &[&target, &rules],
+        &["/workspace/repo", "126"],
+    );
+    let expected_diff = format!(
+        "--- {0}\n+++ {0}\n@@\n-Intro\n+Intro\n+\n+<!-- vibeguard-start -->\n+Repo: /workspace/repo\n+Rules: 126\n+<!-- vibeguard-end -->\nAPPENDED\n",
+        target.display()
+    );
+    assert_success(&diff, &expected_diff);
+    assert_eq!(fs::read_to_string(&target).unwrap(), "Intro\n");
+
+    let inject = run(
+        &fixture,
+        "setup-md-inject",
+        &[&target, &rules],
+        &["/workspace/repo", "126"],
+    );
+    assert_success(&inject, "APPENDED\n");
+    assert_eq!(fs::read_to_string(&target).unwrap(), expected_content);
+
+    let skip_diff = run(
+        &fixture,
+        "setup-md-diff-inject",
+        &[&target, &rules],
+        &["/workspace/repo", "126"],
+    );
+    assert_success(&skip_diff, "SKIP\n");
+    let before_repeat = fs::read(&target).unwrap();
+    let repeat = run(
+        &fixture,
+        "setup-md-inject",
+        &[&target, &rules],
+        &["/workspace/repo", "126"],
+    );
+    assert_success(&repeat, "UPDATED\n");
+    assert_eq!(fs::read(&target).unwrap(), before_repeat);
+    fixture.cleanup();
+}
+
+#[test]
+fn inject_updates_only_the_managed_block() {
+    let fixture = Fixture::new("update");
+    let target = fixture.write(
+        "CLAUDE.md",
+        concat!(
+            "Before\n\n",
+            "<!-- vibeguard-start -->\nold\n<!-- vibeguard-end -->\n\n",
+            "After\n"
+        ),
+    );
+    let rules = fixture.write("rules.md", RULES);
+
+    let output = run(
+        &fixture,
+        "setup-md-inject",
+        &[&target, &rules],
+        &["/new/repo", "80"],
+    );
+    assert_success(&output, "UPDATED\n");
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        concat!(
+            "Before\n\n",
+            "<!-- vibeguard-start -->\n",
+            "Repo: /new/repo\n",
+            "Rules: 80\n",
+            "<!-- vibeguard-end -->\n\n",
+            "After\n"
+        )
+    );
+    fixture.cleanup();
+}
+
+#[test]
+fn remove_distinguishes_missing_plain_managed_and_mixed_files() {
+    let fixture = Fixture::new("remove");
+    let missing = fixture.path("missing.md");
+    assert_success(
+        &run(&fixture, "setup-md-remove", &[&missing], &[]),
+        "NOT_FOUND\n",
+    );
+
+    let plain = fixture.write("plain.md", "Unmanaged text\n");
+    assert_success(
+        &run(&fixture, "setup-md-remove", &[&plain], &[]),
+        "NOT_FOUND\n",
+    );
+    assert_eq!(fs::read_to_string(&plain).unwrap(), "Unmanaged text\n");
+
+    let managed = fixture.write(
+        "managed.md",
+        "<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n",
+    );
+    assert_success(
+        &run(&fixture, "setup-md-remove", &[&managed], &[]),
+        "REMOVED\n",
+    );
+    assert_eq!(fs::read_to_string(&managed).unwrap(), "\n");
+
+    let mixed = fixture.write(
+        "mixed.md",
+        "Before\n\n<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n\nAfter\n",
+    );
+    assert_success(
+        &run(&fixture, "setup-md-remove", &[&mixed], &[]),
+        "REMOVED\n",
+    );
+    assert_eq!(fs::read_to_string(&mixed).unwrap(), "Before\n\nAfter\n");
+    fixture.cleanup();
+}
+
+#[test]
+fn markdown_read_and_write_errors_are_visible_without_success_output() {
+    let fixture = Fixture::new("io-errors");
+    let rules = fixture.write("rules.md", RULES);
+    let blocking_parent = fixture.write("not-a-directory", "blocking file\n");
+    let target = blocking_parent.join("AGENTS.md");
+    let write_error = run(
+        &fixture,
+        "setup-md-inject",
+        &[&target, &rules],
+        &["/repo", "1"],
+    );
+    assert_visible_failure(&write_error, None);
+
+    let directory = fixture.path("directory-target");
+    fs::create_dir_all(&directory).unwrap();
+    let directory_write_error = run(
+        &fixture,
+        "setup-md-inject",
+        &[&directory, &rules],
+        &["/repo", "1"],
+    );
+    assert_visible_failure(&directory_write_error, None);
+    let read_error = run(&fixture, "setup-md-remove", &[&directory], &[]);
+    assert_visible_failure(&read_error, None);
+    fixture.cleanup();
+}

--- a/vibeguard-runtime/tests/setup_settings_cli.rs
+++ b/vibeguard-runtime/tests/setup_settings_cli.rs
@@ -1,0 +1,511 @@
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+struct Fixture {
+    root: PathBuf,
+    repo: PathBuf,
+    home: PathBuf,
+    home_env: String,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "vibeguard-setup-settings-{label}-{}-{id}",
+            std::process::id()
+        ));
+        let repo = root.join("repo");
+        let home = root.join("home");
+        fs::create_dir_all(repo.join("hooks")).expect("hook fixture directory should be created");
+        fs::create_dir_all(&home).expect("fixture HOME should be created");
+        let home_env = slash_path(&home);
+        Self {
+            root,
+            repo,
+            home,
+            home_env,
+        }
+    }
+
+    fn settings(&self, name: &str) -> PathBuf {
+        self.home.join(name)
+    }
+
+    fn write_manifest(&self, manifest: &Value) {
+        fs::write(
+            self.repo.join("hooks/manifest.json"),
+            serde_json::to_vec(manifest).unwrap(),
+        )
+        .expect("hook manifest should be written");
+    }
+
+    fn write_settings(&self, name: &str, settings: &Value) -> PathBuf {
+        let path = self.settings(name);
+        fs::write(&path, serde_json::to_vec_pretty(settings).unwrap())
+            .expect("settings should be written");
+        path
+    }
+
+    fn command(&self, name: &str) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"));
+        command
+            .arg(name)
+            .current_dir(&self.repo)
+            .env("HOME", &self.home_env);
+        command
+    }
+
+    fn wrapper_command(&self, script: &str) -> String {
+        format!("bash {}/.vibeguard/run-hook.sh {script}", self.home_env)
+    }
+
+    fn cleanup(self) {
+        fs::remove_dir_all(self.root).expect("fixture should be removed");
+    }
+}
+
+fn slash_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8(bytes.to_vec()).expect("command output should be UTF-8")
+}
+
+fn assert_success(output: &Output, expected_stdout: &str) {
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        text(&output.stderr)
+    );
+    assert_eq!(text(&output.stdout), expected_stdout);
+    assert_eq!(text(&output.stderr), "");
+}
+
+fn assert_mismatch(output: &Output) {
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(text(&output.stdout), "");
+    assert_eq!(text(&output.stderr), "");
+}
+
+fn assert_visible_failure(output: &Output, stable_message: Option<&str>) {
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(text(&output.stdout), "");
+    let error = text(&output.stderr);
+    assert!(
+        error.starts_with("vibeguard-runtime error: "),
+        "unexpected stderr: {error}"
+    );
+    if let Some(message) = stable_message {
+        assert!(error.contains(message), "stderr={error}");
+    }
+}
+
+fn full_manifest() -> Value {
+    json!({
+        "hooks": [
+            {
+                "script": "pre-a.sh",
+                "claude": {
+                    "enabled": true,
+                    "event": "PreToolUse",
+                    "matchers": ["Bash"],
+                    "profiles": ["minimal", "core", "full", "strict"]
+                }
+            },
+            {
+                "script": "post-a.sh",
+                "claude": {
+                    "enabled": true,
+                    "event": "PostToolUse",
+                    "matchers": ["Edit"],
+                    "profiles": ["minimal", "core", "full", "strict"]
+                }
+            },
+            {
+                "script": "full-a.sh",
+                "claude": {
+                    "enabled": true,
+                    "event": "Stop",
+                    "matchers": [""],
+                    "profiles": ["full", "strict"]
+                }
+            },
+            {
+                "script": "strict-a.sh",
+                "claude": {
+                    "enabled": true,
+                    "event": "SessionStart",
+                    "matchers": [""],
+                    "profiles": ["strict"]
+                }
+            },
+            {"script": "disabled.sh", "claude": {"enabled": false}}
+        ]
+    })
+}
+
+fn single_manifest() -> Value {
+    json!({
+        "hooks": [{
+            "script": "pre-a.sh",
+            "claude": {
+                "enabled": true,
+                "event": "PreToolUse",
+                "matchers": ["Bash"],
+                "profiles": ["minimal", "core", "full", "strict"]
+            }
+        }]
+    })
+}
+
+fn hook_entry(matcher: &str, commands: &[String]) -> Value {
+    json!({
+        "matcher": matcher,
+        "hooks": commands
+            .iter()
+            .map(|command| json!({"type": "command", "command": command}))
+            .collect::<Vec<_>>()
+    })
+}
+
+fn core_settings(fixture: &Fixture) -> Value {
+    json!({
+        "hooks": {
+            "PreToolUse": [hook_entry("Bash", &[fixture.wrapper_command("pre-a.sh")])],
+            "PostToolUse": [hook_entry("Edit", &[fixture.wrapper_command("post-a.sh")])]
+        }
+    })
+}
+
+fn invoke_settings_check(fixture: &Fixture, settings: &Path, target: &str) -> Output {
+    fixture
+        .command("setup-settings-check")
+        .arg(&fixture.repo)
+        .arg(settings)
+        .arg(target)
+        .output()
+        .expect("settings check should run")
+}
+
+fn invoke_settings_upsert(
+    fixture: &Fixture,
+    settings: &Path,
+    profile: &str,
+    flags: &[&str],
+) -> Output {
+    fixture
+        .command("setup-settings-upsert")
+        .arg(&fixture.repo)
+        .arg(settings)
+        .arg(profile)
+        .args(flags)
+        .output()
+        .expect("settings upsert should run")
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_slice(&fs::read(path).expect("settings should be readable"))
+        .expect("settings should be JSON")
+}
+
+#[test]
+fn settings_check_distinguishes_valid_missing_unsupported_duplicate_and_extra_hooks() {
+    let fixture = Fixture::new("check");
+    fixture.write_manifest(&full_manifest());
+    let settings = fixture.write_settings("settings.json", &core_settings(&fixture));
+
+    for target in ["pre-hooks", "post-hooks", "profile-hooks:core"] {
+        assert_success(&invoke_settings_check(&fixture, &settings, target), "");
+    }
+
+    let missing = fixture.settings("missing.json");
+    assert_visible_failure(
+        &invoke_settings_check(&fixture, &missing, "profile-hooks:core"),
+        None,
+    );
+    assert_visible_failure(
+        &invoke_settings_check(&fixture, &settings, "profile-hooks:unknown"),
+        Some("unsupported profile target: unknown"),
+    );
+
+    let mut incomplete = core_settings(&fixture);
+    incomplete["hooks"]
+        .as_object_mut()
+        .unwrap()
+        .remove("PostToolUse");
+    fixture.write_settings("settings.json", &incomplete);
+    assert_mismatch(&invoke_settings_check(
+        &fixture,
+        &settings,
+        "profile-hooks:core",
+    ));
+
+    let mut duplicate = core_settings(&fixture);
+    duplicate["hooks"]["PreToolUse"]
+        .as_array_mut()
+        .unwrap()
+        .push(hook_entry("Bash", &[fixture.wrapper_command("pre-a.sh")]));
+    fixture.write_settings("settings.json", &duplicate);
+    assert_mismatch(&invoke_settings_check(
+        &fixture,
+        &settings,
+        "profile-hooks:core",
+    ));
+
+    let mut extra = core_settings(&fixture);
+    extra["hooks"].as_object_mut().unwrap().insert(
+        "Stop".to_string(),
+        json!([hook_entry("", &[fixture.wrapper_command("full-a.sh")])]),
+    );
+    fixture.write_settings("settings.json", &extra);
+    assert_mismatch(&invoke_settings_check(
+        &fixture,
+        &settings,
+        "profile-hooks:core",
+    ));
+    fixture.cleanup();
+}
+
+#[test]
+fn settings_upsert_dry_run_actual_and_repeat_are_deterministic() {
+    let fixture = Fixture::new("upsert");
+    fixture.write_manifest(&full_manifest());
+    let settings = fixture.settings("settings.json");
+
+    let dry_run = invoke_settings_upsert(&fixture, &settings, "core", &["--dry-run"]);
+    assert_eq!(dry_run.status.code(), Some(0));
+    let dry_stdout = text(&dry_run.stdout);
+    assert!(dry_stdout.contains("--- "), "stdout={dry_stdout}");
+    assert!(dry_stdout.ends_with("CHANGED\n"), "stdout={dry_stdout}");
+    assert!(!settings.exists());
+
+    assert_success(
+        &invoke_settings_upsert(&fixture, &settings, "core", &[]),
+        "CHANGED\n",
+    );
+    let value = read_json(&settings);
+    let rendered = serde_json::to_string(&value).unwrap();
+    assert!(rendered.contains(&fixture.wrapper_command("pre-a.sh")));
+    assert!(rendered.contains(&fixture.wrapper_command("post-a.sh")));
+    assert!(!rendered.contains("full-a.sh"));
+    assert!(!rendered.contains("strict-a.sh"));
+    let before_repeat = fs::read(&settings).unwrap();
+    assert_success(
+        &invoke_settings_upsert(&fixture, &settings, "core", &["--dry-run"]),
+        "SKIP\n",
+    );
+    assert_eq!(fs::read(&settings).unwrap(), before_repeat);
+    assert_success(
+        &invoke_settings_upsert(&fixture, &settings, "core", &[]),
+        "SKIP\n",
+    );
+    assert_eq!(fs::read(&settings).unwrap(), before_repeat);
+    fixture.cleanup();
+}
+
+#[test]
+fn settings_upsert_preserves_custom_commands_unless_force_is_explicit() {
+    let fixture = Fixture::new("custom");
+    fixture.write_manifest(&single_manifest());
+    let custom = "env VG_CUSTOM=1 /custom/run-hook.sh pre-a.sh".to_string();
+    let settings = fixture.write_settings(
+        "settings.json",
+        &json!({"hooks": {"PreToolUse": [hook_entry("Bash", std::slice::from_ref(&custom))]}}),
+    );
+
+    let preserve = invoke_settings_upsert(&fixture, &settings, "core", &[]);
+    assert_eq!(preserve.status.code(), Some(0));
+    assert_eq!(text(&preserve.stdout), "SKIP\n");
+    assert!(text(&preserve.stderr).contains("preserving customized VibeGuard hook command"));
+    assert!(
+        serde_json::to_string(&read_json(&settings))
+            .unwrap()
+            .contains(&custom)
+    );
+
+    assert_success(
+        &invoke_settings_upsert(&fixture, &settings, "core", &["--force-overwrite"]),
+        "CHANGED\n",
+    );
+    let rendered = serde_json::to_string(&read_json(&settings)).unwrap();
+    assert!(!rendered.contains("VG_CUSTOM"));
+    assert!(rendered.contains(&fixture.wrapper_command("pre-a.sh")));
+    fixture.cleanup();
+}
+
+#[test]
+fn settings_remove_preserves_unmanaged_hooks_and_upsert_cleans_stale_installed_hooks() {
+    let fixture = Fixture::new("remove");
+    fixture.write_manifest(&full_manifest());
+    let unmanaged = "node /custom/audit.js".to_string();
+    let settings = fixture.write_settings(
+        "settings.json",
+        &json!({
+            "hooks": {
+                "PreToolUse": [hook_entry(
+                    "Bash",
+                    &[fixture.wrapper_command("pre-a.sh"), unmanaged.clone()]
+                )],
+                "PostToolUse": [hook_entry("Edit", &[fixture.wrapper_command("post-a.sh")])]
+            }
+        }),
+    );
+
+    let removed = fixture
+        .command("setup-settings-remove")
+        .arg(&fixture.repo)
+        .arg(&settings)
+        .output()
+        .unwrap();
+    assert_success(&removed, "CHANGED\n");
+    let rendered = serde_json::to_string(&read_json(&settings)).unwrap();
+    assert!(rendered.contains(&unmanaged));
+    assert!(!rendered.contains("pre-a.sh"));
+    assert!(!rendered.contains("post-a.sh"));
+
+    let second = fixture
+        .command("setup-settings-remove")
+        .arg(&fixture.repo)
+        .arg(&settings)
+        .output()
+        .unwrap();
+    assert_success(&second, "SKIP\n");
+    let missing = fixture.settings("absent.json");
+    let missing_remove = fixture
+        .command("setup-settings-remove")
+        .arg(&fixture.repo)
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert_success(&missing_remove, "SKIP\n");
+
+    fixture.write_manifest(&single_manifest());
+    let stale = "bash ~/.vibeguard/installed/hooks/old.sh".to_string();
+    fixture.write_settings(
+        "settings.json",
+        &json!({"hooks": {"PostToolUse": [hook_entry("Edit", &[stale, unmanaged.clone()])]}}),
+    );
+    assert_success(
+        &invoke_settings_upsert(&fixture, &settings, "core", &[]),
+        "CHANGED\n",
+    );
+    let repaired = serde_json::to_string(&read_json(&settings)).unwrap();
+    assert!(!repaired.contains("old.sh"));
+    assert!(repaired.contains(&unmanaged));
+    assert!(repaired.contains("pre-a.sh"));
+    fixture.cleanup();
+}
+
+#[test]
+fn stale_check_distinguishes_direct_existing_wrapper_missing_and_unresolved_commands() {
+    let fixture = Fixture::new("stale");
+    let installed = fixture.home.join(".vibeguard/installed/hooks");
+    fs::create_dir_all(&installed).unwrap();
+    fs::write(installed.join("existing.sh"), "#!/bin/sh\n").unwrap();
+    fs::write(installed.join("legacy.sh"), "#!/bin/sh\n").unwrap();
+    let settings = fixture.write_settings(
+        "settings.json",
+        &json!({
+            "hooks": {
+                "PostToolUse": [{
+                    "matcher": "Edit",
+                    "hooks": [
+                        {"command": "bash ~/.vibeguard/installed/hooks/legacy.sh"},
+                        {"command": "bash ~/.vibeguard/installed/hooks/direct-missing.sh"},
+                        {"command": "~/.vibeguard/run-hook.sh existing.sh"},
+                        {"command": "~/.vibeguard/run-hook.sh missing.sh"},
+                        {"command": "~/.vibeguard/run-hook.sh nested/unresolved.sh"},
+                        {"command": "node /custom/audit.js"}
+                    ]
+                }]
+            }
+        }),
+    );
+
+    let stale = fixture
+        .command("setup-settings-check-stale")
+        .arg(&settings)
+        .output()
+        .unwrap();
+    assert_eq!(stale.status.code(), Some(1));
+    assert_eq!(text(&stale.stderr), "");
+    let findings = text(&stale.stdout);
+    let expected_findings = format!(
+        concat!(
+            "stale Claude hook command: config=~/settings.json event=PostToolUse matcher=Edit command_path={} repair=bash setup.sh --yes\n",
+            "stale Claude hook command: config=~/settings.json event=PostToolUse matcher=Edit command_path={} repair=bash setup.sh --yes\n",
+            "stale Claude hook command: config=~/settings.json event=PostToolUse matcher=Edit command_path={} repair=bash setup.sh --yes\n"
+        ),
+        installed.join("legacy.sh").display(),
+        installed.join("direct-missing.sh").display(),
+        installed.join("missing.sh").display(),
+    );
+    assert_eq!(findings, expected_findings);
+
+    fixture.write_settings(
+        "settings.json",
+        &json!({"hooks": {"PostToolUse": [hook_entry(
+            "Edit",
+            &["~/.vibeguard/run-hook.sh existing.sh".to_string()]
+        )]}}),
+    );
+    let clean = fixture
+        .command("setup-settings-check-stale")
+        .arg(&settings)
+        .output()
+        .unwrap();
+    assert_success(&clean, "");
+    let missing = fixture.settings("missing.json");
+    let absent = fixture
+        .command("setup-settings-check-stale")
+        .arg(missing)
+        .output()
+        .unwrap();
+    assert_success(&absent, "");
+    fixture.cleanup();
+}
+
+#[test]
+fn settings_argument_manifest_read_and_write_errors_are_visible() {
+    let fixture = Fixture::new("errors");
+    for command in [
+        "setup-settings-check",
+        "setup-settings-upsert",
+        "setup-settings-remove",
+        "setup-settings-check-stale",
+    ] {
+        let output = fixture.command(command).output().unwrap();
+        assert_visible_failure(&output, Some("Usage: vibeguard-runtime setup-settings-"));
+    }
+
+    fixture.write_manifest(&json!({}));
+    let settings = fixture.write_settings("settings.json", &json!({}));
+    assert_visible_failure(
+        &invoke_settings_upsert(&fixture, &settings, "core", &[]),
+        Some("hooks manifest must contain a hooks array"),
+    );
+
+    fixture.write_manifest(&single_manifest());
+    let blocking_parent = fixture.settings("not-a-directory");
+    fs::write(&blocking_parent, "blocking file\n").unwrap();
+    let blocked_settings = blocking_parent.join("settings.json");
+    assert_visible_failure(
+        &invoke_settings_upsert(&fixture, &blocked_settings, "core", &[]),
+        None,
+    );
+    let directory_settings = fixture.settings("directory-settings");
+    fs::create_dir_all(&directory_settings).unwrap();
+    assert_visible_failure(
+        &invoke_settings_check(&fixture, &directory_settings, "profile-hooks:core"),
+        None,
+    );
+    fixture.cleanup();
+}


### PR DESCRIPTION
Closes #581

## Summary
- add deterministic behavioral coverage for observability, hook-status rendering, setup Markdown/settings, and remaining post-edit/history error paths
- raise the blocking Rust line-coverage gate from 76% to the final 80% target and remove the unenforced-target caveat
- mark the GH581 spec packet as an implemented reference

## Coverage evidence
- before: 14,387 / 18,921 = 76.0372%
- final local clean report: 15,447 / 18,921 = 81.6394%
- report SHA-256: `cddb46f0d10bbe0e75fdb8351b33715a902f1a756978ed4a34b8c29731dda180`
- independent T7 review at `693c9719b00df8b8daf5fa3399a39417e75aeb2b`: PASS, P0/P1/P2 = 0/0/0, missing union rows = 0
- all line-specific exceptions were individually accepted; no coverage exclusions, ignored/deleted tests, production semantic changes, weakened assertions, global env/cwd mutation, chmod, or race fixture

## Verification
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- `cargo clippy --locked --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings`
- `cargo check --locked --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --locked --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/ci/self-application/check-u22-coverage.sh`
- `bash scripts/ci/self-application/run-all.sh`
- `bash tests/test_self_application_ci.sh`
- `bash tests/test_release_workflow.sh`
- `bash scripts/local-contract-check.sh --quick`
- W20 runtime drift check and `git diff --check`