### PR TITLE
feat(rules): generate compact table from canonical source (#626)

### DIFF
--- a/claude-md/CLAUDE.md
+++ b/claude-md/CLAUDE.md
@@ -10,6 +10,7 @@ VibeGuard rule injection mechanism. This directory contains template files that 
 
 ## Modify rules
 
-1. Edit `vibeguard-rules.md`
-2. Run `bash setup.sh` to re-inject
-3. Valid in new Claude Code session
+1. Edit the canonical rule under `rules/claude-rules/**`, including its `**Compact guidance:**` field when the rule is selected for compact injection
+2. Run `python3 scripts/generate_rule_docs.py` from the repository root
+3. Run `bash setup.sh` to re-inject
+4. Valid in new Claude Code session

--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -61,6 +61,7 @@ Security > Logic > Data Splitting > Repeating Types > Unwrap > Naming
 
 ## Key Detailed Rules (full set in `rules/claude-rules/**`)
 
+<!-- vibeguard-generated-compact-rules:start -->
 | ID | Severity | Rule |
 |----|----------|------|
 | U-16 | Guideline | Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. Files above 800 must be split. |
@@ -79,4 +80,5 @@ Security > Logic > Data Splitting > Repeating Types > Unwrap > Naming
 | SEC-02 | Critical | No hardcoded keys, credentials, or API tokens. Load from env / secret manager. |
 | SEC-11 | Strict | AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`. |
 | SEC-13 | Strict | High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators. |
+<!-- vibeguard-generated-compact-rules:end -->
 <!-- vibeguard-end -->

--- a/docs/specs/GH626/tasks.md
+++ b/docs/specs/GH626/tasks.md
@@ -8,14 +8,14 @@ GH-626
 
 - Product: `product.md`
 - Tech: `tech.md`
-- Status: draft；执行前必须由维护者批准规格并把 issue 置为 `ready_to_implement`
+- Status: implemented；规格已合并且 issue 已置为 `ready_to_implement`
 
 ## 实现任务
 
-- [ ] `SP626-T1` 增加 canonical `Compact guidance` parser、16-row migration fixture 与有序 selection。Covers: B-001, B-002, B-003, B-007. Owner: implementation agent. Dependencies: spec approval. Done when: 16 个 selected records 各有唯一非空 guidance，renderer 不用 `Rule.summary`/旧表 fallback，selection/selected canonical/guidance 的缺失或重复均 fail-visible，迁移前后 16 行逐行一致。Verify: `python3 tests/test_generate_rule_docs.py`。
-- [ ] `SP626-T2` 增加唯一 inner markers 与区块限定 replacer。Covers: B-005, B-008. Owner: implementation agent. Dependencies: SP626-T1. Done when: missing/duplicate/misordered markers 非零失败，成功 write 的 marker 外 prefix/suffix 字节不变，连续两次生成无 diff。Verify: `python3 tests/test_generate_rule_docs.py`; 连续运行两次 `python3 scripts/generate_rule_docs.py` 后 `git diff --exit-code`。
-- [ ] `SP626-T3` 把 compact output 接入 stale check，更新维护说明并验证 setup/U-32。Covers: B-004, B-006. Owner: implementation agent. Dependencies: SP626-T1, SP626-T2. Done when: canonical guidance/severity/selection 变化会让 `--check` 非零，维护者入口指向 canonical field，默认注入集合与预算不扩大。Verify: `bash scripts/ci/validate-generated-rule-docs.sh`; `bash tests/test_setup.sh`; `bash tests/hooks/test_count_active_constraints.sh`。
-- [ ] `SP626-T4` 运行规则文档提交门禁并记录 fresh output。Covers: B-001..B-008. Owner: verification owner. Dependencies: SP626-T1..T3. Done when: 所有必跑命令在同一提交通过，且人工 diff 确认 inner markers 外无生成改动。Verify: `python3 tests/test_generate_rule_docs.py`; `bash scripts/ci/validate-rules.sh`; `bash scripts/ci/validate-generated-rule-docs.sh`; `bash scripts/verify/doc-freshness-check.sh --strict`; `git diff --check`。
+- [x] `SP626-T1` 增加 canonical `Compact guidance` parser、16-row migration fixture 与有序 selection。Covers: B-001, B-002, B-003, B-007. Owner: implementation agent. Dependencies: spec approval. Done when: 16 个 selected records 各有唯一非空 guidance，renderer 不用 `Rule.summary`/旧表 fallback，selection/selected canonical/guidance 的缺失或重复均 fail-visible，迁移前后 16 行逐行一致。Verify: `python3 tests/test_generate_rule_docs.py`。
+- [x] `SP626-T2` 增加唯一 inner markers 与区块限定 replacer。Covers: B-005, B-008. Owner: implementation agent. Dependencies: SP626-T1. Done when: missing/duplicate/misordered markers 非零失败，成功 write 的 marker 外 prefix/suffix 字节不变，连续两次生成无 diff。Verify: `python3 tests/test_generate_rule_docs.py`; 连续运行两次 `python3 scripts/generate_rule_docs.py` 后 `git diff --exit-code`。
+- [x] `SP626-T3` 把 compact output 接入 stale check，更新维护说明并验证 setup/U-32。Covers: B-004, B-006. Owner: implementation agent. Dependencies: SP626-T1, SP626-T2. Done when: canonical guidance/severity/selection 变化会让 `--check` 非零，维护者入口指向 canonical field，默认注入集合与预算不扩大。Verify: `bash scripts/ci/validate-generated-rule-docs.sh`; `bash tests/test_setup.sh`; `bash tests/hooks/test_count_active_constraints.sh`。
+- [x] `SP626-T4` 运行规则文档提交门禁并记录 fresh output。Covers: B-001..B-008. Owner: verification owner. Dependencies: SP626-T1..T3. Done when: 所有必跑命令在同一提交通过，且人工 diff 确认 inner markers 外无生成改动。Verify: `python3 tests/test_generate_rule_docs.py`; `bash scripts/ci/validate-rules.sh`; `bash scripts/ci/validate-generated-rule-docs.sh`; `bash scripts/verify/doc-freshness-check.sh --strict`; `git diff --check`。
 
 ## 并行拆分
 
@@ -30,6 +30,5 @@ GH-626
 
 ## Handoff Notes
 
-当前仅为 draft task plan。未获得 spec approval 或 `ready_to_implement` 标签时停止；
-不得开始 generator/高上下文文件修改，不得使用 `Rule.summary` 或旧表 fallback，不得扩大
-inner-marker 写入边界，不得降低 16-row migration、U-32、setup 或 freshness 测试。
+实现按已批准规格完成；generator 不使用 `Rule.summary` 或旧表 fallback，inner-marker
+写入边界、16-row migration、U-32、setup 与 freshness 验证均保留为回归门禁。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,7 +6,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 
 | Spec | Status | Use it for |
 |---|---|---|
-| `GH626/` | Draft | Canonical-source generation and freshness enforcement for the compact injected rule table |
+| `GH626/` | Implemented reference | Canonical-source generation and freshness enforcement for the compact injected rule table |
 | `GH644/` | Draft | Deterministic stdin and complete child-error evidence for runtime-policy expected-error integration tests |
 | `GH615/` | Draft | Reminder-aware pre-write escalation counting, same-session Grep/Glob recovery, and actionable block guidance |
 | `GH623/` | Draft | Behavior-preserving decomposition of the oversized self-application CI harness into ordered focused test domains |

--- a/rules/claude-rules/common/coding-style.md
+++ b/rules/claude-rules/common/coding-style.md
@@ -34,9 +34,11 @@ If the intent is unclear, mark it as DEFER or ask the user to clarify.
 Create new objects instead of mutating existing ones. Treat function parameters as read-only.
 
 ## U-16: Keep file size under control (guideline)
+**Compact guidance:** Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. Files above 800 must be split.
 200-400 lines is typical, 800 lines is the hard ceiling. Files above 800 lines must be split.
 
 ## U-17: Handle errors completely (strict)
+**Compact guidance:** Handle errors completely. Do not swallow exceptions silently.
 See U-29 for canonical error-handling guidance. U-17 keeps the compatibility-level principle: do not swallow exception or error paths; surface user-visible failures at error level or raise.
 
 ## U-18: Validate inputs (guideline)
@@ -52,6 +54,7 @@ Use a standard envelope such as `{ data, error, meta }`. Standardize error codes
 Record why the change exists, not just what changed. Use the repository's Lore trailers to preserve constraints, rejected alternatives, confidence, and verification evidence.
 
 ## U-22: Test coverage (strict)
+**Compact guidance:** New code minimum 80% line coverage; critical paths 100%.
 New code must reach at least 80% line coverage. Critical paths require 100% coverage.
 
 **Mechanical checks (agent execution rules)**:
@@ -67,6 +70,7 @@ See U-29 for canonical no-silent-degradation guidance. Unsupported strategies or
 Do not keep function, type, command, or directory aliases. If you find the old name, replace it everywhere and delete the alias.
 
 ## U-25: Fix build failures first (strict)
+**Compact guidance:** Fix build failures first before any other edit; do not add new code while build is red.
 When a build failure is detected, you must fix the build before continuing any other edits. Do not add new code while the build is red.
 
 **Mechanical checks (agent execution rules)**:
@@ -76,6 +80,7 @@ When a build failure is detected, you must fix the build before continuing any o
 - Do not add unrelated feature code while the build is red.
 
 ## U-26: Declaration-execution completeness (strict)
+**Compact guidance:** Declaration-execution completeness: declared Config / Trait / persistence layers must be wired into startup.
 When you declare framework components such as configs, traits, persistence layers, or state containers, you must also finish the startup integration. Do not leave components declared-but-unwired.
 
 **Checklist**:

--- a/rules/claude-rules/common/no-silent-degradation.md
+++ b/rules/claude-rules/common/no-silent-degradation.md
@@ -1,6 +1,7 @@
 # No Silent Degradation Rules
 
 ## U-29: Error-driven downgrade paths must be observable at error level (strict)
+**Compact guidance:** No silent degradation: errors causing user-visible missing data or wrong output must `error` or raise, not `warning` + fallback.
 
 If an error causes user-visible missing data or incorrect output, you must log it at `error` level or raise it. Do not use `warning` plus fallback to silently emit a wrong result.
 

--- a/rules/claude-rules/common/security.md
+++ b/rules/claude-rules/common/security.md
@@ -1,6 +1,7 @@
 # Security Rules
 
 ## SEC-01: SQL / NoSQL / OS command injection (critical)
+**Compact guidance:** No SQL / NoSQL / OS command injection: use parameterized queries and array argument lists.
 String concatenation is used to build queries or commands. Fix: use parameterized queries; pass command arguments as an array instead of a shell string.
 ```python
 cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))  # Correct
