### PR TITLE
feat(eval): pin current Claude model baselines

### DIFF
--- a/docs/specs/GH630/tasks.md
+++ b/docs/specs/GH630/tasks.md
@@ -8,14 +8,14 @@ GH-630
 
 - Product: `product.md`
 - Tech: `tech.md`
-- Status: draft；执行前必须有 spec approval 与 `ready_to_implement`
+- Status: implemented；规格已合并且 issue 已置为 `ready_to_implement`
 
 ## 实现任务
 
-- [ ] `SP630-T1` 定义 model-baseline manifest 与离线 freshness validator。Covers: B-001, B-004, B-005. Owner: implementation agent. Dependencies: spec approval. Done when: 三个精确 ID、官方来源、UTC date 与固定 90-day closed window 可审计，future/day-91 非零且 day-90 有效。Verify: manifest/freshness unit tests。
-- [ ] `SP630-T2` 让 run_eval resolver 消费 baseline 并保留 default/passthrough。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: SP630-T1. Done when: aliases 更新、默认 `haiku` 固定解析到 dated Haiku ID、full ID 不变、既有 `metadata.model` 继续记录 resolved ID。Verify: eval Python unit tests。
-- [ ] `SP630-T3` 对齐 behavior/benchmark entrypoints 与 dry-run/help evidence。Covers: B-006, B-007. Owner: implementation agent. Dependencies: SP630-T2. Done when: 无第二份 mapping，输出显示 resolved baseline，artifact schema/reader 无变化。Verify: `bash tests/test_eval_contract.sh`。
-- [ ] `SP630-T4` 运行 eval 提交门禁。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP630-T1..T3. Done when: unit/integration/dry-run 同一提交通过且未调用 API。Verify: unittest、eval contract test、两条 dry-run commands。
+- [x] `SP630-T1` 定义 model-baseline manifest 与离线 freshness validator。Covers: B-001, B-004, B-005. Owner: implementation agent. Dependencies: spec approval. Done when: 三个精确 ID、官方来源、UTC date 与固定 90-day closed window 可审计，future/day-91 非零且 day-90 有效。Verify: manifest/freshness unit tests。
+- [x] `SP630-T2` 让 run_eval resolver 消费 baseline 并保留 default/passthrough。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: SP630-T1. Done when: aliases 更新、默认 `haiku` 固定解析到 dated Haiku ID、full ID 不变、既有 `metadata.model` 继续记录 resolved ID。Verify: eval Python unit tests。
+- [x] `SP630-T3` 对齐 behavior/benchmark entrypoints 与 dry-run/help evidence。Covers: B-006, B-007. Owner: implementation agent. Dependencies: SP630-T2. Done when: 无第二份 mapping，输出显示 resolved baseline，artifact schema/reader 无变化。Verify: `bash tests/test_eval_contract.sh`。
+- [x] `SP630-T4` 运行 eval 提交门禁。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP630-T1..T3. Done when: unit/integration/dry-run 同一提交通过且未调用 API。Verify: unittest、eval contract test、两条 dry-run commands。
 
 ## 并行拆分
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,7 +6,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 
 | Spec | Status | Use it for |
 |---|---|---|
-| `GH630/` | Draft | Pinned Claude eval aliases, UTC-bounded offline freshness evidence, and one shared model-resolution contract |
+| `GH630/` | Implemented reference | Pinned Claude eval aliases, UTC-bounded offline freshness evidence, and one shared model-resolution contract |
 | `GH629/` | Implemented reference | Fail-visible, schema-backed user runtime config validation with complete getter/template inventory |
 | `GH628/` | Implemented reference | Git-tracked Markdown personal-path detection and strict, scoped doc-path allowlist freshness |
 | `GH627/` | Implemented reference | Closed-map resolution of Codex namespaced hook names to canonical hook files without physical alias shells |

--- a/eval/model_baseline.json
+++ b/eval/model_baseline.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "aliases": {
+    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-5",
+    "opus": "claude-opus-4-8"
+  },
+  "default_alias": "haiku",
+  "official_source": "https://platform.claude.com/docs/en/about-claude/models/overview",
+  "verified_at": "2026-07-17",
+  "freshness_days": 90
+}

