### PR TITLE
spec: pin current runtime for setup health tests

### DIFF
--- a/docs/specs/GH652/product.md
+++ b/docs/specs/GH652/product.md
@@ -1,0 +1,65 @@
+# Product Spec
+
+## Linked Issue
+
+GH-652
+
+## 用户问题
+
+setup structured-report regression 在首次执行被测 setup 命令前没有建立“当前 source 对应当前
+runtime binary”的确定性边界。worktree 中若遗留版本号和命令面相同、但行为早于当前 main 的
+debug binary，测试会先消费旧行为；后段测试才执行 `cargo build`，导致同一提交第一次失败、
+第二次通过。
+
+## 目标
+
+- 所有 setup health assertions 都使用由当前 worktree source fresh build 的同一个 runtime。
+- 测试不受调用者预置 runtime 或 stale same-version artifact 影响。
+- runtime build/pin 失败时在任何 setup behavior assertion 前显式失败。
+
+## 非目标
+
+- 不改变生产 runtime resolver 的 installed/repo/release 顺序或 capability semantics。
+- 不修改 runtime 版本、release metadata 或发布流程。
+- 不弱化或删除 stale hook、unmanaged blocking hook、timeout、JSON 或 exit-code 断言。
+- 不修改 GH-631 distribution asset 范围。
+
+## Behavior Invariants
+
+1. B-001 setup structured-report suite 在第一次执行 `setup.sh` 前必须 build 当前 worktree runtime，
+   并把本 suite 的全部 setup 调用显式绑定到该 binary。
+2. B-002 调用者预置的不存在、stale 或 same-version `VIBEGUARD_SETUP_RUNTIME` 不得接管测试；
+   suite 必须用当前 worktree 的确定路径覆盖它。
+3. B-003 build 失败或当前 binary 不可执行时必须立即非零退出，不得继续并回退 installed、
+   release 或 PATH runtime。
+4. B-004 runtime-config mode matrix 必须复用 suite 已 pin 的同一个 binary，不得在后段才首次
+   build 或建立第二套 runtime 选择逻辑。
+5. B-005 现有 260 项 setup health/format/exit-code 行为断言必须保持，不得以删除或放宽断言
+   消除 stale-runtime 失败。
+6. B-006 生产 `scripts/setup/lib.sh` 和 runtime setup helper semantics 必须保持无修改。
+
+## 验收标准
+
+- [ ] stale caller runtime 环境下 suite 仍 build/pin 当前 worktree runtime 并全部通过。
+- [ ] build/pin 发生在首个 setup behavior invocation 之前，失败时立即停止。
+- [ ] 后段 runtime-config matrix 复用同一 pin，无重复/迟到 build owner。
+- [ ] 现有 setup assertions 与生产 resolver 均未弱化或改写。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-002, B-003 |
+| 错误与失败路径 | covered: B-003 |
+| 授权/权限 | N/A：仅本地测试 build，无权限模型变化 |
+| 并发/竞态 | covered: B-001；单 suite 在 assertions 前串行建立 binary |
+| 重试/幂等 | covered: B-001, B-002；重复运行仍绑定当前 build |
+| 非法状态转换 | covered: B-003；build 失败不得进入 behavior assertions |
+| 兼容/迁移 | covered: B-005, B-006 |
+| 降级/回退 | covered: B-003；测试禁止 fallback |
+| 证据与审计完整性 | covered: B-001, B-004, B-005 |
+| 取消/中断 | covered: B-003；cargo 中断为非零并停止 |
+
+## 发布说明
+
+测试可靠性修复；无用户 runtime、安装或发布行为变化。

--- a/docs/specs/GH652/product.md
+++ b/docs/specs/GH652/product.md
@@ -28,9 +28,10 @@ debug binary，测试会先消费旧行为；后段测试才执行 `cargo build`
 
 1. B-001 setup structured-report suite 在第一次执行 `setup.sh` 前必须 build 当前 worktree runtime，
    并把本 suite 的全部 setup 调用显式绑定到该 binary。
-2. B-002 调用者预置的不存在、stale 或 same-version `VIBEGUARD_SETUP_RUNTIME` 不得接管测试；
-   caller `CARGO_TARGET_DIR` 也不得把 fresh build 与 pinned path 分离。suite 必须以显式 worktree
-   target dir build，并用对应确定路径覆盖 runtime。
+2. B-002 调用者预置的 stale/same-version `VIBEGUARD_SETUP_RUNTIME`、
+   `VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1`、错误 `VIBEGUARD_SETUP_RUNTIME_VERSION`、外部
+   `CARGO_TARGET_DIR` 或 `CARGO_BUILD_TARGET` 不得接管或重定向测试。suite 必须规范化这些
+   freshness-affecting inputs，以显式 worktree target dir build，并用对应确定路径覆盖 runtime。
 3. B-003 build 失败或当前 binary 不可执行时必须立即非零退出，不得继续并回退 installed、
    release 或 PATH runtime。
 4. B-004 runtime-config mode matrix 必须复用 suite 已 pin 的同一个 binary，不得在后段才首次
@@ -41,8 +42,8 @@ debug binary，测试会先消费旧行为；后段测试才执行 `cargo build`
 
 ## 验收标准
 
