### PR TITLE
fix: confirm hook latency breaches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Hook latency benchmark
         shell: bash
-        run: bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
+        run: bash tests/bench_hook_latency.sh --runs=3 --confirmation-runs=3 --fail-on-regression
 
       - name: Upload benchmark results
         if: runner.os == 'Linux'

--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -15,7 +15,12 @@ Future pure Rust/core classifier microbenchmarks must use the separate
 microseconds and must not include hook wrappers, shell process startup,
 stdin/stdout adaptation, config discovery, or logging overhead.
 
-The latency gate measures P50, P95, P99, and max for each benchmark fixture. CI fails when `--fail-on-regression` is enabled and any fixture exceeds its P95 budget.
+The latency gate measures P50, P95, P99, and max for each benchmark fixture.
+An initial P95 budget breach in a healthy environment triggers a second,
+fixture-local confirmation batch with the same workload and budget. CI fails
+when `--fail-on-regression` is enabled only if the confirmation P95 also
+breaches the budget. A confirmation pass is reported as `PASS-CONFIRMED`; it
+does not erase the initial tail-latency evidence.
 
 These are cross-OS CI budgets, not ideal-machine optimization targets. Static performance gates still block dangerous patterns before they can hide behind a broad absolute budget.
 
@@ -38,10 +43,14 @@ Run the gate locally:
 
 ```bash
 cargo build --manifest-path vibeguard-runtime/Cargo.toml --quiet
-bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression
+bash tests/bench_hook_latency.sh --runs=3 --confirmation-runs=3 --fail-on-regression
 ```
 
-Use `--sla=<ms>` only when deliberately testing a temporary global threshold. The default contract is per-hook.
+`--confirmation-runs=<n>` defaults to the initial `--runs=<n>` value and must
+be a positive integer. Healthy fixtures do not run the confirmation batch.
+Environment-distorted fixtures retain the existing suppressed verdict and do
+not fabricate confirmation evidence. Use `--sla=<ms>` only when deliberately
+testing a temporary global threshold. The default contract is per-hook.
 
 ## Direct vs Wrapper Coverage
 
@@ -55,12 +64,25 @@ Post-build fixtures use fake build commands and disable the post-build cache so 
 
 Benchmark output includes `surface=hook_e2e_ms` and a `hotspot=` field. JSON
 output carries the same surface marker at the top level and per result.
-`bench-output.json` uses compact `e2e ... P95` names so GitHub benchmark
-comments stay readable. When a regression fails, the console row must identify
-both the surface and fixture size, such as
+The internal JSON's existing top-level per-result `p50`, `p95`, `p99`, `max`,
+`status`, and `runs` fields always describe the initial batch. Each result also
+records `decision`, an `initial` metrics object, nullable `confirmation`
+metrics, and `confirmation_runs`. Decisions are `normal_pass`,
+`cleared_transient`, `confirmed_regression`, `environment_distorted`, or
+`confirmation_error`.
+
+`bench-output.json` keeps the compact canonical `e2e ... P50/P95/P99` rows as
+initial-batch values so historical series do not silently change meaning. A
+completed confirmation adds `e2e ... confirmation P95`, `e2e ... budget`, and
+a `decision cleared` or `decision confirmed-regression` row. A confirmation
+execution error preserves the initial rows, budget, and `decision
+confirmation-error`, but does not invent confirmation metrics or a cleared
+decision. When a regression fails, the console row must identify both the
+surface and fixture size, such as
 `surface=hook_e2e_ms ... post-write-guard (5000)`.
 
