### PR TITLE
fix(compliance): honor declared language guard matrix

### DIFF
--- a/scripts/lib/project_config_validate.py
+++ b/scripts/lib/project_config_validate.py
@@ -155,6 +155,11 @@ def main() -> int:
     parser.add_argument("config", type=Path)
     parser.add_argument("schema", type=Path)
     parser.add_argument("--quiet", action="store_true", help="Suppress success output")
+    parser.add_argument(
+        "--print-languages",
+        action="store_true",
+        help="Print validated project languages as a comma-separated value",
+    )
     args = parser.parse_args()
 
     try:
@@ -171,7 +176,9 @@ def main() -> int:
             print(f"  {error}", file=sys.stderr)
         return 1
 
-    if not args.quiet:
+    if args.print_languages:
+        print(",".join(config.get("languages", [])))
+    elif not args.quiet:
         print(f"OK: {args.config}")
     return 0
 

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -138,8 +138,12 @@ def _module_languages(module: dict[str, Any], module_id: str) -> set[str]:
             normalized.add(language)
     return normalized
 
+def reject_control_characters(value: str, label: str) -> None:
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"{label} must not contain control characters")
 
 def normalize_guard_source(path_str: str, module_id: str) -> str:
+    reject_control_characters(path_str, f"module {module_id}: guard path")
     source = path_str.rstrip("/")
     if not source:
         raise ValueError(f"module {module_id}: guard path must not be empty")
@@ -159,10 +163,7 @@ def normalize_guard_source(path_str: str, module_id: str) -> str:
     return path.as_posix() + ("/" if path_str.endswith("/") else "")
 
 
-def guard_modules(
-    manifest: dict[str, Any],
-    languages: str | None,
-) -> list[tuple[str, list[str]]]:
+def guard_modules(manifest: dict[str, Any], languages: str | None) -> list[tuple[str, list[str]]]:
     selected_languages = language_filter(languages)
     if not selected_languages:
         raise ValueError("guard module query requires at least one language")