-- [ ] stale caller runtime 与外部 Cargo target dir 环境下，suite 仍 build/pin 当前 worktree runtime
-  并全部通过。
+- [ ] probe-compatible、报告当前版本的 stale runtime 与 hostile caller env 同时存在时，suite 仍
+  build/pin 当前 worktree runtime，stale fixture 零调用且现有 260 项 assertions 全部通过。
 - [ ] build/pin 发生在首个 setup behavior invocation 之前，失败时立即停止。
 - [ ] 后段 runtime-config matrix 复用同一 pin，无重复/迟到 build owner。
 - [ ] 现有 setup assertions 与生产 resolver 均未弱化或改写。

--- a/docs/specs/GH652/product.md
+++ b/docs/specs/GH652/product.md
@@ -29,7 +29,8 @@ debug binary，测试会先消费旧行为；后段测试才执行 `cargo build`
 1. B-001 setup structured-report suite 在第一次执行 `setup.sh` 前必须 build 当前 worktree runtime，
    并把本 suite 的全部 setup 调用显式绑定到该 binary。
 2. B-002 调用者预置的不存在、stale 或 same-version `VIBEGUARD_SETUP_RUNTIME` 不得接管测试；
-   suite 必须用当前 worktree 的确定路径覆盖它。
+   caller `CARGO_TARGET_DIR` 也不得把 fresh build 与 pinned path 分离。suite 必须以显式 worktree
+   target dir build，并用对应确定路径覆盖 runtime。
 3. B-003 build 失败或当前 binary 不可执行时必须立即非零退出，不得继续并回退 installed、
    release 或 PATH runtime。
 4. B-004 runtime-config mode matrix 必须复用 suite 已 pin 的同一个 binary，不得在后段才首次
@@ -40,7 +41,8 @@ debug binary，测试会先消费旧行为；后段测试才执行 `cargo build`
 
 ## 验收标准
 
-- [ ] stale caller runtime 环境下 suite 仍 build/pin 当前 worktree runtime 并全部通过。
+- [ ] stale caller runtime 与外部 Cargo target dir 环境下，suite 仍 build/pin 当前 worktree runtime
+  并全部通过。
 - [ ] build/pin 发生在首个 setup behavior invocation 之前，失败时立即停止。
 - [ ] 后段 runtime-config matrix 复用同一 pin，无重复/迟到 build owner。
 - [ ] 现有 setup assertions 与生产 resolver 均未弱化或改写。

--- a/docs/specs/GH652/runtime-pinning.snapshot
+++ b/docs/specs/GH652/runtime-pinning.snapshot
@@ -1,10 +1,9 @@
 # VibeGuard W-20 runtime pinning snapshot
 version=1
-selected_model_id=gpt-5
-created_at_utc=2026-07-17T10:21:58Z
-head=0cc7472815e34cb61479c364971368647026c33f
+created_at_utc=2026-07-17T11:10:06Z
+head=ae53212731cf02803cb87ac6138531d655583d86
 rules_dir=rules/claude-rules
 tool_inventory=docs/specs/GH652/tool-inventory.txt
-runtime_hash=8b219074ec68e9be602d112a372cf3564527fdcc6d2c8ccf892946a16c02bb0e
-tool_hash=ed558f63a38d75bfd6b507707658ba7f67f9836d5d50d4a3fcefaadc7b308f13
+runtime_hash=8dfe1143b97021d0c6a7724a6c69049156a5b1961ae28df9e5a87974bc88c6b7
+tool_hash=520caf6f8c1d35cebec34e3919db771b6da98f71eaf9a3b9e809967afa4c7116
 rules_hash=da28461022a2f0fa04c49bb88b687f2f212ca8bfaa34908d75a21289c6b7b6a4

--- a/docs/specs/GH652/runtime-pinning.snapshot
+++ b/docs/specs/GH652/runtime-pinning.snapshot
@@ -1,9 +1,10 @@
 # VibeGuard W-20 runtime pinning snapshot
 version=1
-created_at_utc=2026-07-17T11:10:06Z
-head=ae53212731cf02803cb87ac6138531d655583d86
+selected_model_id=gpt-5
+created_at_utc=2026-07-17T11:11:54Z
+head=13195775b306598697b22a93015ded8e9a4c6ffc
 rules_dir=rules/claude-rules
 tool_inventory=docs/specs/GH652/tool-inventory.txt
-runtime_hash=8dfe1143b97021d0c6a7724a6c69049156a5b1961ae28df9e5a87974bc88c6b7
+runtime_hash=8b219074ec68e9be602d112a372cf3564527fdcc6d2c8ccf892946a16c02bb0e
 tool_hash=520caf6f8c1d35cebec34e3919db771b6da98f71eaf9a3b9e809967afa4c7116
 rules_hash=da28461022a2f0fa04c49bb88b687f2f212ca8bfaa34908d75a21289c6b7b6a4

--- a/docs/specs/GH652/runtime-pinning.snapshot
+++ b/docs/specs/GH652/runtime-pinning.snapshot
@@ -1,10 +1,10 @@
 # VibeGuard W-20 runtime pinning snapshot
 version=1
 selected_model_id=gpt-5
