### PR TITLE
docs: specify macOS CI timeout headroom

### DIFF
--- a/docs/specs/GH614/product.md
+++ b/docs/specs/GH614/product.md
@@ -1,0 +1,75 @@
+# Product Spec
+
+## Linked Issue
+
+GH-614: https://github.com/majiayu000/vibeguard/issues/614
+
+## 用户问题
+
+VibeGuard 的必需 macOS CI 与 Ubuntu 共用一个 30 分钟的 `validate-and-test`
+作业上限。PR #613 的实现未修改任何 setup 路径，但 macOS 在
+`Setup regression tests` 仍持续正常输出时，于 30 分 21 秒被 GitHub 取消；
+同一 SHA 重跑后又在 26 分 04 秒通过。近期成功样本还出现过 29 分 44 秒，
+距离上限只剩 16 秒。这会把 runner 时长波动误报为产品回归，并阻止 setup
+之后的必需检查产生证据。
+
+## 目标
+
+- 为健康的 macOS 全量回归保留明确且有界的执行余量。
+- 保持 `bash tests/test_setup.sh` 完整、阻塞、失败可见。
+- 保持现有三个受分支保护的 `CI (*-latest)` check 名称与覆盖面。
+- 用仓库内 contract test 防止超时余量或 setup 阻塞语义回退。
+
+## 非目标
+
+- 不修改 setup 产品行为、fixture、断言或覆盖范围。
+- 不把 setup 测试改成 advisory、`continue-on-error` 或条件跳过。
+- 不在本次工作中拆分 required check、重排 CI 测试或优化 setup 内部性能。
+- 不修改 Windows、Self-Application、release 或 hook latency 的超时与预算。
+
+## Behavior Invariants
+
+1. B-001 — 在已观测的健康 macOS 时长波动范围内，必需 CI 不得再因旧的
+   30 分钟总作业上限取消；新上限仍必须是有限值。
+2. B-002 — `bash tests/test_setup.sh` 必须继续在 macOS 必需 CI 中完整执行，
+   且非零退出必须使该 check 失败。
+3. B-003 — `CI (ubuntu-latest)`、`CI (macos-latest)` 与
+   `CI (windows-latest)` 的稳定名称及其分支保护兼容性不得改变。
+4. B-004 — setup 之后的既有 macOS 回归与 benchmark 命令必须继续保持阻塞；
+   不得用跳过或 advisory 状态换取绿灯。
+5. B-005 — 任何真实测试失败或异常挂起仍必须在有限上限内失败可见，不能
+   静默吞掉或无限等待。
+6. B-006 — Windows、Self-Application、release 与 GH611 hook latency
+   confirmation 的超时、样本数和预算不因本改动变化。
+7. B-007 — workflow contract 必须在总作业上限回退、macOS matrix 覆盖被删除、
+   setup 命令被删除或被标为 `continue-on-error` 时确定性失败。
+
+## 验收标准
+
+- [ ] `validate-and-test` 使用 45 分钟的有限上限，为已记录的 30 分 21 秒取消点
+      提供 14 分 39 秒余量。
+- [ ] `bash tests/test_setup.sh` 仍是 `validate-and-test` 中的精确阻塞命令。
+- [ ] Ubuntu/macOS matrix、Windows job、Self-Application job 与
+      `Benchmark Report` 依赖关系保持不变。
+- [ ] 新 workflow contract 在实现前因 30 分钟旧值失败，在实现后通过。
+- [ ] 实现 head 的本地 focused/broad gate 与完整 GitHub CI 全绿。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | N/A：workflow 使用固定仓库配置，不接受用户输入 |
+| 错误与失败路径 | covered: B-002, B-004, B-005 |
+| 授权/权限 | covered: B-003；不得绕过分支保护 check |
+| 并发/竞态 | covered: B-001；runner 时长波动不能伪造回归 |
+| 重试/幂等 | covered: B-001；同一 SHA 首跑与重跑应受同一有限契约约束 |
+| 非法状态转换 | covered: B-002, B-007 |
+| 兼容/迁移 | covered: B-003, B-006 |
+| 降级/回退 | covered: B-004, B-005, B-007 |
+| 证据与审计完整性 | covered: B-007 |
+| 取消/中断 | covered: B-001, B-005 |
+
+## 发布说明
+
+这是 CI 可靠性修复，不改变用户安装、hook 行为或发布产物。实现 PR 需在说明中
+记录旧上限、实测取消点、新余量、最大异常 runner 成本以及回滚方式。