@@ -8,6 +9,7 @@ subprocess.run(["ls", "-la", path], check=True)                   # Correct
 ```
 
 ## SEC-02: Hardcoded keys / credentials / API tokens (critical)
+**Compact guidance:** No hardcoded keys, credentials, or API tokens. Load from env / secret manager.
 Secrets are written directly in code. Fix: move them to environment variables or a secret manager. Add `.env` to `.gitignore`.
 
 ## SEC-03: Unescaped user input rendered directly into HTML (high)
@@ -35,6 +37,7 @@ Examples include `pickle` and `yaml.load`. Fix: use `yaml.safe_load()` in Python
 Passwords or tokens appear in logs. Fix: redact log output and replace sensitive fields with `***`.
 
 ## SEC-11: AI-generated code security defect baseline (strict)
+**Compact guidance:** AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`.
 AI-generated code carries materially higher security risk than hand-written code, so review intensity must increase accordingly.
 
 **Empirical data** (source: Addy Osmani, "Code Review in the Age of AI", 2026):
@@ -118,6 +121,7 @@ Claude Code v2.1.121 (released 2026-04-28, verified via `gh api repos/anthropics
 **Downgrade path** (U-32 compliance): if a project legitimately needs `alwaysLoad: true` for latency reasons (e.g. an internal MCP server with thousands of vetted tools), the project must record the decision in its repo (e.g. an ADR or `SECURITY.md` note) and re-confirm the decision when any of those tool descriptions changes.
 
 ## SEC-13: High-context file integrity protection (strict)
+**Compact guidance:** High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators.
 `AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, `.claude/**/*.md`, hook configurations and hook scripts (`.claude/hooks/**`, the `hooks` field of `~/.claude/settings.json`, plus the actual command path the hook resolves to), and rule or skill definitions are **high-context files**. If a dependency, build script, or external generator silently rewrites them, it can change the agent's behavior boundaries and summary output.
 
 **Rules**:

--- a/rules/claude-rules/common/workflow.md
+++ b/rules/claude-rules/common/workflow.md
@@ -3,6 +3,7 @@
 > Adapted from the Superpowers framework and made complementary to VibeGuard's existing rules. Focused on debugging, verification, and TDD workflow constraints.
 
 ## W-01: No fixes without root cause (strict)
+**Compact guidance:** No fixes without root cause: reproduce first, then form one hypothesis, then fix.
 Every bug fix must identify the root cause before changing code. Do not make blind "let's try this" patches.
 
 **Four-phase debugging protocol**:
@@ -17,6 +18,7 @@ Every bug fix must identify the root cause before changing code. Do not make bli
 - After the fix, rerun the reproduction step to verify the problem is gone.
 
 ## W-02: Back off after 3 consecutive failures (strict)
+**Compact guidance:** After 3 consecutive failed fixes on the same problem, stop and challenge the hypothesis or architecture.
 If you fail to fix the same problem three times in a row, stop and question the hypothesis or the architectural direction.
 
 **Anti-pattern**: edit -> fail -> fix -> new fail -> fix -> new fail ...
@@ -31,6 +33,7 @@ If you fail to fix the same problem three times in a row, stop and question the 
 Research on multi-round reasoning suggests the optimal stopping policy comes from allocating an error budget across rounds, not from a hardcoded round count. "Three times" is a practical heuristic: after each failed attempt, the confidence of the active hypothesis tree drops exponentially, and the expected value of continuing approaches zero. Past that threshold, changing direction has higher expected value than repeating the same line of attack.
 
 ## W-03: Verify before claiming completion (strict)
+**Compact guidance:** Verify before claiming completion: produce fresh command output proving the claim.
 Before saying "fixed" or "done", produce fresh verification evidence.
 
 **Protocol**:
@@ -93,6 +96,7 @@ REFACTOR -> keep the tests green while cleaning the implementation
 **Not a fit**: exploratory prototypes, configuration changes, documentation updates
 
 ## W-12: Protect test integrity (strict)
+**Compact guidance:** Protect test integrity: fix production code, never weaken assertions or tamper with test infrastructure.
 When tests fail, fix the production code rather than manipulating the test harness. Do not "pass" the suite by weakening tests or infrastructure.
 
 **Source**: OpenAI, "Monitoring Reasoning Models for Misbehavior" (Baker et al., 2026) — seven classes of reward-hacking behavior were observed in RL-trained coding agents, and every one manipulated tests instead of fixing the underlying issue.
@@ -119,6 +123,7 @@ When tests fail, fix the production code rather than manipulating the test harne
 - If source and tests both change, test changes must not reduce assertion strength; run `bash guards/universal/check_test_weakening.sh --base origin/main --head HEAD` during PR review when a diff is available.
 
 ## W-14: Parallel-agent file ownership (strict)
+**Compact guidance:** Parallel agents must have explicit, disjoint file ownership; no shared writable file.
 When multiple agents work in parallel, prompts must assign explicit file ownership so agents cannot silently overwrite one another.
 
 **Root cause** (source: GitHub Copilot CLI / fleet docs, 2026):
@@ -195,6 +200,7 @@ If the information gain shrinks for three consecutive rounds, stop that directio
 - For one-shot suppression in a single edit, the size-cap (300 chars) already prevents large content additions from triggering.
 
 ## W-16: Verification commands must come from this session (strict)
+**Compact guidance:** Verification commands must come from this session. "Earlier passed" / "should work" do not count.
 When you say "fixed", "done", or "verified", you must cite command output produced in this session. Memory, "it passed earlier", or "it should work" do not count.
 
 **Sources** (four-source convergence, 2026-04-16):

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -36,10 +36,12 @@ COMPACT_RULE_IDS = (
     "SEC-13",
 )
 
+RULE_ID_PATTERN = r"(?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+"
 HEADING_RE = re.compile(
-    r"^##\s+((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+):\s+(.+?)\s+\(([^)]+)\)\s*$",
+    rf"^##\s+({RULE_ID_PATTERN}):\s+(.+?)\s+\(([^)]+)\)\s*$",
     re.MULTILINE,
 )
+RULE_HEADING_CANDIDATE_RE = re.compile(rf"^##\s+({RULE_ID_PATTERN}):")
 FENCE_RE = re.compile(r"^```")
 COMPACT_GUIDANCE_RE = re.compile(r"^\*\*Compact guidance:\*\*[ \t]*(.*)$", re.MULTILINE)
 
@@ -109,11 +111,33 @@ def summarize_block(block: str, fallback: str) -> str:
     return text[:137].rstrip() + "..."
 
 
+def find_rule_headings(text: str, source: Path) -> list[re.Match[str]]:
+    matches: list[re.Match[str]] = []
+    in_fence = False
+    offset = 0
+    for line_number, line in enumerate(text.splitlines(keepends=True), start=1):
+        stripped = line.strip()
+        if FENCE_RE.match(stripped):
+            in_fence = not in_fence
+        elif not in_fence:
+            candidate = RULE_HEADING_CANDIDATE_RE.match(line)
+            if candidate:
+                match = HEADING_RE.match(text, offset)
+                if match is None:
+                    raise ValueError(
+                        f"Malformed rule heading {candidate.group(1)} in {source}:{line_number}"
+                    )
+                matches.append(match)
+        offset += len(line)
+    return matches
+
+
 def parse_rules(canonical_rules_dir: Path = CANONICAL_RULES_DIR) -> list[Rule]:
     rules: list[Rule] = []
     for path in sorted(canonical_rules_dir.rglob("*.md")):
         text = path.read_text(encoding="utf-8")
-        matches = list(HEADING_RE.finditer(text))
+        source = path.relative_to(ROOT) if path.is_relative_to(ROOT) else path.relative_to(canonical_rules_dir)
+        matches = find_rule_headings(text, source)
         if not matches:
             continue
         for idx, match in enumerate(matches):
@@ -121,7 +145,6 @@ def parse_rules(canonical_rules_dir: Path = CANONICAL_RULES_DIR) -> list[Rule]:
             end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
             block = text[start:end]
             compact_matches = COMPACT_GUIDANCE_RE.findall(block)
-            source = path.relative_to(ROOT) if path.is_relative_to(ROOT) else path.relative_to(canonical_rules_dir)
             if len(compact_matches) > 1:
                 raise ValueError(
                     f"Rule {match.group(1)} in {source} has duplicate compact guidance fields"

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -14,18 +14,43 @@ from typing import Callable, Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 CANONICAL_RULES_DIR = ROOT / "rules" / "claude-rules"
+COMPACT_RULES_PATH = ROOT / "claude-md" / "vibeguard-rules.md"
+COMPACT_START_MARKER = "<!-- vibeguard-generated-compact-rules:start -->"
+COMPACT_END_MARKER = "<!-- vibeguard-generated-compact-rules:end -->"
+COMPACT_RULE_IDS = (
+    "U-16",
+    "U-17",
+    "U-22",
+    "U-25",
+    "U-26",
+    "U-29",
+    "W-01",
+    "W-02",
+    "W-03",
+    "W-12",
+    "W-14",
+    "W-16",
+    "SEC-01",
+    "SEC-02",
+    "SEC-11",
+    "SEC-13",
+)
 
 HEADING_RE = re.compile(
     r"^##\s+((?:RS|GO|TS|PY|U|SEC|W|TASTE)-[A-Za-z0-9-]+):\s+(.+?)\s+\(([^)]+)\)\s*$",
     re.MULTILINE,
 )
 FENCE_RE = re.compile(r"^```")
+COMPACT_GUIDANCE_RE = re.compile(r"^\*\*Compact guidance:\*\*[ \t]*(.*)$", re.MULTILINE)
+
+
 @dataclass(frozen=True)
 class Rule:
     id: str
     name: str
     severity: str
     summary: str
+    compact_guidance: str | None
     source: Path
 
 
@@ -84,9 +109,9 @@ def summarize_block(block: str, fallback: str) -> str:
     return text[:137].rstrip() + "..."
 
 
-def parse_rules() -> list[Rule]:
+def parse_rules(canonical_rules_dir: Path = CANONICAL_RULES_DIR) -> list[Rule]:
     rules: list[Rule] = []
-    for path in sorted(CANONICAL_RULES_DIR.rglob("*.md")):
+    for path in sorted(canonical_rules_dir.rglob("*.md")):
         text = path.read_text(encoding="utf-8")
         matches = list(HEADING_RE.finditer(text))
         if not matches:
@@ -95,15 +120,76 @@ def parse_rules() -> list[Rule]:
             start = match.end()
             end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
             block = text[start:end]
+            compact_matches = COMPACT_GUIDANCE_RE.findall(block)
+            source = path.relative_to(ROOT) if path.is_relative_to(ROOT) else path.relative_to(canonical_rules_dir)
+            if len(compact_matches) > 1:
+                raise ValueError(
+                    f"Rule {match.group(1)} in {source} has duplicate compact guidance fields"
+                )
+            try:
+                severity = normalize_severity(match.group(3))
+            except ValueError as error:
+                raise ValueError(f"Rule {match.group(1)} in {source}: {error}") from error
             rule = Rule(
                 id=match.group(1),
                 name=match.group(2).strip(),
-                severity=normalize_severity(match.group(3)),
+                severity=severity,
                 summary=summarize_block(block, match.group(2)),
-                source=path.relative_to(ROOT),
+                compact_guidance=compact_matches[0].strip() if compact_matches else None,
+                source=source,
             )
             rules.append(rule)
     return rules
+
+
+def render_compact_table(
+    rules: Iterable[Rule],
+    selection: Iterable[str] = COMPACT_RULE_IDS,
+) -> str:
+    selected_ids = tuple(selection)
+    seen_selection: set[str] = set()
+    for rule_id in selected_ids:
+        if rule_id in seen_selection:
+            raise ValueError(f"duplicate compact rule selection: {rule_id}")
+        seen_selection.add(rule_id)
+
+    rules_by_id: dict[str, list[Rule]] = {}
+    for rule in rules:
+        rules_by_id.setdefault(rule.id, []).append(rule)
+
+    rows = ["| ID | Severity | Rule |", "|----|----------|------|"]
+    for rule_id in selected_ids:
+        matches = rules_by_id.get(rule_id, [])
+        if not matches:
+            raise ValueError(f"missing selected compact rule: {rule_id}")
+        if len(matches) > 1:
+            sources = ", ".join(str(rule.source) for rule in matches)
+            raise ValueError(f"duplicate canonical compact rule {rule_id}: {sources}")
+        rule = matches[0]
+        if not rule.compact_guidance:
+            raise ValueError(f"compact guidance is missing or empty for {rule_id} in {rule.source}")
+        rows.append(f"| {rule.id} | {rule.severity} | {rule.compact_guidance} |")
+    return "\n".join(rows)
+
+
+def replace_compact_region(document: str, table: str) -> str:
+    start_token = COMPACT_START_MARKER + "\n"
+    end_token = COMPACT_END_MARKER
+    if document.count(COMPACT_START_MARKER) != 1 or document.count(COMPACT_END_MARKER) != 1:
+        raise ValueError("compact rule marker must appear exactly once")
+
+    start_index = document.find(start_token)
+    end_index = document.find(end_token)
+    if start_index < 0 or end_index < 0 or end_index < start_index + len(start_token):
+        raise ValueError("compact rule markers must be on their own lines and in order")
+    if start_index > 0 and document[start_index - 1] != "\n":
+        raise ValueError("compact rule marker must be on its own line")
+    after_end = end_index + len(end_token)
+    if after_end < len(document) and document[after_end] != "\n":
+        raise ValueError("compact rule marker must be on its own line")
+
+    content_start = start_index + len(start_token)
+    return document[:content_start] + table.rstrip("\n") + "\n" + document[end_index:]
 
 
 def make_table(headers: list[str], rows: list[list[str]]) -> str:
@@ -519,7 +605,21 @@ GENERATORS: dict[Path, Callable[[list[Rule]], str]] = {
 
 
 def render_all(rules: list[Rule]) -> dict[Path, str]:
-    return {path: generator(rules).rstrip() + "\n" for path, generator in GENERATORS.items()}
+    outputs = {path: generator(rules).rstrip() + "\n" for path, generator in GENERATORS.items()}
+    compact_document = COMPACT_RULES_PATH.read_text(encoding="utf-8")
+    try:
+        outputs[COMPACT_RULES_PATH] = replace_compact_region(
+            compact_document,
+            render_compact_table(rules),
+        )
+    except ValueError as error:
+        relative_path = COMPACT_RULES_PATH.relative_to(ROOT)
+        raise ValueError(f"{relative_path}: {error}") from error
+    return outputs
+
+
+def display_path(path: Path) -> Path:
+    return path.relative_to(ROOT) if path.is_relative_to(ROOT) else path
 
 
 def check_mode(outputs: dict[Path, str]) -> int:
@@ -529,7 +629,7 @@ def check_mode(outputs: dict[Path, str]) -> int:
         if actual == expected:
             continue
         ok = False
-        rel = path.relative_to(ROOT)
+        rel = display_path(path)
         print(f"Generated file drift detected: {rel}", file=sys.stderr)
         diff = difflib.unified_diff(
             actual.splitlines(),
@@ -546,7 +646,7 @@ def check_mode(outputs: dict[Path, str]) -> int:
 def write_mode(outputs: dict[Path, str]) -> int:
     for path, content in outputs.items():
         path.write_text(content, encoding="utf-8")
-        print(f"Updated {path.relative_to(ROOT)}")
+        print(f"Updated {display_path(path)}")
     return 0
 
 
@@ -558,9 +658,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
-    rules = parse_rules()
-    outputs = render_all(rules)
-    return check_mode(outputs) if args.check else write_mode(outputs)
+    try:
+        rules = parse_rules()
+        outputs = render_all(rules)
+        return check_mode(outputs) if args.check else write_mode(outputs)
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -124,6 +125,38 @@ class CompactRuleGenerationTests(unittest.TestCase):
     def test_invalid_severity_fails_with_rule_and_file(self) -> None:
         with self.assertRaisesRegex(ValueError, r"U-16.*rules\.md.*Unknown severity"):
             self.parse_fixture(canonical_rule("U-16", "Guidance.", severity="invalid"))
+
+    def test_malformed_rule_heading_fails_with_id_file_and_line(self) -> None:
+        malformed_selected = "## U-16: Example rule strict\nCanonical body.\n"
+        malformed_unselected = "## U-99: Example rule strict\nCanonical body.\n"
+        valid = canonical_rule("U-16", "Guidance.")
+        cases = {
+            "selected only": malformed_selected,
+            "unselected before valid": malformed_unselected + valid,
+            "unselected after valid": valid + malformed_unselected,
+        }
+        for label, text in cases.items():
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(ValueError, r"U-(?:16|99).*rules\.md:\d+"):
+                    self.parse_fixture(text)
+
+    def test_rule_like_heading_inside_fence_is_not_canonical_input(self) -> None:
+        rules = self.parse_fixture(
+            "```markdown\n## U-99: Example rule strict\n```\n"
+            + canonical_rule("U-16", "Guidance.")
+        )
+        self.assertEqual([rule.id for rule in rules], ["U-16"])
+
+    def test_main_returns_nonzero_for_canonical_parse_failure(self) -> None:
+        error = ValueError("Malformed rule heading U-16 in rules.md:1")
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(generate_rule_docs, "parse_rules", side_effect=error),
+            mock.patch.object(sys, "argv", [str(GENERATOR_PATH), "--check"]),
+            redirect_stderr(stderr),
+        ):
+            self.assertEqual(generate_rule_docs.main(), 1)
+        self.assertIn(str(error), stderr.getvalue())
 
     def test_generated_region_preserves_bytes_outside_inner_markers(self) -> None:
         start = generate_rule_docs.COMPACT_START_MARKER

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Focused regression tests for compact rule generation (GH-626)."""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR_PATH = ROOT / "scripts" / "generate_rule_docs.py"
+SPEC = importlib.util.spec_from_file_location("generate_rule_docs", GENERATOR_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load generator module: {GENERATOR_PATH}")
+generate_rule_docs = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = generate_rule_docs
+SPEC.loader.exec_module(generate_rule_docs)
+
+
+EXPECTED_COMPACT_TABLE = """| ID | Severity | Rule |
+|----|----------|------|
+| U-16 | Guideline | Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. Files above 800 must be split. |
+| U-17 | Strict | Handle errors completely. Do not swallow exceptions silently. |
+| U-22 | Strict | New code minimum 80% line coverage; critical paths 100%. |
+| U-25 | Strict | Fix build failures first before any other edit; do not add new code while build is red. |
+| U-26 | Strict | Declaration-execution completeness: declared Config / Trait / persistence layers must be wired into startup. |
+| U-29 | Strict | No silent degradation: errors causing user-visible missing data or wrong output must `error` or raise, not `warning` + fallback. |
+| W-01 | Strict | No fixes without root cause: reproduce first, then form one hypothesis, then fix. |
+| W-02 | Strict | After 3 consecutive failed fixes on the same problem, stop and challenge the hypothesis or architecture. |
+| W-03 | Strict | Verify before claiming completion: produce fresh command output proving the claim. |
+| W-12 | Strict | Protect test integrity: fix production code, never weaken assertions or tamper with test infrastructure. |
+| W-14 | Strict | Parallel agents must have explicit, disjoint file ownership; no shared writable file. |
+| W-16 | Strict | Verification commands must come from this session. "Earlier passed" / "should work" do not count. |
+| SEC-01 | Critical | No SQL / NoSQL / OS command injection: use parameterized queries and array argument lists. |
+| SEC-02 | Critical | No hardcoded keys, credentials, or API tokens. Load from env / secret manager. |
+| SEC-11 | Strict | AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`. |
+| SEC-13 | Strict | High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators. |"""
+
+
+def canonical_rule(
+    rule_id: str,
+    guidance: str | None,
+    *,
+    severity: str = "strict",
+    body: str = "Canonical body.",
+) -> str:
+    guidance_line = "" if guidance is None else f"**Compact guidance:** {guidance}\n"
+    return f"## {rule_id}: Example rule ({severity})\n{guidance_line}{body}\n"
+
+
+class CompactRuleGenerationTests(unittest.TestCase):
+    def parse_fixture(self, text: str) -> list[object]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "rules.md").write_text(text, encoding="utf-8")
+            return generate_rule_docs.parse_rules(root)
+
+    def test_current_compact_rows_migrate_without_semantic_changes(self) -> None:
+        rules = generate_rule_docs.parse_rules()
+        actual = generate_rule_docs.render_compact_table(rules)
+        self.assertEqual(actual, EXPECTED_COMPACT_TABLE)
+        for rule_id in ("U-17", "SEC-01", "SEC-02", "SEC-13"):
+            expected_row = next(
+                line for line in EXPECTED_COMPACT_TABLE.splitlines() if line.startswith(f"| {rule_id} ")
+            )
+            self.assertIn(expected_row, actual)
+
+    def test_unselected_rules_do_not_expand_compact_table(self) -> None:
+        rules = self.parse_fixture(
+            canonical_rule("U-16", "Selected guidance.")
+            + canonical_rule("U-99", "Unselected guidance.")
+        )
+        actual = generate_rule_docs.render_compact_table(rules, ("U-16",))
+        self.assertIn("Selected guidance.", actual)
+        self.assertNotIn("U-99", actual)
+        self.assertNotIn("Unselected guidance.", actual)
+
+    def test_duplicate_selection_id_fails_visibly(self) -> None:
+        rules = self.parse_fixture(canonical_rule("U-16", "Guidance."))
+        with self.assertRaisesRegex(ValueError, "duplicate.*U-16"):
+            generate_rule_docs.render_compact_table(rules, ("U-16", "U-16"))
+
+    def test_missing_selected_id_fails_visibly(self) -> None:
+        rules = self.parse_fixture(canonical_rule("U-16", "Guidance."))
+        with self.assertRaisesRegex(ValueError, "missing.*U-17"):
+            generate_rule_docs.render_compact_table(rules, ("U-17",))
+
+    def test_duplicate_selected_canonical_id_fails_visibly(self) -> None:
+        rules = self.parse_fixture(
+            canonical_rule("U-16", "First guidance.")
+            + canonical_rule("U-16", "Second guidance.")
+        )
+        with self.assertRaisesRegex(ValueError, r"duplicate canonical.*U-16.*rules\.md"):
+            generate_rule_docs.render_compact_table(rules, ("U-16",))
+
+    def test_missing_or_empty_guidance_never_falls_back_to_summary(self) -> None:
+        for guidance in (None, ""):
+            with self.subTest(guidance=guidance):
+                rules = self.parse_fixture(
+                    canonical_rule(
+                        "U-16",
+                        guidance,
+                        body="This first sentence must not become compact guidance.",
+                    )
+                )
+                with self.assertRaisesRegex(ValueError, r"compact guidance.*U-16.*rules\.md"):
+                    generate_rule_docs.render_compact_table(rules, ("U-16",))
+
+    def test_duplicate_guidance_field_fails_with_rule_and_file(self) -> None:
+        text = canonical_rule(
+            "U-16",
+            "First guidance.",
+            body="**Compact guidance:** Second guidance.\nCanonical body.",
+        )
+        with self.assertRaisesRegex(ValueError, r"U-16.*rules\.md"):
+            self.parse_fixture(text)
+
+    def test_invalid_severity_fails_with_rule_and_file(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"U-16.*rules\.md.*Unknown severity"):
+            self.parse_fixture(canonical_rule("U-16", "Guidance.", severity="invalid"))
+
+    def test_generated_region_preserves_bytes_outside_inner_markers(self) -> None:
+        start = generate_rule_docs.COMPACT_START_MARKER
+        end = generate_rule_docs.COMPACT_END_MARKER
+        prefix = "before\n\n" + start + "\n"
+        suffix = end + "\n\nafter\n"
+        actual = generate_rule_docs.replace_compact_region(
+            prefix + "stale table\n" + suffix,
+            "fresh table",
+        )
+        self.assertEqual(actual, prefix + "fresh table\n" + suffix)
+        self.assertTrue(actual.startswith(prefix))
+        self.assertTrue(actual.endswith(suffix))
+
+    def test_generated_region_rejects_missing_duplicate_and_misordered_markers(self) -> None:
+        start = generate_rule_docs.COMPACT_START_MARKER
+        end = generate_rule_docs.COMPACT_END_MARKER
+        cases = {
+            "missing start": f"before\n{end}\nafter\n",
+            "missing end": f"before\n{start}\nafter\n",
+            "duplicate start": f"{start}\n{start}\n{end}\n",
+            "duplicate end": f"{start}\n{end}\n{end}\n",
+            "misordered": f"{end}\n{start}\n",
+        }
+        for label, document in cases.items():
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(ValueError, "compact rule marker"):
+                    generate_rule_docs.replace_compact_region(document, "table")
+
+    def test_rendering_is_deterministic(self) -> None:
+        rules = self.parse_fixture(canonical_rule("U-16", "Guidance.", severity="guideline"))
+        first = generate_rule_docs.render_compact_table(rules, ("U-16",))
+        second = generate_rule_docs.render_compact_table(rules, ("U-16",))
+        self.assertEqual(first, second)
+
+    def test_compact_input_changes_make_snapshot_stale(self) -> None:
+        rules = generate_rule_docs.parse_rules()
+        current_document = generate_rule_docs.COMPACT_RULES_PATH.read_text(encoding="utf-8")
+        selected_ids = generate_rule_docs.COMPACT_RULE_IDS
+        selected_rule = next(rule for rule in rules if rule.id == selected_ids[0])
+        variants = {
+            "guidance": (
+                [
+                    dataclasses.replace(rule, compact_guidance="Changed guidance.")
+                    if rule is selected_rule
+                    else rule
+                    for rule in rules
+                ],
+                selected_ids,
+            ),
+            "severity": (
+                [
+                    dataclasses.replace(rule, severity="Strict")
+                    if rule is selected_rule
+                    else rule
+                    for rule in rules
+                ],
+                selected_ids,
+            ),
+            "selection order": (rules, (selected_ids[1], selected_ids[0], *selected_ids[2:])),
+        }
+        for label, (variant_rules, selection) in variants.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temp_dir:
+                table = generate_rule_docs.render_compact_table(variant_rules, selection)
+                expected = generate_rule_docs.replace_compact_region(current_document, table)
+                self.assertNotEqual(expected, current_document)
+                output = Path(temp_dir) / "compact.md"
+                output.write_text(current_document, encoding="utf-8")
+                with redirect_stderr(io.StringIO()):
+                    self.assertEqual(generate_rule_docs.check_mode({output: expected}), 1)
+
+    def test_check_mode_fails_on_stale_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "compact.md"
+            output.write_text("stale\n", encoding="utf-8")
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                status = generate_rule_docs.check_mode({output: "expected\n"})
+            self.assertEqual(status, 1)
+            self.assertIn("Generated file drift detected", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题与原因

compact `Key Detailed Rules` 表此前是 canonical rules 的手工副本。维护者修改
`rules/claude-rules/**` 后，现有生成检查仍可能全绿并继续向 Claude/Codex 用户分发旧语义。

## 实现

- 在 16 条 selected canonical records 中加入唯一、单行、非空的 `Compact guidance` 字段。
- 扩展 `scripts/generate_rule_docs.py`：使用显式有序 ID selection 生成 compact 表；禁止
  `Rule.summary`、rule title 或旧产物 fallback。
- 对 selection、canonical ID、guidance 与 inner markers 的缺失/重复/错序显式失败。
- 仅替换唯一 inner-marker 区域；区域外高上下文字节保持不变。
- 将 compact snapshot 接入现有 generated-doc `--check`/CI，并更新维护入口。
- 完成 `SP626-T1`～`SP626-T4`，把 GH626 spec 标记为 implemented reference。

## Spec 与计划

- Spec PR: #634
- Product: `docs/specs/GH626/product.md`
- Technical design: `docs/specs/GH626/tech.md`
- Task plan: `docs/specs/GH626/tasks.md`
- 覆盖：B-001～B-008。

## 验证

- `python3 tests/test_generate_rule_docs.py` — 13/13
- `python3 scripts/generate_rule_docs.py --check`
- `bash scripts/ci/validate-rules.sh`
- `bash scripts/ci/validate-generated-rule-docs.sh`
- `bash scripts/verify/doc-freshness-check.sh --strict`
- `bash tests/hooks/test_count_active_constraints.sh` — 24/24
- `bash tests/test_setup.sh` — 537/537
- `bash scripts/local-contract-check.sh --quick`
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH626`
- `bash guards/universal/check_test_integrity.sh .`
- `bash guards/universal/check_test_weakening.sh --base origin/main --head HEAD`
- `git diff --check origin/main...HEAD`
- 连续两次真实生成的 diff SHA-256 相同；移除两条新增 inner marker 后，compact 文件与
  `origin/main` 旧文件逐字节一致。

## AI 参与与审查重点

- AI Role: 实现、测试与本地验证由 Codex 辅助完成；风险等级 medium（规则生成与高上下文分发表面）。
- Independent Review: 独立只读 reviewer lane 在 head `d0d367b` 完成复审，结论 `RESOLVED / NO BLOCKER`；首轮 B-003 malformed-heading blocker 已闭环。
- Review Focus: fail-visible 完整性；marker 外字节保护；16 行语义是否逐行保持；测试是否真正覆盖 B-004。

Fixes #626
