### PR TITLE
test: stabilize runtime-policy expected-error stdin (#644)

### DIFF
--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -758,38 +758,19 @@ fn runtime_policy_argument_errors_are_visible() {
 }
 
 #[test]
-fn runtime_policy_diag_open_error_is_visible() {
-    let repo = unique_temp_dir("diag_open_error");
-    fs::create_dir_all(&repo).expect("diag directory should be created");
-
-    let output = run_runtime_with_stdin(
-        &[
-            "runtime-policy-diag",
-            repo.to_str().expect("diag path should be utf8"),
-            "pre-bash-guard.sh",
-            "PreToolUse",
-            "policy_error",
-            "run-hook-codex.sh",
-        ],
-        "runtime missing",
-    );
-
-    assert!(!output.status.success());
-    assert!(output.stdout.is_empty());
-    assert!(!output.stderr.is_empty());
-    assert!(repo.is_dir());
-
-    let invalid_payload = run_runtime_with_stdin(
-        &[
+fn runtime_policy_downgrade_output_invalid_payload_is_visible() {
+    let invalid_payload = bin()
+        .args([
             "runtime-policy-downgrade-output",
             "--payload",
             "not-json",
             "post-edit-guard.sh",
-        ],
-        r#"{"decision":"block"}"#,
-    );
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("runtime helper should finish");
+
     assert!(!invalid_payload.status.success());
     assert!(invalid_payload.stdout.is_empty());
     assert!(String::from_utf8_lossy(&invalid_payload.stderr).contains("payload invalid JSON"));
-    let _ = fs::remove_dir_all(repo);
 }

--- a/vibeguard-runtime/tests/runtime_policy_diag_io_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_diag_io_cli.rs
@@ -3,9 +3,13 @@ mod common;
 use common::{bin, unique_temp_dir};
 use std::fs;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_STDIN_FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
 
 fn run_runtime_with_file_stdin(args: &[&str], input: &str) -> std::process::Output {
-    let fixture_dir = unique_temp_dir("policy-diag-stdin");
+    let fixture_id = NEXT_STDIN_FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+    let fixture_dir = unique_temp_dir(&format!("policy-diag-stdin-{fixture_id}"));
     fs::create_dir_all(&fixture_dir).expect("stdin fixture directory should be created");
     let input_path = fixture_dir.join("stdin");
     fs::write(&input_path, input).expect("stdin fixture should be written");

--- a/vibeguard-runtime/tests/runtime_policy_diag_io_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_diag_io_cli.rs
@@ -1,7 +1,25 @@
 mod common;
 
-use common::{run_runtime_with_stdin, unique_temp_dir};
+use common::{bin, unique_temp_dir};
 use std::fs;
+use std::process::Stdio;
+
+fn run_runtime_with_file_stdin(args: &[&str], input: &str) -> std::process::Output {
+    let fixture_dir = unique_temp_dir("policy-diag-stdin");
+    fs::create_dir_all(&fixture_dir).expect("stdin fixture directory should be created");
+    let input_path = fixture_dir.join("stdin");
+    fs::write(&input_path, input).expect("stdin fixture should be written");
+    let input_file = fs::File::open(&input_path).expect("stdin fixture should be opened");
+
+    let output = bin()
+        .args(args)
+        .stdin(Stdio::from(input_file))
+        .output()
+        .expect("runtime helper should finish");
+
+    fs::remove_dir_all(fixture_dir).expect("stdin fixture directory should be removed");
+    output
+}
 
 #[test]
 fn runtime_policy_diag_parent_create_error_is_visible() {
@@ -11,7 +29,7 @@ fn runtime_policy_diag_parent_create_error_is_visible() {
     fs::write(&blocked_parent, "unchanged").expect("blocking file should be written");
     let diag_file = blocked_parent.join("policy.jsonl");
 
-    let output = run_runtime_with_stdin(
+    let output = run_runtime_with_file_stdin(
         &[
             "runtime-policy-diag",
             diag_file.to_str().expect("diagnostic path should be UTF-8"),
@@ -27,13 +45,37 @@ fn runtime_policy_diag_parent_create_error_is_visible() {
     assert!(output.stdout.is_empty());
     assert!(!output.stderr.is_empty());
     assert_eq!(fs::read_to_string(&blocked_parent).unwrap(), "unchanged");
-    let _ = fs::remove_dir_all(repo);
+    fs::remove_dir_all(repo).expect("temporary directory should be removed");
+}
+
+#[test]
+fn runtime_policy_diag_open_error_is_visible() {
+    let repo = unique_temp_dir("diag-open-error");
+    fs::create_dir_all(&repo).expect("diagnostic directory should be created");
+
+    let output = run_runtime_with_file_stdin(
+        &[
+            "runtime-policy-diag",
+            repo.to_str().expect("diagnostic path should be UTF-8"),
+            "pre-bash-guard.sh",
+            "PreToolUse",
+            "policy_error",
+            "run-hook-codex.sh",
+        ],
+        "runtime missing",
+    );
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty());
+    assert!(repo.is_dir());
+    fs::remove_dir_all(repo).expect("diagnostic directory should be removed");
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn runtime_policy_diag_write_error_is_visible() {
-    let output = run_runtime_with_stdin(
+    let output = run_runtime_with_file_stdin(
         &[
             "runtime-policy-diag",
             "/dev/full",


### PR DESCRIPTION
## Why

Two independent remote runs failed the `runtime_policy_diag_open_error_is_visible` test function at its shared piped-stdin `write_all` with `BrokenPipe`, masking the child result. The function contained two helper calls; source-order analysis showed the invalid-`--payload` child rejects its payload before reading stdin and is the strongest direct trigger. The adjacent diagnostic parent-create test is another pre-stdin early-exit path using the same transport.

The old full test target passed 200 local repetitions, so this PR uses the two remote failures as the truthful red baseline instead of claiming a deterministic local reproduction.

## Implementation

- move the open-directory failure case into the existing focused `runtime_policy_diag_io_cli` target;
- give the parent-create, open-directory, and Linux `/dev/full` cases a private file-backed stdin runner, with an atomic per-invocation fixture ID and all fixture/setup/cleanup errors failing loudly;
- rename the remaining invalid-payload test and run it directly with `Stdio::null()`, preserving failed status, empty stdout, and exact `payload invalid JSON` stderr coverage;
- leave the shared piped helper, unrelated stdin tests, all production runtime code, schemas, hooks, and setup untouched;
- reduce `runtime_policy_cli.rs` from 795 to 776 lines; keep the focused diagnostic file at 97 lines.

## Verification

- diagnostic focused target: 2/2 passed on macOS; Linux CI additionally covers `/dev/full`;
- invalid-payload exact case: 1/1 passed;
- related `runtime_policy_cli` target: 24/24 passed;
- diagnostic stress: 200/200 passed with `--test-threads=2` after adding atomic fixture IDs;
- invalid-payload exact stress: 200/200 passed;
- `cargo fmt --manifest-path vibeguard-runtime/Cargo.toml -- --check` passed;
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml` passed;
- full `cargo test --manifest-path vibeguard-runtime/Cargo.toml` passed;
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH644` passed;
- `bash scripts/local-contract-check.sh --quick` passed;
- `git diff --check`, changed-file boundary, production/shared-helper diff, and `<800` line gates passed.

## Spec coverage

B-001..B-008 and SP644-T1/T2 are covered. SP644-T3 is the current PR review/CI/gate/merge lane. The implementation changes exactly the two integration test files authorized by the merged spec.

Fixes #644
