### PR TITLE
spec: define compliance root correction

### DIFF
--- a/docs/specs/GH608/product.md
+++ b/docs/specs/GH608/product.md
@@ -21,7 +21,8 @@ GH-608
 
 ## 非目标
 
-- 不改变 Layer 1 至 Layer 7 的合规判断、PASS/WARN/FAIL 文案或退出码语义。
+- 除纠正 bundled guard discovery 结果外，不改变 Layer 1 至 Layer 7 的判断规则、
+  PASS/WARN/FAIL 文案、计数算法或退出码语义；汇总数值随正确分类自然变化。
 - 不调整 `find_guard` / `find_quality_guard` 的搜索顺序或支持矩阵。
 - 不修改 `scripts/metrics/metrics_collector.sh` 或其他脚本的根目录解析。
 - 不安装、复制或生成 guard 文件，也不修改用户的 Claude/VibeGuard 配置。
@@ -40,7 +41,8 @@ GH-608
 5. B-005 调用者显式设置 `VIBEGUARD_DIR` 时，该值必须保持最高优先级，包括路径含空格
    的有效目录；自动解析不得覆盖它。
 6. B-006 本变更只修正检查器传给共享 guard discovery 的默认根目录。项目本地 fallback、
-   其余 Layer、summary 计数以及现有退出码 contract 必须保持兼容。
+   其余 Layer、summary 计数算法以及现有退出码 contract 必须保持兼容；Layer 1/2 被正确
+   分类后，PASS/WARN 汇总数值必须如实反映新结果。
 7. B-007 验证必须断言具名 guard 的 available/not-found 状态与实际来源路径；不得只断言
    总 PASS/WARN 数量，也不得读取真实用户的 HOME 配置来制造通过结果。
 

--- a/docs/specs/GH608/product.md
+++ b/docs/specs/GH608/product.md
@@ -1,0 +1,74 @@
+# Product Spec
+
+## Linked Issue
+
+GH-608
+
+## 用户问题
+
+直接运行仓库自带的 `scripts/verify/compliance_check.sh` 时，默认的 VibeGuard 安装根目录
+被解析为仓库的 `scripts/` 子目录。Layer 1 与 Layer 2 随后在不存在的
+`scripts/guards/` 下寻找随仓库提供的 duplicate 与 naming guards，并把实际可用的能力
+报告为 `not found`。这会制造错误的合规告警，使用户无法区分真实缺失与检查器自身的
+路径错误。
+
+## 目标
+
+- 默认调用始终从检查器自身位置解析仓库根目录，并找到随仓库提供的 guards。
+- 从任意当前工作目录调用时行为一致。
+- 显式提供的 `VIBEGUARD_DIR` 继续优先于自动解析结果。
+- 用聚焦回归测试固定具名 guard 的来源路径，不依赖开发者本机配置。
+
+## 非目标
+
+- 不改变 Layer 1 至 Layer 7 的合规判断、PASS/WARN/FAIL 文案或退出码语义。
+- 不调整 `find_guard` / `find_quality_guard` 的搜索顺序或支持矩阵。
+- 不修改 `scripts/metrics/metrics_collector.sh` 或其他脚本的根目录解析。
+- 不安装、复制或生成 guard 文件，也不修改用户的 Claude/VibeGuard 配置。
+
+## Behavior Invariants
+
+1. B-001 未设置 `VIBEGUARD_DIR` 时，检查器必须相对于自身脚本位置解析 VibeGuard
+   仓库根目录；不得把 `scripts/` 当作仓库根目录。
+2. B-002 默认调用的 Layer 1 必须把仓库内实际存在的
+   `guards/python/check_duplicates.py` 报告为 available，而不是错误的 not-found WARN。
+3. B-003 默认调用的 Layer 2 必须把仓库内实际存在的
+   `guards/python/check_naming_convention.py` 报告为 available，而不是错误的 not-found
+   WARN。
+4. B-004 B-001 至 B-003 不得依赖调用者当前工作目录；从仓库外目录用绝对脚本路径
+   调用必须得到相同的 guard discovery 结果。
+5. B-005 调用者显式设置 `VIBEGUARD_DIR` 时，该值必须保持最高优先级，包括路径含空格
+   的有效目录；自动解析不得覆盖它。
+6. B-006 本变更只修正检查器传给共享 guard discovery 的默认根目录。项目本地 fallback、
+   其余 Layer、summary 计数以及现有退出码 contract 必须保持兼容。
+7. B-007 验证必须断言具名 guard 的 available/not-found 状态与实际来源路径；不得只断言
+   总 PASS/WARN 数量，也不得读取真实用户的 HOME 配置来制造通过结果。
+
+## 验收标准
+
+- [ ] 在隔离 HOME 与项目 fixture 下，未设置 `VIBEGUARD_DIR` 的检查器找到两项 bundled
+      Python guards。
+- [ ] 从仓库外任意工作目录调用绝对脚本路径时，两项 guard discovery 结果不变。
+- [ ] 显式 `VIBEGUARD_DIR` 指向独立 fixture 时，输出证明该目录优先于自动仓库根目录。
+- [ ] 聚焦测试对 duplicate 与 naming guard 分别做具名断言，并进入 unit test runner。
+- [ ] shell syntax、focused unit、文档路径和 broad local contract 验证通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001, B-006（未传 project 参数与未设置环境变量沿用现有默认行为） |
+| 错误与失败路径 | covered: B-002, B-003, B-006（真实缺失仍按共享 discovery 与现有 WARN 语义报告） |
+| 授权/权限 | N/A：检查器只读取本地路径，本变更不改变权限模型 |
+| 并发/竞态 | N/A：单进程只读检查，无共享可变状态 |
+| 重试/幂等 | covered: B-004, B-006（相同输入重跑结果一致） |
+| 非法状态转换 | N/A：不持久化 workflow 状态 |
+| 兼容/迁移 | covered: B-005, B-006 |
+| 降级/回退 | covered: B-006（项目本地 fallback 搜索保持原样） |
+| 证据与审计完整性 | covered: B-007 |
+| 取消/中断 | N/A：无写入，中断后可安全重跑 |
+
+## 发布说明
+
+这是 compliance checker 的路径正确性修复。仓库内置的 duplicate 与 naming guards 将在
+默认调用中被准确发现；显式配置、其余检查层和退出码不变。