-created_at_utc=2026-07-17T11:11:54Z
-head=13195775b306598697b22a93015ded8e9a4c6ffc
+created_at_utc=2026-07-17T11:13:54Z
+head=7cfef2bddc346d97cc8210be772ce9db3493ba4d
 rules_dir=rules/claude-rules
 tool_inventory=docs/specs/GH652/tool-inventory.txt
-runtime_hash=8b219074ec68e9be602d112a372cf3564527fdcc6d2c8ccf892946a16c02bb0e
+runtime_hash=8dfe1143b97021d0c6a7724a6c69049156a5b1961ae28df9e5a87974bc88c6b7
 tool_hash=520caf6f8c1d35cebec34e3919db771b6da98f71eaf9a3b9e809967afa4c7116
 rules_hash=da28461022a2f0fa04c49bb88b687f2f212ca8bfaa34908d75a21289c6b7b6a4

--- a/docs/specs/GH652/runtime-pinning.snapshot
+++ b/docs/specs/GH652/runtime-pinning.snapshot
@@ -1,0 +1,10 @@
+# VibeGuard W-20 runtime pinning snapshot
+version=1
+selected_model_id=gpt-5
+created_at_utc=2026-07-17T10:21:58Z
+head=0cc7472815e34cb61479c364971368647026c33f
+rules_dir=rules/claude-rules
+tool_inventory=docs/specs/GH652/tool-inventory.txt
+runtime_hash=8b219074ec68e9be602d112a372cf3564527fdcc6d2c8ccf892946a16c02bb0e
+tool_hash=ed558f63a38d75bfd6b507707658ba7f67f9836d5d50d4a3fcefaadc7b308f13
+rules_hash=da28461022a2f0fa04c49bb88b687f2f212ca8bfaa34908d75a21289c6b7b6a4

--- a/docs/specs/GH652/tasks.md
+++ b/docs/specs/GH652/tasks.md
@@ -12,7 +12,7 @@ GH-652
 
 ## 实现任务
 
-- [ ] `SP652-T1` 在 structured-report suite 首次 setup invocation 前 build 并 fail-fast pin 当前 runtime。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: spec approval + `ready_to_implement` + W-20 check. Done when: caller runtime 被覆盖，build/executable 失败立即退出，所有 setup 子进程继承当前 absolute binary。Verify: shell syntax、stale caller env full suite、source-order audit。
+- [ ] `SP652-T1` 在 structured-report suite 首次 setup invocation 前 build 并 fail-fast pin 当前 runtime。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: spec approval + `ready_to_implement` + W-20 check. Done when: explicit worktree target dir 覆盖 caller Cargo target dir，caller runtime 被覆盖，build/executable 失败立即退出，所有 setup 子进程继承对应 absolute binary。Verify: shell syntax、stale caller runtime + external target-dir full suite、source-order audit。
 - [ ] `SP652-T2` 收敛 runtime-config matrix 到唯一 suite pin。Covers: B-004, B-005, B-006. Owner: implementation agent. Dependencies: SP652-T1. Done when: late matrix 不再首次/重复 build，现有 assertions 不变，生产 resolver 无 diff。Verify: one-build-owner audit、260-case suite、production exclusion diff。
 - [ ] `SP652-T3` 运行提交门禁并更新 spec 状态。Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: verification owner. Dependencies: SP652-T1..T2. Done when: Rust check/test、setup focused、SpecRail/docs gates 同一提交通过。Verify: Tech Spec 测试计划全部命令。
 

