### PR TITLE
docs: refresh repository map and presentation metadata

### DIFF
--- a/docs/directory-map.md
+++ b/docs/directory-map.md
@@ -35,7 +35,13 @@ VibeGuard keeps runtime and installable source directories at the repository roo
 | `tests/` | Shell and unit regression tests for hooks, guards, setup, and contracts. |
 | `eval/` | Evaluation samples and runner for rule compliance checks. |
 | `scripts/ci/` | CI contract and static validation scripts. |
+| `scripts/constraints/` | Constraint inventory and recommendation helpers used by guard and budget checks. |
+| `scripts/doctors/` | Maintainer diagnostics for supported agent runtimes and local installations. |
+| `scripts/gc/` | Scheduled and on-demand cleanup, digest, and maintenance helpers. |
+| `scripts/learn/` | Learning analysis, adoption, and trajectory helpers used by the learning workflow. |
+| `scripts/metrics/` | Metrics collection and Prometheus-format export helpers. |
 | `scripts/verify/` | Local verification and freshness checks. |
+| `scripts/systemd/` | Linux user-service templates for scheduled VibeGuard maintenance. |
 | `.github/` | GitHub Actions workflows, issue templates, and PR template. |
 | `data/` | Versioned seed/example files for rule precision tooling; mutable triage, scorecard, and benchmark outputs are ignored. |
 

--- a/docs/internal/benchmarks/benchmark-design.md
+++ b/docs/internal/benchmarks/benchmark-design.md
@@ -2,6 +2,7 @@
 
 > Design date: 2026-03-23
 > Goal: To quantitatively evaluate the actual guarding capabilities of VibeGuard and replace pure artificial perception.
+> Snapshot scope: Rule counts in this document describe the 2026-03-23 design snapshot. They are not the current rule inventory and must not be updated without rerunning the benchmark.
 
 ---
 
@@ -11,7 +12,7 @@
 
 | Dimensions | Current Situation | Problems |
 |------|------|------|
-| Hook coverage | 6/110 rules (5.5%) are enforced by hooks | 94.5% of the rules rely on model awareness |
+| Hook coverage | In the 2026-03-23 design snapshot, 6/110 rules (5.5%) are enforced by hooks | 94.5% of the snapshot rules rely on model awareness |
 | Detection accuracy | test_hooks.sh 51 cases, no TP/FP distinction | Don’t know the false positive rate of each guard |
 | Rule Compliance | run_eval.py covers ~20 rules | 90 rules covered with zero evaluation |
 | Trend tracking | No time series data | After changing the guard, I don’t know whether it will get better or worse |
@@ -287,7 +288,7 @@ Layer2_Score = Severity-Weighted Detection Rate
 
 **Weight allocation basis**:
 - Layer 1 (40%): Hook is a deterministic line of defense, but has less coverage (6 rules)
-- Layer 2 (60%): Covers 110 rules, but has a probabilistic line of defense
+- Layer 2 (60%): Covers 110 rules in the 2026-03-23 design snapshot, but has a probabilistic line of defense
 
 ### 5.2 Grading standards
 

--- a/site/index.html
+++ b/site/index.html
@@ -25,7 +25,7 @@
 
 <section class="hero" id="top">
   <div class="hero-inner">
-    <div class="eyebrow">starlight · vibeguard v1.1</div>
+    <div class="eyebrow">starlight · vibeguard v1 series</div>
     <h1>Stop the slop.<br><span class="accent">Before</span> the commit.</h1>
     <p class="lede">
       Native rules + real-time hooks + static guards to catch what AI coding agents get wrong — before it reaches your codebase. Duplicate files, invented APIs, dangerous shell commands, unverified "I'm done" claims. Blocked, warned, or surfaced with a fix.