-Synthetic slow fixtures are part of the regression suite:
+Deterministic transient direct/wrapper fixtures, a persistent slow fixture,
+and a confirmation execution-error fixture are part of the regression suite:
 
 ```bash
 bash tests/test_hook_perf_contract.sh
@@ -90,6 +112,6 @@ CI runs all three layers:
 
 - `bash scripts/ci/validate-hook-perf.sh`
 - `bash tests/test_hook_perf_contract.sh`
-- `bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression`
+- `bash tests/bench_hook_latency.sh --runs=3 --confirmation-runs=3 --fail-on-regression`
 
 If any layer fails, the PR must either make the hook faster or add a precise `PERF-OK` explanation for a bounded case.

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -8,6 +8,7 @@
 #   bash tests/bench_hook_latency.sh              # normal run
 #   bash tests/bench_hook_latency.sh --json       # JSON output for CI
 #   bash tests/bench_hook_latency.sh --fail-on-regression  # exit 1 if a fixture exceeds its budget
+#   bash tests/bench_hook_latency.sh --confirmation-runs=3 # samples used to confirm an initial breach
 #   bash tests/bench_hook_latency.sh --bench-action-output=/tmp/bench-output.json
 #   bash tests/bench_hook_latency.sh --no-bench-action-output
 #
@@ -25,7 +26,10 @@ FAIL_ON_REGRESSION=false
 GLOBAL_SLA_MS=""
 DEFAULT_BUDGET_MS=300
 RUNS=5
+CONFIRMATION_RUNS=""
 INCLUDE_SLOW_FIXTURE=false
+INCLUDE_TRANSIENT_FIXTURES=false
+INCLUDE_CONFIRMATION_ERROR_FIXTURE=false
 SPAWN_BASELINE_MAX_MS="${VIBEGUARD_BENCH_SPAWN_MAX_MS:-10}"
 SPAWN_BASELINE_MS=""
 ENVIRONMENT_DISTORTED=false
@@ -39,10 +43,25 @@ while [[ $# -gt 0 ]]; do
     --fail-on-regression) FAIL_ON_REGRESSION=true; shift ;;
     --sla=*) GLOBAL_SLA_MS="${1#--sla=}"; shift ;;
     --runs=*) RUNS="${1#--runs=}"; shift ;;
+    --confirmation-runs=*) CONFIRMATION_RUNS="${1#--confirmation-runs=}"; shift ;;
     --include-slow-fixture) INCLUDE_SLOW_FIXTURE=true; shift ;;
+    --include-transient-fixtures) INCLUDE_TRANSIENT_FIXTURES=true; shift ;;
+    --include-confirmation-error-fixture) INCLUDE_CONFIRMATION_ERROR_FIXTURE=true; shift ;;
     *) shift ;;
   esac
 done
+
+if [[ ! "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  printf '%s\n' "ERROR: --runs must be a positive integer" >&2
+  exit 2
+fi
+if [[ -z "$CONFIRMATION_RUNS" ]]; then
+  CONFIRMATION_RUNS="$RUNS"
+fi
+if [[ ! "$CONFIRMATION_RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  printf '%s\n' "ERROR: --confirmation-runs must be a positive integer" >&2
+  exit 2
+fi
 
 # --- High-resolution timer (ms) ---
 _now_ms() {
@@ -194,6 +213,13 @@ fi
 # --- Benchmark runner ---
 RESULTS=()
 FAILURES=0
+EXECUTION_ERRORS=0
+SAMPLE_LATENCIES=()
+SAMPLE_ERROR=""
+METRIC_P50=0
+METRIC_P95=0
+METRIC_P99=0
+METRIC_MAX=0
 
 budget_for() {
   local name="$1"
@@ -212,148 +238,211 @@ budget_for() {
     codex-wrapper\ pre-bash-guard|codex-wrapper\ post-edit-guard\ \(100\)) printf '%s\n' 900 ;;
     post-build-check\ \(fake\ cargo\)) printf '%s\n' 900 ;;
     synthetic-slow-hook) printf '%s\n' 1 ;;
+    synthetic-transient-hook|codex-wrapper\ synthetic-transient-hook|synthetic-confirmation-error-hook) printf '%s\n' 500 ;;
     *) printf '%s\n' "$DEFAULT_BUDGET_MS" ;;
   esac
 }
 
-bench_hook() {
-  local name="$1"
-  local hook_script="$2"
-  local input_file="$3"
-  local events_file="${4:-}"
-  local budget_ms="${5:-$(budget_for "$name")}"
-  local hotspot="${6:-${name}}"
-  local latencies=()
-  local -a extra_env=()
+run_direct_once() {
+  local hook_script="$1" input_file="$2" events_file="$3"
+  shift 3
+  local bench_log_file="${events_file:-$TMPDIR_BENCH/events-bench.jsonl}"
+  local -a run_env=(
+    "VIBEGUARD_LOG_DIR=$TMPDIR_BENCH"
+    "VIBEGUARD_LOG_FILE=$bench_log_file"
+    "VIBEGUARD_SESSION_ID=bench"
+    "VIBEGUARD_CLI=bench"
+    "VIBEGUARD_PROJECT_HASH=bench000"
+    "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
+  )
+  if [[ $# -gt 0 ]]; then
+    run_env+=("$@")
+  fi
+  env "${run_env[@]}" bash "$hook_script" < "$input_file"
+}
 
+run_wrapper_once() {
+  local wrapper_path="$1" hook_name="$2" input_file="$3" events_file="$4"
+  shift 4
+  local bench_log_file="${events_file:-$TMPDIR_BENCH/events-bench.jsonl}"
+  local -a run_env=(
+    "HOME=$CODEX_BENCH_HOME"
+    "VIBEGUARD_LOG_DIR=$TMPDIR_BENCH"
+    "VIBEGUARD_LOG_FILE=$bench_log_file"
+    "VIBEGUARD_SESSION_ID=bench"
+    "VIBEGUARD_PROJECT_HASH=bench000"
+    "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
+    "VIBEGUARD_CODEX_DIAG_FILE=$TMPDIR_BENCH/codex-wrapper.jsonl"
+    "VIBEGUARD_POLICY_DIAG_FILE=$TMPDIR_BENCH/policy.jsonl"
+    "VIBEGUARD_RUNTIME="
+    "VIBEGUARD_POLICY_RUNTIME="
+  )
+  if [[ $# -gt 0 ]]; then
+    run_env+=("$@")
+  fi
+  env "${run_env[@]}" bash "$wrapper_path" "$hook_name" < "$input_file"
+}
+
+sample_batch() {
+  local sample_runs="$1" runner="$2"
+  shift 2
+  local run_number start end elapsed run_status error_file error_text
+  SAMPLE_LATENCIES=()
+  SAMPLE_ERROR=""
+
+  for run_number in $(seq 1 "$sample_runs"); do
+    error_file="$TMPDIR_BENCH/sample-error-${BASHPID:-$$}.log"
+    start=$(_now_ms)
+    run_status=0
+    "$runner" "$@" > /dev/null 2>"$error_file" || run_status=$?
+    end=$(_now_ms)
+    if [[ "$run_status" -ne 0 ]]; then
+      error_text="$(<"$error_file")"
+      rm -f "$error_file"
+      SAMPLE_ERROR="sample ${run_number}/${sample_runs} exited ${run_status}${error_text:+: ${error_text}}"
+      return 1
+    fi
+    rm -f "$error_file"
+    elapsed=$((end - start))
+    SAMPLE_LATENCIES+=("$elapsed")
+  done
+}
+
+calculate_metrics() {
+  local -a latencies=("$@")
+  local sorted count p50_idx p95_idx p99_idx
+  count=${#latencies[@]}
+  [[ "$count" -gt 0 ]] || return 1
+  sorted=$(printf '%s\n' "${latencies[@]}" | sort -n)
+  p50_idx=$((count * 50 / 100))
+  p95_idx=$((count * 95 / 100))
+  p99_idx=$((count * 99 / 100))
+  [[ $p50_idx -ge $count ]] && p50_idx=$((count - 1))
+  [[ $p95_idx -ge $count ]] && p95_idx=$((count - 1))
+  [[ $p99_idx -ge $count ]] && p99_idx=$((count - 1))
+  METRIC_P50=$(sed -n "$((p50_idx + 1))p" <<< "$sorted")
+  METRIC_P95=$(sed -n "$((p95_idx + 1))p" <<< "$sorted")
+  METRIC_P99=$(sed -n "$((p99_idx + 1))p" <<< "$sorted")
+  METRIC_MAX=$(tail -1 <<< "$sorted")
+  [[ "$METRIC_P50" =~ ^[0-9]+$ && "$METRIC_P95" =~ ^[0-9]+$ \
+    && "$METRIC_P99" =~ ^[0-9]+$ && "$METRIC_MAX" =~ ^[0-9]+$ ]]
+}
+
+metrics_json() {
+  local p50="$1" p95="$2" p99="$3" max_lat="$4" runs="$5"
+  printf '{"p50":%d,"p95":%d,"p99":%d,"max":%d,"runs":%d}' \
+    "$p50" "$p95" "$p99" "$max_lat" "$runs"
+}
+
+print_metrics_row() {
+  local name="$1" label="$2" p50="$3" p95="$4" p99="$5" max_lat="$6"
+  local budget_ms="$7" hotspot="$8" status="$9"
+  printf "  %-35s surface=%s  %s P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" \
+    "$name" "$BENCH_SURFACE" "$label" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
+}
+
+benchmark_fixture() {
+  local name="$1" budget_ms="$2" hotspot="$3" runner="$4"
+  shift 4
+  local -a runner_args=("$@")
+  local initial_p50=0 initial_p95=0 initial_p99=0 initial_max=0
+  local confirmation_p50=0 confirmation_p95=0 confirmation_p99=0 confirmation_max=0
+  local initial_json confirmation_json="null" confirmation_runs=0
+  local status="PASS" decision="normal_pass"
+
+  if ! sample_batch "$RUNS" "$runner" "${runner_args[@]}"; then
+    status="ERROR"
+    decision="confirmation_error"
+    EXECUTION_ERRORS=$((EXECUTION_ERRORS + 1))
+    printf '%s\n' "ERROR: initial sampling failed for ${name}: ${SAMPLE_ERROR}" >&2
+  elif ! calculate_metrics "${SAMPLE_LATENCIES[@]}"; then
+    status="ERROR"
+    decision="confirmation_error"
+    EXECUTION_ERRORS=$((EXECUTION_ERRORS + 1))
+    printf '%s\n' "ERROR: initial sampling produced incomplete metrics for ${name}" >&2
+  else
+    initial_p50="$METRIC_P50"
+    initial_p95="$METRIC_P95"
+    initial_p99="$METRIC_P99"
+    initial_max="$METRIC_MAX"
+    if [[ "$initial_p95" -gt "$budget_ms" ]]; then
+      if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
+        status="ENV-DISTORTED"
+        decision="environment_distorted"
+      else
+        print_metrics_row "$name" "initial" "$initial_p50" "$initial_p95" "$initial_p99" "$initial_max" "$budget_ms" "$hotspot" "INITIAL-BREACH"
+        printf '    confirming fixture after initial P95 breach: %s (runs=%s)\n' "$name" "$CONFIRMATION_RUNS"
+        if ! sample_batch "$CONFIRMATION_RUNS" "$runner" "${runner_args[@]}"; then
+          status="ERROR"
+          decision="confirmation_error"
+          EXECUTION_ERRORS=$((EXECUTION_ERRORS + 1))
+          printf '%s\n' "ERROR: confirmation failed for ${name}: ${SAMPLE_ERROR}" >&2
+        elif ! calculate_metrics "${SAMPLE_LATENCIES[@]}"; then
+          status="ERROR"
+          decision="confirmation_error"
+          EXECUTION_ERRORS=$((EXECUTION_ERRORS + 1))
+          printf '%s\n' "ERROR: confirmation failed for ${name}: incomplete metrics" >&2
+        else
+          confirmation_p50="$METRIC_P50"
+          confirmation_p95="$METRIC_P95"
+          confirmation_p99="$METRIC_P99"
+          confirmation_max="$METRIC_MAX"
+          confirmation_runs="$CONFIRMATION_RUNS"
+          confirmation_json=$(metrics_json "$confirmation_p50" "$confirmation_p95" "$confirmation_p99" "$confirmation_max" "$confirmation_runs")
+          if [[ "$confirmation_p95" -gt "$budget_ms" ]]; then
+            status="CONFIRMED-REGRESSION"
+            decision="confirmed_regression"
+            FAILURES=$((FAILURES + 1))
+          else
+            status="PASS-CONFIRMED"
+            decision="cleared_transient"
+          fi
+          print_metrics_row "$name" "confirmation" "$confirmation_p50" "$confirmation_p95" "$confirmation_p99" "$confirmation_max" "$budget_ms" "$hotspot" "$status"
+        fi
+      fi
+    fi
+  fi
+
+  if [[ "$initial_p95" -le "$budget_ms" || "$ENVIRONMENT_DISTORTED" == "true" || "$status" == "ERROR" ]]; then
+    print_metrics_row "$name" "initial" "$initial_p50" "$initial_p95" "$initial_p99" "$initial_max" "$budget_ms" "$hotspot" "$status"
+  fi
+
+  initial_json=$(metrics_json "$initial_p50" "$initial_p95" "$initial_p99" "$initial_max" "$RUNS")
+  RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$initial_p50,\"p95\":$initial_p95,\"p99\":$initial_p99,\"max\":$initial_max,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS,\"decision\":\"$decision\",\"initial\":$initial_json,\"confirmation\":$confirmation_json,\"confirmation_runs\":$confirmation_runs}")
+}
+
+bench_hook() {
+  local name="$1" hook_script="$2" input_file="$3" events_file="${4:-}"
+  local budget_ms="${5:-$(budget_for "$name")}" hotspot="${6:-${name}}"
+  local -a extra_env=()
   if [[ $# -gt 6 ]]; then
     shift 6
     extra_env=("$@")
   fi
-
-  for _run in $(seq 1 "$RUNS"); do
-    # Keep benchmark runs isolated from the caller's ambient project log and
-    # avoid measuring parent-process session discovery instead of hook work.
-    local bench_log_file="${events_file:-$TMPDIR_BENCH/events-bench.jsonl}"
-    local -a hook_env=(
-      "VIBEGUARD_LOG_DIR=$TMPDIR_BENCH"
-      "VIBEGUARD_LOG_FILE=$bench_log_file"
-      "VIBEGUARD_SESSION_ID=bench"
-      "VIBEGUARD_CLI=bench"
-      "VIBEGUARD_PROJECT_HASH=bench000"
-      "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
-    )
-    local -a run_env=("${hook_env[@]}")
-    if [[ ${#extra_env[@]} -gt 0 ]]; then
-      run_env+=("${extra_env[@]}")
-    fi
-
-    local start=$(_now_ms)
-    env "${run_env[@]}" bash "$hook_script" < "$input_file" > /dev/null 2>&1 || true
-    local end=$(_now_ms)
-    local elapsed=$((end - start))
-    latencies+=("$elapsed")
-  done
-
-  # Calculate P50/P95/P99/max
-  local sorted
-  sorted=$(printf '%s\n' "${latencies[@]}" | sort -n)
-  local count=${#latencies[@]}
-  local p50_idx=$(( (count * 50 / 100) ))
-  local p95_idx=$(( (count * 95 / 100) ))
-  local p99_idx=$(( (count * 99 / 100) ))
-  [[ $p50_idx -ge $count ]] && p50_idx=$((count - 1))
-  [[ $p95_idx -ge $count ]] && p95_idx=$((count - 1))
-  [[ $p99_idx -ge $count ]] && p99_idx=$((count - 1))
-
-  local p50=$(echo "$sorted" | sed -n "$((p50_idx + 1))p")
-  local p95=$(echo "$sorted" | sed -n "$((p95_idx + 1))p")
-  local p99=$(echo "$sorted" | sed -n "$((p99_idx + 1))p")
-  local max_lat=$(echo "$sorted" | tail -1)
-
-  local status="PASS"
-  if [[ "$p95" -gt "$budget_ms" ]]; then
-    if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
-      status="ENV-DISTORTED"
-    else
-      status="FAIL"
-      FAILURES=$((FAILURES + 1))
-    fi
-  fi
-
-  printf "  %-35s surface=%s  P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$BENCH_SURFACE" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
-
-  RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
+  benchmark_fixture "$name" "$budget_ms" "$hotspot" run_direct_once \
+    "$hook_script" "$input_file" "$events_file" "${extra_env[@]}"
 }
 
 bench_codex_wrapper() {
-  local name="$1"
-  local hook_name="$2"
-  local input_file="$3"
-  local events_file="${4:-}"
-  local budget_ms="${5:-$(budget_for "$name")}"
-  local hotspot="${6:-~/.vibeguard/run-hook-codex.sh ${hook_name}}"
-  local latencies=()
-
-  for _run in $(seq 1 "$RUNS"); do
-    local bench_log_file="${events_file:-$TMPDIR_BENCH/events-bench.jsonl}"
-    local -a hook_env=(
-      "HOME=$CODEX_BENCH_HOME"
-      "VIBEGUARD_LOG_DIR=$TMPDIR_BENCH"
-      "VIBEGUARD_LOG_FILE=$bench_log_file"
-      "VIBEGUARD_SESSION_ID=bench"
-      "VIBEGUARD_PROJECT_HASH=bench000"
-      "VIBEGUARD_PROJECT_LOG_DIR=$TMPDIR_BENCH"
-      "VIBEGUARD_CODEX_DIAG_FILE=$TMPDIR_BENCH/codex-wrapper.jsonl"
-      "VIBEGUARD_POLICY_DIAG_FILE=$TMPDIR_BENCH/policy.jsonl"
-      "VIBEGUARD_RUNTIME="
-      "VIBEGUARD_POLICY_RUNTIME="
-    )
-
-    local start=$(_now_ms)
-    env "${hook_env[@]}" bash "$CODEX_BENCH_WRAPPER" "$hook_name" < "$input_file" > /dev/null 2>&1 || true
-    local end=$(_now_ms)
-    local elapsed=$((end - start))
-    latencies+=("$elapsed")
-  done
-
-  local sorted
-  sorted=$(printf '%s\n' "${latencies[@]}" | sort -n)
-  local count=${#latencies[@]}
-  local p50_idx=$(( (count * 50 / 100) ))
-  local p95_idx=$(( (count * 95 / 100) ))
-  local p99_idx=$(( (count * 99 / 100) ))
-  [[ $p50_idx -ge $count ]] && p50_idx=$((count - 1))
-  [[ $p95_idx -ge $count ]] && p95_idx=$((count - 1))
-  [[ $p99_idx -ge $count ]] && p99_idx=$((count - 1))
-
-  local p50=$(echo "$sorted" | sed -n "$((p50_idx + 1))p")
-  local p95=$(echo "$sorted" | sed -n "$((p95_idx + 1))p")
-  local p99=$(echo "$sorted" | sed -n "$((p99_idx + 1))p")
-  local max_lat=$(echo "$sorted" | tail -1)
-
-  local status="PASS"
-  if [[ "$p95" -gt "$budget_ms" ]]; then
-    if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
-      status="ENV-DISTORTED"
-    else
-      status="FAIL"
-      FAILURES=$((FAILURES + 1))
-    fi
+  local name="$1" hook_name="$2" input_file="$3" events_file="${4:-}"
+  local budget_ms="${5:-$(budget_for "$name")}" hotspot="${6:-~/.vibeguard/run-hook-codex.sh ${hook_name}}"
+  local wrapper_path="${7:-$CODEX_BENCH_WRAPPER}"
+  local -a extra_env=()
+  if [[ $# -gt 7 ]]; then
+    shift 7
+    extra_env=("$@")
   fi
-
-  printf "  %-35s surface=%s  P50=%4dms  P95=%4dms  P99=%4dms  max=%4dms  budget=%4dms  hotspot=%s  [%s]\n" "$name" "$BENCH_SURFACE" "$p50" "$p95" "$p99" "$max_lat" "$budget_ms" "$hotspot" "$status"
-
-  RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max_lat,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS}")
+  benchmark_fixture "$name" "$budget_ms" "$hotspot" run_wrapper_once \
+    "$wrapper_path" "$hook_name" "$input_file" "$events_file" "${extra_env[@]}"
 }
 
 echo "======================================"
 echo "VibeGuard Hook Latency Benchmark"
 echo "Surface: ${BENCH_SURFACE} (end-to-end hook process latency)"
 if [[ -n "$GLOBAL_SLA_MS" ]]; then
-  echo "Budget mode: global <${GLOBAL_SLA_MS}ms (P95)  Runs: ${RUNS}  Tail: P99/max reported"
+  echo "Budget mode: global <${GLOBAL_SLA_MS}ms (P95)  Runs: ${RUNS}  Confirmation runs: ${CONFIRMATION_RUNS}  Tail: P99/max reported"
 else
-  echo "Budget mode: per-hook P95 budgets  Runs: ${RUNS}  Tail: P99/max reported"
+  echo "Budget mode: per-hook P95 budgets  Runs: ${RUNS}  Confirmation runs: ${CONFIRMATION_RUNS}  Tail: P99/max reported"
 fi
 echo "Spawn baseline: /usr/bin/true P95=${SPAWN_BASELINE_MS}ms  threshold=${SPAWN_BASELINE_MAX_MS}ms"
 if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
@@ -396,6 +485,49 @@ bench_hook "stop-guard (5000)" "$HOOKS_DIR/stop-guard.sh" "$TMPDIR_BENCH/stop-in
 bench_hook "learn-evaluator (5000)" "$HOOKS_DIR/learn-evaluator.sh" "$TMPDIR_BENCH/stop-input.json" "$TMPDIR_BENCH/events-5000.jsonl"
 echo ""
 
+if [[ "$INCLUDE_TRANSIENT_FIXTURES" == "true" ]]; then
+  cat > "$TMPDIR_BENCH/synthetic-transient-hook.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file="${VIBEGUARD_SYNTHETIC_STATE:?}"
+initial_runs="${VIBEGUARD_SYNTHETIC_INITIAL_RUNS:?}"
+count=0
+[[ ! -f "$state_file" ]] || count=$(<"$state_file")
+count=$((count + 1))
+printf '%s\n' "$count" > "$state_file"
+if [[ "$count" -le "$initial_runs" ]]; then
+  sleep 1
+fi
+EOF
+  chmod +x "$TMPDIR_BENCH/synthetic-transient-hook.sh"
+
+  cat > "$TMPDIR_BENCH/synthetic-transient-wrapper.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file="${VIBEGUARD_SYNTHETIC_STATE:?}"
+initial_runs="${VIBEGUARD_SYNTHETIC_INITIAL_RUNS:?}"
+count=0
+[[ ! -f "$state_file" ]] || count=$(<"$state_file")
+count=$((count + 1))
+printf '%s\n' "$count" > "$state_file"
+if [[ "$count" -le "$initial_runs" ]]; then
+  sleep 1
+fi
+exec bash "${VIBEGUARD_SYNTHETIC_REAL_WRAPPER:?}" "$@"
+EOF
+  chmod +x "$TMPDIR_BENCH/synthetic-transient-wrapper.sh"
+
+  echo "[Synthetic transient confirmation fixtures]"
+  bench_hook "synthetic-transient-hook" "$TMPDIR_BENCH/synthetic-transient-hook.sh" "$TMPDIR_BENCH/stop-input.json" "" 500 "synthetic transient direct fixture" \
+    "VIBEGUARD_SYNTHETIC_STATE=$TMPDIR_BENCH/direct-transient.count" \
+    "VIBEGUARD_SYNTHETIC_INITIAL_RUNS=$RUNS"
+  bench_codex_wrapper "codex-wrapper synthetic-transient-hook" "vibeguard-pre-bash-guard.sh" "$TMPDIR_BENCH/codex-pre-bash-input.json" "" 500 "synthetic transient Codex wrapper fixture" "$TMPDIR_BENCH/synthetic-transient-wrapper.sh" \
+    "VIBEGUARD_SYNTHETIC_STATE=$TMPDIR_BENCH/wrapper-transient.count" \
+    "VIBEGUARD_SYNTHETIC_INITIAL_RUNS=$RUNS" \
+    "VIBEGUARD_SYNTHETIC_REAL_WRAPPER=$CODEX_BENCH_WRAPPER"
+  echo ""
+fi
+
 if [[ "$INCLUDE_SLOW_FIXTURE" == "true" ]]; then
   cat > "$TMPDIR_BENCH/synthetic-slow-hook.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -408,9 +540,34 @@ EOF
   echo ""
 fi
 
+if [[ "$INCLUDE_CONFIRMATION_ERROR_FIXTURE" == "true" ]]; then
+  cat > "$TMPDIR_BENCH/synthetic-confirmation-error-hook.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file="${VIBEGUARD_SYNTHETIC_STATE:?}"
+initial_runs="${VIBEGUARD_SYNTHETIC_INITIAL_RUNS:?}"
+count=0
+[[ ! -f "$state_file" ]] || count=$(<"$state_file")
+count=$((count + 1))
+printf '%s\n' "$count" > "$state_file"
+sleep 1
+if [[ "$count" -eq "$initial_runs" ]]; then
+  rm -f "$0"
+fi
+EOF
+  chmod +x "$TMPDIR_BENCH/synthetic-confirmation-error-hook.sh"
+  echo "[Synthetic confirmation error fixture]"
+  bench_hook "synthetic-confirmation-error-hook" "$TMPDIR_BENCH/synthetic-confirmation-error-hook.sh" "$TMPDIR_BENCH/stop-input.json" "" 500 "synthetic confirmation execution error" \
+    "VIBEGUARD_SYNTHETIC_STATE=$TMPDIR_BENCH/confirmation-error.count" \
+    "VIBEGUARD_SYNTHETIC_INITIAL_RUNS=$RUNS"
+  echo ""
+fi
+
 # --- Summary ---
 echo "======================================"
-if [[ $FAILURES -gt 0 ]]; then
+if [[ $EXECUTION_ERRORS -gt 0 ]]; then
+  printf "\033[31mERROR: %d hook fixture(s) could not complete sampling\033[0m\n" "$EXECUTION_ERRORS"
+elif [[ $FAILURES -gt 0 ]]; then
   printf "\033[31mFAILED: %d hook fixture(s) exceeded latency budget\033[0m\n" "$FAILURES"
 elif [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
   printf "\033[33mENVIRONMENT DISTORTED: spawn baseline too high; SLA verdict suppressed\033[0m\n"
@@ -421,12 +578,13 @@ fi
 # --- JSON output (internal format) ---
 if [[ -n "$RESULTS_FILE" ]]; then
   mkdir -p "$(dirname "$RESULTS_FILE")"
-  printf '{"date":"%s","surface":"%s","budget_mode":"%s","global_sla_ms":"%s","runs":%d,"spawn_baseline_ms":%d,"environment_distorted":%s,"results":[%s]}\n' \
+  printf '{"date":"%s","surface":"%s","budget_mode":"%s","global_sla_ms":"%s","runs":%d,"confirmation_runs":%d,"spawn_baseline_ms":%d,"environment_distorted":%s,"results":[%s]}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "$BENCH_SURFACE" \
     "$([[ -n "$GLOBAL_SLA_MS" ]] && printf global || printf per-hook)" \
     "${GLOBAL_SLA_MS}" \
     "$RUNS" \
+    "$CONFIRMATION_RUNS" \
     "$SPAWN_BASELINE_MS" \
     "$ENVIRONMENT_DISTORTED" \
     "$(IFS=,; echo "${RESULTS[*]}")" \
@@ -447,12 +605,23 @@ bench_action_name() {
     "post-build-check (fake cargo)") printf "post-build fake" ;;
     "codex-wrapper pre-bash-guard") printf "codex pre-bash" ;;
     "codex-wrapper post-edit-guard (100)") printf "codex post-edit 100" ;;
+    "codex-wrapper synthetic-transient-hook") printf "codex synthetic-transient" ;;
     "post-edit-guard (5000)") printf "post-edit 5000" ;;
     "post-write-guard (5000)") printf "post-write 5000" ;;
     "stop-guard (5000)") printf "stop 5000" ;;
     "learn-evaluator (5000)") printf "learn 5000" ;;
     *) printf "%s" "$1" ;;
   esac
+}
+
+bench_action_row() {
+  local name="$1" value="$2"
+  if [[ "$_first" == "true" ]]; then
+    _first=false
+  else
+    echo ","
+  fi
+  printf '  {"name": "e2e %s", "unit": "ms", "value": %s}' "$name" "$value"
 }
 
 if [[ -n "$BENCH_ACTION_FILE" ]]; then
@@ -466,12 +635,28 @@ if [[ -n "$BENCH_ACTION_FILE" ]]; then
       _p50=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p50'])" 2>/dev/null || echo "0")
       _p95=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p95'])" 2>/dev/null || echo "0")
       _p99=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p99'])" 2>/dev/null || echo "0")
-      if [[ "$_first" == "true" ]]; then _first=false; else echo ","; fi
-      printf '  {"name": "e2e %s P50", "unit": "ms", "value": %s}' "$_display_name" "$_p50"
-      echo ","
-      printf '  {"name": "e2e %s P95", "unit": "ms", "value": %s}' "$_display_name" "$_p95"
-      echo ","
-      printf '  {"name": "e2e %s P99", "unit": "ms", "value": %s}' "$_display_name" "$_p99"
+      _budget=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['budget_ms'])" 2>/dev/null || echo "0")
+      _decision=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['decision'])" 2>/dev/null || echo "confirmation_error")
+      _confirmation_p95=$(echo "$r" | python3 -c "import json,sys; data=json.load(sys.stdin); print('' if data['confirmation'] is None else data['confirmation']['p95'])" 2>/dev/null || echo "")
+      bench_action_row "$_display_name P50" "$_p50"
+      bench_action_row "$_display_name P95" "$_p95"
+      bench_action_row "$_display_name P99" "$_p99"
+      case "$_decision" in
+        cleared_transient)
+          bench_action_row "$_display_name confirmation P95" "$_confirmation_p95"
+          bench_action_row "$_display_name budget" "$_budget"
+          bench_action_row "$_display_name decision cleared" "$_confirmation_p95"
+          ;;
+        confirmed_regression)
+          bench_action_row "$_display_name confirmation P95" "$_confirmation_p95"
+          bench_action_row "$_display_name budget" "$_budget"
+          bench_action_row "$_display_name decision confirmed-regression" "$_confirmation_p95"
+          ;;
+        confirmation_error)
+          bench_action_row "$_display_name budget" "$_budget"
+          bench_action_row "$_display_name decision confirmation-error" "$_p95"
+          ;;
+      esac
     done
     echo ""
     echo "]"
@@ -483,6 +668,9 @@ fi
 
 echo "======================================"
 
+if [[ $EXECUTION_ERRORS -gt 0 ]]; then
+  exit 1
+fi
 if [[ "$FAIL_ON_REGRESSION" == "true" ]] && [[ $FAILURES -gt 0 ]]; then
   exit 1
 fi

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -27,9 +27,11 @@ GLOBAL_SLA_MS=""
 DEFAULT_BUDGET_MS=300
 RUNS=5
 CONFIRMATION_RUNS=""
+CONFIRMATION_RUNS_SET=false
 INCLUDE_SLOW_FIXTURE=false
 INCLUDE_TRANSIENT_FIXTURES=false
 INCLUDE_CONFIRMATION_ERROR_FIXTURE=false
+INCLUDE_INITIAL_ERROR_FIXTURE=false
 SPAWN_BASELINE_MAX_MS="${VIBEGUARD_BENCH_SPAWN_MAX_MS:-10}"
 SPAWN_BASELINE_MS=""
 ENVIRONMENT_DISTORTED=false
@@ -43,10 +45,11 @@ while [[ $# -gt 0 ]]; do
     --fail-on-regression) FAIL_ON_REGRESSION=true; shift ;;
     --sla=*) GLOBAL_SLA_MS="${1#--sla=}"; shift ;;
     --runs=*) RUNS="${1#--runs=}"; shift ;;
-    --confirmation-runs=*) CONFIRMATION_RUNS="${1#--confirmation-runs=}"; shift ;;
+    --confirmation-runs=*) CONFIRMATION_RUNS="${1#--confirmation-runs=}"; CONFIRMATION_RUNS_SET=true; shift ;;
     --include-slow-fixture) INCLUDE_SLOW_FIXTURE=true; shift ;;
     --include-transient-fixtures) INCLUDE_TRANSIENT_FIXTURES=true; shift ;;
     --include-confirmation-error-fixture) INCLUDE_CONFIRMATION_ERROR_FIXTURE=true; shift ;;
+    --include-initial-error-fixture) INCLUDE_INITIAL_ERROR_FIXTURE=true; shift ;;
     *) shift ;;
   esac
 done
@@ -55,7 +58,7 @@ if [[ ! "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
   printf '%s\n' "ERROR: --runs must be a positive integer" >&2
   exit 2
 fi
-if [[ -z "$CONFIRMATION_RUNS" ]]; then
+if [[ "$CONFIRMATION_RUNS_SET" == "false" ]]; then
   CONFIRMATION_RUNS="$RUNS"
 fi
 if [[ ! "$CONFIRMATION_RUNS" =~ ^[1-9][0-9]*$ ]]; then
@@ -238,7 +241,7 @@ budget_for() {
     codex-wrapper\ pre-bash-guard|codex-wrapper\ post-edit-guard\ \(100\)) printf '%s\n' 900 ;;
     post-build-check\ \(fake\ cargo\)) printf '%s\n' 900 ;;
     synthetic-slow-hook) printf '%s\n' 1 ;;
-    synthetic-transient-hook|codex-wrapper\ synthetic-transient-hook|synthetic-confirmation-error-hook) printf '%s\n' 500 ;;
+    synthetic-transient-hook|codex-wrapper\ synthetic-transient-hook|synthetic-confirmation-error-hook|synthetic-initial-error-hook) printf '%s\n' 500 ;;
     *) printf '%s\n' "$DEFAULT_BUDGET_MS" ;;
   esac
 }
@@ -347,8 +350,9 @@ benchmark_fixture() {
   local -a runner_args=("$@")
   local initial_p50=0 initial_p95=0 initial_p99=0 initial_max=0
   local confirmation_p50=0 confirmation_p95=0 confirmation_p99=0 confirmation_max=0
-  local initial_json confirmation_json="null" confirmation_runs=0
-  local status="PASS" decision="normal_pass"
+  local initial_json="null" confirmation_json="null" confirmation_runs=0
+  local initial_complete=false
+  local status="PASS" legacy_status="PASS" decision="normal_pass"
 
   if ! sample_batch "$RUNS" "$runner" "${runner_args[@]}"; then
     status="ERROR"
@@ -365,6 +369,7 @@ benchmark_fixture() {
     initial_p95="$METRIC_P95"
     initial_p99="$METRIC_P99"
     initial_max="$METRIC_MAX"
+    initial_complete=true
     if [[ "$initial_p95" -gt "$budget_ms" ]]; then
       if [[ "$ENVIRONMENT_DISTORTED" == "true" ]]; then
         status="ENV-DISTORTED"
@@ -403,12 +408,28 @@ benchmark_fixture() {
     fi
   fi
 
-  if [[ "$initial_p95" -le "$budget_ms" || "$ENVIRONMENT_DISTORTED" == "true" || "$status" == "ERROR" ]]; then
+  if [[ "$initial_complete" == "false" ]]; then
+    printf "  %-35s surface=%s  initial metrics=unavailable  budget=%4dms  hotspot=%s  [ERROR]\n" \
+      "$name" "$BENCH_SURFACE" "$budget_ms" "$hotspot"
+  elif [[ "$initial_p95" -le "$budget_ms" || "$ENVIRONMENT_DISTORTED" == "true" || "$status" == "ERROR" ]]; then
     print_metrics_row "$name" "initial" "$initial_p50" "$initial_p95" "$initial_p99" "$initial_max" "$budget_ms" "$hotspot" "$status"
   fi
 
-  initial_json=$(metrics_json "$initial_p50" "$initial_p95" "$initial_p99" "$initial_max" "$RUNS")
-  RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$initial_p50,\"p95\":$initial_p95,\"p99\":$initial_p99,\"max\":$initial_max,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$status\",\"runs\":$RUNS,\"decision\":\"$decision\",\"initial\":$initial_json,\"confirmation\":$confirmation_json,\"confirmation_runs\":$confirmation_runs}")
+  if [[ "$initial_complete" == "true" ]]; then
+    initial_json=$(metrics_json "$initial_p50" "$initial_p95" "$initial_p99" "$initial_max" "$RUNS")
+  fi
+  case "$decision" in
+    environment_distorted) legacy_status="ENV-DISTORTED" ;;
+    cleared_transient|confirmed_regression) legacy_status="FAIL" ;;
+    confirmation_error)
+      [[ "$initial_p95" -gt "$budget_ms" ]] && legacy_status="FAIL" || legacy_status="ERROR"
+      ;;
+  esac
+  if [[ "$initial_complete" == "true" ]]; then
+    RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":$initial_p50,\"p95\":$initial_p95,\"p99\":$initial_p99,\"max\":$initial_max,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"$legacy_status\",\"runs\":$RUNS,\"decision\":\"$decision\",\"initial\":$initial_json,\"confirmation\":$confirmation_json,\"confirmation_runs\":$confirmation_runs}")
+  else
+    RESULTS+=("{\"name\":\"$name\",\"surface\":\"$BENCH_SURFACE\",\"p50\":null,\"p95\":null,\"p99\":null,\"max\":null,\"budget_ms\":$budget_ms,\"hotspot\":\"$hotspot\",\"status\":\"ERROR\",\"runs\":0,\"decision\":\"confirmation_error\",\"initial\":null,\"confirmation\":null,\"confirmation_runs\":0}")
+  fi
 }
 
 bench_hook() {
@@ -563,6 +584,12 @@ EOF
   echo ""
 fi
 
+if [[ "$INCLUDE_INITIAL_ERROR_FIXTURE" == "true" ]]; then
+  echo "[Synthetic initial sampling error fixture]"
+  bench_hook "synthetic-initial-error-hook" "$TMPDIR_BENCH/missing-initial-hook.sh" "$TMPDIR_BENCH/stop-input.json" "" 500 "synthetic initial execution error"
+  echo ""
+fi
+
 # --- Summary ---
 echo "======================================"
 if [[ $EXECUTION_ERRORS -gt 0 ]]; then
@@ -632,12 +659,15 @@ if [[ -n "$BENCH_ACTION_FILE" ]]; then
     for r in "${RESULTS[@]}"; do
       _name=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])" 2>/dev/null || echo "unknown")
       _display_name=$(bench_action_name "$_name")
-      _p50=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p50'])" 2>/dev/null || echo "0")
-      _p95=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p95'])" 2>/dev/null || echo "0")
-      _p99=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['p99'])" 2>/dev/null || echo "0")
+      _p50=$(echo "$r" | python3 -c "import json,sys; value=json.load(sys.stdin)['p50']; print('' if value is None else value)" 2>/dev/null || echo "")
+      _p95=$(echo "$r" | python3 -c "import json,sys; value=json.load(sys.stdin)['p95']; print('' if value is None else value)" 2>/dev/null || echo "")
+      _p99=$(echo "$r" | python3 -c "import json,sys; value=json.load(sys.stdin)['p99']; print('' if value is None else value)" 2>/dev/null || echo "")
       _budget=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['budget_ms'])" 2>/dev/null || echo "0")
       _decision=$(echo "$r" | python3 -c "import json,sys; print(json.load(sys.stdin)['decision'])" 2>/dev/null || echo "confirmation_error")
       _confirmation_p95=$(echo "$r" | python3 -c "import json,sys; data=json.load(sys.stdin); print('' if data['confirmation'] is None else data['confirmation']['p95'])" 2>/dev/null || echo "")
+      if [[ -z "$_p95" ]]; then
+        continue
+      fi
       bench_action_row "$_display_name P50" "$_p50"
       bench_action_row "$_display_name P95" "$_p95"
       bench_action_row "$_display_name P99" "$_p99"

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -24,6 +24,8 @@ TRANSIENT_JSON_TEMP="${TMP_DIR}/transient-bench-latency.json"
 TRANSIENT_ACTION_TEMP="${TMP_DIR}/transient-bench-output.json"
 CONFIRMATION_ERROR_JSON_TEMP="${TMP_DIR}/confirmation-error-bench-latency.json"
 CONFIRMATION_ERROR_ACTION_TEMP="${TMP_DIR}/confirmation-error-bench-output.json"
+INITIAL_ERROR_JSON_TEMP="${TMP_DIR}/initial-error-bench-latency.json"
+INITIAL_ERROR_ACTION_TEMP="${TMP_DIR}/initial-error-bench-output.json"
 ROOT_BENCH_ACTION_FILE="${REPO_DIR}/bench-output.json"
 BENCH_JSON_EXISTED=false
 BENCH_JSON_BACKUP="${TMP_DIR}/bench-latency-existing.json"
@@ -324,6 +326,7 @@ assert_cmd "persistent slow JSON preserves both batches" python3 -c 'import json
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 row = next(item for item in data["results"] if item["name"] == "synthetic-slow-hook")
 assert row["decision"] == "confirmed_regression"
+assert row["status"] == "FAIL"
 assert row["confirmation"] is not None
 assert row["p95"] == row["initial"]["p95"]
 assert row["confirmation"]["p95"] > row["budget_ms"]
@@ -341,13 +344,14 @@ rows = [item for item in data["results"] if item["name"] in names]
 assert {row["name"] for row in rows} == names
 for row in rows:
     assert row["decision"] == "cleared_transient"
-    assert row["status"] == "PASS-CONFIRMED"
+    assert row["status"] == "FAIL"
     assert row["confirmation_runs"] == 1
     assert row["confirmation"] is not None
     assert row["p95"] == row["initial"]["p95"]
     assert row["initial"]["p95"] > row["budget_ms"]
     assert row["confirmation"]["p95"] <= row["budget_ms"]
 ' "${TRANSIENT_JSON_TEMP}"
+assert_file_contains "${TMP_DIR}/transient.out" "PASS-CONFIRMED" "transient console reports the final cleared state"
 assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e synthetic-transient-hook decision cleared" "direct transient action output records cleared decision"
 assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e codex synthetic-transient decision cleared" "wrapper transient action output records cleared decision"
 assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e synthetic-transient-hook confirmation P95" "direct transient action output records confirmation P95"
@@ -361,6 +365,7 @@ data = json.load(open(sys.argv[1], encoding="utf-8"))
 assert data["results"]
 for row in data["results"]:
     assert row["decision"] == "normal_pass"
+    assert row["status"] == "PASS"
     assert row["confirmation"] is None
     assert row["confirmation_runs"] == 0
 ' "${BENCH_JSON_TEMP}"
@@ -395,6 +400,7 @@ assert_cmd "confirmation error JSON retains initial evidence" python3 -c 'import
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 row = next(item for item in data["results"] if item["name"] == "synthetic-confirmation-error-hook")
 assert row["decision"] == "confirmation_error"
+assert row["status"] == "FAIL"
 assert row["confirmation"] is None
 assert row["initial"]["p95"] == row["p95"]
 ' "${CONFIRMATION_ERROR_JSON_TEMP}"
@@ -405,6 +411,20 @@ assert_file_not_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "synthetic-confirma
 assert_file_not_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "decision cleared" "confirmation error action output never records cleared"
 assert_file_not_contains "${TMP_DIR}/confirmation-error.out" "PASS-CONFIRMED" "confirmation error console never reports confirmed pass"
 assert_fail_contains "zero confirmation runs fails validation" "--confirmation-runs must be a positive integer" "${TMP_DIR}/invalid-confirmation-runs.out" bash "${BENCH}" --confirmation-runs=0 --no-bench-action-output
+assert_fail_contains "empty confirmation runs fails validation" "--confirmation-runs must be a positive integer" "${TMP_DIR}/empty-confirmation-runs.out" bash "${BENCH}" --confirmation-runs= --no-bench-action-output
+
+assert_fail_contains "initial fixture execution error fails visibly" "ERROR: initial sampling failed" "${TMP_DIR}/initial-error.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --confirmation-runs=1 --include-initial-error-fixture --json-output="${INITIAL_ERROR_JSON_TEMP}" --bench-action-output="${INITIAL_ERROR_ACTION_TEMP}" --sla=100000
+assert_file_contains "${TMP_DIR}/initial-error.out" "initial metrics=unavailable" "initial execution error console reports unavailable metrics"
+assert_cmd "initial execution error JSON contains no fabricated samples" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+row = next(item for item in data["results"] if item["name"] == "synthetic-initial-error-hook")
+assert row["status"] == "ERROR"
+assert row["decision"] == "confirmation_error"
+assert row["runs"] == 0
+assert row["p50"] is None and row["p95"] is None and row["p99"] is None and row["max"] is None
+assert row["initial"] is None and row["confirmation"] is None
+' "${INITIAL_ERROR_JSON_TEMP}"
+assert_file_not_contains "${INITIAL_ERROR_ACTION_TEMP}" "synthetic-initial-error-hook" "initial execution error action output omits unavailable numeric metrics"
 assert_file_contains "${REPO_DIR}/.github/workflows/ci.yml" '--confirmation-runs=3' "CI pins confirmation sample count explicitly"
 
 header "benchmark score gate"

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -18,6 +18,12 @@ TMP_DIR="$(mktemp -d)"
 BENCH_JSON_FILE="${REPO_DIR}/.vibeguard/benchmarks/bench-latency-$(date +%Y%m%d).json"
 BENCH_JSON_TEMP="${TMP_DIR}/bench-latency.json"
 BENCH_ACTION_TEMP="${TMP_DIR}/bench-output.json"
+SLOW_JSON_TEMP="${TMP_DIR}/slow-bench-latency.json"
+SLOW_ACTION_TEMP="${TMP_DIR}/slow-bench-output.json"
+TRANSIENT_JSON_TEMP="${TMP_DIR}/transient-bench-latency.json"
+TRANSIENT_ACTION_TEMP="${TMP_DIR}/transient-bench-output.json"
+CONFIRMATION_ERROR_JSON_TEMP="${TMP_DIR}/confirmation-error-bench-latency.json"
+CONFIRMATION_ERROR_ACTION_TEMP="${TMP_DIR}/confirmation-error-bench-output.json"
 ROOT_BENCH_ACTION_FILE="${REPO_DIR}/bench-output.json"
 BENCH_JSON_EXISTED=false
 BENCH_JSON_BACKUP="${TMP_DIR}/bench-latency-existing.json"
@@ -89,6 +95,23 @@ assert_file_not_contains() {
     PASS=$((PASS + 1))
   else
     red "$desc (unexpected: $unexpected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_occurrences() {
+  local file="$1"
+  local expected="$2"
+  local count="$3"
+  local desc="$4"
+  local actual
+  TOTAL=$((TOTAL + 1))
+  actual=$(grep -cF -- "$expected" "$file" 2>/dev/null || true)
+  if [[ "$actual" -eq "$count" ]]; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected ${count}, got ${actual}: ${expected})"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -288,7 +311,7 @@ assert_fail_contains "subprocess loop in executable hook fails static validator"
 assert_file_contains "${TMP_DIR}/bad-exec-loop.out" "pre-commit" "executable loop output names the hook"
 
 header "dynamic latency gate"
-assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
+assert_fail_contains "synthetic slow hook fails latency budget" "synthetic-slow-hook" "${TMP_DIR}/slow.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --confirmation-runs=1 --include-slow-fixture --fail-on-regression --json-output="${SLOW_JSON_TEMP}" --bench-action-output="${SLOW_ACTION_TEMP}"
 assert_file_contains "${TMP_DIR}/slow.out" "Surface: hook_e2e_ms" "latency gate declares hook e2e surface"
 assert_file_contains "${TMP_DIR}/slow.out" "surface=hook_e2e_ms" "latency rows include hook e2e surface marker"
 assert_file_contains "${TMP_DIR}/slow.out" "exceeded latency budget" "slow hook output explains budget failure"
@@ -296,9 +319,52 @@ assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "sl
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper pre-bash-guard" "latency gate includes Codex PreToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper post-edit-guard (100)" "latency gate includes Codex PostToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "post-build-check (fake cargo)" "latency gate includes post-build fake command fixture"
-assert_success_contains "JSON latency output is written to override path" "Results: ${BENCH_JSON_TEMP}" "${TMP_DIR}/json.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --json-output="${BENCH_JSON_TEMP}" --bench-action-output="${BENCH_ACTION_TEMP}" --sla=100000
+assert_file_contains "${TMP_DIR}/slow.out" "CONFIRMED-REGRESSION" "persistent slow hook reports confirmed regression"
+assert_cmd "persistent slow JSON preserves both batches" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+row = next(item for item in data["results"] if item["name"] == "synthetic-slow-hook")
+assert row["decision"] == "confirmed_regression"
+assert row["confirmation"] is not None
+assert row["p95"] == row["initial"]["p95"]
+assert row["confirmation"]["p95"] > row["budget_ms"]
+' "${SLOW_JSON_TEMP}"
+assert_file_contains "${SLOW_ACTION_TEMP}" "e2e synthetic-slow-hook decision confirmed-regression" "persistent slow action output records confirmed decision"
+assert_file_contains "${SLOW_ACTION_TEMP}" "e2e synthetic-slow-hook confirmation P95" "persistent slow action output records confirmation P95"
+assert_file_contains "${SLOW_ACTION_TEMP}" "e2e synthetic-slow-hook budget" "persistent slow action output records budget"
+
+assert_success_contains "transient direct and wrapper outliers are cleared" "PASSED: All hooks within latency budget" "${TMP_DIR}/transient.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --confirmation-runs=1 --include-transient-fixtures --fail-on-regression --json-output="${TRANSIENT_JSON_TEMP}" --bench-action-output="${TRANSIENT_ACTION_TEMP}" --sla=100000
+assert_file_occurrences "${TMP_DIR}/transient.out" "confirming fixture after initial P95 breach" 2 "direct and wrapper fixtures each trigger exactly one confirmation batch"
+assert_cmd "transient JSON uses one shared decision schema" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+names = {"synthetic-transient-hook", "codex-wrapper synthetic-transient-hook"}
+rows = [item for item in data["results"] if item["name"] in names]
+assert {row["name"] for row in rows} == names
+for row in rows:
+    assert row["decision"] == "cleared_transient"
+    assert row["status"] == "PASS-CONFIRMED"
+    assert row["confirmation_runs"] == 1
+    assert row["confirmation"] is not None
+    assert row["p95"] == row["initial"]["p95"]
+    assert row["initial"]["p95"] > row["budget_ms"]
+    assert row["confirmation"]["p95"] <= row["budget_ms"]
+' "${TRANSIENT_JSON_TEMP}"
+assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e synthetic-transient-hook decision cleared" "direct transient action output records cleared decision"
+assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e codex synthetic-transient decision cleared" "wrapper transient action output records cleared decision"
+assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e synthetic-transient-hook confirmation P95" "direct transient action output records confirmation P95"
+assert_file_contains "${TRANSIENT_ACTION_TEMP}" "e2e codex synthetic-transient budget" "wrapper transient action output records budget"
+
+assert_success_contains "JSON latency output is written to override path" "Results: ${BENCH_JSON_TEMP}" "${TMP_DIR}/json.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --confirmation-runs=1 --json-output="${BENCH_JSON_TEMP}" --bench-action-output="${BENCH_ACTION_TEMP}" --sla=100000
 assert_file_contains "${BENCH}" '.vibeguard/benchmarks/bench-latency-' "default latency JSON path stays out of data/"
 assert_file_contains "${BENCH_JSON_TEMP}" '"surface":"hook_e2e_ms"' "JSON latency output declares hook e2e surface"
+assert_cmd "normal fixtures do not run confirmation" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data["results"]
+for row in data["results"]:
+    assert row["decision"] == "normal_pass"
+    assert row["confirmation"] is None
+    assert row["confirmation_runs"] == 0
+' "${BENCH_JSON_TEMP}"
+assert_file_not_contains "${BENCH_ACTION_TEMP}" " confirmation P95" "normal action output has no confirmation rows"
 assert_file_contains "${BENCH_ACTION_TEMP}" " P50" "benchmark action output includes P50 samples"
 assert_file_contains "${BENCH_ACTION_TEMP}" " P95" "benchmark action output includes P95 samples"
 assert_file_contains "${BENCH_ACTION_TEMP}" " P99" "benchmark action output includes P99 samples"
@@ -322,6 +388,24 @@ assert_file_contains "${REPO_DIR}/vibeguard-runtime/benches/core_us.rs" 'benchma
 assert_file_contains "${REPO_DIR}/vibeguard-runtime/benches/core_us.rs" 'bash_destructive_restore' "core_us benchmark keeps bash classifier sample"
 assert_file_contains "${REPO_DIR}/vibeguard-runtime/benches/core_us.rs" 'write_clean_rust_fast_path' "core_us benchmark keeps write classifier sample"
 assert_success_contains "distorted spawn baseline suppresses latency failure" "ENVIRONMENT DISTORTED" "${TMP_DIR}/distorted.out" env VIBEGUARD_BENCH_SPAWN_BASELINE_MS=999 VIBEGUARD_BENCH_SPAWN_MAX_MS=10 bash "${BENCH}" --runs=1 --include-slow-fixture --fail-on-regression --no-bench-action-output
+assert_file_not_contains "${TMP_DIR}/distorted.out" "confirming fixture after initial P95 breach" "distorted environment does not fabricate confirmation"
+
+assert_fail_contains "confirmation execution error fails visibly" "ERROR: confirmation failed" "${TMP_DIR}/confirmation-error.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --confirmation-runs=1 --include-confirmation-error-fixture --fail-on-regression --json-output="${CONFIRMATION_ERROR_JSON_TEMP}" --bench-action-output="${CONFIRMATION_ERROR_ACTION_TEMP}" --sla=100000
+assert_cmd "confirmation error JSON retains initial evidence" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+row = next(item for item in data["results"] if item["name"] == "synthetic-confirmation-error-hook")
+assert row["decision"] == "confirmation_error"
+assert row["confirmation"] is None
+assert row["initial"]["p95"] == row["p95"]
+' "${CONFIRMATION_ERROR_JSON_TEMP}"
+assert_file_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "e2e synthetic-confirmation-error-hook decision confirmation-error" "confirmation error action output records error decision"
+assert_file_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "e2e synthetic-confirmation-error-hook P95" "confirmation error action output retains initial P95"
+assert_file_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "e2e synthetic-confirmation-error-hook budget" "confirmation error action output records budget"
+assert_file_not_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "synthetic-confirmation-error-hook confirmation P95" "confirmation error action output does not invent confirmation metrics"
+assert_file_not_contains "${CONFIRMATION_ERROR_ACTION_TEMP}" "decision cleared" "confirmation error action output never records cleared"
+assert_file_not_contains "${TMP_DIR}/confirmation-error.out" "PASS-CONFIRMED" "confirmation error console never reports confirmed pass"
+assert_fail_contains "zero confirmation runs fails validation" "--confirmation-runs must be a positive integer" "${TMP_DIR}/invalid-confirmation-runs.out" bash "${BENCH}" --confirmation-runs=0 --no-bench-action-output
+assert_file_contains "${REPO_DIR}/.github/workflows/ci.yml" '--confirmation-runs=3' "CI pins confirmation sample count explicitly"
 
 header "benchmark score gate"
 BENCHMARK_CSV="${TMP_DIR}/precision-fixture.csv"

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -595,7 +595,7 @@ workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
 required_steps = {
     "Hook performance static analysis": "bash scripts/ci/validate-hook-perf.sh",
     "Hook performance contract regression tests": "bash tests/test_hook_perf_contract.sh",
-    "Hook latency benchmark": "bash tests/bench_hook_latency.sh --runs=3 --fail-on-regression",
+    "Hook latency benchmark": "bash tests/bench_hook_latency.sh --runs=3 --confirmation-runs=3 --fail-on-regression",
 }
 
 for name, command in required_steps.items():


### PR DESCRIPTION
## Summary

- confirm an initial per-fixture P95 breach with an independent batch before failing the hard gate
- share sampling, percentile, decision, and evidence serialization across direct and Codex wrapper adapters
- preserve initial P50/P95/P99 rows while adding confirmation, budget, and final-decision evidence
- fail visibly when initial or confirmation sampling cannot complete and pin CI to 3 initial + 3 confirmation samples

## Why

With three samples, the existing P95 calculation selects the maximum. One scheduler/process stall therefore failed an unrelated PR even when the same head passed on rerun. The gate could not distinguish an isolated outlier from a persistent regression.

## Plan implemented

1. Add deterministic red contracts for direct/wrapper transient outliers, persistent regression, normal, distorted, initial-error, and confirmation-error paths.
2. Replace duplicated direct/wrapper decision logic with one fixture evaluator and adapter-specific runners.
3. Keep legacy initial metrics/status stable and add explicit internal/action/console confirmation evidence.
4. Document the contract and make the CI confirmation sample count explicit.

## Verification

- Red before implementation: hook performance contract 91/104; 13 new assertions failed for the missing behavior.
- Green: `bash tests/test_hook_perf_contract.sh` — 117/117 passed.
- `bash tests/test_workflow_contracts.sh` — 21/21 passed.
- ShellCheck: benchmark clean; harness clean with intentional SC2016 fixture literals excluded.
- Real gate: `bash tests/bench_hook_latency.sh --runs=3 --confirmation-runs=3 --fail-on-regression` — all 12 fixtures within unchanged budgets.
- `bash scripts/ci/validate-hook-perf.sh` — passed.
- `bash scripts/local-contract-check.sh --quick` — passed.
- SpecRail workflow, doc path, doc command path, workflow contract, and `git diff --check` validators — passed.
- First CI run exposed a stale exact-command assertion in `tests/test_workflow_contracts.sh`; the assertion now pins the full 3+3 command and passes locally.
- Current head CI is green after one macOS infrastructure-timeout rerun; the timeout is tracked separately in #614.

## Risk and compatibility

- No latency budget, production hook, or fixture workload changed.
- Healthy fixtures do not run confirmation, so their workload stays unchanged.
- Legacy machine P50/P95/P99/status values remain the initial batch; new fields/rows carry the final decision.
- Missing initial samples serialize as null with runs 0 and do not fabricate Benchmark Action numeric rows.
- Persistent slow, initial-error, and confirmation-error fixtures remain fail-closed.
- Benchmark Report remains advisory (fail-on-alert false), so preserved initial evidence cannot override the confirmed hard-gate decision.

Spec: docs/specs/GH611/product.md, docs/specs/GH611/tech.md, docs/specs/GH611/tasks.md

Refs #611
Closes #611