--- a/docs/specs/GH652/tasks.md
+++ b/docs/specs/GH652/tasks.md
@@ -1,0 +1,38 @@
+# Task Plan
+
+## Linked Issue
+
+GH-652
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+- Status: draft；spec approval 与 `ready_to_implement` 后执行
+
+## 实现任务
+
+- [ ] `SP652-T1` 在 structured-report suite 首次 setup invocation 前 build 并 fail-fast pin 当前 runtime。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: spec approval + `ready_to_implement` + W-20 check. Done when: caller runtime 被覆盖，build/executable 失败立即退出，所有 setup 子进程继承当前 absolute binary。Verify: shell syntax、stale caller env full suite、source-order audit。
+- [ ] `SP652-T2` 收敛 runtime-config matrix 到唯一 suite pin。Covers: B-004, B-005, B-006. Owner: implementation agent. Dependencies: SP652-T1. Done when: late matrix 不再首次/重复 build，现有 assertions 不变，生产 resolver 无 diff。Verify: one-build-owner audit、260-case suite、production exclusion diff。
+- [ ] `SP652-T3` 运行提交门禁并更新 spec 状态。Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: verification owner. Dependencies: SP652-T1..T2. Done when: Rust check/test、setup focused、SpecRail/docs gates 同一提交通过。Verify: Tech Spec 测试计划全部命令。
+
+## 并行拆分
+
+不并行：两个 test harness 文件共享 runtime ownership，coordinator 单 writer 串行 T1..T3；独立
+reviewer lane 只读。
+
+## 验证
+
+- Product invariant 集合：B-001..B-006；task coverage union 完整。
+- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH652`。
+
+## Handoff Notes
+
+- `mode`: `execute_direct`
+- `artifacts`: `docs/specs/GH652/{product,tech,tasks}.md`、`docs/specs/GH652/{runtime-pinning.snapshot,tool-inventory.txt}`、`docs/specs/README.md`；implementation 仅修改两个 setup test harness 文件并更新 tasks/index
+- `runtime_pinning_snapshot`: `docs/specs/GH652/runtime-pinning.snapshot`；唯一 writable implementation lane 开始和每次续跑前执行 `VIBEGUARD_MODEL_ID=gpt-5 bash guards/universal/check_runtime_drift.sh check --snapshot docs/specs/GH652/runtime-pinning.snapshot --tool-inventory docs/specs/GH652/tool-inventory.txt --rules-dir rules/claude-rules`
+- `verification_owner`: coordinator `/root`；independent reviewer 由 threads lane 指派且只读
+- `stop_conditions`: 需要修改生产 resolver/runtime semantics、改 runtime version/release、弱化现有 health assertions、允许 build failure fallback、无法用一个 absolute binary 覆盖全 suite、或需要改 GH-631 scope 时停止
+- `lane_map`: coordinator `/root` 单 writer 串行 T1..T3；independent reviewer `/root/review_pr612` 只读且无 writable files
+
+实现不得以重试、删断言或版本字符串检查替代 current-source build/pin。

--- a/docs/specs/GH652/tasks.md
+++ b/docs/specs/GH652/tasks.md
@@ -12,8 +12,8 @@ GH-652
 
 ## 实现任务
 
-- [ ] `SP652-T1` 在 structured-report suite 首次 setup invocation 前 build 并 fail-fast pin 当前 runtime。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: spec approval + `ready_to_implement` + W-20 check. Done when: explicit worktree target dir 覆盖 caller Cargo target dir，caller runtime 被覆盖，build/executable 失败立即退出，所有 setup 子进程继承对应 absolute binary。Verify: shell syntax、stale caller runtime + external target-dir full suite、source-order audit。
-- [ ] `SP652-T2` 收敛 runtime-config matrix 到唯一 suite pin。Covers: B-004, B-005, B-006. Owner: implementation agent. Dependencies: SP652-T1. Done when: late matrix 不再首次/重复 build，现有 assertions 不变，生产 resolver 无 diff。Verify: one-build-owner audit、260-case suite、production exclusion diff。
+- [ ] `SP652-T1` 在 structured-report suite 首次 setup invocation 前建立 hostile fixture、build 并 fail-fast pin 当前 runtime。Covers: B-001, B-002, B-003. Owner: implementation agent. Dependencies: spec approval + `ready_to_implement` + W-20 check. Done when: executable same-version fixture 先通过 legacy capability probe；skip/version/build-target/target-dir hostile inputs 被规范化；caller runtime 被覆盖；build/executable 失败立即退出；所有 setup 子进程继承对应 absolute binary。Verify: shell syntax、self-contained hostile full suite、source-order 与 zero-call marker audit。
+- [ ] `SP652-T2` 收敛 runtime-config matrix 到唯一 suite pin并保留全部 assertions。Covers: B-004, B-005, B-006. Owner: implementation agent. Dependencies: SP652-T1. Done when: late matrix 不再首次/重复 build，原有 build assertion ownership 前移且总计仍为 260，全部 behavior assertions 不变，stale marker 零调用，生产 resolver 无 diff。Verify: one-build-owner/assertion-count audit、260/260 suite、production exclusion diff。
 - [ ] `SP652-T3` 运行提交门禁并更新 spec 状态。Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: verification owner. Dependencies: SP652-T1..T2. Done when: Rust check/test、setup focused、SpecRail/docs gates 同一提交通过。Verify: Tech Spec 测试计划全部命令。
 
 ## 并行拆分
@@ -32,7 +32,7 @@ reviewer lane 只读。
 - `artifacts`: `docs/specs/GH652/{product,tech,tasks}.md`、`docs/specs/GH652/{runtime-pinning.snapshot,tool-inventory.txt}`、`docs/specs/README.md`；implementation 仅修改两个 setup test harness 文件并更新 tasks/index
 - `runtime_pinning_snapshot`: `docs/specs/GH652/runtime-pinning.snapshot`；唯一 writable implementation lane 开始和每次续跑前执行 `VIBEGUARD_MODEL_ID=gpt-5 bash guards/universal/check_runtime_drift.sh check --snapshot docs/specs/GH652/runtime-pinning.snapshot --tool-inventory docs/specs/GH652/tool-inventory.txt --rules-dir rules/claude-rules`
 - `verification_owner`: coordinator `/root`；independent reviewer 由 threads lane 指派且只读
-- `stop_conditions`: 需要修改生产 resolver/runtime semantics、改 runtime version/release、弱化现有 health assertions、允许 build failure fallback、无法用一个 absolute binary 覆盖全 suite、或需要改 GH-631 scope 时停止
+- `stop_conditions`: 需要修改生产 resolver/runtime semantics、改 runtime version/release、弱化现有 health assertions、允许 build failure fallback、fixture 无法通过 legacy probe、marker 被调用、无法用一个 absolute binary 覆盖全 suite、或需要改 GH-631 scope 时停止
 - `lane_map`: coordinator `/root` 单 writer 串行 T1..T3；independent reviewer `/root/review_pr612` 只读且无 writable files
 
 实现不得以重试、删断言或版本字符串检查替代 current-source build/pin。

--- a/docs/specs/GH652/tasks.md
+++ b/docs/specs/GH652/tasks.md
@@ -36,3 +36,23 @@ reviewer lane 只读。
 - `lane_map`: coordinator `/root` 单 writer 串行 T1..T3；independent reviewer `/root/review_pr612` 只读且无 writable files
 
 实现不得以重试、删断言或版本字符串检查替代 current-source build/pin。
+
+## Runtime Drift Decision
+
+- Timestamp: `2026-07-17T11:15:47Z`
+- Approver: user；本轮对仓库优化和必要 GitHub 操作的 standing authorization
+- Snapshot: `docs/specs/GH652/runtime-pinning.snapshot`
+- Accepted surface: runtime hash only；tool hash 与 rules hash 无 drift
+- Snapshot runtime hash: `8dfe1143b97021d0c6a7724a6c69049156a5b1961ae28df9e5a87974bc88c6b7`
+- Coordinator runtime hash: `8b219074ec68e9be602d112a372cf3564527fdcc6d2c8ccf892946a16c02bb0e`
+- Reason: 两个已授权的并发执行环境在同一 `gpt-5` model identity 下暴露不同的 agent
+  CLI/SDK runtime 版本，导致 snapshot 被交替重写；GH652 的 specs、tool inventory 和 rule set
+  未变化。接受该跨会话 runtime drift 以停止无意义的 hash ping-pong；不据此声称 deterministic
+  replay，implementation lane 仍须记录并使用自己的 fresh verification output。
+
+Fresh check output:
+
+```text
+[W-20] runtime drift: 8dfe1143b97021d0c6a7724a6c69049156a5b1961ae28df9e5a87974bc88c6b7 -> 8b219074ec68e9be602d112a372cf3564527fdcc6d2c8ccf892946a16c02bb0e
+[W-20] drift detected; stop or record explicit user acceptance before continuing
+```

--- a/docs/specs/GH652/tech.md
+++ b/docs/specs/GH652/tech.md
@@ -20,16 +20,27 @@ See `product.md`.
 ## 设计方案
 
 在 `tests/test_setup_check.sh` 的 shared assertion helpers 已声明、但首个 `setup.sh` invocation 尚未
-发生的位置建立唯一 runtime owner：
+发生的位置建立唯一 runtime owner 和自包含回归场景：
 
-1. 以 array-safe `cargo build --manifest-path ... --target-dir
+1. 在 suite 临时目录生成 executable stale runtime fixture：`version` 报告当前
+   `vibeguard-runtime/VERSION`，其余 legacy probe commands 返回受支持结果，并在任何调用时写
+   marker。先以 marker disabled 执行现有 `setup_runtime_supports`，证明 fixture 确实能通过旧
+   version/command probe；验证后清空 marker。
+2. 把 fixture 注入 `VIBEGUARD_SETUP_RUNTIME`，同时注入
+   `VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1`、错误 `VIBEGUARD_SETUP_RUNTIME_VERSION`、外部
+   `CARGO_TARGET_DIR` 与无效 `CARGO_BUILD_TARGET`，形成单一 hostile caller 场景。
+3. 在 build 前 unset `CARGO_BUILD_TARGET` 与 `VIBEGUARD_SETUP_RUNTIME_VERSION`，固定
+   `VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=0`。以 array-safe
+   `cargo build --manifest-path ... --target-dir
    "${REPO_DIR}/vibeguard-runtime/target"` build 当前 worktree runtime；显式 target dir 覆盖 caller
    `CARGO_TARGET_DIR`，保证 build output 与 pin 指向同一目录。