@@ -182,6 +183,7 @@ def guard_modules(
         module_id = module.get("id")
         if not isinstance(module_id, str) or not module_id:
             raise ValueError("guard module id must be a non-empty string")
+        reject_control_characters(module_id, "guard module id")
         module_languages = _module_languages(module, module_id)
         matched_languages = selected_languages & module_languages
         if not matched_languages:

--- a/scripts/lib/vibeguard_manifest.py
+++ b/scripts/lib/vibeguard_manifest.py
@@ -139,6 +139,73 @@ def _module_languages(module: dict[str, Any], module_id: str) -> set[str]:
     return normalized
 
 
+def normalize_guard_source(path_str: str, module_id: str) -> str:
+    source = path_str.rstrip("/")
+    if not source:
+        raise ValueError(f"module {module_id}: guard path must not be empty")
+    if "\\" in source:
+        raise ValueError(f"module {module_id}: guard path must use forward slashes: {path_str}")
+    path = PurePosixPath(source)
+    if path.is_absolute():
+        raise ValueError(f"module {module_id}: guard path must be repo-relative: {path_str}")
+    if ".." in path.parts:
+        raise ValueError(f"module {module_id}: guard path must not contain '..': {path_str}")
+    try:
+        relative = path.relative_to(PurePosixPath("guards"))
+    except ValueError as exc:
+        raise ValueError(f"module {module_id}: guard path must live under guards/: {path_str}") from exc
+    if not relative.parts:
+        raise ValueError(f"module {module_id}: guard path must name a guard source: {path_str}")
+    return path.as_posix() + ("/" if path_str.endswith("/") else "")
+
+
+def guard_modules(
+    manifest: dict[str, Any],
+    languages: str | None,
+) -> list[tuple[str, list[str]]]:
+    selected_languages = language_filter(languages)
+    if not selected_languages:
+        raise ValueError("guard module query requires at least one language")
+
+    modules = manifest.get("modules", [])
+    if not isinstance(modules, list):
+        raise ValueError("manifest modules must be a list")
+
+    matches: list[tuple[str, list[str]]] = []
+    covered_languages: set[str] = set()
+    seen_module_ids: set[str] = set()
+    for module in modules:
+        if not isinstance(module, dict):
+            raise ValueError("manifest module entry is not an object")
+        if module.get("kind") != "guards":
+            continue
+        module_id = module.get("id")
+        if not isinstance(module_id, str) or not module_id:
+            raise ValueError("guard module id must be a non-empty string")
+        module_languages = _module_languages(module, module_id)
+        matched_languages = selected_languages & module_languages
+        if not matched_languages:
+            continue
+        if module_id in seen_module_ids:
+            raise ValueError(f"duplicate matching guard module id: {module_id}")
+        paths = module.get("paths")
+        if not isinstance(paths, list) or not paths:
+            raise ValueError(f"module {module_id}: paths must be a non-empty list")
+        normalized_paths: list[str] = []
+        for path_str in paths:
+            if not isinstance(path_str, str):
+                raise ValueError(f"module {module_id}: non-string guard path")
+            normalized_paths.append(normalize_guard_source(path_str, module_id))
+        matches.append((module_id, normalized_paths))
+        seen_module_ids.add(module_id)
+        covered_languages.update(matched_languages)
+
+    missing_languages = sorted(selected_languages - covered_languages)
+    if missing_languages:
+        raise ValueError(f"no language-specific guard module for: {', '.join(missing_languages)}")
+    return matches
+
+
 def normalize_skill_source(path_str: str, module_id: str) -> str:
     source = path_str.rstrip("/")
     if not source:
@@ -623,6 +690,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("hook-names", help="List user-disableable hook names")
     sub.add_parser("guard-names", help="List known guard names")
+    guard_module = sub.add_parser("guard-modules", help="List language-specific guard modules")
+    guard_module.add_argument("--languages", required=True)
+    guard_module.add_argument("--manifest-file", default=str(MANIFEST_FILE))
     rule_link = sub.add_parser("rule-links", help="List installable rule files")
     rule_link.add_argument("--languages", default="")
     rule_link.add_argument("--manifest-file", default=str(MANIFEST_FILE))
@@ -680,6 +750,12 @@ def main() -> int:
 
     if args.command == "guard-names":
         print_lines(guard_names())
+        return 0
+
+    if args.command == "guard-modules":
+        manifest = load_manifest(Path(args.manifest_file))
+        for module_id, paths in guard_modules(manifest, args.languages):
+            print("\t".join([module_id, *paths]))
         return 0
 
     if args.command == "rule-links":

--- a/scripts/verify/compliance_check.sh
+++ b/scripts/verify/compliance_check.sh
@@ -58,17 +58,36 @@ if [[ "${LANGUAGE_SCOPE_VALID}" == "true" && -n "${LANGUAGES}" ]]; then
     --languages "${LANGUAGES}" \
     --manifest-file "${SCRIPT_ROOT}/schemas/install-modules.json" 2>&1)"; then
     while IFS= read -r module_line; do
+      if [[ -z "${module_line}" ]]; then
+        check_fail "language guard module resolution returned an empty record"
+        LANGUAGE_SCOPE_VALID=false
+        continue
+      fi
       IFS=$'\t' read -r -a module_fields <<< "${module_line}"
