### PR TITLE
fix: make pre-write L1 escalation recoverable (#615)

### DIFF
--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -185,33 +185,107 @@ rm -rf "$cb_state_dir"
 export VIBEGUARD_LOG_DIR="$prev_log_dir"
 unset VIBEGUARD_SESSION_ID VG_CB_LOCK_TIMEOUT_SECONDS cb_state_dir lock_file
 
-# Escalation must count source-new attempts even when the circuit breaker is
-# OPEN and individual reminder advisories are being silenced.
-header "pre-write-guard.sh — escalation counts circuit-breaker auto-pass attempts"
+# Escalation evidence must be based on advisories that were actually visible.
+header "pre-write-guard.sh — silent circuit-breaker attempts do not escalate"
 
 cb_state_dir=$(mktemp -d)
 export VIBEGUARD_LOG_DIR="$cb_state_dir"
+export VIBEGUARD_PROJECT_LOG_DIR="$cb_state_dir/project"
+export VIBEGUARD_LOG_FILE="$VIBEGUARD_PROJECT_LOG_DIR/events.jsonl"
+export VIBEGUARD_SESSION_ID="prewrite-silent-attempts"
 export VG_CB_THRESHOLD=1
 export VG_CB_COOLDOWN=300
 export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=3
 
-result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_escalate_1.go"}}' | bash hooks/pre-write-guard.sh)
-assert_contains "$result" "[L1]" "escalate: write #1 emits L1 advisory"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_silent_1.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "silent attempts: write #1 emits the only visible reminder"
 
-result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_escalate_2.go"}}' | bash hooks/pre-write-guard.sh)
-assert_not_contains "$result" "VIBEGUARD" "escalate: write #2 is silenced by open circuit"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_silent_2.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "silent attempts: write #2 is silenced by the open circuit"
 
-result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_escalate_3.go"}}' | bash hooks/pre-write-guard.sh)
-assert_not_contains "$result" "VIBEGUARD" "escalate: write #3 is also silenced by open circuit"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_silent_3.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "silent attempts: write #3 remains silent without escalating"
 
-result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_escalate_4.go"}}' | bash hooks/pre-write-guard.sh)
-assert_contains "$result" '"decision": "block"' "escalate: write #4 blocks after counted source-new attempts"
-assert_contains "$result" "3 new source file attempts" "escalate: block message reports counted attempts"
-assert_contains "$result" "VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0" "escalate: block message names an effective disable knob"
-assert_not_contains "$result" "VIBEGUARD_WRITE_MODE=warn" "escalate: block message does not suggest no-op warn mode"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_silent_4.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" "VIBEGUARD" "silent attempts: write #4 remains silent without escalating"
+
+silent_events=$(cat "$VIBEGUARD_LOG_FILE")
+assert_occurrences "$silent_events" "New source file reminder" "1" "silent attempts: only one visible reminder is recorded"
+assert_occurrences "$silent_events" "New source file attempt" "4" "silent attempts: attempt telemetry remains complete"
+assert_not_contains "$silent_events" '"decision": "escalate"' "silent attempts: no escalation event is recorded"
 
 rm -rf "$cb_state_dir"
-unset VG_CB_THRESHOLD VG_CB_COOLDOWN VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD cb_state_dir
+unset cb_state_dir silent_events
+
+# Only same-session Grep/Glob events form a recovery boundary. Invalid or
+# unrelated history must not weaken escalation, and new reminders after a
+# valid boundary must be able to escalate again.
+header "pre-write-guard.sh — escalation recovers after same-session search"
+
+cb_state_dir=$(mktemp -d)
+export VIBEGUARD_LOG_DIR="$cb_state_dir"
+export VIBEGUARD_PROJECT_LOG_DIR="$cb_state_dir/project"
+export VIBEGUARD_LOG_FILE="$VIBEGUARD_PROJECT_LOG_DIR/events.jsonl"
+export VIBEGUARD_SESSION_ID="prewrite-search-recovery"
+export VG_CB_THRESHOLD=100
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_search_1.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: reminder #1 is visible"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_search_2.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: reminder #2 is visible"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_search_3.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: reminder #3 is visible"
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_search_blocked.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "search recovery: threshold still blocks unheeded visible reminders"
+assert_contains "$result" "3 visible new source file reminders" "search recovery: block reports visible reminder count"
+assert_contains "$result" "~/.vibeguard/config.json" "search recovery: threshold alternative names the persistent config path"
+assert_contains "$result" "write_escalate_threshold" "search recovery: threshold alternative names the config key"
+assert_contains "$result" "persistent global change" "search recovery: threshold alternative explains global persistence"
+assert_not_contains "$result" "VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0" "search recovery: block omits ineffective session-local export"
+
+printf '%s\n' 'not-json' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_malformed.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "search recovery: malformed history does not reset escalation"
+
+printf '%s\n' '{"session":"prewrite-search-recovery","hook":"other-hook","tool":"Grep","reason":"New source file reminder"}' >> "$VIBEGUARD_LOG_FILE"
+printf '%s\n' '{"session":"prewrite-search-recovery","hook":"analysis-paralysis-guard","tool":"Edit","reason":"New source file reminder"}' >> "$VIBEGUARD_LOG_FILE"
+printf '%s\n' '{"session":"prewrite-search-recovery","hook":"pre-write-guard","tool":"Write","reason":"unrelated"}' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_unrelated.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "search recovery: unrelated hook/tool/reason events do not reset escalation"
+
+printf '%s\n' '{"session":"prewrite-search-recovery","hook":"analysis-paralysis-guard","tool":"Read"}' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_read.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "search recovery: same-session Read does not reset escalation"
+
+printf '%s\n' '{"session":"other-session","hook":"analysis-paralysis-guard","tool":"Grep"}' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_other_session.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "search recovery: other-session Grep does not reset escalation"
+
+printf '%s\n' '{"session":"prewrite-search-recovery","hook":"analysis-paralysis-guard","tool":"Grep"}' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_grep_1.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: same-session Grep releases the old escalation"
+assert_not_contains "$result" '"decision": "block"' "search recovery: Grep retry is not trapped by old reminders"
+
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_grep_2.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: post-Grep reminder #2 is visible"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_grep_3.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: post-Grep reminder #3 is visible"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_grep_blocked.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" '"decision": "block"' "search recovery: reminders after Grep can escalate again"
+
+printf '%s\n' '{"session":"prewrite-search-recovery","hook":"analysis-paralysis-guard","tool":"Glob"}' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_after_glob.go"}}' | bash hooks/pre-write-guard.sh)
+assert_contains "$result" "[L1]" "search recovery: same-session Glob also releases escalation"
+assert_not_contains "$result" '"decision": "block"' "search recovery: Glob retry is not trapped by old reminders"
+
+export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_escalation_disabled.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "search recovery: threshold zero keeps escalation disabled"
+
+rm -rf "$cb_state_dir"
+unset VG_CB_THRESHOLD VG_CB_COOLDOWN VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD
+unset VIBEGUARD_PROJECT_LOG_DIR VIBEGUARD_LOG_FILE VIBEGUARD_SESSION_ID cb_state_dir result
 
 # Codex P2 regression: a non-advisory write between source-file writes must
 # reset the breaker so the threshold counts CONSECUTIVE advisories, not

--- a/tests/hooks/test_pre_write_guard.sh
+++ b/tests/hooks/test_pre_write_guard.sh
@@ -214,6 +214,11 @@ assert_occurrences "$silent_events" "New source file reminder" "1" "silent attem
 assert_occurrences "$silent_events" "New source file attempt" "4" "silent attempts: attempt telemetry remains complete"
 assert_not_contains "$silent_events" '"decision": "escalate"' "silent attempts: no escalation event is recorded"
 
+printf '%s\n' '{"session":"prewrite-silent-attempts","hook":"analysis-paralysis-guard","tool":"Grep"}' >> "$VIBEGUARD_LOG_FILE"
+result=$(echo '{"tool_input":{"file_path":"/tmp/vg_cb_silent_after_grep.go"}}' | bash hooks/pre-write-guard.sh)
+assert_not_contains "$result" '"decision": "block"' "silent attempts: Grep recovery is not trapped while the circuit remains open"
+assert_not_contains "$result" "VIBEGUARD" "silent attempts: the still-open circuit may keep the recovered retry silent"
+
 rm -rf "$cb_state_dir"
 unset cb_state_dir silent_events
 

--- a/vibeguard-runtime/src/hook_orchestrator.rs
+++ b/vibeguard-runtime/src/hook_orchestrator.rs
@@ -313,7 +313,7 @@ fn run_source_new(
         "5",
     );
     let prior_count = if threshold > 0 {
-        count_recent_source_new_attempts(ctx).unwrap_or(0)
+        count_unheeded_source_new_reminders(ctx).unwrap_or(0)
     } else {
         0
     };
@@ -323,14 +323,14 @@ fn run_source_new(
             HookKind::PreWrite,
             decision::ESCALATE,
             status::ESCALATE,
-            &format!("L1 escalation after {prior_count} unheeded source-new attempts"),
+            &format!("L1 escalation after {prior_count} unheeded source-new reminders"),
             file_path,
             elapsed_ms(start),
         )?;
         print_pretty_decision(
             "block",
             &format!(
-                "VIBEGUARD [L1] [block] [escalation] OBSERVATION: {prior_count} new source file attempts in this session went unheeded\nSCOPE: pause new file creation — run Grep for similar function/class names and Glob for same-named files in this repo before any further Write\nACTION: REVIEW — confirm no duplicate exists; after manual verification start a new session, raise VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD, or export VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD=0 to disable escalation for this session"
+                "VIBEGUARD [L1] [block] [escalation] OBSERVATION: {prior_count} visible new source file reminders in this session went unheeded\nSCOPE: pause new file creation — run Grep for similar function/class names and Glob for same-named files in this repo before any further Write\nACTION: REVIEW — confirm no duplicate exists, then retry Write. To change the threshold, edit write_escalate_threshold in ~/.vibeguard/config.json; this is a persistent global change"
             ),
         );
         return Ok(());
@@ -506,25 +506,36 @@ fn breaker_config(ctx: &RuntimeContext, hook: &str) -> BreakerConfig {
     }
 }
 
