### PR TITLE
ci: add macOS timeout headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   validate-and-test:
     name: CI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -624,35 +624,57 @@ from pathlib import Path
 import re
 import sys
 
+def validate(workflow: str) -> None:
+    job_match = re.search(
+        r"(?ms)^  validate-and-test:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if job_match is None:
+        raise SystemExit("missing validate-and-test job")
+    job = job_match.group(0)
+    job_lines = job.splitlines()
+    required_lines = {
+        "stable required check name": "    name: CI (${{ matrix.os }})",
+        "finite timeout headroom": "    timeout-minutes: 45",
+        "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
+    }
+    for description, line in required_lines.items():
+        if line not in job_lines:
+            raise SystemExit(f"validate-and-test missing {description}: {line}")
+    for prefix in ("    if:", "    continue-on-error:", "        include:", "        exclude:"):
+        if any(line.startswith(prefix) for line in job_lines):
+            raise SystemExit(f"validate-and-test must not contain {prefix.strip()}")
+
+    setup_match = re.search(
+        r"(?ms)^      - name: Setup regression tests\n(?P<body>.*?)(?=^      - name:|\Z)",
+        job,
+    )
+    if setup_match is None:
+        raise SystemExit("missing Setup regression tests step")
+    setup_lines = setup_match.group(0).splitlines()
+    run_lines = [line.strip() for line in setup_lines if line.strip().startswith("run:")]
+    if run_lines != ["run: bash tests/test_setup.sh"]:
+        raise SystemExit("Setup regression tests must run bash tests/test_setup.sh exactly once")
+    for prefix in ("if:", "continue-on-error:"):
+        if any(line.strip().startswith(prefix) for line in setup_lines):
+            raise SystemExit(f"Setup regression tests must not use {prefix}")
+
+
 workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
-job_match = re.search(
-    r"(?ms)^  validate-and-test:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
-    workflow,
-)
-if job_match is None:
-    raise SystemExit("missing validate-and-test job")
-job = job_match.group(0)
-
-required_lines = {
-    "stable required check name": "    name: CI (${{ matrix.os }})",
-    "finite timeout headroom": "    timeout-minutes: 45",
-    "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
+validate(workflow)
+mutations = {
+    "macOS setup skip": ("        shell: bash\n        run: bash tests/test_setup.sh", "        if: runner.os == 'Linux'\n        shell: bash\n        run: bash tests/test_setup.sh"),
+    "job advisory": ("    runs-on: ${{ matrix.os }}", "    runs-on: ${{ matrix.os }}\n    continue-on-error: true"),
 }
-for description, line in required_lines.items():
-    if line not in job.splitlines():
-        raise SystemExit(f"validate-and-test missing {description}: {line}")
-
-setup_match = re.search(
-    r"(?ms)^      - name: Setup regression tests\n(?P<body>.*?)(?=^      - name:|\Z)",
-    job,
-)
-if setup_match is None:
-    raise SystemExit("missing Setup regression tests step")
-setup_step = setup_match.group(0)
-if "        run: bash tests/test_setup.sh" not in setup_step.splitlines():
-    raise SystemExit("Setup regression tests must run bash tests/test_setup.sh exactly")
-if any(line.strip().startswith("continue-on-error:") for line in setup_step.splitlines()):
-    raise SystemExit("Setup regression tests must not use continue-on-error")
+for description, (old, new) in mutations.items():
+    mutated = workflow.replace(old, new, 1)
+    if mutated == workflow:
+        raise SystemExit(f"failed to create {description} mutation")
+    try:
+        validate(mutated)
+    except SystemExit:
+        continue
+    raise SystemExit(f"contract accepted forbidden mutation: {description}")
 PY
   green "CI setup stays blocking with bounded timeout headroom"
   PASS=$((PASS + 1))

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -617,6 +617,50 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+header "ci setup timeout headroom"
+TOTAL=$((TOTAL + 1))
+if python3 - "${REPO_DIR}/.github/workflows/ci.yml" >/dev/null <<'PY'; then
+from pathlib import Path
+import re
+import sys
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+job_match = re.search(
+    r"(?ms)^  validate-and-test:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+    workflow,
+)
+if job_match is None:
+    raise SystemExit("missing validate-and-test job")
+job = job_match.group(0)
+
+required_lines = {
+    "stable required check name": "    name: CI (${{ matrix.os }})",
+    "finite timeout headroom": "    timeout-minutes: 45",
+    "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
+}
+for description, line in required_lines.items():
+    if line not in job.splitlines():
+        raise SystemExit(f"validate-and-test missing {description}: {line}")
+
+setup_match = re.search(
+    r"(?ms)^      - name: Setup regression tests\n(?P<body>.*?)(?=^      - name:|\Z)",
+    job,
+)
+if setup_match is None:
+    raise SystemExit("missing Setup regression tests step")
+setup_step = setup_match.group(0)
+if "        run: bash tests/test_setup.sh" not in setup_step.splitlines():
+    raise SystemExit("Setup regression tests must run bash tests/test_setup.sh exactly")
+if any(line.strip().startswith("continue-on-error:") for line in setup_step.splitlines()):
+    raise SystemExit("Setup regression tests must not use continue-on-error")
+PY
+  green "CI setup stays blocking with bounded timeout headroom"
+  PASS=$((PASS + 1))
+else
+  red "CI setup stays blocking with bounded timeout headroom"
+  FAIL=$((FAIL + 1))
+fi
+
 header "consumer drift failures"
 HANDOFF_FIXTURE="${TMP_DIR}/handoff"
 copy_schemas "${HANDOFF_FIXTURE}"


### PR DESCRIPTION
## Summary

- increase only the existing validate-and-test job timeout from 30 to 45 minutes
- add a deterministic workflow contract for the finite timeout, stable required check name, Ubuntu/macOS matrix, exact setup command, and blocking semantics
- preserve every existing job id, check name, matrix entry, step, command, order, and Benchmark Report dependency

## Why

The required macOS CI job has recently completed in 22m24s, 27m18s, and 29m44s. PR #613 was then canceled at 30m21s while Setup regression tests still produced healthy output; rerunning the same SHA passed in 26m04s. A 30-minute total job budget therefore has no dependable headroom and can reject healthy changes nondeterministically.

The 45-minute finite limit adds 14m39s beyond the observed cancellation point while remaining fail-closed.

## Red / Green Evidence

Before the workflow edit, the new contract produced 21/22 passes and failed only with:

`validate-and-test missing finite timeout headroom:     timeout-minutes: 45`

After the one-line workflow edit, the focused contract passed 22/22.

Independent review found that the first contract could still accept a Linux-only setup condition or job-level advisory mode. The original PR branch was hardened to reject setup/job conditions, job-level `continue-on-error`, matrix include/exclude, and duplicate setup run keys. Six independent in-memory mutations were then rejected: setup if, job advisory, job if, matrix include, matrix exclude, and duplicate run.

## Verification

- `bash -n tests/test_workflow_contracts.sh`
- `bash tests/test_workflow_contracts.sh` — 22/22
- `bash tests/test_setup.sh` — 499/499
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash scripts/ci/validate-doc-paths.sh` — 123 files
- `bash scripts/ci/validate-doc-command-paths.sh` — 126 references
- `bash tests/test_hook_perf_contract.sh` — 117/117
- `python3 checks/check_workflow.py --repo . --spec-dir=docs/specs/GH614`
- `python3 checks/check_workflow.py --repo .`
- `bash scripts/local-contract-check.sh --quick`
- `git diff --check`

## Risk and Cost

Normal CI duration and runner cost are unchanged because the timeout is only an upper bound. A genuinely hung Ubuntu or macOS matrix leg may now consume at most 15 additional runner-minutes. The limit remains finite, setup remains blocking, and no tests are skipped or weakened.

## Rollback

Revert this implementation and its contract together. Because the 30-minute false cancellation is already demonstrated, any rollback should reopen GH614 or replace it with an approved alternative rather than silently deleting the regression contract.

Refs #614

Closes #614
