### PR TITLE
fix(rust): classify *_tests.rs as test paths

### DIFF
--- a/guards/rust/common.sh
+++ b/guards/rust/common.sh
@@ -11,7 +11,7 @@ VIBEGUARD_EXCLUDE_PATHS='(.harness/worktrees/|/target/|/.git/|/node_modules/)'
 
 # Fallback only. The authoritative test-path classifier is
 # `vibeguard-runtime test-path-filter`; keep this for old/unbuilt runtime paths.
-VIBEGUARD_TEST_FILE_PATTERN='((^|/)tests/|(^|/)test/|(^|/)__tests__/|(^|/)spec/|(^|/)fixtures/|(^|/)mocks/|(^|/)testdata/|(^|/)examples/|(^|/)benches/|(^|/)test_|_test\.rs$|tests\.rs$|test_helpers\.rs$)'
+VIBEGUARD_TEST_FILE_PATTERN='((^|/)tests/|(^|/)test/|(^|/)__tests__/|(^|/)spec/|(^|/)fixtures/|(^|/)mocks/|(^|/)testdata/|(^|/)examples/|(^|/)benches/|(^|/)test_|_test\.rs$|_tests\.rs$|tests\.rs$|test_helpers\.rs$)'
 
 vibeguard_rust_runtime_path() {
   local script_dir repo_dir candidate

--- a/guards/rust/common.sh
+++ b/guards/rust/common.sh
@@ -11,7 +11,7 @@ VIBEGUARD_EXCLUDE_PATHS='(.harness/worktrees/|/target/|/.git/|/node_modules/)'
 
 # Fallback only. The authoritative test-path classifier is
 # `vibeguard-runtime test-path-filter`; keep this for old/unbuilt runtime paths.
-VIBEGUARD_TEST_FILE_PATTERN='((^|/)tests/|(^|/)test/|(^|/)__tests__/|(^|/)spec/|(^|/)fixtures/|(^|/)mocks/|(^|/)testdata/|(^|/)examples/|(^|/)benches/|(^|/)test_|_test\.rs$|_tests\.rs$|tests\.rs$|test_helpers\.rs$)'
+VIBEGUARD_TEST_FILE_PATTERN='((^|/)tests/|(^|/)test/|(^|/)__tests__/|(^|/)spec/|(^|/)fixtures/|(^|/)mocks/|(^|/)testdata/|(^|/)examples/|(^|/)benches/|(^|/)test_|_test\.rs$|_[tT][eE][sS][tT][sS]\.[rR][sS]$|tests\.rs$|test_helpers\.rs$)'
 
 vibeguard_rust_runtime_path() {
   local script_dir repo_dir candidate

--- a/tests/lib/hook_test_lib.sh
+++ b/tests/lib/hook_test_lib.sh
@@ -111,7 +111,7 @@ case "$command" in
         tests/*|test/*|__tests__/*|spec/*|fixtures/*|mocks/*|testdata/*|examples/*|benches/*|test_*|*/tests/*|*/test/*|*/__tests__/*|*/spec/*|*/fixtures/*|*/mocks/*|*/testdata/*|*/examples/*|*/benches/*|*/test_*) is_test=1 ;;
       esac
       case "$base" in
-        tests.rs|test_helpers.rs|test_*|*_test.*|*.test.*|*.spec.*|*_test.rs) is_test=1 ;;
+        tests.rs|test_helpers.rs|test_*|*_test.*|*.test.*|*.spec.*|*_test.rs|*_tests.rs) is_test=1 ;;
       esac
       if [[ "$mode" == "--test" && "$is_test" -eq 1 ]] || [[ "$mode" == "--prod" && "$is_test" -eq 0 ]]; then
         printf '%s\n' "$path"

--- a/tests/unit/test_rust_check_unwrap_in_prod.sh
+++ b/tests/unit/test_rust_check_unwrap_in_prod.sh
@@ -29,8 +29,38 @@ assert_output_contains() {
   else red "$desc (missing: $expected)"; FAIL=$((FAIL+1)); fi
 }
 