--- a/docs/specs/GH608/tasks.md
+++ b/docs/specs/GH608/tasks.md
@@ -1,0 +1,69 @@
+# Task Plan
+
+## Linked Issue
+
+GH-608
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP608-T1` Owner: implementation agent — 新增隔离的 compliance focused harness，先复现默认调用把 bundled duplicate/naming guards 报告为缺失。Depends on: Spec PR merged and live implementation route allowed。Covers: B-002, B-003, B-004, B-007。Done when: 测试从仓库外 cwd 调用 absolute entrypoint，使用临时 HOME/project，失败证据绑定两个具名 guard 和错误来源路径。Verify: `bash tests/unit/test_compliance_check.sh` 在 production fix 前以预期断言失败。
+- [ ] `SP608-T2` Owner: implementation agent — 修正 compliance entrypoint 的默认 VibeGuard 根目录，同时保留显式环境变量优先级与完整 quoting。Depends on: SP608-T1。Covers: B-001, B-002, B-003, B-004, B-005, B-006。Done when: 默认 fixture 找到仓库 bundled guards；路径含空格的显式 fixture 被优先使用；shared discovery、其他 Layer 与 exit contract 未改。Verify: 对 entrypoint 与新增 focused harness 执行 shell syntax check，再运行该 focused harness。
+- [ ] `SP608-T3` Owner: implementation agent — 把 focused harness 纳入现有 unit runner 并执行文档/跨表面回归，不修改 runner discovery。Depends on: SP608-T2。Covers: B-004, B-006, B-007。Done when: `test_compliance_check.sh` 被自动发现，具名断言与 expected status 全部通过，未固定 summary totals。Verify: `bash tests/unit/run_all.sh`; `bash scripts/ci/validate-doc-paths.sh`; `bash scripts/ci/validate-doc-command-paths.sh`; `bash scripts/local-contract-check.sh --quick`; `git diff --check`。
+- [ ] `SP608-T4` Owner: verification owner + independent reviewer — 对 product/tech/tasks、implementation diff 与 fresh verification 做逐项覆盖审查。Depends on: SP608-T3。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007。Done when: reviewer 确认根因被修复、无 shared search matrix 复制、无真实 HOME 依赖、无 exit semantics 或非目标脚本变化；当前 PR head 的 CI、review threads 与 SpecRail PR gate 均有有效证据。Verify: SpecRail implementation check、advisory review 与 PR gate 输出。
+
+## 并行拆分
+
+T1-T3 共享 entrypoint 与 focused harness，必须由单一 implementation lane 串行完成。
+T4 的 independent reviewer 只读，不与实现 lane 共享 writable file。
+
+| Lane | Owner | Writable files |
+| --- | --- | --- |
+| implementation | `/root` | `scripts/verify/compliance_check.sh` 与新增 compliance focused harness |
+| verification | `/root` | none（只运行命令与记录证据） |
+| independent_review | native reviewer agent | none（只读 review） |
+
+## Plan-First Handoff
+
+```yaml
+handoff:
+  mode: specrail-implement
+  artifacts:
+    - docs/specs/GH608/product.md
+    - docs/specs/GH608/tech.md
+    - docs/specs/GH608/tasks.md
+  runtime_pinning_snapshot: None
+  verification_owner: /root
+  stop_conditions:
+    - The default root still resolves to scripts instead of the repository root.
+    - An explicit VIBEGUARD_DIR override or a path containing spaces stops working.
+    - Tests depend on the real user HOME, swallow an unexpected status, or assert only summary totals.
+    - The shared guard search matrix, exit semantics, metrics collector, or another non-goal changes.
+    - A real CI, review-thread, or SpecRail PR gate is blocked.
+  lane_map:
+    implementation: /root
+    verification: /root
+    independent_review: native reviewer agent (read-only)
+```
+
+## 验证
+
+```bash
+python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH608
+python3 checks/check_workflow.py --repo . --all-specs
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+git diff --check
+```
+
+## Handoff Notes
+
+- 写作基线：`origin/main@57f4128b091d6b84add94d0fa491b68b69564629`。
+- Issue #608 的 live readiness label、实现前最新 `origin/main` 基线与当前 PR head 证据都必须
+  重新获取；durable spec packet 不替代 live state。
+- 本规格只覆盖已复现的 compliance entrypoint root bug。support matrix 与其他脚本的相似
+  finding 必须独立 triage，不能借本 PR 顺带修改。

--- a/docs/specs/GH608/tech.md
+++ b/docs/specs/GH608/tech.md
@@ -1,0 +1,96 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-608
+
+## Product Spec
+
+`docs/specs/GH608/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Compliance entrypoint | `scripts/verify/compliance_check.sh` | 默认值只从 `scripts/verify/` 向上一级，得到仓库内的 `scripts/`，随后把它作为 `VIBEGUARD_DIR` | 根因所在；bundled guard 搜索因此多出一层 `scripts/` |
+| Shared discovery | `scripts/lib/guard_paths.sh` | `find_guard` 先检查 `VIBEGUARD_DIR/guards/`，再检查目标项目本地的 guard 路径 | 其输入 contract 正确，本修复不应复制或改变搜索矩阵 |
+| Unit runner | `tests/unit/run_all.sh` | 自动发现同目录所有 `test_*.sh` 并汇总断言结果 | 新聚焦测试无需修改 runner 即可进入 CI |
+| CI unit job | `.github/workflows/ci.yml` | unit job 调用 `bash tests/unit/run_all.sh` | 聚焦回归会由现有 CI 路径执行 |
+
+## 根因与复现证据
+
+`compliance_check.sh` 位于 `scripts/verify/`，当前默认表达式只执行一次父目录跳转。fresh
+trace 显示 `VIBEGUARD_DIR` 被赋值为仓库的 `scripts/`，共享 discovery 随后探测
+错误地在 scripts/guards 下探测 duplicate 与 naming guard。实际 bundled files 位于仓库根目录下的
+`guards/python/`，所以两个存在的 guard 被报告为 not found。
+
+## 设计方案
+
+1. 只在 `scripts/verify/compliance_check.sh` 中修正默认根目录表达式：从脚本目录向上两级
+   到仓库根目录。保留 `${VIBEGUARD_DIR:-...}`，因此非空显式覆盖继续优先。
+2. 保留脚本路径与环境变量引用的完整 quoting，确保脚本或显式根目录包含空格时不会被
+   分词。
+3. 新增 compliance checker 聚焦单元测试，构造隔离的 HOME 与项目 fixture，使其余
+   Layer 的必需文件存在，避免测试结果依赖真实用户配置。
+4. 默认路径用例从仓库外临时目录调用检查器的绝对路径，分别断言 duplicate/naming
+   guard 为 available、输出来源为仓库 `guards/python/`，且不存在对应 not-found 文案。
+5. override 用例创建路径含空格的独立 VibeGuard fixture，并放置两个具名 guard 文件；
+   显式设置 `VIBEGUARD_DIR` 后断言输出使用 fixture 路径，从而证明 override precedence
+   与 quoting。
+6. 测试只对具名行和来源路径作断言，不固定 summary 总数。捕获并显式验证命令退出码，
+   不用 `|| true` 掩盖非预期失败。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 默认仓库根解析 | `scripts/verify/compliance_check.sh` 默认 `VIBEGUARD_DIR` | focused harness 断言输出路径位于仓库 `guards/python/` 而非错误的 scripts/guards 目录 |
+| B-002 duplicate guard 可用 | Layer 1 调用现有 `find_guard` | focused test 断言 `check_duplicates.py available` 且无对应 not-found 文案 |
+| B-003 naming guard 可用 | Layer 2 调用现有 `find_guard` | focused test 断言 `check_naming_convention.py available` 且无对应 not-found 文案 |
+| B-004 cwd 无关 | absolute entrypoint invocation | 在仓库外临时工作目录执行 focused fixture |
+| B-005 override precedence 与空格路径 | 保留环境变量优先级和 quoting | focused override fixture 断言两项来源均为显式目录 |
+| B-006 其余行为兼容 | 单行 production change、现有 shared discovery | focused test 验证预期退出码；unit runner 与 broad local contract 回归 |
+| B-007 证据独立完整 | isolated HOME/project fixtures 与具名断言 | test source review + focused output；不使用总 PASS/WARN threshold |
+
+## 数据流
+
+1. 调用者可选传入 project directory，并可选显式设置 `VIBEGUARD_DIR`。
+2. 未显式设置时，entrypoint 根据自身目录解析仓库根；显式值存在时直接保留。
+3. Layer 1/2 把该根目录与 project directory 交给共享 `find_guard`。
+4. `find_guard` 先检查 bundled root，再执行现有 project-local fallback。
+5. 每个 Layer 沿用现有 PASS/WARN/FAIL 汇总与最终退出码逻辑。
+
+## 备选方案
+
+- 修改 `find_guard` 让它猜测传入的是仓库根还是 `scripts/`：拒绝。会模糊共享 contract，
+  并把 entrypoint 的错误输入扩散成兼容分支。
+- 在 compliance checker 中硬编码两个 guard 的绝对相对路径：拒绝。会复制
+  `guard_paths.sh` 的搜索矩阵。
+- 同时扫描并修复所有脚本的相似表达式：拒绝。超出 GH-608 的已复现范围，其他 finding
+  应独立 triage、spec 与实现。
+- 只测试默认当前仓库目录：拒绝。无法证明 cwd independence，也容易意外使用开发者 HOME。
+
+## 风险
+
+- Security: 目录值只作为被引用的文件路径使用；不得引入 `eval`、命令拼接或执行 fixture
+  guard 内容。
+- Compatibility: 若调用者依赖错误的 `scripts/` 默认值，修复会改变 guard 来源；该旧行为
+  与公开路径布局冲突，显式 `VIBEGUARD_DIR` 仍提供稳定覆盖。
+- Test isolation: compliance checker 会读取 HOME 和 project 配置；fixture 必须覆盖这些
+  输入并在退出时清理，防止本机状态造成假阳性。
+- Scope drift: 搜索矩阵、support matrix、metrics collector 与 Layer 语义保持不变。
+
+## 测试计划
+
+- [ ] Syntax: `bash -n scripts/verify/compliance_check.sh tests/unit/test_compliance_check.sh`。
+- [ ] Focused: `bash tests/unit/test_compliance_check.sh`。
+- [ ] Unit integration: `bash tests/unit/run_all.sh`。
+- [ ] Docs/contracts: doc path、doc command path validators。
+- [ ] Broad: `bash scripts/local-contract-check.sh --quick` 与 `git diff --check`。
+- [ ] Review: product-to-test 逐项审查，确认没有改变 shared search matrix 或退出语义。
+
+## 回滚方案
+
+将 entrypoint 的默认根目录修复和新增聚焦测试作为一个原子变更回滚。回滚不会迁移数据，
+但会恢复 bundled guards 被错误报告缺失的行为。不得通过删除失败断言或放宽测试来保留错误
+实现。