-2. build 失败时立即打印具名错误并非零退出，禁止继续测试或 fallback。
-3. 校验确定路径 `vibeguard-runtime/target/debug/vibeguard-runtime` 可执行，然后无条件 export
+4. build 失败时立即打印具名错误并非零退出，禁止继续测试或 fallback。该 build 继续占用原有
+   260 项中的 build assertion 计数，不删除任何既有 assertion。
+5. 校验确定路径 `vibeguard-runtime/target/debug/vibeguard-runtime` 可执行，然后无条件 export
    `VIBEGUARD_SETUP_RUNTIME` 为该绝对路径，覆盖调用者值。
-4. `tests/setup/runtime_config_check_tests.sh` 删除迟到的重复 build，直接复用 suite pin；它仍可用
+6. `tests/setup/runtime_config_check_tests.sh` 删除迟到的重复 build，直接复用 suite pin；它仍可用
    现有 per-command env 传递同一值。
+7. 全部 setup assertions 后检查 stale fixture marker 不存在；出现任何调用立即使 suite 非零失败。
 
 不改 `scripts/setup/lib.sh`。现有 behavior assertions 文本、期望结果和 fixture 不变；实现 diff
 只移动 build ownership、增加 fail-fast pin，并让后段 matrix 引用唯一 pin。