--- a/docs/specs/GH614/tasks.md
+++ b/docs/specs/GH614/tasks.md
@@ -1,0 +1,68 @@
+# Task Plan
+
+## Linked Issue
+
+GH-614: https://github.com/majiayu000/vibeguard/issues/614
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP614-T1` Owner: `/root` — 在 `tests/test_workflow_contracts.sh` 添加 timeout、稳定 check 名称、Ubuntu/macOS matrix、setup 精确命令和阻塞语义 contract。Depends on: Spec PR merged and live implementation route allowed。Covers: B-001, B-002, B-003, B-005, B-007。Done when: 旧 `timeout-minutes: 30` 上的新 contract 确定性失败，且失败原因指向缺失的 45 分钟余量。Verify: `bash tests/test_workflow_contracts.sh`。
+- [ ] `SP614-T2` Owner: `/root` — 将 `.github/workflows/ci.yml` 的 `validate-and-test.timeout-minutes` 从 30 调到 45，不改 job id、名称、matrix、步骤、命令或依赖。Depends on: SP614-T1。Covers: B-001, B-003, B-004, B-005, B-006。Done when: workflow diff 只有目标 timeout 一行，新增 contract 转绿。Verify: `git diff -- .github/workflows/ci.yml && bash tests/test_workflow_contracts.sh`。
+- [ ] `SP614-T3` Owner: `/root` — 运行 setup、workflow、文档与 broad contract 验证并记录 fresh 输出。Depends on: SP614-T2。Covers: B-002, B-004, B-006, B-007。Done when: focused/setup/quick/static 命令全部通过且 worktree 无意外产物。Verify: `bash tests/test_setup.sh && bash scripts/local-contract-check.sh --quick`。
+- [ ] `SP614-T4` Owner: `/root` + independent reviewer — 创建独立 Impl PR，获取独立 reviewer、当前 SHA 全量 CI、reviewThreads 与 SpecRail required PR gate 证据后合并。Depends on: SP614-T3。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007。Done when: gate 为 `allowed`、PR 已合并且 GH614 已关闭。Verify: `python3 checks/pr_gate.py --repo . --evidence <current-evidence> --mode required --json`。
+
+## 并行拆分
+
+实现改动只有两个相互关联文件，采用单一可写 lane：
+
+- implementation：`/root`，独占 `.github/workflows/ci.yml` 与
+  `tests/test_workflow_contracts.sh`。
+- independent_review：只读 reviewer，不拥有文件、不提交修改。
+
+禁止两个 agent 同时写 workflow contract 或 CI YAML。
+
+## 验证
+
+实现时先记录红态，再执行：
+
+```bash
+bash -n tests/test_workflow_contracts.sh
+bash tests/test_workflow_contracts.sh
+bash tests/test_setup.sh
+bash scripts/ci/validate-workflow-contracts.sh
+bash scripts/ci/validate-doc-paths.sh
+bash scripts/ci/validate-doc-command-paths.sh
+bash scripts/local-contract-check.sh --quick
+git diff --check
+```
+
+最后读取实现 PR 当前 head 的 GitHub CI、独立 review 与 SpecRail PR gate。
+
+## Handoff Notes
+
+```yaml
+handoff:
+  mode: specrail-implement
+  artifacts:
+    - docs/specs/GH614/product.md
+    - docs/specs/GH614/tech.md
+    - docs/specs/GH614/tasks.md
+  runtime_pinning_snapshot: None
+  verification_owner: /root
+  stop_conditions:
+    - 新 contract 未在旧 30 分钟配置上先红
+    - 实现需要修改 setup 产品行为、fixture 或断言
+    - required check 名、OS matrix、步骤命令或 benchmark 依赖发生变化
+    - 任一真实 CI、独立审查、review thread 或 required PR gate 未通过
+  lane_map:
+    implementation: /root
+    independent_review: read_only_reviewer
+```
+
+关键决策：使用 45 分钟有限总上限，不拆 job、不改 required context、不弱化测试；
+实现必须从 Spec PR 合并后的最新 `origin/main` 创建独立 worktree 与 Impl PR。

--- a/docs/specs/GH614/tech.md
+++ b/docs/specs/GH614/tech.md
@@ -1,0 +1,101 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-614: https://github.com/majiayu000/vibeguard/issues/614
+
+## Product Spec
+
+[`product.md`](product.md)
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| 主 CI matrix | `.github/workflows/ci.yml:21` | `validate-and-test` 生成稳定的 Ubuntu/macOS required check | 必须保持 job id、名称表达式和 OS matrix |
+| 总作业上限 | `.github/workflows/ci.yml:24` | Ubuntu/macOS 共用 `timeout-minutes: 30` | macOS 已在 30 分 21 秒被取消 |
+| setup 覆盖 | `.github/workflows/ci.yml:239` | `bash tests/test_setup.sh` 是普通阻塞步骤 | 不能删除、跳过、弱化或改成 advisory |
+| 后续回归 | `.github/workflows/ci.yml:251` | setup 后仍有 GC、hook、stats、precision、performance 与 benchmark 检查 | 总作业取消会使后续证据全部缺失 |
+| benchmark 依赖 | `.github/workflows/ci.yml:435` | `Benchmark Report` 依赖完整 `validate-and-test` | 必须保持依赖和现有 check 拓扑 |
+| workflow contract | `tests/test_workflow_contracts.sh:588` | 已检查 performance 三步命令及阻塞语义，但不检查总超时与 setup 覆盖 | 需要增加针对 GH614 的确定性回归 |
+| spec 索引 | `docs/specs/README.md:5` | 维护 active/draft spec 入口 | GH614 在 Spec PR 中登记为 Draft |
+
+远端事实快照（2026-07-16）：main 分支保护要求
+`CI (ubuntu-latest)`、`CI (macos-latest)`、`CI (windows-latest)`；PR #613
+run `29484565228` 的 macOS 首次尝试在 setup 步骤于 30 分 21 秒取消，同一 SHA
+重跑在 26 分 04 秒通过。实现不得通过改名 required context 规避该事实。
+
+## 设计方案
+
+1. 在 `.github/workflows/ci.yml` 中仅把 `validate-and-test.timeout-minutes`
+   从 `30` 调整为 `45`。
+2. 保持 `validate-and-test` job id、`CI (${{ matrix.os }})` 名称、
+   `os: [ubuntu-latest, macos-latest]`、全部步骤顺序及
+   `benchmark-report.needs: validate-and-test` 不变。
+3. 45 分钟相对已观测的 30 分 21 秒取消点提供 14 分 39 秒余量，也比旧上限
+   增加 50%。它仍是 fail-closed 的有限上限；正常运行的计费时长不变，只有
+   异常挂起时每个 matrix leg 的最坏上限增加 15 runner-minutes。
+4. 在 `tests/test_workflow_contracts.sh` 新增 `ci setup timeout headroom` contract：
+   - 定位 `validate-and-test` job block；
+   - 要求稳定名称、Ubuntu/macOS matrix 与 `timeout-minutes: 45`；
+   - 定位 `Setup regression tests` step，要求精确命令
+     `bash tests/test_setup.sh` 且不存在 `continue-on-error`；
+   - 不把 GitHub 历史运行时长写成脆弱的动态测试输入。
+5. contract 必须先在旧值 `30` 上红，再进行 workflow 一行实现，确保测试真正
+   证明缺失行为而不是事后装饰。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `.github/workflows/ci.yml` 总上限 | `bash tests/test_workflow_contracts.sh`；实现 PR 完整 macOS CI |
+| B-002 | setup step block | contract 检查精确命令与无 `continue-on-error`；`bash tests/test_setup.sh` |
+| B-003 | job name 与 OS matrix | contract 检查 `CI (${{ matrix.os }})` 和两个 OS；读取 main branch protection evidence |
+| B-004 | 既有步骤与 benchmark 依赖不变 | `git diff -- .github/workflows/ci.yml` 只出现 timeout 一行；完整 CI rollup |
+| B-005 | 有限 45 分钟上限 | contract 精确要求 `timeout-minutes: 45`，不得删除或设为无界 |
+| B-006 | 非目标 job/latency contract | `git diff --check`；`bash tests/test_hook_perf_contract.sh`；workflow diff review |
+| B-007 | workflow contract | 红态 fixture/旧值运行失败证据；绿态 `bash tests/test_workflow_contracts.sh` |
+
+## 数据流
+
+GitHub 事件触发 `validate-and-test` → matrix 生成 Ubuntu/macOS 两个稳定 check →
+每个 leg 继承 45 分钟有限总上限 → 按原顺序执行全部阻塞步骤（含 setup）→ 两个
+leg 成功后才触发 `Benchmark Report`。没有新增持久化、外部写入、secret 或网络接口。
+
+## 备选方案
+
+- 只重跑超时 job：已证明同一 SHA 可能在 30 分 21 秒失败、26 分 04 秒通过，
+  重跑不能消除错误状态与人工等待，因此拒绝。
+- 拆分独立 macOS setup job：能隔离长步骤，但会引入新的 check 名、branch
+  protection 迁移、依赖聚合和额外 runner 启动；对当前 P0 修复风险过高，后续可在
+  有独立成本/拓扑 spec 时评估。
+- 修改或删减 setup fixture：违反覆盖与测试完整性，拒绝。
+- 按 OS 动态 timeout：需要把简单 OS list 改成 include matrix；正常运行成本并不
+  由上限决定，因此本次不为仅减少异常最坏成本增加 YAML 复杂度。
+- 直接设为无界或极大值：会掩盖真实挂起并增加成本，拒绝。
+
+## 风险
+
+- Security: 不新增权限、secret 或外部调用；required checks 仍由现有分支保护约束。
+- Compatibility: required check 名、job id、matrix 和 benchmark 依赖保持不变。
+- Performance: 正常运行耗时不变；异常挂起的最坏上限从 30 增至 45 分钟。
+- Maintenance: contract 固定 45 分钟策略值；未来调整必须同步 spec 与测试，避免
+  静默回退到无余量配置。
+
+## 测试计划
+
+- [ ] Unit tests: N/A；纯 GitHub Actions 配置与 shell contract 改动。
+- [ ] Integration tests: `bash tests/test_workflow_contracts.sh`，先红后绿。
+- [ ] Integration tests: `bash tests/test_setup.sh`，证明 setup 覆盖未弱化。
+- [ ] Integration tests: `bash scripts/local-contract-check.sh --quick`。
+- [ ] Static validation: `bash scripts/ci/validate-workflow-contracts.sh`、
+      `bash scripts/ci/validate-doc-paths.sh`、
+      `bash scripts/ci/validate-doc-command-paths.sh`、`git diff --check`。
+- [ ] Manual verification: 读取实现 PR 当前 head 的 GitHub CI rollup，要求全部 check
+      completed/success、无 unresolved review thread，并运行 SpecRail required PR gate。
+
+## 回滚方案
+
+若 45 分钟上限造成不可接受的异常成本，回滚 workflow 与对应 contract 提交，恢复
+30 分钟；回滚前必须重新打开 GH614 或建立替代 Issue，因为已知的 macOS 健康运行
+仍会再次逼近或越过 30 分钟。禁止只删除 contract、保留未证明的配置。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,6 +7,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | Spec | Status | Use it for |
 |---|---|---|
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
+| `GH614/` | Draft | Bounded macOS CI timeout headroom while preserving required check names and blocking setup coverage |
 | `GH581/` | Implemented reference | Rust coverage ratchets from a latest-head clean measurement through risk-ordered, independently reviewed tranches to the enforced 80% gate |
 | `GH588/` | Draft | Scheduled GC execution freshness, platform-correct wrapper/internal log evidence, and preserved setup-check mode semantics |
 | `GH589/` | Draft | Repo-scoped code-slop self-scan precision for Rust CLI stdout and line-scoped detector pattern sources |


### PR DESCRIPTION
## Summary

- add the SpecRail product, technical, and task specifications for GH614
- define a bounded increase of the existing validate-and-test job timeout from 30 to 45 minutes
- preserve required check names, matrix topology, command order, and fail-closed setup regression behavior
- add a deterministic workflow contract before the implementation edit

## Why

The required macOS CI job has recently completed in 22m24s, 27m18s, and 29m44s. PR #613 then reached the 30-minute job limit during healthy setup regression output and was canceled at 30m21s; rerunning the same SHA passed in 26m04s. The current budget therefore has effectively no reliable headroom and can reject a healthy change nondeterministically.

## Plan

1. Add a red workflow contract asserting the finite 45-minute budget and unchanged protected job shape.
2. Change only validate-and-test.timeout-minutes from 30 to 45.
3. Run focused SpecRail/workflow checks, the setup regression suite, and the quick local contract gate.
4. Use a separate implementation PR after this specification merges.

## Risk

The proposal keeps a finite fail-closed limit. Normal runner duration and cost are unchanged; only a genuinely hung matrix leg may consume up to 15 additional minutes. The spec explicitly excludes test weakening, job splitting, check renaming, matrix changes, command reordering, and setup internals.

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH614`
- `python3 checks/check_workflow.py --repo .`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

Spec only; no implementation is included.

Refs #614