+      if (( ${#module_fields[@]} < 2 )) || [[ -z "${module_fields[0]}" ]]; then
+        check_fail "language guard module resolution returned a malformed record"
+        LANGUAGE_SCOPE_VALID=false
+        continue
+      fi
       module_id="${module_fields[0]}"
       module_available=true
+      module_record_valid=true
       for ((field_index = 1; field_index < ${#module_fields[@]}; field_index++)); do
         module_path="${module_fields[${field_index}]%/}"
+        if [[ -z "${module_path}" ]]; then
+          check_fail "language guard module resolution returned an empty path for ${module_id}"
+          LANGUAGE_SCOPE_VALID=false
+          module_record_valid=false
+          break
+        fi
         if [[ ! -e "${VIBEGUARD_DIR}/${module_path}" ]]; then
           module_available=false
           break
         fi
       done
-      if [[ "${module_available}" == "true" ]]; then
+      if [[ "${module_record_valid}" != "true" ]]; then
+        continue
+      elif [[ "${module_available}" == "true" ]]; then
         check_pass "guard module ${module_id} available"
       else
         check_warn "guard module ${module_id} unavailable under ${VIBEGUARD_DIR}"

--- a/scripts/verify/compliance_check.sh
+++ b/scripts/verify/compliance_check.sh
@@ -9,15 +9,20 @@ set -euo pipefail
 #   bash vibeguard/scripts/verify/compliance_check.sh /path/to/my-project
 
 PROJECT_DIR="${1:-.}"
-VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
-source "$(dirname "$0")/../lib/guard_paths.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VIBEGUARD_DIR="${VIBEGUARD_DIR:-${SCRIPT_ROOT}}"
+source "${SCRIPT_DIR}/../lib/guard_paths.sh"
 PASS=0
 FAIL=0
 WARN=0
+LANGUAGES=""
+LANGUAGE_SCOPE_VALID=true
 
 check_pass() { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
 check_fail() { echo "  [FAIL] $1"; FAIL=$((FAIL + 1)); }
 check_warn() { echo "  [WARN] $1"; WARN=$((WARN + 1)); }
+language_selected() { [[ ",${LANGUAGES}," == *",$1,"* ]]; }
 
 echo "======================================"
 echo "VibeGuard Compliance Check"
@@ -26,24 +31,77 @@ echo "Date: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "======================================"
 echo
 
-# --- Layer 1: Anti-duplication system ---
-echo "--- Layer 1: Anti-Duplication ---"
-
-dup_guard=$(find_guard "python/check_duplicates.py" "$PROJECT_DIR")
-if [[ -n "$dup_guard" ]]; then
-  check_pass "check_duplicates.py available (${dup_guard})"
+echo "--- Language Guard Packs ---"
+PROJECT_CONFIG="${PROJECT_DIR}/.vibeguard.json"
+if [[ ! -f "${PROJECT_CONFIG}" ]]; then
+  check_warn "project language scope undeclared (.vibeguard.json not found)"
 else
-  check_warn "check_duplicates.py not found (install vibeguard or copy guards/python/)"
+  if config_output="$(python3 \
+    "${SCRIPT_ROOT}/scripts/lib/project_config_validate.py" \
+    "${PROJECT_CONFIG}" \
+    "${SCRIPT_ROOT}/schemas/vibeguard-project.schema.json" \
+    --print-languages 2>&1)"; then
+    LANGUAGES="${config_output}"
+    if [[ -z "${LANGUAGES}" ]]; then
+      check_warn "project language scope undeclared (.vibeguard.json languages missing or empty)"
+    fi
+  else
+    check_fail "project language configuration invalid: ${config_output}"
+    LANGUAGE_SCOPE_VALID=false
+  fi
+fi
+
+if [[ "${LANGUAGE_SCOPE_VALID}" == "true" && -n "${LANGUAGES}" ]]; then
+  if guard_modules_output="$(python3 \
+    "${SCRIPT_ROOT}/scripts/lib/vibeguard_manifest.py" \
+    guard-modules \
+    --languages "${LANGUAGES}" \
+    --manifest-file "${SCRIPT_ROOT}/schemas/install-modules.json" 2>&1)"; then
+    while IFS= read -r module_line; do
+      IFS=$'\t' read -r -a module_fields <<< "${module_line}"
+      module_id="${module_fields[0]}"
+      module_available=true
+      for ((field_index = 1; field_index < ${#module_fields[@]}; field_index++)); do
+        module_path="${module_fields[${field_index}]%/}"
+        if [[ ! -e "${VIBEGUARD_DIR}/${module_path}" ]]; then
+          module_available=false
+          break
+        fi
+      done
+      if [[ "${module_available}" == "true" ]]; then
+        check_pass "guard module ${module_id} available"
+      else
+        check_warn "guard module ${module_id} unavailable under ${VIBEGUARD_DIR}"
+      fi
+    done <<< "${guard_modules_output}"
+  else
+    check_fail "language guard module resolution failed: ${guard_modules_output}"
+    LANGUAGE_SCOPE_VALID=false
+  fi
+fi
+
+# --- Layer 1: Anti-duplication system ---
+if [[ "${LANGUAGE_SCOPE_VALID}" == "true" ]] && language_selected "python"; then
+  echo "--- Layer 1: Anti-Duplication ---"
+
+  dup_guard=$(find_guard "python/check_duplicates.py" "$PROJECT_DIR")
+  if [[ -n "$dup_guard" ]]; then
+    check_pass "check_duplicates.py available (${dup_guard})"
+  else
+    check_warn "check_duplicates.py not found (install vibeguard or copy guards/python/)"
+  fi
 fi
 
 # --- Layer 2: Naming constraints ---
-echo "--- Layer 2: Naming Convention ---"
+if [[ "${LANGUAGE_SCOPE_VALID}" == "true" ]] && language_selected "python"; then
+  echo "--- Layer 2: Naming Convention ---"
 
-naming_guard=$(find_guard "python/check_naming_convention.py" "$PROJECT_DIR")
-if [[ -n "$naming_guard" ]]; then
-  check_pass "check_naming_convention.py available (${naming_guard})"
-else
-  check_warn "check_naming_convention.py not found (install vibeguard or copy guards/python/)"
+  naming_guard=$(find_guard "python/check_naming_convention.py" "$PROJECT_DIR")
+  if [[ -n "$naming_guard" ]]; then
+    check_pass "check_naming_convention.py available (${naming_guard})"
+  else
+    check_warn "check_naming_convention.py not found (install vibeguard or copy guards/python/)"
+  fi
 fi
 
 # --- Layer 3: Pre-commit Hooks ---
@@ -58,23 +116,27 @@ if [[ -f "${PROJECT_DIR}/.pre-commit-config.yaml" ]]; then
     check_warn "gitleaks not found in pre-commit config"
   fi
 
-  if grep -q "ruff" "${PROJECT_DIR}/.pre-commit-config.yaml"; then
-    check_pass "ruff linting configured"
-  else
-    check_warn "ruff not found in pre-commit config"
+  if [[ "${LANGUAGE_SCOPE_VALID}" == "true" ]] && language_selected "python"; then
+    if grep -q "ruff" "${PROJECT_DIR}/.pre-commit-config.yaml"; then
+      check_pass "ruff linting configured"
+    else
+      check_warn "ruff not found in pre-commit config"
+    fi
   fi
 else
   check_fail ".pre-commit-config.yaml not found"
 fi
 
 # --- Layer 4: Architecture Guard ---
-echo "--- Layer 4: Architecture Guards ---"
+if [[ "${LANGUAGE_SCOPE_VALID}" == "true" ]] && language_selected "python"; then
+  echo "--- Layer 4: Architecture Guards ---"
 
-guard_file=$(find_quality_guard "$PROJECT_DIR")
-if [[ -n "${guard_file}" ]]; then
-  check_pass "test_code_quality_guards.py exists: ${guard_file}"
-else
-  check_warn "test_code_quality_guards.py not found (recommended: copy from vibeguard/guards/python/)"
+  guard_file=$(find_quality_guard "$PROJECT_DIR")
+  if [[ -n "${guard_file}" ]]; then
+    check_pass "test_code_quality_guards.py exists: ${guard_file}"
+  else
+    check_warn "test_code_quality_guards.py not found (recommended: copy from vibeguard/guards/python/)"
+  fi
 fi
 
 # --- Layer 5: Workflows ---

--- a/tests/unit/test_compliance_check.sh
+++ b/tests/unit/test_compliance_check.sh
@@ -139,6 +139,8 @@ OUTSIDE_CWD="${TMP_DIR}/outside cwd"
 OVERRIDE_ROOT="${TMP_DIR}/explicit root"
 MISSING_MAPPING_ROOT="${TMP_DIR}/missing mapping distribution"
 INVALID_PATHS_ROOT="${TMP_DIR}/invalid paths distribution"
+CONTROL_PATH_ROOT="${TMP_DIR}/control path distribution"
+MALFORMED_OUTPUT_ROOT="${TMP_DIR}/malformed output distribution"
 
 mkdir -p \
   "${FIXTURE_HOME}/.claude/skills/vibeguard" \
@@ -305,6 +307,38 @@ run_checker "${INVALID_PATHS_ROOT}/scripts/verify/compliance_check.sh" "${RUST_P
 assert_eq "empty guard paths fail compliance" 1 "${LAST_STATUS}"
 assert_contains "empty guard paths emit named failure" "${LAST_OUTPUT}" "language guard module resolution failed"
 assert_not_contains "empty guard paths do not fall back to Python" "${LAST_OUTPUT}" "check_duplicates.py"
+
+copy_distribution "${CONTROL_PATH_ROOT}"
+python3 - "${CONTROL_PATH_ROOT}/schemas/install-modules.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+for module in manifest["modules"]:
+    if module.get("id") == "guards-rust":
+        module["paths"] = ["guards/rust/\nforged"]
+path.write_text(json.dumps(manifest), encoding="utf-8")
+PY
+run_checker "${CONTROL_PATH_ROOT}/scripts/verify/compliance_check.sh" "${RUST_PROJECT}"
+assert_eq "control-character guard path fails compliance" 1 "${LAST_STATUS}"
+assert_contains "control-character guard path emits named failure" "${LAST_OUTPUT}" "language guard module resolution failed"
+assert_not_contains "control-character guard path cannot forge availability" "${LAST_OUTPUT}" "guard module forged available"
+assert_not_contains "control-character guard path does not fall back to Python" "${LAST_OUTPUT}" "check_duplicates.py"
+
+copy_distribution "${MALFORMED_OUTPUT_ROOT}"
+printf '%s\n' \
+  'import sys' \
+  'if "guard-modules" in sys.argv:' \
+  '    print("forged")' \
+  'else:' \
+  '    raise SystemExit(1)' \
+  > "${MALFORMED_OUTPUT_ROOT}/scripts/lib/vibeguard_manifest.py"
+run_checker "${MALFORMED_OUTPUT_ROOT}/scripts/verify/compliance_check.sh" "${RUST_PROJECT}"
+assert_eq "malformed helper record fails compliance" 1 "${LAST_STATUS}"
+assert_contains "malformed helper record emits named failure" "${LAST_OUTPUT}" "language guard module resolution returned a malformed record"
+assert_not_contains "malformed helper record cannot forge availability" "${LAST_OUTPUT}" "guard module forged available"
 
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' \

--- a/tests/unit/test_compliance_check.sh
+++ b/tests/unit/test_compliance_check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Unit tests for scripts/verify/compliance_check.sh bundled guard discovery.
+# Unit tests for scripts/verify/compliance_check.sh language-aware guard discovery.
 
 set -euo pipefail
 
@@ -55,47 +55,135 @@ assert_not_contains() {
   fi
 }
 
+assert_count() {
+  local desc="$1"
+  local output="$2"
+  local expected_text="$3"
+  local expected_count="$4"
+  local actual_count
+  actual_count="$(grep -cF "${expected_text}" <<< "${output}" || true)"
+  assert_eq "${desc}" "${expected_count}" "${actual_count}"
+}
+
+make_project() {
+  local project_dir="$1"
+  mkdir -p "${project_dir}"
+  printf '%s\n' \
+    'repos:' \
+    '  - repo: local' \
+    '    hooks:' \
+    '      - id: gitleaks' \
+    '      - id: ruff' \
+    > "${project_dir}/.pre-commit-config.yaml"
+  printf '%s\n' \
+    'Search before writing.' \
+    'No backward compatibility.' \
+    'No hardcoding.' \
+    > "${project_dir}/CLAUDE.md"
+}
+
+run_checker() {
+  local checker="$1"
+  local project_dir="$2"
+  local guard_root="${3:-}"
+  set +e
+  if [[ -n "${guard_root}" ]]; then
+    LAST_OUTPUT="$({
+      cd "${OUTSIDE_CWD}" || exit 97
+      HOME="${FIXTURE_HOME}" VIBEGUARD_DIR="${guard_root}" \
+        bash "${checker}" "${project_dir}"
+    } 2>&1)"
+  else
+    LAST_OUTPUT="$({
+      cd "${OUTSIDE_CWD}" || exit 97
+      unset VIBEGUARD_DIR
+      HOME="${FIXTURE_HOME}" bash "${checker}" "${project_dir}"
+    } 2>&1)"
+  fi
+  LAST_STATUS=$?
+  set -e
+}
+
+copy_distribution() {
+  local target="$1"
+  mkdir -p "${target}/scripts/verify" "${target}/scripts/lib" "${target}/schemas"
+  cp "${REPO_DIR}/scripts/verify/compliance_check.sh" "${target}/scripts/verify/"
+  cp "${REPO_DIR}/scripts/lib/guard_paths.sh" "${target}/scripts/lib/"
+  cp "${REPO_DIR}/scripts/lib/hooks_manifest.py" "${target}/scripts/lib/"
+  cp "${REPO_DIR}/scripts/lib/project_config_validate.py" "${target}/scripts/lib/"
+  cp "${REPO_DIR}/scripts/lib/project_schema_contract.py" "${target}/scripts/lib/"
+  cp "${REPO_DIR}/scripts/lib/vibeguard_manifest.py" "${target}/scripts/lib/"
+  cp "${REPO_DIR}/schemas/vibeguard-project.schema.json" "${target}/schemas/"
+  cp "${REPO_DIR}/schemas/install-modules.json" "${target}/schemas/"
+  cp -R "${REPO_DIR}/guards" "${target}/guards"
+}
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 PROJECT_DIR="${TMP_DIR}/project"
+RUST_PROJECT="${TMP_DIR}/rust project"
+GO_PROJECT="${TMP_DIR}/go project"
+JS_PROJECT="${TMP_DIR}/javascript project"
+TS_PROJECT="${TMP_DIR}/typescript project"
+TS_JS_PROJECT="${TMP_DIR}/typescript javascript project"
+MIXED_PROJECT="${TMP_DIR}/mixed project"
+MISSING_CONFIG_PROJECT="${TMP_DIR}/missing config project"
+MISSING_LANGUAGES_PROJECT="${TMP_DIR}/missing languages project"
+EMPTY_LANGUAGES_PROJECT="${TMP_DIR}/empty languages project"
+INVALID_JSON_PROJECT="${TMP_DIR}/invalid json project"
+INVALID_TYPE_PROJECT="${TMP_DIR}/invalid type project"
+UNSUPPORTED_LANGUAGE_PROJECT="${TMP_DIR}/unsupported language project"
 FIXTURE_HOME="${TMP_DIR}/home"
 OUTSIDE_CWD="${TMP_DIR}/outside cwd"
 OVERRIDE_ROOT="${TMP_DIR}/explicit root"
+MISSING_MAPPING_ROOT="${TMP_DIR}/missing mapping distribution"
+INVALID_PATHS_ROOT="${TMP_DIR}/invalid paths distribution"
 
 mkdir -p \
-  "${PROJECT_DIR}" \
   "${FIXTURE_HOME}/.claude/skills/vibeguard" \
   "${FIXTURE_HOME}/.claude/rules/vibeguard" \
   "${OUTSIDE_CWD}" \
   "${OVERRIDE_ROOT}/guards/python"
 
-printf '%s\n' \
-  'repos:' \
-  '  - repo: local' \
-  '    hooks:' \
-  '      - id: gitleaks' \
-  '      - id: ruff' \
-  > "${PROJECT_DIR}/.pre-commit-config.yaml"
-printf '%s\n' \
-  'Search before writing.' \
-  'No backward compatibility.' \
-  'No hardcoding.' \
-  > "${PROJECT_DIR}/CLAUDE.md"
+for project in \
+  "${PROJECT_DIR}" \
+  "${RUST_PROJECT}" \
+  "${GO_PROJECT}" \
+  "${JS_PROJECT}" \
+  "${TS_PROJECT}" \
+  "${TS_JS_PROJECT}" \
+  "${MIXED_PROJECT}" \
+  "${MISSING_CONFIG_PROJECT}" \
+  "${MISSING_LANGUAGES_PROJECT}" \
+  "${EMPTY_LANGUAGES_PROJECT}" \
+  "${INVALID_JSON_PROJECT}" \
+  "${INVALID_TYPE_PROJECT}" \
+  "${UNSUPPORTED_LANGUAGE_PROJECT}"; do
+  make_project "${project}"
+done
+
+printf '%s\n' '{"languages":["python"]}' > "${PROJECT_DIR}/.vibeguard.json"
+printf '%s\n' '{"languages":["rust"]}' > "${RUST_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["go"]}' > "${GO_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["javascript"]}' > "${JS_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["typescript"]}' > "${TS_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["typescript","javascript"]}' > "${TS_JS_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["rust","go","typescript","javascript"]}' > "${MIXED_PROJECT}/.vibeguard.json"
+printf '%s\n' '{}' > "${MISSING_LANGUAGES_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":[]}' > "${EMPTY_LANGUAGES_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["rust"]' > "${INVALID_JSON_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":"rust"}' > "${INVALID_TYPE_PROJECT}/.vibeguard.json"
+printf '%s\n' '{"languages":["ruby"]}' > "${UNSUPPORTED_LANGUAGE_PROJECT}/.vibeguard.json"
 printf '%s\n' 'VibeGuard anti-hallucination rules.' > "${FIXTURE_HOME}/.claude/CLAUDE.md"
 printf '%s\n' '# duplicate fixture' > "${OVERRIDE_ROOT}/guards/python/check_duplicates.py"
 printf '%s\n' '# naming fixture' > "${OVERRIDE_ROOT}/guards/python/check_naming_convention.py"
 
-printf '\n=== compliance_check bundled guard discovery ===\n'
+printf '\n=== compliance_check language-aware guard discovery ===\n'
 
-set +e
-default_output="$({
-  cd "${OUTSIDE_CWD}" || exit 97
-  unset VIBEGUARD_DIR
-  HOME="${FIXTURE_HOME}" bash "${CHECKER}" "${PROJECT_DIR}"
-} 2>&1)"
-default_status=$?
-set -e
+run_checker "${CHECKER}" "${PROJECT_DIR}"
+default_output="${LAST_OUTPUT}"
+default_status="${LAST_STATUS}"
 
 assert_eq "default invocation preserves compliance exit contract" 0 "${default_status}"
 assert_contains \
@@ -114,15 +202,13 @@ assert_not_contains \
   "default invocation does not emit naming guard not-found warning" \
   "${default_output}" \
   "check_naming_convention.py not found"
+assert_contains "Python project reports manifest guard module" "${default_output}" "guard module guards-python available"
+assert_contains "Python project preserves ruff check" "${default_output}" "ruff linting configured"
+assert_contains "Python project preserves architecture guard check" "${default_output}" "test_code_quality_guards.py not found"
 
-set +e
-override_output="$({
-  cd "${OUTSIDE_CWD}" || exit 97
-  HOME="${FIXTURE_HOME}" VIBEGUARD_DIR="${OVERRIDE_ROOT}" \
-    bash "${CHECKER}" "${PROJECT_DIR}"
-} 2>&1)"
-override_status=$?
-set -e
+run_checker "${CHECKER}" "${PROJECT_DIR}" "${OVERRIDE_ROOT}"
+override_output="${LAST_OUTPUT}"
+override_status="${LAST_STATUS}"
 
 assert_eq "explicit root preserves compliance exit contract" 0 "${override_status}"
 assert_contains \