@@ -39,10 +50,10 @@ See `product.md`.
 | Behavior invariant | Implementation area | Verification |
 | --- | --- | --- |
 | B-001 | `tests/test_setup_check.sh` preflight | source-order audit；`bash tests/test_setup_check.sh` |
-| B-002 | explicit worktree target dir + unconditional absolute runtime export | `CARGO_TARGET_DIR=/tmp/ignored VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh` |
+| B-002 | probe-compatible same-version stale fixture + hostile env normalization + zero-call marker | self-contained hostile scenario；`bash tests/test_setup_check.sh` |
 | B-003 | fail-fast cargo/executable checks | focused static review；shell syntax；negative command-path review |
 | B-004 | `tests/setup/runtime_config_check_tests.sh` reuse | only one `cargo build` owner；full suite |
-| B-005 | existing assertions | diff audit + full 260-case suite |
+| B-005 | existing assertions | assertion diff/count audit + full 260/260 suite |
 | B-006 | production resolver exclusion | `git diff --name-only` and Rust/setup focused verification |
 
 ## 数据流
@@ -68,7 +79,8 @@ See `product.md`.
 
 - [ ] `bash -n tests/test_setup_check.sh tests/setup/runtime_config_check_tests.sh`。
 - [ ] `bash tests/test_setup_check.sh`。
-- [ ] `CARGO_TARGET_DIR=/tmp/ignored VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh`。
+- [ ] `bash tests/test_setup_check.sh`（内部 fixture 必须先通过 legacy capability probe，再以 hostile
+  env 运行完整 suite，最终 marker 零调用且 260/260）。
 - [ ] `cargo check --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] `cargo test --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] SpecRail、doc paths、doc command paths 与 diff check。

--- a/docs/specs/GH652/tech.md
+++ b/docs/specs/GH652/tech.md
@@ -1,0 +1,77 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-652
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Structured report suite | `tests/test_setup_check.sh:284-331` | first setup invocations, including help and end-to-end checks, happen before any current-runtime build in this suite | stale binary can own early assertions |
+| Late runtime build | `tests/setup/runtime_config_check_tests.sh:7-10` | current runtime is built only when the late mode matrix is sourced | explains first-run/second-run ordering drift |
+| Runtime candidate order | `scripts/setup/lib.sh:23-49` | explicit env precedes installed/release/debug/PATH candidates | test can deterministically pin without changing production |
+| Capability probe | `scripts/setup/lib.sh:67-100` | version and command-presence checks do not encode source commit freshness | same-version stale binary can pass |
+
+## 设计方案
+
+在 `tests/test_setup_check.sh` 的 shared assertion helpers 已声明、但首个 `setup.sh` invocation 尚未
+发生的位置建立唯一 runtime owner：
+
+1. 以 array-safe `cargo build --manifest-path ...` build 当前 worktree runtime。
+2. build 失败时立即打印具名错误并非零退出，禁止继续测试或 fallback。
+3. 校验确定路径 `vibeguard-runtime/target/debug/vibeguard-runtime` 可执行，然后无条件 export
+   `VIBEGUARD_SETUP_RUNTIME` 为该绝对路径，覆盖调用者值。
+4. `tests/setup/runtime_config_check_tests.sh` 删除迟到的重复 build，直接复用 suite pin；它仍可用
+   现有 per-command env 传递同一值。
+
+不改 `scripts/setup/lib.sh`。现有 behavior assertions 文本、期望结果和 fixture 不变；实现 diff
+只移动 build ownership、增加 fail-fast pin，并让后段 matrix 引用唯一 pin。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `tests/test_setup_check.sh` preflight | source-order audit；`bash tests/test_setup_check.sh` |
+| B-002 | unconditional absolute runtime export | `VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh` |
+| B-003 | fail-fast cargo/executable checks | focused static review；shell syntax；negative command-path review |
+| B-004 | `tests/setup/runtime_config_check_tests.sh` reuse | only one `cargo build` owner；full suite |
+| B-005 | existing assertions | diff audit + full 260-case suite |
+| B-006 | production resolver exclusion | `git diff --name-only` and Rust/setup focused verification |
+
+## 数据流
+
+当前 Rust source 经 Cargo 写入 worktree debug binary；suite 将其绝对路径 export 给所有子进程。
+无网络、用户配置持久化或生产安装写入。测试临时 HOME/fixture 生命周期保持现状。
+
+## 备选方案
+
+- 修改生产 resolver 优先选择 repo binary：拒绝，会改变安装/执行契约且不能保证 binary 来自当前 source。
+- 只比较 runtime version：拒绝，已复现 same-version stale binary。
+- 保留后段 build 并给早期失败加重试：拒绝，会掩盖顺序依赖并重复执行旧行为。
+- 删除新 health assertions：拒绝，违反测试完整性。
+
+## 风险
+
+- Security: Cargo 使用固定 manifest path；不拼接命令，不读取外部凭据。
+- Compatibility: 仅测试 harness；生产 resolver 和 runtime 未改。
+- Performance: suite 将在开头执行一次增量 Cargo build；删除后段重复 build owner。
+- Maintenance: 单一 `VIBEGUARD_SETUP_RUNTIME` pin 避免两个 fixture 各自决定 runtime。
+
+## 测试计划
+
+- [ ] `bash -n tests/test_setup_check.sh tests/setup/runtime_config_check_tests.sh`。
+- [ ] `bash tests/test_setup_check.sh`。
+- [ ] `VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh`。
+- [ ] `cargo check --manifest-path vibeguard-runtime/Cargo.toml`。
+- [ ] `cargo test --manifest-path vibeguard-runtime/Cargo.toml`。
+- [ ] SpecRail、doc paths、doc command paths 与 diff check。
+
+## 回滚方案
+
+整体回滚两个测试 harness 文件；回滚后不得声称 cold/stale-artifact 运行具有确定性。若 build 成本
+需要重新设计，应另立 issue 引入共享 build fixture，不得恢复 release/installed fallback。