--- a/tests/test_docs_metadata_contract.sh
+++ b/tests/test_docs_metadata_contract.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Focused regression tests for repository-map and presentation metadata contracts.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fails_with() {
+  local desc="$1" expected="$2"
+  shift 2
+  TOTAL=$((TOTAL + 1))
+  local output
+  if output="$("$@" 2>&1)"; then
+    red "$desc (expected failure)"
+    FAIL=$((FAIL + 1))
+  elif grep -qF -- "$expected" <<< "$output"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected output to contain: $expected)"
+    printf '%s\n' "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_directory_map() {
+  local repo_dir="$1" map_file="$2"
+  local script_dir missing=0
+
+  while IFS= read -r script_dir; do
+    if ! grep -qF -- "\`${script_dir}/\`" "$map_file"; then
+      printf 'missing script directory: %s/\n' "$script_dir" >&2
+      missing=1
+    fi
+  done < <(
+    git -C "$repo_dir" ls-files 'scripts/*/**' |
+      awk -F/ 'NF >= 3 {print "scripts/" $2}' |
+      LC_ALL=C sort -u
+  )
+
+  return "$missing"
+}
+
+assert_cmd "directory map covers every tracked first-level scripts directory" \
+  check_directory_map "$REPO_DIR" "$REPO_DIR/docs/directory-map.md"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+fixture="$TMP_DIR/repo"
+mkdir -p "$fixture/scripts/ci" "$fixture/scripts/unknown" "$fixture/docs"
+printf '#!/usr/bin/env bash\n' > "$fixture/scripts/ci/check.sh"
+printf '#!/usr/bin/env bash\n' > "$fixture/scripts/unknown/check.sh"
+printf '| Path | Role |\n| --- | --- |\n| `scripts/ci/` | CI |\n' > "$fixture/docs/directory-map.md"
+git -C "$fixture" init -q
+git -C "$fixture" add .
+assert_fails_with "unknown tracked scripts directory fails map validation" \
+  "missing script directory: scripts/unknown/" \
+  check_directory_map "$fixture" "$fixture/docs/directory-map.md"
+
+assert_cmd "site uses patch-stable v1 series wording" \
+  grep -qF 'starlight · vibeguard v1 series' "$REPO_DIR/site/index.html"
+assert_cmd "historical 110-rule references carry snapshot context" \
+  bash -c 'test "$(grep -c "110 rules.*2026-03-23 design snapshot\|2026-03-23 design snapshot.*110 rules" "$1")" -eq 2' _ \
+  "$REPO_DIR/docs/internal/benchmarks/benchmark-design.md"
+assert_cmd "plan-mode exposes one activation heading" \
+  bash -c 'test "$(grep -c "^## When to Activate$" "$1")" -eq 1' _ \
+  "$REPO_DIR/workflows/plan-mode/SKILL.md"
+
+echo
+echo "=============================="
+printf "Total: %d  Pass: \033[32m%d\033[0m  Fail: \033[31m%d\033[0m\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -784,6 +784,8 @@ assert_contains "${command_doc_path_out}" ".claude/commands/vibeguard/bad.md" "f
 assert_contains "${command_doc_path_out}" ".claude/commands/vg/bad.md" "shortcut command doc missing path fails validation"
 assert_cmd "structured doc path allowlist fixtures pass" \
   bash "${REPO_DIR}/tests/test_doc_path_allowlist.sh"
+assert_cmd "documentation metadata contracts pass" \
+  bash "${REPO_DIR}/tests/test_docs_metadata_contract.sh"
 
 echo
 echo "=============================="

--- a/workflows/plan-mode/SKILL.md
+++ b/workflows/plan-mode/SKILL.md
@@ -14,18 +14,14 @@ Goal: Develop a implementable and traceable technical execution plan for the tas
 - User explicitly says `/plan`, `/prompts:plan`, or "enter Plan mode".
 - User wants a structured execution plan written under `plan/`.
 - User asks for planning before implementation and does not want code changes yet.
+- The task should be decomposed before implementation instead of executed directly.
+- A previous plan needs a deliberate update or replacement with traceable scope.
 
 > Note: This skill only takes effect when the user explicitly triggers Plan mode and does not affect normal conversations.
 > In actual use, you can pass:
 >
 > - Enter `/` and select `/prompts:plan` in the pop-up window; or
 > - Configure shortcut keys in the terminal and automatically enter `/prompts:plan` to obtain a one-click experience similar to "/plan".
-
-## When to Activate
-
-- The user explicitly asks for Plan mode, `/prompts:plan`, `/plan`, or a plan file under `plan/`.
-- The task should be decomposed before implementation instead of executed directly.
-- A previous plan needs a deliberate update or replacement with traceable scope.
 
 ## Red Flags
 


### PR DESCRIPTION
## 摘要

- 补齐 repository map 中所有 tracked 一级 `scripts/` 目录的职责说明
- 将站点版本文案改为不随 patch 漂移的 `v1 series`
- 把 `110 rules` 明确标记为 2026-03-23 benchmark 设计快照
- 合并 plan-mode 重复的 `When to Activate` 标题并保留全部独特触发条件
- 新增动态目录完整性正反例，并接入 workflow contract CI 入口

## 验证

- `bash tests/test_docs_metadata_contract.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash scripts/ci/validate-doc-paths.sh`
- `bash scripts/ci/validate-doc-command-paths.sh`
- `bash scripts/ci/validate-skill-format.sh`
- `python3 checks/check_workflow.py --repo . --spec-dir docs/specs/GH632`
- `git diff --check`

Closes #632