+assert_output_not_contains() {
+  local desc="$1" unexpected="$2"; shift 2; TOTAL=$((TOTAL+1))
+  local out; out=$("$@" 2>&1 || true)
+  if ! echo "$out" | grep -qF "$unexpected"; then green "$desc"; PASS=$((PASS+1))
+  else red "$desc (unexpected: $unexpected)"; FAIL=$((FAIL+1)); fi
+}
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
+
+runtime_wrapper="${tmpdir}/runtime-wrapper"
+cat > "$runtime_wrapper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec cargo run --quiet --manifest-path "${VG_TEST_RUNTIME_MANIFEST:?}" -- "$@"
+EOF
+chmod +x "$runtime_wrapper"
+
+failing_runtime="${tmpdir}/failing-runtime"
+cat > "$failing_runtime" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$failing_runtime"
+
+run_guard_with_runtime() {
+  local runtime="$1"; shift
+  env \
+    VG_TEST_RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml" \
+    VIBEGUARD_RUNTIME="$runtime" \
+    bash "$GUARD" "$@"
+}
 
 printf '\n=== check_unwrap_in_prod (RS-03) ===\n'
 
@@ -123,6 +153,73 @@ fn bench() {
 }
 EOF
 assert_ok "tests.rs/test_helpers/examples/benches are ignored" bash "$GUARD" --strict "$proj5b"
+
+# --- PASS: *_tests.rs is ignored by authoritative runtime and shell fallback ---
+proj5c="${tmpdir}/pass_tests_suffix"
+mkdir -p "${proj5c}/src/nested"
+cat > "${proj5c}/src/nested/parser_tests.rs" <<'EOF'
+fn parser_fixture() {
+    let x: Option<i32> = Some(42);
+    let _ = x.expect("fixture");
+}
+EOF
+assert_ok "*_tests.rs is ignored by runtime classifier" \
+  run_guard_with_runtime "$runtime_wrapper" --strict "$proj5c"
+assert_ok "*_tests.rs is ignored by shell fallback" \
+  run_guard_with_runtime "$failing_runtime" --strict "$proj5c"
+
+# --- FAIL: similar production names stay visible while *_tests.rs stays ignored ---
+proj5d="${tmpdir}/tests_suffix_boundaries"
+mkdir -p "${proj5d}/src"
+for name in contest latest tests_support; do
+  cat > "${proj5d}/src/${name}.rs" <<EOF
+fn ${name}() { let _ = Some(1).unwrap(); }
+EOF
+done
+cat > "${proj5d}/src/foo_tests.rs" <<'EOF'
+fn fixture() { let _ = Some(1).unwrap(); }
+EOF
+for runtime in "$runtime_wrapper" "$failing_runtime"; do
+  label="runtime classifier"
+  [[ "$runtime" == "$failing_runtime" ]] && label="shell fallback"
+  assert_fail "similar production names fail with ${label}" \
+    run_guard_with_runtime "$runtime" --strict "$proj5d"
+  for name in contest latest tests_support; do
+    assert_output_contains "${name}.rs remains visible with ${label}" "${name}.rs" \
+      run_guard_with_runtime "$runtime" --strict "$proj5d"
+  done
+  assert_output_not_contains "foo_tests.rs stays ignored with ${label}" "foo_tests.rs" \
+    run_guard_with_runtime "$runtime" --strict "$proj5d"
+done
+
+# --- STAGED: production finding remains while *_tests.rs is excluded ---
+proj5e="${tmpdir}/staged_tests_suffix"
+mkdir -p "${proj5e}/src"
+git -C "$proj5e" init -q
+git -C "$proj5e" config user.email "vibeguard-tests@example.invalid"
+git -C "$proj5e" config user.name "VibeGuard Tests"
+cat > "${proj5e}/src/foo.rs" <<'EOF'
+fn production() { let _ = Some(1).unwrap(); }
+EOF
+cat > "${proj5e}/src/foo_tests.rs" <<'EOF'
+fn fixture() { let _ = Some(1).unwrap(); }
+EOF
+git -C "$proj5e" add src/foo.rs src/foo_tests.rs
+staged_files="${proj5e}/staged-files"
+printf '%s\n' "src/foo.rs" "src/foo_tests.rs" > "$staged_files"
+run_staged_guard() {
+  (
+    cd "$proj5e"
+    env \
+      VG_TEST_RUNTIME_MANIFEST="${REPO_DIR}/vibeguard-runtime/Cargo.toml" \
+      VIBEGUARD_RUNTIME="$runtime_wrapper" \
+      VIBEGUARD_STAGED_FILES="$staged_files" \
+      bash "$GUARD" --strict "$proj5e"
+  )
+}
+assert_fail "staged production unwrap remains visible" run_staged_guard
+assert_output_contains "staged output contains foo.rs" "src/foo.rs" run_staged_guard
+assert_output_not_contains "staged output excludes foo_tests.rs" "foo_tests.rs" run_staged_guard
 
 # --- PASS: empty project (no .rs files) ---
 proj6="${tmpdir}/pass_empty"