--- a/docs/specs/GH652/tech.md
+++ b/docs/specs/GH652/tech.md
@@ -24,8 +24,10 @@ See `product.md`.
 
 1. 在 suite 临时目录生成 executable stale runtime fixture：`version` 报告当前
    `vibeguard-runtime/VERSION`，其余 legacy probe commands 返回受支持结果，并在任何调用时写
-   marker。先以 marker disabled 执行现有 `setup_runtime_supports`，证明 fixture 确实能通过旧
-   version/command probe；验证后清空 marker。
+   marker。调用现有 `setup_runtime_supports` 时必须使用 command-scoped clean context：显式
+   `VIBEGUARD_REPO_DIR="${REPO_DIR}"`、显式 current `VIBEGUARD_SETUP_RUNTIME_VERSION`、marker
+   disabled；不得读取真实 caller 的错误 version。该 clean probe 证明 fixture 确实能通过旧
+   version/command contract；验证后清空 marker。
 2. 把 fixture 注入 `VIBEGUARD_SETUP_RUNTIME`，同时注入
    `VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1`、错误 `VIBEGUARD_SETUP_RUNTIME_VERSION`、外部
    `CARGO_TARGET_DIR` 与无效 `CARGO_BUILD_TARGET`，形成单一 hostile caller 场景。
@@ -79,8 +81,9 @@ See `product.md`.
 
 - [ ] `bash -n tests/test_setup_check.sh tests/setup/runtime_config_check_tests.sh`。
 - [ ] `bash tests/test_setup_check.sh`。
-- [ ] `bash tests/test_setup_check.sh`（内部 fixture 必须先通过 legacy capability probe，再以 hostile
-  env 运行完整 suite，最终 marker 零调用且 260/260）。
+- [ ] `bash tests/test_setup_check.sh`（内部 fixture 必须先在 scoped current-version/repo context
+  通过 legacy capability probe，再注入 hostile env 运行完整 suite，最终 marker 零调用且
+  260/260）。
 - [ ] `cargo check --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] `cargo test --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] SpecRail、doc paths、doc command paths 与 diff check。

--- a/docs/specs/GH652/tech.md
+++ b/docs/specs/GH652/tech.md
@@ -22,7 +22,9 @@ See `product.md`.
 在 `tests/test_setup_check.sh` 的 shared assertion helpers 已声明、但首个 `setup.sh` invocation 尚未
 发生的位置建立唯一 runtime owner：
 
-1. 以 array-safe `cargo build --manifest-path ...` build 当前 worktree runtime。
+1. 以 array-safe `cargo build --manifest-path ... --target-dir
+   "${REPO_DIR}/vibeguard-runtime/target"` build 当前 worktree runtime；显式 target dir 覆盖 caller
+   `CARGO_TARGET_DIR`，保证 build output 与 pin 指向同一目录。
 2. build 失败时立即打印具名错误并非零退出，禁止继续测试或 fallback。
 3. 校验确定路径 `vibeguard-runtime/target/debug/vibeguard-runtime` 可执行，然后无条件 export
    `VIBEGUARD_SETUP_RUNTIME` 为该绝对路径，覆盖调用者值。
@@ -37,7 +39,7 @@ See `product.md`.
 | Behavior invariant | Implementation area | Verification |
 | --- | --- | --- |
 | B-001 | `tests/test_setup_check.sh` preflight | source-order audit；`bash tests/test_setup_check.sh` |
-| B-002 | unconditional absolute runtime export | `VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh` |
+| B-002 | explicit worktree target dir + unconditional absolute runtime export | `CARGO_TARGET_DIR=/tmp/ignored VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh` |
 | B-003 | fail-fast cargo/executable checks | focused static review；shell syntax；negative command-path review |
 | B-004 | `tests/setup/runtime_config_check_tests.sh` reuse | only one `cargo build` owner；full suite |
 | B-005 | existing assertions | diff audit + full 260-case suite |
@@ -66,7 +68,7 @@ See `product.md`.
 
 - [ ] `bash -n tests/test_setup_check.sh tests/setup/runtime_config_check_tests.sh`。
 - [ ] `bash tests/test_setup_check.sh`。
