### PR TITLE
docs(spec): define GH605 Rust test suffix precision

### DIFF
--- a/docs/specs/GH605/product.md
+++ b/docs/specs/GH605/product.md
@@ -1,0 +1,72 @@
+# Product Spec
+
+## Linked Issue
+
+GH-605
+
+## 用户问题
+
+VibeGuard 的 Rust 测试路径分类器不识别常用的 `*_tests.rs` 文件名。RS-03
+因此把测试模块中的 `unwrap()` / `expect()` 当作生产代码风险；在当前
+`origin/main` 自扫描的 70 条 finding 中有 59 条属于这一类误报。高比例噪声会
+掩盖剩余 11 条需要真实审查的生产代码 finding，并让所有复用统一分类器的 hook 与
+scanner 行为偏离仓库实际模块布局。
+
+## 目标
+
+- runtime 分类器和无 runtime 的 shell fallback 都识别 `*_tests.rs`。
+- RS-03 不再报告这类测试文件，同时继续报告生产文件中的真实命中。
+- 用正例、负例和 fallback 测试固定分类边界，避免相似生产文件被排除。
+
+## 非目标
+
+- 不修改 RS-03 对 `unwrap()` / `expect()` 的检测语义或 severity。
+- 不清理当前 11 条生产代码 finding。
+- 不重命名现有 Rust 测试模块，不改变 U-16 阈值或 hook enforcement mode。
+- 不新增新的测试目录约定或通用 filename allowlist。
+
+## Behavior Invariants
+
+1. B-001 对任意 basename 以 `_tests.rs` 结尾的 Rust 路径，runtime
+   `test-path-filter --test` 必须保留该路径，`--prod` 必须排除该路径；路径位于
+   `src/` 或更深层目录时行为相同。
+2. B-002 runtime 不可用或执行失败而进入 shell fallback 时，`*_tests.rs` 必须得到与
+   B-001 相同的分类结果；authoritative runtime 与 fallback 不得产生分裂。
+3. B-003 新规则只能匹配完整 `_tests.rs` 后缀；`contest.rs`、`latest.rs`、
+   `tests_support.rs`、`foo_tests.py` 和普通 `*.rs` 生产文件不得因本变更被排除。
+4. B-004 RS-03 standalone 与 staged-file 路径必须复用同一生产路径过滤边界：
+   `*_tests.rs` 内的 `unwrap()` / `expect()` 不产生 finding，而等价内容位于普通
+   `.rs` 文件时继续产生 finding。
+5. B-005 所有现有测试路径约定、大小写/路径分隔符规范化、strict/non-strict exit
+   contract 与 hook consumers 必须保持兼容；该修复不得引入第二套分类实现。
+6. B-006 验证必须绑定具名路径和 finding presence/absence；当前 59/11 计数只作基线
+   证据，不得成为固定阈值或让未来仓库增长导致误判。
+
+## 验收标准
+
+- [ ] runtime `--test`/`--prod` 对临时 fixture `foo_tests.rs` 给出互补且正确的结果。
+- [ ] 强制禁用 runtime 后，shell fallback 对同一路径给出相同结果。
+- [ ] `foo_tests.rs` 中的 RS-03 命中被忽略，普通 `foo.rs` 中的命中仍可见。
+- [ ] 相似生产文件负例与现有 test-path 正例全部通过。
+- [ ] focused guard/runtime tests、guard/hook validators、Rust check/test 和 broad local
+      contract quick 通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-005（现有空行过滤与空项目行为保持兼容） |
+| 错误与失败路径 | covered: B-002（runtime 缺失或失败时 fallback 一致） |
+| 授权/权限 | N/A：本地只读路径分类与 guard 不处理权限状态 |
+| 并发/竞态 | N/A：分类器逐行处理不可变输入，无共享可变状态 |
+| 重试/幂等 | covered: B-005, B-006（同一输入重跑得到相同分类） |
+| 非法状态转换 | N/A：不持久化 workflow 状态 |
+| 兼容/迁移 | covered: B-003, B-005 |
+| 降级/回退 | covered: B-002, B-004 |
+| 证据与审计完整性 | covered: B-004, B-006 |
+| 取消/中断 | N/A：无持久写入，中断后可安全重跑 |
+
+## 发布说明
+
+这是 RS-03 与共享 Rust test-path classifier 的 precision 修复。它只补齐
+`*_tests.rs` 后缀，不改变普通生产文件、既有测试约定或 guard enforcement。