--- a/eval/model_baseline.py
+++ b/eval/model_baseline.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Strict, offline contract for VibeGuard eval model aliases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
+DEFAULT_BASELINE_PATH = Path(__file__).with_name("model_baseline.json")
+EXPECTED_ALIASES = frozenset({"haiku", "sonnet", "opus"})
+EXPECTED_SCHEMA_VERSION = 1
+EXPECTED_FRESHNESS_DAYS = 90
+OFFICIAL_SOURCE = "https://platform.claude.com/docs/en/about-claude/models/overview"
+
+
+class ModelBaselineError(ValueError):
+    """Raised when the checked-in model baseline violates its contract."""
+
+
+@dataclass(frozen=True)
+class ModelBaseline:
+    aliases: Mapping[str, str]
+    default_alias: str
+    official_source: str
+    verified_at: date
+    freshness_days: int
+    as_of: date
+
+    @property
+    def age_days(self) -> int:
+        return (self.as_of - self.verified_at).days
+
+    def resolve(self, requested: str) -> str:
+        if not requested:
+            raise ModelBaselineError("requested model must not be empty")
+        return self.aliases.get(requested, requested)
+
+    def alias_table(self) -> str:
+        return ", ".join(
+            f"{alias} -> {self.aliases[alias]}" for alias in sorted(self.aliases)
+        )
+
+
+def _require_exact_keys(value: object, expected: set[str], location: str) -> dict:
+    if not isinstance(value, dict):
+        raise ModelBaselineError(f"{location} must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ModelBaselineError(
+            f"{location} keys mismatch: missing={missing}, extra={extra}"
+        )
+    return value
+
+
+def _require_string(value: object, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ModelBaselineError(f"{location} must be a non-empty string")
+    return value
+
+
+def _parse_verified_at(value: object) -> date:
+    text = _require_string(value, "verified_at")
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as error:
+        raise ModelBaselineError("verified_at must be an ISO YYYY-MM-DD date") from error
+    if parsed.isoformat() != text:
+        raise ModelBaselineError("verified_at must use canonical YYYY-MM-DD form")
+    return parsed
+
+
+def _utc_today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def load_model_baseline(
+    path: Path = DEFAULT_BASELINE_PATH,
+    *,
+    as_of: date | None = None,
+) -> ModelBaseline:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ModelBaselineError(f"cannot read model baseline {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ModelBaselineError(f"model baseline is invalid JSON: {error.msg}") from error
+
+    root = _require_exact_keys(
+        raw,
+        {
+            "schema_version",
+            "aliases",
+            "default_alias",
+            "official_source",
+            "verified_at",
+            "freshness_days",
+        },
+        "model baseline",
+    )
+    if type(root["schema_version"]) is not int or root["schema_version"] != EXPECTED_SCHEMA_VERSION:
+        raise ModelBaselineError("schema_version must be integer 1")
+
+    aliases_raw = _require_exact_keys(root["aliases"], set(EXPECTED_ALIASES), "aliases")
+    aliases = {
+        alias: _require_string(aliases_raw[alias], f"aliases.{alias}")
+        for alias in sorted(EXPECTED_ALIASES)
+    }
+    if len(set(aliases.values())) != len(aliases):
+        raise ModelBaselineError("alias targets must be unique")
+
+    default_alias = _require_string(root["default_alias"], "default_alias")
+    if default_alias not in aliases:
+        raise ModelBaselineError("default_alias must name an alias")
+
+    official_source = _require_string(root["official_source"], "official_source")
+    if official_source != OFFICIAL_SOURCE:
+        raise ModelBaselineError(f"official_source must be {OFFICIAL_SOURCE}")
+
+    freshness_days = root["freshness_days"]
+    if type(freshness_days) is not int or freshness_days != EXPECTED_FRESHNESS_DAYS:
+        raise ModelBaselineError("freshness_days must be integer 90")
+
+    verified_at = _parse_verified_at(root["verified_at"])
+    current_date = as_of or _utc_today()
+    age_days = (current_date - verified_at).days
+    if age_days < 0:
+        raise ModelBaselineError("verified_at must not be in the future relative to UTC")
+    if age_days > freshness_days:
+        raise ModelBaselineError(
+            f"model baseline is stale: age_days={age_days}, limit={freshness_days}"
+        )
+
+    return ModelBaseline(
+        aliases=MappingProxyType(aliases),
+        default_alias=default_alias,
+        official_source=official_source,
+        verified_at=verified_at,
+        freshness_days=freshness_days,
+        as_of=current_date,
+    )
+
+
+def _parse_as_of(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected YYYY-MM-DD") from error
+    if parsed.isoformat() != value:
+        raise argparse.ArgumentTypeError("expected canonical YYYY-MM-DD")
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the offline eval model baseline")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE_PATH)
+    parser.add_argument("--as-of", type=_parse_as_of, help="inject UTC date for deterministic checks")
+    args = parser.parse_args()
+    try:
+        baseline = load_model_baseline(args.baseline, as_of=args.as_of)
+    except ModelBaselineError as error:
+        print(f"Invalid eval model baseline: {error}", file=sys.stderr)
+        return 2
+    print(
+        "OK: eval model baseline valid "
+        f"(verified_at={baseline.verified_at.isoformat()}, "
+        f"age_days={baseline.age_days}, freshness_days={baseline.freshness_days})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/model_baseline.py
+++ b/eval/model_baseline.py
@@ -46,6 +46,22 @@ class ModelBaseline:
             f"{alias} -> {self.aliases[alias]}" for alias in sorted(self.aliases)
         )
 
+    def evidence_lines(self, requested: str) -> tuple[str, ...]:
+        return (
+            f"Requested model: {requested}",
+            f"Resolved model: {self.resolve(requested)}",
+            f"Model baseline verified at (UTC): {self.verified_at.isoformat()}",
+            f"Model baseline source: {self.official_source}",
+        )
+
+    def help_lines(self) -> tuple[str, ...]:
+        return (
+            f"Default model alias: {self.default_alias}",
+            f"Model aliases: {self.alias_table()}",
+            f"Model baseline verified at (UTC): {self.verified_at.isoformat()}",
+            f"Model baseline source: {self.official_source}",
+        )
+
 
 def _require_exact_keys(value: object, expected: set[str], location: str) -> dict:
     if not isinstance(value, dict):
@@ -162,17 +178,32 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Validate the offline eval model baseline")
     parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE_PATH)
     parser.add_argument("--as-of", type=_parse_as_of, help="inject UTC date for deterministic checks")
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--print-default", action="store_true")
+    output.add_argument("--print-help-evidence", action="store_true")
+    output.add_argument("--describe", metavar="MODEL")
     args = parser.parse_args()
     try:
         baseline = load_model_baseline(args.baseline, as_of=args.as_of)
     except ModelBaselineError as error:
         print(f"Invalid eval model baseline: {error}", file=sys.stderr)
         return 2
-    print(
-        "OK: eval model baseline valid "
-        f"(verified_at={baseline.verified_at.isoformat()}, "
-        f"age_days={baseline.age_days}, freshness_days={baseline.freshness_days})"
-    )
+    try:
+        if args.print_default:
+            print(baseline.default_alias)
+        elif args.print_help_evidence:
+            print("\n".join(baseline.help_lines()))
+        elif args.describe is not None:
+            print("\n".join(baseline.evidence_lines(args.describe)))
+        else:
+            print(
+                "OK: eval model baseline valid "
+                f"(verified_at={baseline.verified_at.isoformat()}, "
+                f"age_days={baseline.age_days}, freshness_days={baseline.freshness_days})"
+            )
+    except ModelBaselineError as error:
+        print(f"Invalid requested model: {error}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/eval/run_behavior_eval.py
+++ b/eval/run_behavior_eval.py
@@ -22,6 +22,7 @@ from artifacts import (
     utc_timestamp,
     write_run_artifacts,
 )
+from model_baseline import ModelBaseline, ModelBaselineError, load_model_baseline
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_DATASET_PATH = REPO_ROOT / "eval" / "behavior" / "datasets" / "v1.jsonl"
@@ -441,7 +442,8 @@ def print_text_report(report: dict[str, Any]) -> None:
     print("====================================")
 
 
-def run_behavior_eval(args: argparse.Namespace) -> int:
+def run_behavior_eval(args: argparse.Namespace, baseline: ModelBaseline) -> int:
+    baseline.resolve(args.model)
     dataset_path = Path(args.dataset).resolve()
     requirements_path = Path(args.requirements).resolve()
     thresholds_path = Path(args.thresholds).resolve()
@@ -470,6 +472,7 @@ def run_behavior_eval(args: argparse.Namespace) -> int:
         if args.json:
             print(json.dumps({"metadata": metadata, "samples": samples}, indent=2, ensure_ascii=False))
         else:
+            print("\n".join(baseline.evidence_lines(args.model)))
             print(f"Behavior dataset source: {dataset_path}")
             print(f"Behavior sample count: {len(samples)}")
             print(f"Behavior sample digest: {digest}")
@@ -518,7 +521,17 @@ def run_behavior_eval(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run zero-cost VibeGuard behavior evals")
+    try:
+        baseline = load_model_baseline()
+    except ModelBaselineError as error:
+        print(f"Invalid eval model baseline: {error}", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(
+        description="Run zero-cost VibeGuard behavior evals",
+        epilog="\n".join(baseline.help_lines()),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
     parser.add_argument("--requirements", default=str(DEFAULT_REQUIREMENTS_PATH))
     parser.add_argument("--thresholds", default=str(DEFAULT_THRESHOLDS_PATH))
@@ -529,9 +542,17 @@ def main() -> int:
     parser.add_argument("--fail-on-threshold", action="store_true")
     parser.add_argument("--no-artifacts", action="store_true")
     parser.add_argument("--model-gate", action="store_true", help="also run eval/run_eval.py for manual/API-backed gates")
-    parser.add_argument("--model", default="haiku")
+    parser.add_argument(
+        "--model",
+        default=baseline.default_alias,
+        help="Model alias or full ID",
+    )
     parser.add_argument("--model-rules", help="optional rule prefix for the model-backed gate")
-    return run_behavior_eval(parser.parse_args())
+    try:
+        return run_behavior_eval(parser.parse_args(), baseline)
+    except ModelBaselineError as error:
+        print(f"Invalid requested model: {error}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -27,13 +27,8 @@ from dataset import (
     sample_set_digest,
     sha256_text,
 )
+from model_baseline import ModelBaseline, ModelBaselineError, load_model_baseline
 from scoring import CONFIDENCE_SCORES, ScorerParseError, parse_confidence, parse_scorer_output
-
-MODELS = {
-    "haiku": "claude-haiku-4-5-20251001",
-    "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-6",
-}
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RULES_DIR = REPO_ROOT / "rules" / "claude-rules"
@@ -210,7 +205,18 @@ def filter_samples(samples: list[dict], args) -> list[dict]:
     return filtered
 
 
-def run_eval(args):
+def print_model_evidence(
+    baseline: ModelBaseline,
+    requested_model: str,
+    resolved_model: str,
+) -> None:
+    print(f"Requested model: {requested_model}")
+    print(f"Resolved model: {resolved_model}")
+    print(f"Model baseline verified at (UTC): {baseline.verified_at.isoformat()}")
+    print(f"Model baseline source: {baseline.official_source}")
+
+
+def run_eval(args, baseline: ModelBaseline):
     rules_dir = Path(args.rules_dir).resolve()
     core_rules_file = Path(args.core_rules_file).resolve() if args.core_rules_file else None
     dataset_path = Path(args.dataset).resolve()
@@ -226,8 +232,10 @@ def run_eval(args):
     dataset_digest = file_digest(dataset_path)
     samples = filter_samples(all_samples, args)
     filtered_sample_digest = sample_set_digest(samples)
+    model = baseline.resolve(args.model)
 
     if args.dry_run:
+        print_model_evidence(baseline, args.model, model)
         print(f"Rule text length: {len(rules)} characters")
         print(f"Number of samples: {len(samples)}")
         print(f"Dataset source: {dataset_path}")
@@ -242,7 +250,6 @@ def run_eval(args):
             print(f"  [{tag}] {s['id']}: {s['description']}")
         return
 
-    model = MODELS.get(args.model, args.model)
     try:
         import anthropic
     except ImportError:
@@ -250,6 +257,7 @@ def run_eval(args):
         sys.exit(1)
     client = anthropic.Anthropic()
 
+    print_model_evidence(baseline, args.model, model)
     print(f"Model: {model}")
     print(f"Number of samples: {len(samples)}")
     print(f"Rule text: {len(rules)} characters")
@@ -551,9 +559,23 @@ def print_calibration(results: list[dict]) -> None:
         )
 
 
-def main():
+def main() -> int:
+    try:
+        baseline = load_model_baseline()
+    except ModelBaselineError as error:
+        print(f"Invalid eval model baseline: {error}", file=sys.stderr)
+        return 2
+
     parser = argparse.ArgumentParser(description="VibeGuard LLM-as-Judge Evaluation")
-    parser.add_argument("--model", default="haiku", help="Model: haiku/sonnet/opus or full ID")
+    parser.add_argument(
+        "--model",
+        default=baseline.default_alias,
+        help=(
+            f"Model alias or full ID (default: {baseline.default_alias}; "
+            f"{baseline.alias_table()}; verified_at={baseline.verified_at.isoformat()}; "
+            f"source={baseline.official_source})"
+        ),
+    )
     parser.add_argument("--rules", help="Rule prefix filtering (such as SEC, PY, TS, GO, RS)")
     parser.add_argument("--type", choices=["tp", "fp"], help="Sample type filtering: tp=violation, fp=legal")
     parser.add_argument("--dry-run", action="store_true", help="Only display samples without adjusting API")
@@ -578,8 +600,9 @@ def main():
         help="Core constraint snippet file to append (defaults to repository snapshot)",
     )
     args = parser.parse_args()
-    run_eval(args)
+    run_eval(args, baseline)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -208,12 +208,8 @@ def filter_samples(samples: list[dict], args) -> list[dict]:
 def print_model_evidence(
     baseline: ModelBaseline,
     requested_model: str,
-    resolved_model: str,
 ) -> None:
-    print(f"Requested model: {requested_model}")
-    print(f"Resolved model: {resolved_model}")
-    print(f"Model baseline verified at (UTC): {baseline.verified_at.isoformat()}")
-    print(f"Model baseline source: {baseline.official_source}")
+    print("\n".join(baseline.evidence_lines(requested_model)))
 
 
 def run_eval(args, baseline: ModelBaseline):
@@ -235,7 +231,7 @@ def run_eval(args, baseline: ModelBaseline):
     model = baseline.resolve(args.model)
 
     if args.dry_run:
-        print_model_evidence(baseline, args.model, model)
+        print_model_evidence(baseline, args.model)
         print(f"Rule text length: {len(rules)} characters")
         print(f"Number of samples: {len(samples)}")
         print(f"Dataset source: {dataset_path}")
@@ -257,7 +253,7 @@ def run_eval(args, baseline: ModelBaseline):
         sys.exit(1)
     client = anthropic.Anthropic()
 
-    print_model_evidence(baseline, args.model, model)
+    print_model_evidence(baseline, args.model)
     print(f"Model: {model}")
     print(f"Number of samples: {len(samples)}")
     print(f"Rule text: {len(rules)} characters")
@@ -566,15 +562,15 @@ def main() -> int:
         print(f"Invalid eval model baseline: {error}", file=sys.stderr)
         return 2
 
-    parser = argparse.ArgumentParser(description="VibeGuard LLM-as-Judge Evaluation")
+    parser = argparse.ArgumentParser(
+        description="VibeGuard LLM-as-Judge Evaluation",
+        epilog="\n".join(baseline.help_lines()),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "--model",
         default=baseline.default_alias,
-        help=(
-            f"Model alias or full ID (default: {baseline.default_alias}; "
-            f"{baseline.alias_table()}; verified_at={baseline.verified_at.isoformat()}; "
-            f"source={baseline.official_source})"
-        ),
+        help="Model alias or full ID",
     )
     parser.add_argument("--rules", help="Rule prefix filtering (such as SEC, PY, TS, GO, RS)")
     parser.add_argument("--type", choices=["tp", "fp"], help="Sample type filtering: tp=violation, fp=legal")
@@ -600,7 +596,11 @@ def main() -> int:
         help="Core constraint snippet file to append (defaults to repository snapshot)",
     )
     args = parser.parse_args()
-    run_eval(args, baseline)
+    try:
+        run_eval(args, baseline)
+    except ModelBaselineError as error:
+        print(f"Invalid requested model: {error}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/eval/test_model_baseline.py
+++ b/eval/test_model_baseline.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Tests for the offline eval model baseline contract."""
+
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+
+from model_baseline import (
+    DEFAULT_BASELINE_PATH,
+    ModelBaselineError,
+    load_model_baseline,
+)
+
+VERIFIED_AT = date(2026, 7, 17)
+
+
+class ModelBaselineTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.valid = json.loads(DEFAULT_BASELINE_PATH.read_text(encoding="utf-8"))
+
+    def write_baseline(self, value: object) -> tuple[tempfile.TemporaryDirectory, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        path = Path(temporary.name) / "baseline.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return temporary, path
+
+    def assert_invalid(self, value: object, expected: str) -> None:
+        temporary, path = self.write_baseline(value)
+        self.addCleanup(temporary.cleanup)
+        with self.assertRaisesRegex(ModelBaselineError, expected):
+            load_model_baseline(path, as_of=VERIFIED_AT)
+
+    def test_checked_in_manifest_has_exact_resolution_contract(self) -> None:
+        baseline = load_model_baseline(DEFAULT_BASELINE_PATH, as_of=VERIFIED_AT)
+
+        self.assertEqual(baseline.default_alias, "haiku")
+        self.assertEqual(baseline.resolve("haiku"), "claude-haiku-4-5-20251001")
+        self.assertEqual(baseline.resolve("sonnet"), "claude-sonnet-5")
+        self.assertEqual(baseline.resolve("opus"), "claude-opus-4-8")
+        self.assertEqual(baseline.resolve("claude-sonnet-4-6"), "claude-sonnet-4-6")
+        self.assertEqual(baseline.age_days, 0)
+
+    def test_freshness_boundary_is_utc_day_0_through_90_inclusive(self) -> None:
+        for age in (0, 89, 90):
+            with self.subTest(age=age):
+                baseline = load_model_baseline(
+                    DEFAULT_BASELINE_PATH,
+                    as_of=VERIFIED_AT + timedelta(days=age),
+                )
+                self.assertEqual(baseline.age_days, age)
+
+        with self.assertRaisesRegex(ModelBaselineError, "stale: age_days=91"):
+            load_model_baseline(
+                DEFAULT_BASELINE_PATH,
+                as_of=VERIFIED_AT + timedelta(days=91),
+            )
+
+    def test_future_verified_date_fails(self) -> None:
+        with self.assertRaisesRegex(ModelBaselineError, "must not be in the future"):
+            load_model_baseline(
+                DEFAULT_BASELINE_PATH,
+                as_of=VERIFIED_AT - timedelta(days=1),
+            )
+
+    def test_root_keys_are_closed(self) -> None:
+        missing = copy.deepcopy(self.valid)
+        missing.pop("official_source")
+        self.assert_invalid(missing, "missing=\\['official_source'\\]")
+
+        extra = copy.deepcopy(self.valid)
+        extra["evergreen"] = True
+        self.assert_invalid(extra, "extra=\\['evergreen'\\]")
+
+    def test_schema_and_freshness_are_exact_integers(self) -> None:
+        for field, value, expected in (
+            ("schema_version", True, "schema_version must be integer 1"),
+            ("schema_version", 2, "schema_version must be integer 1"),
+            ("freshness_days", True, "freshness_days must be integer 90"),
+            ("freshness_days", 89, "freshness_days must be integer 90"),
+        ):
+            with self.subTest(field=field, value=value):
+                invalid = copy.deepcopy(self.valid)
+                invalid[field] = value
+                self.assert_invalid(invalid, expected)
+
+    def test_alias_map_is_closed_unique_and_nonempty(self) -> None:
+        missing = copy.deepcopy(self.valid)
+        missing["aliases"].pop("opus")
+        self.assert_invalid(missing, "aliases keys mismatch")
+
+        extra = copy.deepcopy(self.valid)
+        extra["aliases"]["fable"] = "claude-fable-5"
+        self.assert_invalid(extra, "aliases keys mismatch")
+
+        empty = copy.deepcopy(self.valid)
+        empty["aliases"]["opus"] = ""
+        self.assert_invalid(empty, "aliases.opus must be a non-empty string")
+
+        duplicate = copy.deepcopy(self.valid)
+        duplicate["aliases"]["opus"] = duplicate["aliases"]["sonnet"]
+        self.assert_invalid(duplicate, "alias targets must be unique")
+
+    def test_default_source_and_date_are_strict(self) -> None:
+        invalid_default = copy.deepcopy(self.valid)
+        invalid_default["default_alias"] = "fable"
+        self.assert_invalid(invalid_default, "default_alias must name an alias")
+
+        invalid_source = copy.deepcopy(self.valid)
+        invalid_source["official_source"] = "https://example.com/models"
+        self.assert_invalid(invalid_source, "official_source must be")
+
+        invalid_date = copy.deepcopy(self.valid)
+        invalid_date["verified_at"] = "2026-7-17"
+        self.assert_invalid(invalid_date, "ISO YYYY-MM-DD")
+
+    def test_malformed_missing_and_empty_requested_model_fail_visibly(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        malformed = Path(temporary.name) / "malformed.json"
+        malformed.write_text("{", encoding="utf-8")
+        with self.assertRaisesRegex(ModelBaselineError, "invalid JSON"):
+            load_model_baseline(malformed, as_of=VERIFIED_AT)
+
+        with self.assertRaisesRegex(ModelBaselineError, "cannot read"):
+            load_model_baseline(Path(temporary.name) / "missing.json", as_of=VERIFIED_AT)
+
+        baseline = load_model_baseline(DEFAULT_BASELINE_PATH, as_of=VERIFIED_AT)
+        with self.assertRaisesRegex(ModelBaselineError, "must not be empty"):
+            baseline.resolve("")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -17,14 +17,16 @@ RUN_TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
 COMMIT_SHA=$(git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 RUN_ID="${RUN_TIMESTAMP}-${COMMIT_SHA}"
 MODE="fast"
-L2_MODEL="haiku"
+MODEL_BASELINE_TOOL="$REPO_DIR/eval/model_baseline.py"
+L2_MODEL="$(python3 "$MODEL_BASELINE_TOOL" --print-default)"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --mode=*) MODE="${1#--mode=}"; shift ;;
     --model=*) L2_MODEL="${1#--model=}"; shift ;;
     --help|-h)
-      echo "Usage: bash scripts/benchmark.sh [--mode=fast|standard|full] [--model=haiku|sonnet]"
+      echo "Usage: bash scripts/benchmark.sh [--mode=fast|standard|full] [--model=ALIAS_OR_FULL_ID]"
+      python3 "$MODEL_BASELINE_TOOL" --print-help-evidence
       exit 0
       ;;
     *) shift ;;
@@ -144,14 +146,15 @@ L2_RESULT='{"layer2_score": 0, "sws": 0, "fpr": 0, "detection_rate": 0, "total_s
 
 if [[ "$MODE" == "standard" ]] || [[ "$MODE" == "full" ]]; then
   echo "[Layer 2: Rule compliance (model=$L2_MODEL)]"
+  python3 "$MODEL_BASELINE_TOOL" --describe "$L2_MODEL"
 
-  L2_RULES_FLAG=""
+  L2_RULES_ARGS=()
   if [[ "$MODE" == "standard" ]]; then
-    L2_RULES_FLAG="--rules SEC"
+    L2_RULES_ARGS=(--rules SEC)
   fi
 
   # Run LLM-as-Judge evaluation
-  L2_OUTPUT=$(cd "$REPO_DIR" && python3 eval/run_eval.py --model "$L2_MODEL" $L2_RULES_FLAG 2>&1)
+  L2_OUTPUT=$(cd "$REPO_DIR" && python3 eval/run_eval.py --model "$L2_MODEL" "${L2_RULES_ARGS[@]}" 2>&1)
   L2_RESULT_PATH=$(printf '%s\n' "$L2_OUTPUT" | awk -F'Result saved: ' '/Result saved:/ {print $2}' | tail -1)
 
   # Read the immutable eval run artifact emitted by run_eval.py.

--- a/tests/test_eval_contract.sh
+++ b/tests/test_eval_contract.sh
@@ -59,6 +59,7 @@ assert_cmd "eval support modules syntax is correct" python3 -m py_compile \
   "${REPO_DIR}/eval/dataset.py" \
   "${REPO_DIR}/eval/scoring.py" \
   "${REPO_DIR}/eval/artifacts.py" \
+  "${REPO_DIR}/eval/model_baseline.py" \
   "${REPO_DIR}/eval/sample_ids.py" \
   "${REPO_DIR}/eval/samples.py" \
   "${REPO_DIR}/eval/summarize_runs.py"
@@ -75,7 +76,27 @@ assert_contains "${normalized_out}" "Sample digest:" "dry-run reports sample dig
 assert_contains "${normalized_out}" "Rules source: ${REPO_DIR_RESOLVED}/rules/claude-rules" "dry-run reports repository rule source"
 assert_contains "${normalized_out}" "Rule digest:" "dry-run reports rule digest"
 assert_contains "${normalized_out}" "Core constraint source: ${REPO_DIR_RESOLVED}/claude-md/vibeguard-rules.md" "dry-run reports repository core rules source"
+assert_contains "${normalized_out}" "Requested model: haiku" "dry-run reports requested default model"
+assert_contains "${normalized_out}" "Resolved model: claude-haiku-4-5-20251001" "dry-run resolves default model from baseline"
+assert_contains "${normalized_out}" "Model baseline verified at (UTC): 2026-07-17" "dry-run reports baseline verification date"
+assert_contains "${normalized_out}" "Model baseline source: https://platform.claude.com/docs/en/about-claude/models/overview" "dry-run reports baseline source"
 assert_cmd "dry-run does not write mutable eval/results.json" test ! -e "${REPO_DIR}/eval/results.json"
+
+sonnet_dry_run_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --dry-run --model sonnet)"
+assert_contains "${sonnet_dry_run_out}" "Resolved model: claude-sonnet-5" "sonnet alias resolves from baseline"
+opus_dry_run_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --dry-run --model opus)"
+assert_contains "${opus_dry_run_out}" "Resolved model: claude-opus-4-8" "opus alias resolves from baseline"
+historical_dry_run_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --dry-run --model claude-sonnet-4-6)"
+assert_contains "${historical_dry_run_out}" "Resolved model: claude-sonnet-4-6" "full historical model ID passes through"
+empty_model_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --dry-run --model '' 2>&1 || true)"
+assert_cmd "empty requested model fails visibly" bash -c "cd '${REPO_DIR}' && ! python3 eval/run_eval.py --dry-run --model ''"
+assert_contains "${empty_model_out}" "Invalid requested model: requested model must not be empty" "empty requested model explains failure"
+
+eval_help_out="$(cd "${REPO_DIR}" && python3 eval/run_eval.py --help)"
+assert_contains "${eval_help_out}" "Default model alias: haiku" "eval help reports baseline default"
+assert_contains "${eval_help_out}" "haiku -> claude-haiku-4-5-20251001" "eval help reports Haiku alias"
+assert_contains "${eval_help_out}" "sonnet -> claude-sonnet-5" "eval help reports Sonnet alias"
+assert_contains "${eval_help_out}" "opus -> claude-opus-4-8" "eval help reports Opus alias"
 
 header "behavior eval dry-run"
 behavior_dry_run_out="$(cd "${REPO_DIR}" && python3 eval/run_behavior_eval.py --dry-run)"
@@ -84,6 +105,18 @@ assert_contains "${behavior_normalized_out}" "Behavior dataset source: ${REPO_DI
 assert_contains "${behavior_normalized_out}" "Behavior sample digest:" "behavior dry-run reports sample digest"
 assert_contains "${behavior_normalized_out}" "Required coverage source: ${REPO_DIR_RESOLVED}/eval/behavior/requirements.json" "behavior dry-run reports required coverage source"
 assert_contains "${behavior_normalized_out}" "Threshold source: ${REPO_DIR_RESOLVED}/eval/behavior/thresholds.json" "behavior dry-run reports threshold source"
+assert_contains "${behavior_normalized_out}" "Requested model: haiku" "behavior dry-run reports requested default model"
+assert_contains "${behavior_normalized_out}" "Resolved model: claude-haiku-4-5-20251001" "behavior dry-run resolves shared default model"
+behavior_help_out="$(cd "${REPO_DIR}" && python3 eval/run_behavior_eval.py --help)"
+assert_contains "${behavior_help_out}" "sonnet -> claude-sonnet-5" "behavior help reports shared alias table"
+assert_contains "${behavior_help_out}" "Model baseline verified at (UTC): 2026-07-17" "behavior help reports baseline evidence"
+
+benchmark_help_out="$(cd "${REPO_DIR}" && bash scripts/benchmark.sh --help)"
+assert_contains "${benchmark_help_out}" "Default model alias: haiku" "benchmark help reads shared default"
+assert_contains "${benchmark_help_out}" "haiku -> claude-haiku-4-5-20251001" "benchmark help reports Haiku alias"
+assert_contains "${benchmark_help_out}" "sonnet -> claude-sonnet-5" "benchmark help reports Sonnet alias"
+assert_contains "${benchmark_help_out}" "opus -> claude-opus-4-8" "benchmark help reports Opus alias"
+assert_contains "${benchmark_help_out}" "Model baseline verified at (UTC): 2026-07-17" "benchmark help reports baseline evidence"
 
 header "eval summary index"
 assert_cmd "eval run summary schema loads" python3 -c '


### PR DESCRIPTION
## Linked work

Closes #630

Spec PR: #639
Spec packet: `docs/specs/GH630/{product,tech,tasks}.md`

## Why

The eval aliases for Sonnet and Opus still targeted Claude 4.6, so maintainers could unknowingly benchmark an obsolete baseline. The mapping also lived in one entrypoint while behavior and benchmark surfaces maintained separate defaults/help, leaving room for contract drift.

## Implementation plan and result

- add a strict, versioned offline model-baseline manifest with exact Claude API IDs, official-source evidence, a UTC verification date, and a closed 90-day freshness window
- resolve aliases/default/full-ID passthrough through one Python contract and fail visibly on missing, malformed, future, stale, or empty input
- make `run_eval.py`, `run_behavior_eval.py`, and `scripts/benchmark.sh` consume the shared default/mapping/evidence renderer
- expose requested/resolved model and baseline evidence in dry-run/help without changing artifact schemas or readers
- add unit and integration coverage for exact aliases, full-ID passthrough, future/day-90/day-91 boundaries, entrypoint help/dry-run, and visible invalid-input failures
- mark the approved GH630 task packet and spec index as implemented after the implementation gates passed

## Verification

Fresh on implementation head before PR creation:

- `VIBEGUARD_MODEL_ID=gpt-5 bash guards/universal/check_runtime_drift.sh check --snapshot docs/specs/GH630/runtime-pinning.snapshot --tool-inventory docs/specs/GH630/tool-inventory.txt --rules-dir rules/claude-rules`
- `python3 -m unittest discover -s eval -p 'test_*.py'` — 33 passed
- `bash tests/test_eval_contract.sh` — 44/44 passed
- `python3 eval/run_eval.py --dry-run --model sonnet` — resolved `claude-sonnet-5`, no API call
- `python3 eval/run_eval.py --dry-run --model opus` — resolved `claude-opus-4-8`, no API call
- `shellcheck -e SC1003 scripts/benchmark.sh tests/test_eval_contract.sh`
- `bash tests/test_behavior_eval.sh` — 16/16 passed
- `bash tests/test_hook_perf_contract.sh` — 117/117 passed
- `bash scripts/local-contract-check.sh --quick` — passed
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml` — passed
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml` — passed
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH630` — passed
- `bash scripts/ci/validate-doc-paths.sh` — passed
- `bash scripts/ci/validate-doc-command-paths.sh` — passed
- `git diff --check` — passed

## Risk and rollback

- No network discovery or API calls were added to validation/CI.
- No secrets, auth, scoring semantics, dataset semantics, artifact fields, schema versions, or readers changed.
- Full model IDs still pass through unchanged for historical reproduction.
- Rollback is limited to the baseline/resolver integration; existing artifacts require no migration.