-fn count_recent_source_new_attempts(ctx: &RuntimeContext) -> Result<u64> {
+fn count_unheeded_source_new_reminders(ctx: &RuntimeContext) -> Result<u64> {
     let text = match fs::read_to_string(&ctx.log_file) {
         Ok(text) => text,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
         Err(err) => return Err(err.into()),
     };
-    let count = text
+    let mut count = 0;
+    for event in text
         .lines()
         .rev()
         .take(500)
         .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .filter(|event| {
-            event.get(field::SESSION).and_then(Value::as_str) == Some(ctx.session_id.as_str())
-                && event.get(field::HOOK).and_then(Value::as_str) == Some("pre-write-guard")
-                && event.get(field::REASON).and_then(Value::as_str)
-                    == Some("New source file attempt")
-        })
-        .count();
-    Ok(count as u64)
+    {
+        if event.get(field::SESSION).and_then(Value::as_str) != Some(ctx.session_id.as_str()) {
+            continue;
+        }
+        let hook = event.get(field::HOOK).and_then(Value::as_str);
+        let event_tool = event.get(field::TOOL).and_then(Value::as_str);
+        if hook == Some("analysis-paralysis-guard")
+            && matches!(event_tool, Some(tool::GREP) | Some(tool::GLOB))
+        {
+            break;
+        }
+        if hook == Some("pre-write-guard")
+            && event.get(field::REASON).and_then(Value::as_str) == Some("New source file reminder")
+        {
+            count += 1;
+        }
+    }
+    Ok(count)
 }
 
 const MALFORMED_PRE_WRITE_REASON: &str = "VIBEGUARD interception: malformed PreToolUse(Write) hook input. The write request could not be validated, so it was blocked instead of being treated as a safe skip.";


### PR DESCRIPTION
## Summary

Makes pre-write L1 escalation depend on reminders the user actually saw and lets same-session Grep/Glob satisfy the search requirement.

- counts only visible `New source file reminder` events
- stops counting at the latest same-session `analysis-paralysis-guard` Grep/Glob event
- preserves `New source file attempt` telemetry and circuit-breaker behavior
- replaces the ineffective session-local export advice with search/retry plus accurate persistent global config guidance
- covers malformed/unrelated events, other sessions, Read, re-escalation, threshold zero, and recovery while the breaker remains OPEN

Spec: #642

## Why

The previous counter treated circuit-breaker-silenced writes as ignored advice and never consulted the Grep/Glob evidence the block itself requested. After the threshold, a session could remain trapped even after performing the required search.

## Plan implemented

- `SP615-T1`: red-first end-to-end hook contract
- `SP615-T2`: reminder-aware bounded history counter and corrected block copy
- `SP615-T3`: N/A; the focused shell suite deterministically covers event ordering, so no new Rust integration file was needed
- `SP615-T4`: focused, Rust, hook, validator, and broad contract verification

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New guard script

## Red / green evidence

- Before production fix: focused suite `58/68`, 10 expected GH615 failures.
- OPEN-breaker combination against old production: `58/70`, 12 expected failures, including both OPEN → Grep → retry assertions.
- Current implementation: focused suite `70/70`.

## Verification

- [x] `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check`
- [x] `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- [x] `cargo test --quiet --manifest-path vibeguard-runtime/Cargo.toml`
- [x] `bash tests/hooks/test_pre_write_guard.sh`
- [x] `bash tests/test_hooks.sh`
- [x] `bash scripts/ci/validate-hooks.sh`
- [x] `bash scripts/ci/validate-hooks-manifest.sh`
- [x] `bash scripts/local-contract-check.sh --quick`
- [x] `git diff --check`
- [x] `hook_orchestrator.rs` remains below U-16 hard limit: 788 lines
- [x] existing 799-line Rust integration file was not modified

## Checklist

- [x] Tests pass
- [x] Guard scripts tested
- [x] Linked SpecRail packet followed
- [x] No event-schema or config migration
- [x] No hardcoded personal paths
- [x] Conventional commit messages used

## Related issues

Fixes #615

## Screenshots / logs

Not applicable; command evidence is summarized above.