--- a/tests/unit/test_rust_check_unwrap_in_prod.sh
+++ b/tests/unit/test_rust_check_unwrap_in_prod.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 GUARD="${REPO_DIR}/guards/rust/check_unwrap_in_prod.sh"
+source "${REPO_DIR}/tests/lib/hook_test_lib.sh"
 
 PASS=0; FAIL=0; TOTAL=0
 
@@ -53,6 +54,16 @@ cat > "$failing_runtime" <<'EOF'
 exit 1
 EOF
 chmod +x "$failing_runtime"
+
+stub_home="${tmpdir}/stub-home"
+hook_test_install_runtime_stub "$stub_home"
+stub_runtime="${stub_home}/.vibeguard/installed/bin/vibeguard-runtime"
+
+run_stub_filter() {
+  local mode="$1"
+  printf '%s\n' "src/foo_tests.rs" "src/Foo_Tests.rs" "src/contest.rs" \
+    | "$stub_runtime" test-path-filter "$mode"
+}
 
 run_guard_with_runtime() {
   local runtime="$1"; shift
@@ -163,10 +174,21 @@ fn parser_fixture() {
     let _ = x.expect("fixture");
 }
 EOF
+cat > "${proj5c}/src/Foo_Tests.rs" <<'EOF'
+fn mixed_case_fixture() { let _ = Some(42).unwrap(); }
+EOF
 assert_ok "*_tests.rs is ignored by runtime classifier" \
   run_guard_with_runtime "$runtime_wrapper" --strict "$proj5c"
 assert_ok "*_tests.rs is ignored by shell fallback" \
   run_guard_with_runtime "$failing_runtime" --strict "$proj5c"
+assert_output_contains "hook runtime stub --test includes lowercase suffix" "src/foo_tests.rs" \
+  run_stub_filter --test
+assert_output_contains "hook runtime stub --test normalizes mixed-case suffix" "src/Foo_Tests.rs" \
+  run_stub_filter --test
+assert_output_contains "hook runtime stub --prod keeps production path" "src/contest.rs" \
+  run_stub_filter --prod
+assert_output_not_contains "hook runtime stub --prod excludes test suffix" "Foo_Tests.rs" \
+  run_stub_filter --prod
 
 # --- FAIL: similar production names stay visible while *_tests.rs stays ignored ---
 proj5d="${tmpdir}/tests_suffix_boundaries"

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -651,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_path_matches_rust_guard_exclusions() {
-        let test_paths = "tests/integration.rs src/tests.rs src/test_helpers.rs src/test_helpers/mod.rs src/test_utils/helper.rs examples/demo.rs benches/throughput.rs test_root.rs src/math_test.rs src/math_tests.rs src/nested/parser_tests.rs src/lib.test.rs";
+        let test_paths = "tests/integration.rs src/tests.rs src/test_helpers.rs src/test_helpers/mod.rs src/test_utils/helper.rs examples/demo.rs benches/throughput.rs test_root.rs src/math_test.rs src/math_tests.rs src/Foo_Tests.rs src/nested/parser_tests.rs src/lib.test.rs";
         for path in test_paths.split_whitespace() {
             assert!(is_test_path(path), "{path} should be classified as test");
         }

--- a/vibeguard-runtime/src/hook_checks_common.rs
+++ b/vibeguard-runtime/src/hook_checks_common.rs
@@ -93,6 +93,7 @@ pub(crate) fn is_test_path(path: &str) -> bool {
         || basename.contains(".test.")
         || basename.contains(".spec.")
         || basename.ends_with("_test.rs")
+        || basename.ends_with("_tests.rs")
 }
 
 fn has_path_segment(path: &str, segment: &str) -> bool {
@@ -650,23 +651,17 @@ mod tests {
 
     #[test]
     fn test_path_matches_rust_guard_exclusions() {
-        for path in [
-            "tests/integration.rs",
-            "src/tests.rs",
-            "src/test_helpers.rs",
-            "src/test_helpers/mod.rs",
-            "src/test_utils/helper.rs",
-            "examples/demo.rs",
-            "benches/throughput.rs",
-            "test_root.rs",
-            "src/math_test.rs",
-            "src/lib.test.rs",
-        ] {
+        let test_paths = "tests/integration.rs src/tests.rs src/test_helpers.rs src/test_helpers/mod.rs src/test_utils/helper.rs examples/demo.rs benches/throughput.rs test_root.rs src/math_test.rs src/math_tests.rs src/nested/parser_tests.rs src/lib.test.rs";
+        for path in test_paths.split_whitespace() {
             assert!(is_test_path(path), "{path} should be classified as test");
         }
-        assert!(!is_test_path("src/contest.rs"));
-        assert!(!is_test_path("src/contest_helpers/mod.rs"));
-        assert!(!is_test_path("src/prod_helpers.rs"));
+        let prod_paths = "src/contest.rs src/latest.rs src/tests_support.rs src/foo_tests.py src/contest_helpers/mod.rs src/prod_helpers.rs";
+        for path in prod_paths.split_whitespace() {
+            assert!(
+                !is_test_path(path),
+                "{path} should be classified as production"
+            );
+        }
     }
 
     #[test]

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -106,6 +106,7 @@ fn help_lists_all_commands() {
 fn test_path_filter_classifies_rust_tests_suffix_without_broad_matches() {
     let input = concat!(
         "src/foo_tests.rs\n",
+        "src/Foo_Tests.rs\n",
         "src/nested/parser_tests.rs\n",
         "src/contest.rs\n",
         "src/latest.rs\n",
@@ -117,7 +118,7 @@ fn test_path_filter_classifies_rust_tests_suffix_without_broad_matches() {
     assert!(test_output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&test_output.stdout),
-        "src/foo_tests.rs\nsrc/nested/parser_tests.rs\n"
+        "src/foo_tests.rs\nsrc/Foo_Tests.rs\nsrc/nested/parser_tests.rs\n"
     );
 
     let prod_output = run_runtime_with_stdin(&["test-path-filter", "--prod"], input);

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::bin;
+use common::{bin, run_runtime_with_stdin};
 
 #[test]
 fn no_args_exits_2() {
@@ -100,4 +100,35 @@ fn help_lists_all_commands() {
             "expected '{name}' in help output: {stderr}"
         );
     }
+}
+
+#[test]
+fn test_path_filter_classifies_rust_tests_suffix_without_broad_matches() {
+    let input = concat!(
+        "src/foo_tests.rs\n",
+        "src/nested/parser_tests.rs\n",
+        "src/contest.rs\n",
+        "src/latest.rs\n",
+        "src/tests_support.rs\n",
+        "src/foo_tests.py\n",
+    );
+
+    let test_output = run_runtime_with_stdin(&["test-path-filter", "--test"], input);
+    assert!(test_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&test_output.stdout),
+        "src/foo_tests.rs\nsrc/nested/parser_tests.rs\n"
+    );
+
+    let prod_output = run_runtime_with_stdin(&["test-path-filter", "--prod"], input);
+    assert!(prod_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&prod_output.stdout),
+        concat!(
+            "src/contest.rs\n",
+            "src/latest.rs\n",
+            "src/tests_support.rs\n",
+            "src/foo_tests.py\n",
+        )
+    );
 }


### PR DESCRIPTION
## Why

RS-03 and the shared Rust path classifier treated common `*_tests.rs` modules as production code. On the baseline checkout this created 59 false-positive findings that obscured 11 production findings.

## Implementation plan completed

- extend the authoritative runtime classifier with the exact `_tests.rs` suffix
- keep the shell fallback and hook-test runtime stub behavior aligned
- preserve runtime case normalization for the new fallback suffix without globally changing older fallback rules
- prove `--test` and `--prod` complementary output with named positive and negative paths
- cover standalone and staged RS-03 behavior under both the real runtime and forced fallback

## Spec

- Product: `docs/specs/GH605/product.md`
- Technical design: `docs/specs/GH605/tech.md`
- Tasks: `docs/specs/GH605/tasks.md`

## Verification

- `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_matches_rust_guard_exclusions`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml test_path_filter_classifies_rust_tests_suffix_without_broad_matches`
- `bash tests/unit/test_rust_check_unwrap_in_prod.sh` — 28/28
- `bash scripts/ci/self-application/check-rust-test-path-classifier.sh .`
- `bash scripts/ci/validate-guards.sh`
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash scripts/local-contract-check.sh --quick`
- repository RS-03 self-scan: no `_tests.rs` findings; production findings remain visible
- `python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH605`
- `git diff --check`

## Independent review

Round 1 found a runtime/fallback mixed-case mismatch and missing behavior coverage for the hook runtime stub. Head `d960097` fixes both; round 2 marked both findings resolved and reported `NO BLOCKER`.

## Risk and rollback

The change uses an exact basename suffix, so similar production names such as `latest.rs` and `tests_support.rs` remain in scope. Rollback must revert runtime, fallback, stub, and tests together to avoid classifier drift.

Closes #605