@@ -141,6 +227,84 @@ assert_not_contains \
   "explicit root does not fall back to repository naming guard" \
   "${override_output}" \
   "check_naming_convention.py available (${REPO_DIR}/guards/python/check_naming_convention.py)"
+
+run_checker "${CHECKER}" "${RUST_PROJECT}"
+assert_eq "Rust project preserves compliance exit contract" 0 "${LAST_STATUS}"
+assert_contains "Rust project reports manifest guard module" "${LAST_OUTPUT}" "guard module guards-rust available"
+for python_surface in check_duplicates.py check_naming_convention.py "ruff linting" test_code_quality_guards.py; do
+  assert_not_contains "Rust project omits Python surface: ${python_surface}" "${LAST_OUTPUT}" "${python_surface}"
+done
+
+run_checker "${CHECKER}" "${GO_PROJECT}"
+assert_eq "Go project preserves compliance exit contract" 0 "${LAST_STATUS}"
+assert_contains "Go project reports manifest guard module" "${LAST_OUTPUT}" "guard module guards-go available"
+
+run_checker "${CHECKER}" "${JS_PROJECT}"
+assert_eq "JavaScript project preserves compliance exit contract" 0 "${LAST_STATUS}"
+assert_contains "JavaScript maps to TypeScript guard module" "${LAST_OUTPUT}" "guard module guards-typescript available"
+
+run_checker "${CHECKER}" "${TS_PROJECT}"
+assert_eq "TypeScript project preserves compliance exit contract" 0 "${LAST_STATUS}"
+assert_contains "TypeScript project reports manifest guard module" "${LAST_OUTPUT}" "guard module guards-typescript available"
+
+run_checker "${CHECKER}" "${TS_JS_PROJECT}"
+assert_eq "TypeScript and JavaScript project preserves exit contract" 0 "${LAST_STATUS}"
+assert_count "TypeScript and JavaScript share one guard module report" "${LAST_OUTPUT}" "guard module guards-typescript available" 1
+
+run_checker "${CHECKER}" "${MIXED_PROJECT}"
+assert_eq "mixed project preserves compliance exit contract" 0 "${LAST_STATUS}"
+assert_count "mixed project reports Rust guard once" "${LAST_OUTPUT}" "guard module guards-rust available" 1
+assert_count "mixed project reports Go guard once" "${LAST_OUTPUT}" "guard module guards-go available" 1
+assert_count "mixed project reports shared TypeScript guard once" "${LAST_OUTPUT}" "guard module guards-typescript available" 1
+
+for undeclared_project in "${MISSING_CONFIG_PROJECT}" "${MISSING_LANGUAGES_PROJECT}" "${EMPTY_LANGUAGES_PROJECT}"; do
+  run_checker "${CHECKER}" "${undeclared_project}"
+  assert_eq "undeclared language scope preserves compliance exit contract: ${undeclared_project}" 0 "${LAST_STATUS}"
+  assert_contains "undeclared language scope emits warning: ${undeclared_project}" "${LAST_OUTPUT}" "project language scope undeclared"
+  assert_not_contains "undeclared language scope does not fabricate guard coverage: ${undeclared_project}" "${LAST_OUTPUT}" "guard module guards-"
+  assert_not_contains "undeclared language scope does not fall back to Python: ${undeclared_project}" "${LAST_OUTPUT}" "check_duplicates.py"
+done
+
+for invalid_project in "${INVALID_JSON_PROJECT}" "${INVALID_TYPE_PROJECT}" "${UNSUPPORTED_LANGUAGE_PROJECT}"; do
+  run_checker "${CHECKER}" "${invalid_project}"
+  assert_eq "invalid language config fails compliance: ${invalid_project}" 1 "${LAST_STATUS}"
+  assert_contains "invalid language config emits named failure: ${invalid_project}" "${LAST_OUTPUT}" "project language configuration invalid"
+  assert_not_contains "invalid language config does not fall back to Python: ${invalid_project}" "${LAST_OUTPUT}" "check_duplicates.py"
+done
+
+copy_distribution "${MISSING_MAPPING_ROOT}"
+python3 - "${MISSING_MAPPING_ROOT}/schemas/install-modules.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["modules"] = [module for module in manifest["modules"] if module.get("id") != "guards-rust"]
+path.write_text(json.dumps(manifest), encoding="utf-8")
+PY
+run_checker "${MISSING_MAPPING_ROOT}/scripts/verify/compliance_check.sh" "${RUST_PROJECT}"
+assert_eq "missing language guard mapping fails compliance" 1 "${LAST_STATUS}"
+assert_contains "missing language guard mapping emits named failure" "${LAST_OUTPUT}" "language guard module resolution failed"
+assert_not_contains "missing language guard mapping does not fall back to Python" "${LAST_OUTPUT}" "check_duplicates.py"
+
+copy_distribution "${INVALID_PATHS_ROOT}"
+python3 - "${INVALID_PATHS_ROOT}/schemas/install-modules.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+for module in manifest["modules"]:
+    if module.get("id") == "guards-rust":
+        module["paths"] = []
+path.write_text(json.dumps(manifest), encoding="utf-8")
+PY
+run_checker "${INVALID_PATHS_ROOT}/scripts/verify/compliance_check.sh" "${RUST_PROJECT}"
+assert_eq "empty guard paths fail compliance" 1 "${LAST_STATUS}"
+assert_contains "empty guard paths emit named failure" "${LAST_OUTPUT}" "language guard module resolution failed"
+assert_not_contains "empty guard paths do not fall back to Python" "${LAST_OUTPUT}" "check_duplicates.py"
 
 echo
 printf 'Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n' \