--- a/docs/specs/GH608/tech.md
+++ b/docs/specs/GH608/tech.md
@@ -58,7 +58,8 @@ trace 显示 `VIBEGUARD_DIR` 被赋值为仓库的 `scripts/`，共享 discovery
 2. 未显式设置时，entrypoint 根据自身目录解析仓库根；显式值存在时直接保留。
 3. Layer 1/2 把该根目录与 project directory 交给共享 `find_guard`。
 4. `find_guard` 先检查 bundled root，再执行现有 project-local fallback。
-5. 每个 Layer 沿用现有 PASS/WARN/FAIL 汇总与最终退出码逻辑。
+5. 每个 Layer 沿用现有 PASS/WARN/FAIL 计数算法与最终退出码逻辑；Layer 1/2 的数值随
+   corrected discovery result 自然变化。
 
 ## 备选方案
 


### PR DESCRIPTION
## Summary

- define the user-visible contract for resolving the bundled VibeGuard root
- map default cwd-independent discovery and explicit override precedence to focused tests
- constrain implementation scope, risks, rollback, and plan-first handoff

## Why

The compliance checker currently resolves its default root to `scripts/`, so two bundled guards are falsely reported as missing. This spec records the reproduced root cause and separates the later implementation PR.

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH608`
- `python3 checks/check_workflow.py --repo . --all-specs`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

Refs #608