--- a/docs/specs/GH605/tasks.md
+++ b/docs/specs/GH605/tasks.md
@@ -1,0 +1,68 @@
+# Task Plan
+
+## Linked Issue
+
+GH-605
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP605-T1` Owner: implementation agent — 在 authoritative runtime classifier 中加入精确 `_tests.rs` suffix，并扩展 unit/CLI 正负例。Depends on: Spec PR merged and user authorization recorded。Covers: B-001, B-003, B-005。Done when: `--test`/`--prod` 互补分类正确，现有 test conventions 与相似 production names 保持原行为。Verify: `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`；focused CLI filter assertions。
+- [ ] `SP605-T2` Owner: implementation agent — 同步 shell fallback 与 hook runtime stub，不在任何 hook/guard consumer 新增独立 glob。Depends on: SP605-T1。Covers: B-002, B-003, B-005。Done when: forced runtime failure 与正常 runtime 对具名路径分类一致，self-application check 证明没有第二套 consumer classifier。Verify: `bash tests/unit/test_rust_check_unwrap_in_prod.sh`; `bash scripts/ci/self-application/check-rust-test-path-classifier.sh .`。
+- [ ] `SP605-T3` Owner: implementation agent — 扩展 RS-03 focused harness，覆盖 standalone/staged 的 `_tests.rs` ignore、普通 `.rs` finding、相似文件负例与 strict/non-strict contract。Depends on: SP605-T2。Covers: B-003, B-004, B-006。Done when: assertions 绑定具名路径/finding，不含 checkout count threshold，不弱化现有 production failure assertions。Verify: `bash tests/unit/test_rust_check_unwrap_in_prod.sh`; manual self-scan grep。
+- [ ] `SP605-T4` Owner: verification owner + independent reviewer — 执行 focused、Rust、hook/guard 与 broad gates，并按 product spec 做逐项覆盖审查。Depends on: SP605-T3。Covers: B-001, B-002, B-003, B-004, B-005, B-006。Done when: deterministic checks 全绿；review 确认无通用 contains-tests 排除、无复制 classifier、无固定计数或测试弱化。Verify: `bash scripts/ci/validate-guards.sh`; `bash scripts/ci/validate-hooks.sh`; `cargo check --manifest-path vibeguard-runtime/Cargo.toml`; `cargo test --manifest-path vibeguard-runtime/Cargo.toml`; `bash scripts/local-contract-check.sh --quick`; `git diff --check`。
+
+## 并行拆分
+
+T1-T3 共享 classifier/focused harness 且有顺序依赖，必须由单一 implementation lane 串行
+完成。T4 的 independent reviewer 只读，不与实现 lane 共享 writable file。
+
+| Lane | Owner | Writable files |
+| --- | --- | --- |
+| implementation | `/root` | `vibeguard-runtime/src/hook_checks_common.rs`, `guards/rust/common.sh`, `tests/lib/hook_test_lib.sh`, `tests/unit/test_rust_check_unwrap_in_prod.sh` 及必要的现有 classifier test file |
+| verification | `/root` | none（只运行命令与记录证据） |
+| independent_review | native reviewer agent | none（只读 review） |
+
+## Plan-First Handoff
+
+```yaml
+handoff:
+  mode: specrail-implement
+  artifacts:
+    - docs/specs/GH605/product.md
+    - docs/specs/GH605/tech.md
+    - docs/specs/GH605/tasks.md
+  runtime_pinning_snapshot: None
+  verification_owner: /root
+  stop_conditions:
+    - A real CI, review-thread, or SpecRail PR gate is blocked.
+    - The implementation would classify filenames by broad substring instead of exact suffix.
+    - Any hook or guard consumer introduces a duplicate test-path classifier.
+    - A production finding disappears, a test assertion is weakened, or scope expands beyond GH-605.
+  lane_map:
+    implementation: /root
+    verification: /root
+    independent_review: native reviewer agent (read-only)
+```
+
+## 验证
+
+```bash
+python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH605
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+git diff --check
+```
+
+## Handoff Notes
+
+- 写作基线：`origin/main@2a2190ce2e890d8c8a5599dbf4c3a558dfa01a51`。
+- Issue #605 的 `ready_to_spec` 来自 live GitHub label，`state_trusted: true`；用户在当前
+  对话明确授权 Issue、标签、Spec/Impl PR 与通过真实 gates 后的 merge。
+- Spec PR 合并后，将 Issue label 切换到 `ready_to_implement`，重新收集 live issue 与
+  duplicate-work evidence，再创建独立 implementation branch。
+- 59 个 test-suffix finding 与 11 个 production finding 只是诊断快照，不得写入测试阈值。

--- a/docs/specs/GH605/tasks.md
+++ b/docs/specs/GH605/tasks.md
@@ -11,7 +11,7 @@ GH-605
 
 ## 实现任务
 
-- [ ] `SP605-T1` Owner: implementation agent — 在 authoritative runtime classifier 中加入精确 `_tests.rs` suffix，并扩展 unit/CLI 正负例。Depends on: Spec PR merged and user authorization recorded。Covers: B-001, B-003, B-005。Done when: `--test`/`--prod` 互补分类正确，现有 test conventions 与相似 production names 保持原行为。Verify: `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`；focused CLI filter assertions。
+- [ ] `SP605-T1` Owner: implementation agent — 在 authoritative runtime classifier 中加入精确 `_tests.rs` suffix，并扩展 unit/CLI 正负例。Depends on: Spec PR merged and live implementation route allowed。Covers: B-001, B-003, B-005。Done when: `--test`/`--prod` 互补分类正确，现有 test conventions 与相似 production names 保持原行为。Verify: `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`；focused CLI filter assertions。
 - [ ] `SP605-T2` Owner: implementation agent — 同步 shell fallback 与 hook runtime stub，不在任何 hook/guard consumer 新增独立 glob。Depends on: SP605-T1。Covers: B-002, B-003, B-005。Done when: forced runtime failure 与正常 runtime 对具名路径分类一致，self-application check 证明没有第二套 consumer classifier。Verify: `bash tests/unit/test_rust_check_unwrap_in_prod.sh`; `bash scripts/ci/self-application/check-rust-test-path-classifier.sh .`。
 - [ ] `SP605-T3` Owner: implementation agent — 扩展 RS-03 focused harness，覆盖 standalone/staged 的 `_tests.rs` ignore、普通 `.rs` finding、相似文件负例与 strict/non-strict contract。Depends on: SP605-T2。Covers: B-003, B-004, B-006。Done when: assertions 绑定具名路径/finding，不含 checkout count threshold，不弱化现有 production failure assertions。Verify: `bash tests/unit/test_rust_check_unwrap_in_prod.sh`; manual self-scan grep。
 - [ ] `SP605-T4` Owner: verification owner + independent reviewer — 执行 focused、Rust、hook/guard 与 broad gates，并按 product spec 做逐项覆盖审查。Depends on: SP605-T3。Covers: B-001, B-002, B-003, B-004, B-005, B-006。Done when: deterministic checks 全绿；review 确认无通用 contains-tests 排除、无复制 classifier、无固定计数或测试弱化。Verify: `bash scripts/ci/validate-guards.sh`; `bash scripts/ci/validate-hooks.sh`; `cargo check --manifest-path vibeguard-runtime/Cargo.toml`; `cargo test --manifest-path vibeguard-runtime/Cargo.toml`; `bash scripts/local-contract-check.sh --quick`; `git diff --check`。
@@ -61,8 +61,7 @@ git diff --check
 ## Handoff Notes
 
 - 写作基线：`origin/main@2a2190ce2e890d8c8a5599dbf4c3a558dfa01a51`。
-- Issue #605 的 `ready_to_spec` 来自 live GitHub label，`state_trusted: true`；用户在当前
-  对话明确授权 Issue、标签、Spec/Impl PR 与通过真实 gates 后的 merge。
-- Spec PR 合并后，将 Issue label 切换到 `ready_to_implement`，重新收集 live issue 与
-  duplicate-work evidence，再创建独立 implementation branch。
+- Issue #605 的 readiness 必须由 live GitHub label 证明；durable spec packet 不构成未来
+  PR 的 merge authorization。每次 merge 前仍需当前 head 的 CI、独立 review、review
+  threads 与 SpecRail PR gate 证据。
 - 59 个 test-suffix finding 与 11 个 production finding 只是诊断快照，不得写入测试阈值。

--- a/docs/specs/GH605/tech.md
+++ b/docs/specs/GH605/tech.md
@@ -38,7 +38,7 @@ GH-605
 | --- | --- | --- |
 | B-001 runtime 识别 `_tests.rs` | `is_test_path()` 与 unit/CLI filter | `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`；具名 `test-path-filter --test/--prod` fixture |
 | B-002 fallback 与 runtime 一致 | `VIBEGUARD_TEST_FILE_PATTERN`、forced-failure fixture | `bash tests/unit/test_rust_check_unwrap_in_prod.sh` 中真实 runtime 与失败 runtime 两组断言 |
-| B-003 不排除相似生产文件 | runtime unit negatives 与 shell focused negatives | 同一 focused test 对 `contest.rs`、`latest.rs`、`tests_support.rs` 和普通 `.rs` 断言 finding 保留 |
+| B-003 不排除相似生产文件 | runtime unit negatives 与 shell focused negatives | 同一 focused test 对 `contest.rs`、`latest.rs`、`tests_support.rs`、`foo_tests.py` 和普通 `.rs` 断言 finding 保留 |
 | B-004 RS-03 standalone/staged 边界 | `filter_rs_prod_paths()`、RS-03 harness | `bash tests/unit/test_rust_check_unwrap_in_prod.sh`；staged fixture 确认 `_tests.rs` 不进入 finding、普通 `.rs` 仍进入 |
 | B-005 兼容且无第二套实现 | classifier/stub/self-application checks | `bash scripts/ci/self-application/check-rust-test-path-classifier.sh .`、Rust 全测、hook/guard validators |
 | B-006 精确证据，无固定计数 | focused assertions 与 manual self-scan | test source review 不含 `59`/`11` threshold；default self-scan 按具名 `_tests.rs`/production path 核对 |

--- a/docs/specs/GH605/tech.md
+++ b/docs/specs/GH605/tech.md
@@ -1,0 +1,81 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-605
+
+## Product Spec
+
+`docs/specs/GH605/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Authoritative classifier | `vibeguard-runtime/src/hook_checks_common.rs:76`, `vibeguard-runtime/src/hook_checks_common.rs:652` | `is_test_path()` normalizes slash/case and recognizes `_test.rs`，但没有 `_tests.rs`；单测也缺该正例 | 所有 runtime hook/scanner consumers 的单一事实源 |
+| Shell fallback | `guards/rust/common.sh:12`, `guards/rust/common.sh:32` | runtime 可用时调用 `test-path-filter --prod`，否则用 `VIBEGUARD_TEST_FILE_PATTERN`；fallback 同样遗漏 `_tests.rs` | 必须与 runtime 保持故障降级一致 |
+| RS-03 focused harness | `tests/unit/test_rust_check_unwrap_in_prod.sh:37`, `tests/unit/test_rust_check_unwrap_in_prod.sh:87` | 已覆盖生产 finding、`tests/`、`_test.rs`、`tests.rs` 等，但没有 `*_tests.rs` 和相似生产文件负例 | 最接近用户可见误报的回归入口 |
+| Classifier self-application | `scripts/ci/self-application/check-rust-test-path-classifier.sh:9` | 防止 Rust hook/guard 重建内联分类器，但不检查 suffix 行为 | 保持单一分类器架构，不新增重复逻辑 |
+| Hook test runtime stub | `tests/lib/hook_test_lib.sh:90` | 测试 stub 复制 runtime 的 test-path case，当前也遗漏 `*_tests.rs` | 若不同步，hook tests 会掩盖 runtime/fixture drift |
+
+## 设计方案
+
+1. 在 `is_test_path()` 的 basename 后缀判断中加入精确
+   `basename.ends_with("_tests.rs")`，复用现有 slash/case normalization。
+2. 在 `VIBEGUARD_TEST_FILE_PATTERN` 的 basename suffix 部分加入
+   `_tests\.rs$`，仅作为 runtime 不可用/失败时 fallback。
+3. 同步 `hook_test_install_runtime_stub` 的 basename case，使测试替身不再与真实 runtime
+   漂移；不在各 hook 中加入新 glob。
+4. 扩展既有 Rust unit/focused tests：加入临时 fixture `foo_tests.rs` 正例，并加入
+   `contest.rs`、`latest.rs`、`tests_support.rs`、`foo_tests.py` 等负例。使用显式
+   `VIBEGUARD_RUNTIME` 选择真实 runtime 与失败 stub，分别证明 authoritative/fallback。
+5. RS-03 fixture 同时放置 `foo_tests.rs` 与普通 `foo.rs`，断言前者不报告、后者仍报告；
+   不使用 checkout 总 finding 数量作为断言。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 runtime 识别 `_tests.rs` | `is_test_path()` 与 unit/CLI filter | `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`；具名 `test-path-filter --test/--prod` fixture |
+| B-002 fallback 与 runtime 一致 | `VIBEGUARD_TEST_FILE_PATTERN`、forced-failure fixture | `bash tests/unit/test_rust_check_unwrap_in_prod.sh` 中真实 runtime 与失败 runtime 两组断言 |
+| B-003 不排除相似生产文件 | runtime unit negatives 与 shell focused negatives | 同一 focused test 对 `contest.rs`、`latest.rs`、`tests_support.rs` 和普通 `.rs` 断言 finding 保留 |
+| B-004 RS-03 standalone/staged 边界 | `filter_rs_prod_paths()`、RS-03 harness | `bash tests/unit/test_rust_check_unwrap_in_prod.sh`；staged fixture 确认 `_tests.rs` 不进入 finding、普通 `.rs` 仍进入 |
+| B-005 兼容且无第二套实现 | classifier/stub/self-application checks | `bash scripts/ci/self-application/check-rust-test-path-classifier.sh .`、Rust 全测、hook/guard validators |
+| B-006 精确证据，无固定计数 | focused assertions 与 manual self-scan | test source review 不含 `59`/`11` threshold；default self-scan 按具名 `_tests.rs`/production path 核对 |
+
+## 数据流
+
+1. guard 从 git/staged/find 获得 `.rs` 路径列表。
+2. `filter_rs_prod_paths()` 优先把路径流交给 runtime `test-path-filter --prod`。
+3. runtime 的 `is_test_path()` 规范化路径并按 segment/basename 分类；`*_tests.rs` 进入
+   test 集合，不进入 production 输出。
+4. runtime 不可用或失败时，shell fallback 对同一路径执行等价 suffix 过滤。
+5. RS-03 只扫描 production 输出；finding summary 与 strict exit contract 保持原样。
+
+## 备选方案
+
+- 仅在 RS-03 中排除 `*_tests.rs`：拒绝。会重新制造 #430 已消除的多实现漂移。
+- 排除所有文件名包含 `tests` 的路径：拒绝。会误伤 `tests_support.rs` 等生产文件。
+- 只修 runtime、不修 fallback/stub：拒绝。运行时缺失与测试环境会继续产生分裂。
+
+## 风险
+
+- Security: 只处理路径字符串，不执行输入；不得引入 `eval` 或命令拼接。
+- Compatibility: `_tests.rs` 理论上可能被用作生产文件；Rust 社区与本仓库均把该后缀用作
+  测试模块，因此用精确完整后缀限定，并用相似文件负例控制范围。
+- Performance: 增加一次固定 suffix 比较/regex alternative，复杂度不变。
+- Maintenance: runtime、fallback、test stub 三处必须在同一 implementation PR 同步并由
+  focused drift tests 固定；hook consumers 不得复制规则。
+
+## 测试计划
+
+- [ ] Unit: `is_test_path()` 正负例与 `test-path-filter` mode 输出。
+- [ ] Focused guard: runtime/fallback、standalone/staged、test/prod finding 精确断言。
+- [ ] Integration: self-application classifier、hook/guard validators。
+- [ ] Broad: Rust check/test、`bash scripts/local-contract-check.sh --quick`、`git diff --check`。
+- [ ] Manual: 当前仓库 RS-03 输出不再含 `src/*_tests.rs`，生产 finding 仍可见。
+
+## 回滚方案
+
+将 runtime suffix、shell fallback、hook-test stub 与所有新增测试作为一个原子变更回滚。
+不得只回滚 authoritative classifier 或只保留 fallback，否则会恢复分类分裂。


### PR DESCRIPTION
## Summary

为 GH-605 建立 SpecRail packet，定义 Rust test-path classifier 对 `*_tests.rs` 的精确分类契约。

## 优化原因

当前 RS-03 自扫描 70 条 finding 中有 59 条来自 `src/*_tests.rs` 测试模块误报。根因是 authoritative runtime classifier、shell fallback 与 hook test stub 均只覆盖 `*_test.rs`。

## 规格内容

- `product.md`：6 个可测试 behavior invariants、非目标与完整边界清单。
- `tech.md`：当前代码锚点、runtime/fallback/stub 一致性设计、风险、替代方案和 Product-to-Test mapping。
- `tasks.md`：`SP605-T1` 至 `SP605-T4`、串行 ownership、stop conditions 和验证命令。

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH605`
- `python3 checks/check_workflow.py --repo . --all-specs`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

全部通过。

Refs #605