### PR DESCRIPTION
## Summary

- validate project-declared languages through the existing project schema helper
- resolve language-specific guard modules from the canonical install manifest
- report Rust, Go, Python, TypeScript, and JavaScript guard packs without duplicate JS/TS output
- run Python duplicate, naming, ruff, and architecture checks only when Python is declared
- fail visibly for invalid config, invalid guard paths, or a declared language with no guard mapping

## Optimization rationale

The compliance checker previously ran Python-only checks for every project and ignored the repository's declared language guard matrix. That produced irrelevant evidence for Rust/Go/TypeScript/JavaScript projects and could silently accept a schema/manifest contradiction.

## Implementation plan completed

1. expanded the existing isolated focused harness with language, undeclared, invalid-config, and mutated-manifest fixtures
2. added validated machine-readable language output to the existing project config helper
3. added a deduplicated, completeness-checked guard-module query to the existing manifest helper
4. gated Python-only checks while preserving universal checks, summary counters, and explicit guard-root overrides
5. ran focused, unit, manifest, workflow, docs, SpecRail, and quick contract gates

## Verification

- `bash tests/unit/test_compliance_check.sh` — 58/58
- `bash tests/unit/run_all.sh` — 23/23
- `bash tests/test_manifest_contract.sh` — 95/95
- `bash tests/test_workflow_contracts.sh` — 22/22
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/local-contract-check.sh --quick`
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH618`
- `bash -n scripts/verify/compliance_check.sh tests/unit/test_compliance_check.sh`
- `python3 -m py_compile scripts/lib/project_config_validate.py scripts/lib/vibeguard_manifest.py`
- `git diff --check`

## Risk and rollback

This is a developer-validator change; it does not alter setup, hooks, runtime, schemas, manifests, or guard implementations. Projects without a language declaration now receive a WARN and no fabricated language coverage. Reverting this PR restores the previous unconditional Python behavior without data migration.

Closes #618