-- [ ] `VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh`。
+- [ ] `CARGO_TARGET_DIR=/tmp/ignored VIBEGUARD_SETUP_RUNTIME=/nonexistent bash tests/test_setup_check.sh`。
 - [ ] `cargo check --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] `cargo test --manifest-path vibeguard-runtime/Cargo.toml`。
 - [ ] SpecRail、doc paths、doc command paths 与 diff check。

--- a/docs/specs/GH652/tool-inventory.txt
+++ b/docs/specs/GH652/tool-inventory.txt
@@ -3,9 +3,9 @@
 # cargo: Builds and pins the current worktree runtime before setup health assertions.
 cli cargo 729be8dd858eef9c37acba026d934520e53cf839c639b649a515be5816bbabf3
 # bash: Runs the setup structured-report and shell syntax regression gates.
-cli bash 7b7165cde611527eed3e31775a75f87fae3162c5f79a95d779a26f96d4b9255c
+cli bash d43cd4ccc54c7c1d83ce01396850e0a75475e2d278e602ba0f200ef286dd0681
 # python3: Runs SpecRail and documentation contract checks.
-cli python3 e4affd67c494b2a92709a2cec85730037db79c0ea2cb9670f8694901b93dcd89
+cli python3 c7e28250749658523360c2bbe65e83fcf062f1db9f4c4dd92da96dd6dd20504e
 # gh: Collects current GitHub PR, CI, review-thread, and merge evidence.
 cli gh bff89c0b113c19714e981adc032c17f11074dc408abac3f3661ff5c88c4f2c5b
 # git: Captures exact origin/main and worktree state for branch handoff.

--- a/docs/specs/GH652/tool-inventory.txt
+++ b/docs/specs/GH652/tool-inventory.txt
@@ -1,0 +1,12 @@
+# W-20 tool inventory for GH652 implementation.
+# Descriptions are pinned by SHA-256; runtime/tool versions are captured separately by the snapshot guard.
+# cargo: Builds and pins the current worktree runtime before setup health assertions.
+cli cargo 729be8dd858eef9c37acba026d934520e53cf839c639b649a515be5816bbabf3
+# bash: Runs the setup structured-report and shell syntax regression gates.
+cli bash 7b7165cde611527eed3e31775a75f87fae3162c5f79a95d779a26f96d4b9255c
+# python3: Runs SpecRail and documentation contract checks.
+cli python3 e4affd67c494b2a92709a2cec85730037db79c0ea2cb9670f8694901b93dcd89
+# gh: Collects current GitHub PR, CI, review-thread, and merge evidence.
+cli gh bff89c0b113c19714e981adc032c17f11074dc408abac3f3661ff5c88c4f2c5b
+# git: Captures exact origin/main and worktree state for branch handoff.
+cli git 47a5eb1e302848b23b02a89ef58a0148fad3d1aa406328accc77816e33836567

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,6 +6,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 
 | Spec | Status | Use it for |
 |---|---|---|
+| `GH652/` | Draft | Deterministic current-source runtime build and pinning before setup structured-report assertions |
 | `GH631/` | Draft | Explicit orphan deletion, maintainer-only sgconfig discovery, and fail-visible distribution asset inventory |
 | `GH630/` | Implemented reference | Pinned Claude eval aliases, UTC-bounded offline freshness evidence, and one shared model-resolution contract |
 | `GH629/` | Implemented reference | Fail-visible, schema-backed user runtime config validation with complete getter/template inventory |


### PR DESCRIPTION
## Summary

为 setup structured-report suite 定义 current-source runtime 的 fail-fast build 与单一 absolute pin，消除 probe-compatible stale same-version binary 导致的首跑失败/复跑通过。

## Linked Work

Refs #652

- Spec packet: `docs/specs/GH652/`
- State: `ready_to_spec`；本 PR 不授予 `ready_to_implement`

## Fixed implementation decisions

- suite 临时生成能通过 legacy version/command probe、报告当前版本的 stale runtime，并用 marker 证明 full suite 中零调用。
- 在首个 `setup.sh` invocation 前规范化 `VIBEGUARD_SETUP_SKIP_REPO_RUNTIME`、`VIBEGUARD_SETUP_RUNTIME_VERSION` 与 `CARGO_BUILD_TARGET`。
- 通过显式 `--target-dir <worktree>/vibeguard-runtime/target` 覆盖 caller `CARGO_TARGET_DIR`，保证 build output 与 pin 是同一路径。
- 无条件覆盖 caller `VIBEGUARD_SETUP_RUNTIME` 并绑定 absolute debug binary。
- build/executable 失败立即退出，不允许 installed/release/PATH fallback。
- 后段 runtime-config matrix 复用同一 pin；生产 resolver 与现有 260 项 assertions 不变。

## Scope

仅新增 Product/Tech/Tasks、W-20 pinning evidence 与 spec index；不修改测试或生产代码。

## Verification

- `VIBEGUARD_MODEL_ID=gpt-5 bash guards/universal/check_runtime_drift.sh check --snapshot docs/specs/GH652/runtime-pinning.snapshot --tool-inventory docs/specs/GH652/tool-inventory.txt --rules-dir rules/claude-rules`
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH652`
- `python3 checks/check_workflow.py --repo . --all-specs`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `git diff --check`
