### PR TITLE
spec: make pre-write L1 escalation recoverable (#615)

### DIFF
--- a/artifacts/triage/issue-615.json
+++ b/artifacts/triage/issue-615.json
@@ -1,0 +1,14 @@
+{
+  "issue": 615,
+  "recommended_state": "ready_to_spec",
+  "confidence": 0.99,
+  "evidence": [
+    "Latest origin/main@4b5952a still counts every pre-write New source file attempt before checking the circuit breaker.",
+    "An isolated current-runtime reproduction emitted reminders for attempts 1-3, no output for attempts 4-5, and blocked attempt 6 after five counted attempts.",
+    "The reproduction log contains five attempt events but only three reminder events, proving circuit-breaker-silenced attempts are counted as unheeded.",
+    "After a same-session analysis-paralysis-guard Grep pass event, attempt 7 remained blocked with the same five-attempt escalation.",
+    "Search across open and closed issues, pull requests, docs/specs, and plan artifacts found no duplicate Spec or active implementation for GH615.",
+    "The report is public runtime-policy behavior, not a private security disclosure, and its goals, non-goals, root cause, and expected recovery behavior are sufficiently specified for a Spec PR."
+  ],
+  "maintainer_questions": []
+}

--- a/docs/specs/GH615/product.md
+++ b/docs/specs/GH615/product.md
@@ -1,0 +1,87 @@
+# Product Spec: pre-write L1 escalation 可恢复搜索边界
+
+## Linked Issue
+
+GH-615
+
+## 用户问题
+
+`pre-write-guard` 当前把同一会话中的每次新 source file 尝试都视为“未响应提醒”，包括 circuit
+breaker 已经静默放行、用户根本看不到 L1 提醒的尝试。达到阈值后，即使用户按阻断文案执行了
+Grep 或 Glob，同一会话仍永久阻断后续新文件；文案建议在当前 session 中 `export` 环境变量，但
+hook 子进程无法修改已运行 agent 的父进程环境。结果是正常 greenfield scaffolding 可能被无证据、
+不可恢复地锁死。
+
+## 目标
+
+- escalation 只累计用户实际可见的 `New source file reminder`，不累计 circuit-breaker-silenced
+  attempt。
+- 同一 session 中实际执行 Grep 或 Glob 后，清除此前未响应提醒的计数边界，使下一次新 source
+  file write 不再被旧 escalation 锁死。
+- 保留“搜索后若继续忽略新的可见提醒，仍会再次 escalation”的 L1 anti-duplication 约束。
+- escalation 文案只给出当前 session 内真实可执行的恢复动作，不再声称 child hook 内的 `export`
+  能解除父进程中的阈值。
+
+## 非目标
+
+- 不引入“greenfield repository”、commit 数量、文件数量或目录为空等新启发式。
+- 不改变 `VIBEGUARD_WRITE_MODE=block` 的立即阻断语义，也不改变 escalation threshold 为 `0` 时的
+  禁用语义。
+- 不改变 circuit breaker 的 threshold、cooldown、状态文件或 pass/reset 规则。
+- 不删除 `New source file attempt` 观测事件，不改变现有 event schema、字段名或持久化格式。
+- 不把 Read 视为满足 L1“search first”的恢复证据；仅 Grep 与 Glob 有效。
+- 不扩展为 event-log 读取错误、损坏历史或超过 500 条窗口的全新失败策略。
+
+## Behavior Invariants
+
+1. B-001：只有同一 session 中实际产生的 `New source file reminder` 才算一次未响应提醒；仅有
+   `New source file attempt`、circuit-breaker-silenced write 或其他 hook event 不增加 escalation
+   计数。
+2. B-002：同一 session 最新一次由 `analysis-paralysis-guard` 记录的 Grep 或 Glob 是 heed boundary；
+   escalation 只计算该边界之后的可见 source-new reminders。
+3. B-003：Read、其他 session 的 Grep/Glob、malformed event 与不相关 hook/tool/reason 不得创建 heed
+   boundary，也不得增加计数。
+4. B-004：circuit breaker OPEN 期间的新 source-file writes 继续保持既有空输出/允许语义，并且不会
+   因静默 attempts 推进 escalation；breaker 自身的 cooldown/reset 行为不变。
+5. B-005：在最近一次有效搜索之后，如果可见 reminders 再次达到配置阈值，下一次新 source-file
+   write 仍必须阻断，并报告实际未响应 reminder 数量。
+6. B-006：一次 escalation 后，同一 session 的 Grep 或 Glob 必须让下一次新 source-file write 不再
+   被旧 reminder 历史阻断；若 circuit breaker 仍 OPEN，该次 write 可以继续被 breaker 静默，但
+   不能被旧 escalation trap 阻断。
+7. B-007：escalation block 文案要求用户运行 Grep/Glob 后重试，不再建议
+   `export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0` 可在当前 agent session 生效；不再把必须新建
+   session 作为唯一恢复路径。
+8. B-008：`VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0`、`VIBEGUARD_WRITE_MODE=block`、现有 event
+   schema、`New source file attempt` observability 与最多扫描最近 500 条 event 的边界保持兼容。
+
+## 验收标准
+
+- [ ] threshold=3、breaker threshold=1 时，仅第一条可见 reminder 被计数；后续多个静默 writes
+  不触发 escalation。
+- [ ] breaker 允许连续输出至少 threshold 条 reminders 时，下一次 write 正常 escalation，并报告
+  reminder 数而非全部 attempts。
+- [ ] escalation 后同一 session 的 Grep 和 Glob 分别都能恢复；Read 与其他 session 的 Grep 不恢复。
+- [ ] 搜索恢复后产生的新可见 reminders 可以重新累计并再次触发 escalation。
+- [ ] block 文案包含可执行的 Grep/Glob retry 指引，且不包含无效的 session-local `export` 建议。
+- [ ] threshold=0、write-mode block、circuit breaker 与既有 attempt/reminder telemetry 回归全绿。
+- [ ] focused hook test、Rust tests、hook validators、quick contract 与 current-head CI 全绿。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-008；沿用现有 pre-write input 与缺失 event-log 行为 |
+| 错误与失败路径 | covered: B-003, B-005, B-007 |
+| 授权/权限 | N/A：本变更不新增授权或外部权限面 |
+| 并发/竞态 | covered: B-004, B-008；沿用既有 append-only event log 与 breaker locking |
+| 重试/幂等 | covered: B-002, B-005, B-006 |
+| 非法状态转换 | covered: B-003, B-004, B-006 |
+| 兼容/迁移 | covered: B-008；无 schema 或持久化迁移 |
+| 降级/回退 | covered: B-001, B-004；静默 breaker 不得伪造未响应证据 |
+| 证据与审计完整性 | covered: B-001, B-002, B-003, B-008 |
+| 取消/中断 | N/A：hook 调用是单次同步判定，无独立取消状态 |
+
+## 发布说明
+
+这是 pre-write L1 escalation 的纠错与可恢复性修复。用户看到的搜索要求不变，但阻断只由真正展示过
+且搜索后仍未响应的提醒触发；同一 session 完成 Grep/Glob 后即可重试。配置和 event schema 无需迁移。

--- a/docs/specs/GH615/product.md
+++ b/docs/specs/GH615/product.md
@@ -48,9 +48,10 @@ hook 子进程无法修改已运行 agent 的父进程环境。结果是正常 g
 6. B-006：一次 escalation 后，同一 session 的 Grep 或 Glob 必须让下一次新 source-file write 不再
    被旧 reminder 历史阻断；若 circuit breaker 仍 OPEN，该次 write 可以继续被 breaker 静默，但
    不能被旧 escalation trap 阻断。
-7. B-007：escalation block 文案要求用户运行 Grep/Glob 后重试，不再建议
-   `export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0` 可在当前 agent session 生效；不再把必须新建
-   session 作为唯一恢复路径。
+7. B-007：escalation block 文案以运行 Grep/Glob 后重试作为主要恢复路径，不再建议
+   `export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0` 可在当前 agent session 生效；如果同时提示调整或
+   禁用阈值，必须准确指向 `~/.vibeguard/config.json` 的 `write_escalate_threshold`，并明确这是持久、
+   全局变更，而非 session-local 恢复。
 8. B-008：`VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0`、`VIBEGUARD_WRITE_MODE=block`、现有 event
    schema、`New source file attempt` observability 与最多扫描最近 500 条 event 的边界保持兼容。
 
@@ -62,7 +63,8 @@ hook 子进程无法修改已运行 agent 的父进程环境。结果是正常 g
   reminder 数而非全部 attempts。
 - [ ] escalation 后同一 session 的 Grep 和 Glob 分别都能恢复；Read 与其他 session 的 Grep 不恢复。
 - [ ] 搜索恢复后产生的新可见 reminders 可以重新累计并再次触发 escalation。
-- [ ] block 文案包含可执行的 Grep/Glob retry 指引，且不包含无效的 session-local `export` 建议。
+- [ ] block 文案包含可执行的 Grep/Glob retry 指引，且不包含无效的 session-local `export` 建议；任何
+  阈值调整提示都同时包含 `~/.vibeguard/config.json`、`write_escalate_threshold` 和持久全局影响说明。
 - [ ] threshold=0、write-mode block、circuit breaker 与既有 attempt/reminder telemetry 回归全绿。
 - [ ] focused hook test、Rust tests、hook validators、quick contract 与 current-head CI 全绿。
 

--- a/docs/specs/GH615/tasks.md
+++ b/docs/specs/GH615/tasks.md
@@ -1,0 +1,48 @@
+# Task Plan: GH615 pre-write escalation recovery
+
+## Linked Issue
+
+GH-615
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP615-T1` Owner: `/root` — 在 `tests/hooks/test_pre_write_guard.sh` 将“silent attempts 也累计”的旧合同改为 reminder-aware recovery 合同，覆盖 breaker-silenced writes、达到阈值、same-session Grep/Glob、Read、other-session Grep、重新累计与 copy。Depends on: Spec PR merged and implementation route allowed。Covers: B-001-B-008。Done when: 当前 production 对新期望确定性红，失败来自 GH-615 语义而非 fixture/环境错误，并单独提交 red test commit。Verify: `bash tests/hooks/test_pre_write_guard.sh`（production 修复前预期红）。
+- [ ] `SP615-T2` Owner: `/root` — 在 `vibeguard-runtime/src/hook_orchestrator.rs` 实现 same-session Grep/Glob boundary 之后的 visible reminder counter，保留 attempt telemetry、breaker flow、500-event bound 与 mode/config semantics，并改正 escalation copy。Depends on: SP615-T1。Covers: B-001-B-008。Done when: focused red tests转绿；silent attempts 不计数；有效搜索恢复；无效事件不恢复；重新忽略 reminders 会再次阻断。Verify: focused shell test 与 Rust tests。
+- [ ] `SP615-T3` Owner: `/root` — 仅在 shell test 无法确定性覆盖 counter event ordering 时，新建 `cli_hook_pre_write` focused Rust integration target；不得向 799 行的 `cli_hook_orchestrator.rs` 追加。Depends on: SP615-T2。Covers: B-001, B-002, B-003, B-005, B-006。Done when: 缺失的 runtime contract 被 focused integration test 覆盖，或以已有 shell evidence 记录本任务 N/A。Verify: `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test cli_hook_pre_write`（若创建）。
+- [ ] `SP615-T4` Owner: `/root` — 执行 hook/Rust/broad regression、独立审查和 current-head PR gates。Depends on: SP615-T2 and SP615-T3 disposition。Covers: B-001-B-008。Done when: tech spec 全部 fresh 命令通过，独立 reviewer 无 blocker，CI/threads/SpecRail required gate 全部通过。Verify: tech spec 测试计划中的全部命令。
+
+## 并行拆分
+
+实现由单一 writer `/root` 顺序完成 red test 与 production fix，避免 runtime/test expectation 由不同 writer
+竞态修改。独立 reviewer `/root/review_pr612` 只读检查 linked Issue、Spec、red/green evidence 与 PR diff，
+无可写文件。
+
+## 验证
+
+- Red-first shell evidence 与独立 red commit。
+- Focused same-session/other-session、Grep/Glob/Read、breaker OPEN 与 re-escalation matrix。
+- Fresh Rust check/test、hook validators、full hook suite、quick contract 与 diff check。
+- Independent review、current-head CI、zero unresolved threads、SpecRail required PR gate。
+
+## Handoff Notes
+
+- `mode`: `specrail-implement`
+- `artifacts`: `docs/specs/GH615/product.md`, `docs/specs/GH615/tech.md`,
+  `docs/specs/GH615/tasks.md`
+- `runtime_pinning_snapshot`: None；实现必须从 Spec merge 后的最新 `origin/main` 建立独立 worktree，并在
+  PR evidence 中记录 exact base/head SHA；不跨 runtime/tool inventory 切换。
+- `verification_owner`: `/root`
+- `stop_conditions`: 需要新增 greenfield/commit/file-count heuristic；需要 event schema 或 breaker
+  state migration；Grep/Glob event producer 与已核实合同不符；必须改变 threshold=0 或 block-mode 语义；
+  必须向 799 行 integration file 追加；任一 focused/Rust/hook/quick test 失败；独立 reviewer 有 blocker；
+  current-head CI、review threads 或 SpecRail required gate 未通过。
+- `lane_map`: specification `/root` 独占 `docs/specs/GH615/`、triage artifact 与 spec index；
+  implementation `/root` 独占 `vibeguard-runtime/src/hook_orchestrator.rs`、
+  `tests/hooks/test_pre_write_guard.sh` 及必要时新增的 focused Rust test；independent reviewer
+  `/root/review_pr612` 只读，无可写文件。
+- Spec PR 只 `Refs #615`；只有独立 Impl PR 使用 `Fixes #615` 并在合并后关闭 Issue。

--- a/docs/specs/GH615/tasks.md
+++ b/docs/specs/GH615/tasks.md
@@ -11,7 +11,7 @@ GH-615
 
 ## 实现任务
 
-- [ ] `SP615-T1` Owner: `/root` — 在 `tests/hooks/test_pre_write_guard.sh` 将“silent attempts 也累计”的旧合同改为 reminder-aware recovery 合同，覆盖 breaker-silenced writes、达到阈值、same-session Grep/Glob、Read、other-session Grep、重新累计与 copy。Depends on: Spec PR merged and implementation route allowed。Covers: B-001-B-008。Done when: 当前 production 对新期望确定性红，失败来自 GH-615 语义而非 fixture/环境错误，并单独提交 red test commit。Verify: `bash tests/hooks/test_pre_write_guard.sh`（production 修复前预期红）。
+- [ ] `SP615-T1` Owner: `/root` — 在 `tests/hooks/test_pre_write_guard.sh` 将“silent attempts 也累计”的旧合同改为 reminder-aware recovery 合同，覆盖 breaker-silenced writes、达到阈值、same-session Grep/Glob、Read、other-session Grep、malformed/unrelated events、重新累计与 copy。Depends on: Spec PR merged and implementation route allowed。Covers: B-001-B-008。Done when: 当前 production 对新期望确定性红，失败来自 GH-615 语义而非 fixture/环境错误，并单独提交 red test commit；copy assertion 禁止 session-local export，并在保留 threshold 备选时要求 exact config path/key/persistent-global 说明。Verify: `bash tests/hooks/test_pre_write_guard.sh`（production 修复前预期红）。
 - [ ] `SP615-T2` Owner: `/root` — 在 `vibeguard-runtime/src/hook_orchestrator.rs` 实现 same-session Grep/Glob boundary 之后的 visible reminder counter，保留 attempt telemetry、breaker flow、500-event bound 与 mode/config semantics，并改正 escalation copy。Depends on: SP615-T1。Covers: B-001-B-008。Done when: focused red tests转绿；silent attempts 不计数；有效搜索恢复；无效事件不恢复；重新忽略 reminders 会再次阻断。Verify: focused shell test 与 Rust tests。
 - [ ] `SP615-T3` Owner: `/root` — 仅在 shell test 无法确定性覆盖 counter event ordering 时，新建 `cli_hook_pre_write` focused Rust integration target；不得向 799 行的 `cli_hook_orchestrator.rs` 追加。Depends on: SP615-T2。Covers: B-001, B-002, B-003, B-005, B-006。Done when: 缺失的 runtime contract 被 focused integration test 覆盖，或以已有 shell evidence 记录本任务 N/A。Verify: `cargo test --manifest-path vibeguard-runtime/Cargo.toml --test cli_hook_pre_write`（若创建）。
 - [ ] `SP615-T4` Owner: `/root` — 执行 hook/Rust/broad regression、独立审查和 current-head PR gates。Depends on: SP615-T2 and SP615-T3 disposition。Covers: B-001-B-008。Done when: tech spec 全部 fresh 命令通过，独立 reviewer 无 blocker，CI/threads/SpecRail required gate 全部通过。Verify: tech spec 测试计划中的全部命令。
@@ -39,7 +39,8 @@ GH-615
 - `verification_owner`: `/root`
 - `stop_conditions`: 需要新增 greenfield/commit/file-count heuristic；需要 event schema 或 breaker
   state migration；Grep/Glob event producer 与已核实合同不符；必须改变 threshold=0 或 block-mode 语义；
-  必须向 799 行 integration file 追加；任一 focused/Rust/hook/quick test 失败；独立 reviewer 有 blocker；
+  必须向 799 行 integration file 追加；production runtime 文件无法保持 `<800`；任一
+  focused/Rust/hook/quick test 失败；独立 reviewer 有 blocker；
   current-head CI、review threads 或 SpecRail required gate 未通过。
 - `lane_map`: specification `/root` 独占 `docs/specs/GH615/`、triage artifact 与 spec index；
   implementation `/root` 独占 `vibeguard-runtime/src/hook_orchestrator.rs`、

--- a/docs/specs/GH615/tech.md
+++ b/docs/specs/GH615/tech.md
@@ -34,14 +34,16 @@ GH-615
    却不构成用户忽略提醒的证据。
 4. escalation event reason 与 block 文案使用 `unheeded source-new reminders`/`visible ... reminders`
    语义。ACTION 明确“在本 repo 运行 Grep/Glob，确认无重复，然后重试 Write”，删除 child process 中
-   session-local `export` 和必须新 session 的恢复建议。threshold 的持久配置方式不在本修复中改写。
+   session-local `export` 和必须新 session 的恢复建议。若 copy 同时保留调高/禁用 threshold 的备选
+   路径，必须准确写出 `~/.vibeguard/config.json` 的 `write_escalate_threshold`，并标明它会产生持久、
+   全局影响；hook 不自动写该配置。
 5. 保持 `threshold == 0` 短路、`write_mode == block` 早期阻断、breaker record/check、attempt/reminder
    event schema 与 log read behavior 不变。本 Issue 不扩大为 log I/O 错误策略重构。
 6. Red-first 改写 `tests/hooks/test_pre_write_guard.sh` 的旧错误合同，使用隔离 log/state：
    - breaker threshold=1：一条 visible reminder 后多个 silent writes 不 escalation；
    - breaker threshold 高于 escalation threshold：可见 reminders 达阈值后下一次阻断；
    - append/emit 同 session Grep 或 Glob 后下一次 write 不再被旧 history 阻断；
-   - Read 与 other-session Grep 不恢复；
+   - Read、other-session Grep、malformed event 与 unrelated hook/tool/reason 不恢复；
    - 恢复后的新 reminders 可重新累计；
    - block copy 不含无效 export。
 7. 若 shell end-to-end test 无法确定性覆盖 event ordering，搜索后新增独立的
@@ -55,11 +57,11 @@ GH-615
 | --- | --- | --- |
 | B-001 | reminder-based history counter | focused breaker-silence regression + event-count assertions |
 | B-002 | reverse scan Grep/Glob boundary | same-session Grep and Glob recovery cases |
-| B-003 | session/tool/reason filters | Read, other-session Grep and malformed/unrelated event cases |
+| B-003 | session/tool/reason filters | Read、other-session Grep、malformed event、unrelated hook/tool/reason cases |
 | B-004 | unchanged breaker flow | threshold=1 silent-write regression and existing CB tests |
 | B-005 | post-boundary reminder accumulation | visible reminders reach threshold and next write blocks |
 | B-006 | escalation recovery | blocked → Grep/Glob → retry sequence, including OPEN breaker case |
-| B-007 | escalation copy | exact positive Grep/Glob guidance and negative export assertion |
+| B-007 | escalation copy | exact positive Grep/Glob guidance；negative export assertion；若保留 threshold 备选则 exact config path/key/persistent-global assertions |
 | B-008 | early modes, telemetry, bounded schema | existing threshold/write-mode/Rust telemetry tests + changed-file audit |
 
 ## 数据流
@@ -89,13 +91,16 @@ escalation 并输出 block。`analysis-paralysis-guard.sh` 已把 Grep/Glob tool
 - Silent degradation：malformed event 继续按现状忽略，log read 错误继续由现有调用层处理；本 Issue 不
   宣称修复该兼容边界，也不新增 fallback。
 - File size：`cli_hook_orchestrator.rs` 已 799 行，禁止追加；优先使用已有 focused shell test，必要时
-  新建职责单一的 Rust integration file。
+  新建职责单一的 Rust integration file。`hook_orchestrator.rs` 当前 777 行，production 修改后必须仍
+  `<800`；若无法在硬上限内清晰实现，停止并先拆分职责，不压缩可读性或绕过 guard。
 
 ## 测试计划
 
 - [ ] Red evidence：先改旧 shell regression 期待“silent attempts 不累计、search 可恢复、无 export”，
   在 production 未改时确定性失败并保存输出。
 - [ ] Focused：`bash tests/hooks/test_pre_write_guard.sh`。
+- [ ] Size：`wc -l vibeguard-runtime/src/hook_orchestrator.rs`，必须 `<800`；不得修改 799 行的既有 Rust
+  integration test。
 - [ ] Rust build/test：`cargo check --manifest-path vibeguard-runtime/Cargo.toml`；
   `cargo test --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] Hook contracts：`bash tests/test_hooks.sh`；`bash scripts/ci/validate-hooks.sh`；

--- a/docs/specs/GH615/tech.md
+++ b/docs/specs/GH615/tech.md
@@ -1,0 +1,111 @@
+# Tech Spec: reminder-aware pre-write escalation recovery
+
+## Linked Issue
+
+GH-615
+
+## Product Spec
+
+[`product.md`](product.md)
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Source-new orchestration | `vibeguard-runtime/src/hook_orchestrator.rs:284-366` | 在 breaker check 前记录 attempt；以全部 prior attempts 触发 escalation；仅 breaker Run 时记录 reminder | 当前把不可见 attempt 错算为未响应证据 |
+| Escalation history | `vibeguard-runtime/src/hook_orchestrator.rs:509-528` | 逆序扫描最近 500 行，只按 session/hook/`New source file attempt` 计数，不识别 Grep/Glob 边界 | 需要改为 visible-reminder-since-search 语义 |
+| Search evidence producer | `hooks/analysis-paralysis-guard.sh:97-108` | 每次 Read/Glob/Grep 都以原始 tool name 记录同 session pass event，且不受其 breaker 静默影响 | 已有 schema 足够表示 Grep/Glob heed boundary |
+| Shell regression | `tests/hooks/test_pre_write_guard.sh:188-214` | 明确断言 breaker-silenced attempts 会累计并断言无效 export 文案 | 必须 red-first 改写为新合同 |
+| Rust integration | `vibeguard-runtime/tests/cli_hook_orchestrator.rs:321-375` | 覆盖首次 attempt/reminder telemetry；文件已 799 行 | 保留 telemetry 回归，不在该文件继续追加超过 U-16 上限 |
+
+## 设计方案
+
+1. 将 `count_recent_source_new_attempts` 改名为
+   `count_unheeded_source_new_reminders`，保持返回 `Result<u64>` 和最近 500 行的有界读取。
+2. 从 event log 最新向最旧遍历并只处理可解析 JSON：
+   - 先过滤 `session_id == ctx.session_id`；
+   - 遇到 `hook == analysis-paralysis-guard` 且 `tool` 为 `Grep` 或 `Glob` 时停止遍历，该事件是最近
+     heed boundary；
+   - 在边界之前，仅累计 `hook == pre-write-guard` 且
+     `reason == New source file reminder` 的 event；
+   - Read、其他 session、attempt、escalation、breaker 与 malformed lines 均忽略。
+3. `run_source_new` 在 threshold check 前调用新 counter。保留 attempt event 在 breaker check 前的现有
+   位置作为 observability，但 attempt 不再参与 escalation。这样 breaker OPEN 的静默 calls 仍留痕，
+   却不构成用户忽略提醒的证据。
+4. escalation event reason 与 block 文案使用 `unheeded source-new reminders`/`visible ... reminders`
+   语义。ACTION 明确“在本 repo 运行 Grep/Glob，确认无重复，然后重试 Write”，删除 child process 中
+   session-local `export` 和必须新 session 的恢复建议。threshold 的持久配置方式不在本修复中改写。
+5. 保持 `threshold == 0` 短路、`write_mode == block` 早期阻断、breaker record/check、attempt/reminder
+   event schema 与 log read behavior 不变。本 Issue 不扩大为 log I/O 错误策略重构。
+6. Red-first 改写 `tests/hooks/test_pre_write_guard.sh` 的旧错误合同，使用隔离 log/state：
+   - breaker threshold=1：一条 visible reminder 后多个 silent writes 不 escalation；
+   - breaker threshold 高于 escalation threshold：可见 reminders 达阈值后下一次阻断；
+   - append/emit 同 session Grep 或 Glob 后下一次 write 不再被旧 history 阻断；
+   - Read 与 other-session Grep 不恢复；
+   - 恢复后的新 reminders 可重新累计；
+   - block copy 不含无效 export。
+7. 若 shell end-to-end test 无法确定性覆盖 event ordering，搜索后新增独立的
+   `cli_hook_pre_write` focused Rust integration target；禁止向已 799 行的
+   `cli_hook_orchestrator.rs` 追加。新文件只覆盖缺失的 runtime integration contract，不复制全部 hook
+   harness。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | reminder-based history counter | focused breaker-silence regression + event-count assertions |
+| B-002 | reverse scan Grep/Glob boundary | same-session Grep and Glob recovery cases |
+| B-003 | session/tool/reason filters | Read, other-session Grep and malformed/unrelated event cases |
+| B-004 | unchanged breaker flow | threshold=1 silent-write regression and existing CB tests |
+| B-005 | post-boundary reminder accumulation | visible reminders reach threshold and next write blocks |
+| B-006 | escalation recovery | blocked → Grep/Glob → retry sequence, including OPEN breaker case |
+| B-007 | escalation copy | exact positive Grep/Glob guidance and negative export assertion |
+| B-008 | early modes, telemetry, bounded schema | existing threshold/write-mode/Rust telemetry tests + changed-file audit |
+
+## 数据流
+
+`pre-write-guard.sh` 将 Write input 交给 Rust orchestrator。source-new warn path 读取同一 append-only JSONL
+event log 的最近 500 行，从尾部找到本 session 最新 Grep/Glob boundary，并累计其后的 visible reminder
+events。未达到阈值时仍记录 attempt，再由 circuit breaker 决定是否记录/输出 reminder；达到阈值则记录
+escalation 并输出 block。`analysis-paralysis-guard.sh` 已把 Grep/Glob tool name 和 session 写入同一日志，
+无需新字段、跨进程状态或外部调用。
+
+## 备选方案
+
+- 继续累计 attempts、只提高默认阈值：拒绝；不可见事件仍会伪造“unheeded”证据。
+- 仅在任何 analysis event 后清零：拒绝；Read 不满足 L1 search-first，其他 session 也不能证明当前
+  用户已响应。
+- 删除 escalation：拒绝；会失去重复忽略可见提醒时的 anti-duplication enforcement。
+- 在 escalation 后自动清零计数：拒绝；用户未搜索即可反复绕过，且没有真实 heed evidence。
+- 新增 greenfield heuristic：拒绝；这是独立产品决策，超出 GH-615 的 A+B+F 修复范围。
+- 让 hook 执行 `export`：拒绝；child process 不能修改已运行 agent 的父进程环境。
+
+## 风险
+
+- Security：错误识别 boundary 会削弱 L1；严格限定 same-session、exact hook、exact Grep/Glob。
+- Compatibility：保留 event schema、attempt telemetry、threshold=0 与 block mode；只改变错误计数语义。
+- Performance：继续最多解析最近 500 行，复杂度与当前实现相同。
+- Maintenance：reason/tool 字符串是现有事件合同；集中在一个 counter，tests 锁定正负边界。
+- Silent degradation：malformed event 继续按现状忽略，log read 错误继续由现有调用层处理；本 Issue 不
+  宣称修复该兼容边界，也不新增 fallback。
+- File size：`cli_hook_orchestrator.rs` 已 799 行，禁止追加；优先使用已有 focused shell test，必要时
+  新建职责单一的 Rust integration file。
+
+## 测试计划
+
+- [ ] Red evidence：先改旧 shell regression 期待“silent attempts 不累计、search 可恢复、无 export”，
+  在 production 未改时确定性失败并保存输出。
+- [ ] Focused：`bash tests/hooks/test_pre_write_guard.sh`。
+- [ ] Rust build/test：`cargo check --manifest-path vibeguard-runtime/Cargo.toml`；
+  `cargo test --manifest-path vibeguard-runtime/Cargo.toml`。
+- [ ] Hook contracts：`bash tests/test_hooks.sh`；`bash scripts/ci/validate-hooks.sh`；
+  `bash scripts/ci/validate-hooks-manifest.sh`。
+- [ ] Broad：`bash scripts/local-contract-check.sh --quick`；`git diff --check`。
+- [ ] Review/gate：独立 reviewer 对照 GH-615 与三份 Spec；current-head CI 全绿、零 unresolved review
+  threads、SpecRail required PR gate allowed。
+
+## 回滚方案
+
+恢复 attempt-based counter、旧 escalation copy 与旧 shell expectation 即可回滚；没有 schema、用户数据、
+配置或 breaker state 迁移。若恢复会重新引入 GH-615 的不可恢复锁死，应仅在新回归证据表明搜索边界
+误判时执行，并重新进入 Spec 流程。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,6 +6,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 
 | Spec | Status | Use it for |
 |---|---|---|
+| `GH615/` | Draft | Reminder-aware pre-write escalation counting, same-session Grep/Glob recovery, and actionable block guidance |
 | `GH623/` | Draft | Behavior-preserving decomposition of the oversized self-application CI harness into ordered focused test domains |
 | `GH621/` | Draft | Behavior-preserving extraction of install-time runtime acquisition, provenance, and source fallback from the oversized setup entrypoint |
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |


### PR DESCRIPTION
## Summary

Defines the SpecRail product, technical, and task contracts for making pre-write L1 escalation evidence-based and recoverable.

- count only visible `New source file reminder` events
- treat same-session Grep/Glob as the heed boundary
- preserve breaker/config/event-schema compatibility
- replace the ineffective session-local export advice with an actionable search-and-retry path
- record triage evidence and the red-first implementation plan

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## Checklist

- [x] SpecRail focused and all-spec checks pass
- [x] Documentation path and command-path validation pass
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH615`
- `python3 checks/check_workflow.py --repo . --all-specs`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`

## Related issues

Refs #615

## Screenshots / logs

Not applicable; spec-only PR.