### PR TITLE
fix: resolve compliance root from repository

### DIFF
--- a/scripts/verify/compliance_check.sh
+++ b/scripts/verify/compliance_check.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   bash vibeguard/scripts/verify/compliance_check.sh /path/to/my-project
 
 PROJECT_DIR="${1:-.}"
-VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 source "$(dirname "$0")/../lib/guard_paths.sh"
 PASS=0
 FAIL=0

--- a/tests/unit/test_compliance_check.sh
+++ b/tests/unit/test_compliance_check.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/verify/compliance_check.sh bundled guard discovery.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECKER="${REPO_DIR}/scripts/verify/compliance_check.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red() { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "${actual}" == "${expected}" ]]; then
+    green "${desc}"
+    PASS=$((PASS + 1))
+  else
+    red "${desc} (expected ${expected}, got ${actual})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1"
+  local output="$2"
+  local expected="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qF "${expected}" <<< "${output}"; then
+    green "${desc}"
+    PASS=$((PASS + 1))
+  else
+    red "${desc} (missing: ${expected})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1"
+  local output="$2"
+  local unexpected="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -qF "${unexpected}" <<< "${output}"; then
+    red "${desc} (unexpected: ${unexpected})"
+    FAIL=$((FAIL + 1))
+  else
+    green "${desc}"
+    PASS=$((PASS + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+PROJECT_DIR="${TMP_DIR}/project"
+FIXTURE_HOME="${TMP_DIR}/home"
+OUTSIDE_CWD="${TMP_DIR}/outside cwd"
+OVERRIDE_ROOT="${TMP_DIR}/explicit root"
+
+mkdir -p \
+  "${PROJECT_DIR}" \
+  "${FIXTURE_HOME}/.claude/skills/vibeguard" \
+  "${FIXTURE_HOME}/.claude/rules/vibeguard" \
+  "${OUTSIDE_CWD}" \
+  "${OVERRIDE_ROOT}/guards/python"
+
+printf '%s\n' \
+  'repos:' \
+  '  - repo: local' \
+  '    hooks:' \
+  '      - id: gitleaks' \
+  '      - id: ruff' \
+  > "${PROJECT_DIR}/.pre-commit-config.yaml"
+printf '%s\n' \
+  'Search before writing.' \
+  'No backward compatibility.' \
+  'No hardcoding.' \
+  > "${PROJECT_DIR}/CLAUDE.md"
+printf '%s\n' 'VibeGuard anti-hallucination rules.' > "${FIXTURE_HOME}/.claude/CLAUDE.md"
+printf '%s\n' '# duplicate fixture' > "${OVERRIDE_ROOT}/guards/python/check_duplicates.py"
+printf '%s\n' '# naming fixture' > "${OVERRIDE_ROOT}/guards/python/check_naming_convention.py"
+
+printf '\n=== compliance_check bundled guard discovery ===\n'
+
+set +e
+default_output="$({
+  cd "${OUTSIDE_CWD}" || exit 97
+  unset VIBEGUARD_DIR
+  HOME="${FIXTURE_HOME}" bash "${CHECKER}" "${PROJECT_DIR}"
+} 2>&1)"
+default_status=$?
+set -e
+
+assert_eq "default invocation preserves compliance exit contract" 0 "${default_status}"
+assert_contains \
+  "default invocation finds bundled duplicate guard from external cwd" \
+  "${default_output}" \
+  "check_duplicates.py available (${REPO_DIR}/guards/python/check_duplicates.py)"
+assert_contains \
+  "default invocation finds bundled naming guard from external cwd" \
+  "${default_output}" \
+  "check_naming_convention.py available (${REPO_DIR}/guards/python/check_naming_convention.py)"
+assert_not_contains \
+  "default invocation does not emit duplicate guard not-found warning" \
+  "${default_output}" \
+  "check_duplicates.py not found"
+assert_not_contains \
+  "default invocation does not emit naming guard not-found warning" \
+  "${default_output}" \
+  "check_naming_convention.py not found"
+
+set +e
+override_output="$({
+  cd "${OUTSIDE_CWD}" || exit 97
+  HOME="${FIXTURE_HOME}" VIBEGUARD_DIR="${OVERRIDE_ROOT}" \
+    bash "${CHECKER}" "${PROJECT_DIR}"
+} 2>&1)"
+override_status=$?
+set -e
+
+assert_eq "explicit root preserves compliance exit contract" 0 "${override_status}"
+assert_contains \
+  "explicit root with spaces wins for duplicate guard" \
+  "${override_output}" \
+  "check_duplicates.py available (${OVERRIDE_ROOT}/guards/python/check_duplicates.py)"
+assert_contains \
+  "explicit root with spaces wins for naming guard" \
+  "${override_output}" \
+  "check_naming_convention.py available (${OVERRIDE_ROOT}/guards/python/check_naming_convention.py)"
+assert_not_contains \
+  "explicit root does not fall back to repository duplicate guard" \
+  "${override_output}" \
+  "check_duplicates.py available (${REPO_DIR}/guards/python/check_duplicates.py)"
+assert_not_contains \
+  "explicit root does not fall back to repository naming guard" \
+  "${override_output}" \
+  "check_naming_convention.py available (${REPO_DIR}/guards/python/check_naming_convention.py)"
+
+echo
+printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' \
+  "${TOTAL}" "${PASS}" "${FAIL}"
+[[ "${FAIL}" -gt 0 ]] && exit 1 || exit 0


### PR DESCRIPTION
## Summary

- resolve the default `VIBEGUARD_DIR` from the repository root instead of `scripts/`
- add an isolated compliance checker regression harness that runs from an external cwd
- preserve explicit `VIBEGUARD_DIR` precedence, including roots containing spaces

## Why

The checker lives under `scripts/verify/` but only walked up one directory. Shared guard discovery therefore searched `scripts/guards/` and falsely reported the bundled duplicate and naming guards as missing.

## Implementation plan completed

- SP608-T1: add a red regression proving both default guard lookups fail
- SP608-T2: correct the single default-root expression and verify explicit override behavior
- SP608-T3: run focused, full unit, SpecRail, doc-contract, and broad local gates

## Spec

- `docs/specs/GH608/product.md`
- `docs/specs/GH608/tech.md`
- `docs/specs/GH608/tasks.md`

## Verification

- `bash -n scripts/verify/compliance_check.sh tests/unit/test_compliance_check.sh`
- `bash tests/unit/test_compliance_check.sh` — 10/10
- `bash tests/unit/run_all.sh` — 23/23 test files
- `python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH608`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`

Closes #608