### PR TITLE
fix(gc): rotate all runtime logs, bound current month, record hook exit codes

### DIFF
--- a/hooks/_lib/codex_runner.sh
+++ b/hooks/_lib/codex_runner.sh
@@ -140,9 +140,15 @@ codex_run_hook() {
     fi
 
     if [[ ${hook_exit} -ne 0 ]]; then
-      codex_diag "${hook_name}" "${event_name}" "wrapped-hook-nonzero" "${hook_err:-${hook_output}}"
+      # Exit code is the only forensic signal when the hook dies without
+      # output (e.g. EMFILE or a signal kill), so always record it.
+      local nonzero_reason="exit=${hook_exit}"
+      if (( hook_exit > 128 )); then
+        nonzero_reason="exit=${hook_exit} (signal $((hook_exit - 128)))"
+      fi
+      codex_diag "${hook_name}" "${event_name}" "wrapped-hook-nonzero" "${nonzero_reason}: ${hook_err:-${hook_output:-<no output>}}"
       rm -f "${normalized_file}" "${normalized_payload_file}" 2>/dev/null || true
-      codex_visible_failure_raw "${event_name}" "VIBEGUARD hook failed: wrapped hook exited nonzero."
+      codex_visible_failure_raw "${event_name}" "VIBEGUARD hook failed: wrapped hook exited nonzero (${nonzero_reason})."
       return 0
     fi
 

--- a/scripts/gc/gc-logs.sh
+++ b/scripts/gc/gc-logs.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # VibeGuard GC — Log Archiving
 #
-# events.jsonl Archives (gzip) monthly when threshold is exceeded, retaining the last 3 months.
+# events.jsonl / codex-wrapper.jsonl archive (gzip) monthly when threshold is
+# exceeded, retaining the last 3 months. The current month is additionally
+# capped by line count so heavy-usage months cannot grow unbounded.
 #
 # Usage:
 # bash gc-logs.sh # Default 10MB threshold
@@ -20,10 +22,13 @@ source "${SCRIPT_DIR}/../lib/project_config.sh"
 
 LOG_DIR="${VIBEGUARD_LOG_DIR:-${HOME}/.vibeguard}"
 LOG_FILE="${LOG_DIR}/events.jsonl"
+WRAPPER_LOG_FILE="${LOG_DIR}/codex-wrapper.jsonl"
 ARCHIVE_DIR="${LOG_DIR}/archive"
 THRESHOLD_MB="$(vg_config_positive_int VIBEGUARD_GC_LOG_THRESHOLD_MB gc.log_threshold_mb 10)"
 DRY_RUN=false
 RETAIN_MONTHS="$(vg_config_positive_int VIBEGUARD_GC_ARCHIVE_RETAIN_MONTHS gc.archive_retain_months 3)"
+# Must stay below THRESHOLD_MB or the post-GC size re-check keeps failing.
+CURRENT_MONTH_MAX_KB="$(vg_config_positive_int VIBEGUARD_GC_CURRENT_MONTH_MAX_KB gc.current_month_max_kb 8192)"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -38,6 +43,7 @@ gc_one_log_file() {
   local log_file="$1"
   local archive_dir="$2"
   local label="$3"
+  local prefix="${4:-events}"
   local file_size_mb
 
   file_size_mb=$(du -m "$log_file" | cut -f1)
@@ -50,6 +56,8 @@ gc_one_log_file() {
 
     _GC_LOG_FILE="$log_file" \
     _GC_ARCHIVE_DIR="$archive_dir" \
+    _GC_ARCHIVE_PREFIX="$prefix" \
+    _GC_CURRENT_MONTH_MAX_KB="$CURRENT_MONTH_MAX_KB" \
     _GC_DRY_RUN="$([[ "$DRY_RUN" == "true" ]] && echo 1 || echo 0)" \
     python3 <<'PYEOF'
 import fcntl
@@ -61,6 +69,8 @@ from collections import defaultdict
 
 log_file = os.environ['_GC_LOG_FILE']
 archive_dir = os.environ['_GC_ARCHIVE_DIR']
+prefix = os.environ.get('_GC_ARCHIVE_PREFIX', 'events')
+max_current_bytes = int(os.environ.get('_GC_CURRENT_MONTH_MAX_KB', '0') or '0') * 1024
 dry_run = os.environ['_GC_DRY_RUN'] == '1'
 lock_dir = log_file + '.lock.d'
 lock_file = log_file + '.lock'
@@ -117,6 +127,23 @@ def atomic_replace_log(lines):
             pass
         raise
 
+run_stamp = time.strftime('%Y%m%dT%H%M%S')
+
+def archive_target(month):
+    # A compressed archive for this month may already exist from a previous
+    # run; appending to a fresh plain file and re-running `gzip -f` would
+    # silently replace it. Use a run-stamped name in that case.
+    path = os.path.join(archive_dir, f'{prefix}-{month}.jsonl')
+    if os.path.exists(path + '.gz'):
+        path = os.path.join(archive_dir, f'{prefix}-{month}-{run_stamp}.jsonl')
+    return path
+
+def append_archive(path, lines):
+    with open(path, 'a', encoding='utf-8') as af:
+        af.write('\n'.join(lines) + '\n')
+        af.flush()
+        os.fsync(af.fileno())
+
 lock_fd = acquire_lock()
 try:
     with open(log_file, encoding='utf-8', errors='replace') as f:
@@ -136,23 +163,46 @@ try:
             except json.JSONDecodeError:
                 kept.append(line)
 
-    # Keep the current month's data in the main file
+    # Keep the current month's data in the main file, capped by byte budget so
+    # a heavy month cannot keep the main file above the size threshold until
+    # month rollover. Newest lines are kept first.
+    current_month = None
+    current_lines = []
     sorted_months = sorted(months.keys())
     if sorted_months:
         current_month = sorted_months[-1]
-        kept.extend(months.pop(current_month))
+        current_lines = months.pop(current_month)
+
+    overflow = []
+    if max_current_bytes > 0:
+        budget = max_current_bytes
+        keep_from = len(current_lines)
+        for idx in range(len(current_lines) - 1, -1, -1):
+            budget -= len(current_lines[idx].encode('utf-8')) + 1
+            if budget < 0:
+                break
+            keep_from = idx
+        overflow = current_lines[:keep_from]
+        current_lines = current_lines[keep_from:]
+    kept.extend(current_lines)
 
     archived = 0
     for month, lines in sorted(months.items()):
-        archive_path = os.path.join(archive_dir, f'events-{month}.jsonl')
+        archive_path = archive_target(month)
         if dry_run:
             print(f' [DRY-RUN] Archive {len(lines)} -> {archive_path}')
         else:
-            with open(archive_path, 'a', encoding='utf-8') as af:
-                af.write('\n'.join(lines) + '\n')
-                af.flush()
-                os.fsync(af.fileno())
+            append_archive(archive_path, lines)
         archived += len(lines)
+
+    if overflow:
+        overflow_path = os.path.join(
+            archive_dir, f'{prefix}-{current_month}-{run_stamp}.jsonl')
+        if dry_run:
+            print(f' [DRY-RUN] Archive current-month overflow {len(overflow)} -> {overflow_path}')
+        else:
+            append_archive(overflow_path, overflow)
+        archived += len(overflow)
 
     if not dry_run and archived > 0:
         atomic_replace_log(kept)
@@ -164,7 +214,7 @@ PYEOF
 
     # Compress archive files for this log target.
     if [[ "$DRY_RUN" == "false" ]]; then
-      for f in "${archive_dir}"/events-*.jsonl; do
+      for f in "${archive_dir}/${prefix}-"*.jsonl; do
         [[ -f "$f" ]] || continue
         gzip -f "$f" 2>/dev/null && green "Compressed: $(basename "$f").gz"
       done
@@ -177,9 +227,9 @@ PYEOF
   if [[ -d "$archive_dir" ]]; then
     CUTOFF=$(date -v-${RETAIN_MONTHS}m +%Y-%m 2>/dev/null || date -d "${RETAIN_MONTHS} months ago" +%Y-%m 2>/dev/null || echo "")
     if [[ -n "$CUTOFF" ]]; then
-      for f in "${archive_dir}"/events-*.jsonl.gz; do
+      for f in "${archive_dir}/${prefix}-"*.jsonl.gz; do
         [[ -f "$f" ]] || continue
-        MONTH=$(basename "$f" | sed 's/events-\(.*\)\.jsonl\.gz/\1/')
+        MONTH=$(basename "$f" | sed "s/^${prefix}-\(.*\)\.jsonl\.gz$/\1/")
         if [[ "$MONTH" < "$CUTOFF" ]]; then
           if [[ "$DRY_RUN" == "true" ]]; then
             yellow " [DRY-RUN] Delete expired archives: $(basename "$f")"
@@ -193,9 +243,28 @@ PYEOF
   fi
 }
 
+cleanup_stale_markers() {
+  # Per-session learn-metrics warning dedup flags; useless once the session
+  # is gone, and they otherwise accumulate forever (thousands of empty files).
+  local stale_count
+  stale_count=$(find "$LOG_DIR" -maxdepth 1 -name '.learn_metrics_truncated_*' -mtime +1 2>/dev/null | wc -l | tr -d ' ')
+  [[ "$stale_count" -gt 0 ]] || return 0
+  if [[ "$DRY_RUN" == "true" ]]; then
+    yellow " [DRY-RUN] Delete ${stale_count} stale learn-metrics markers"
+  else
+    find "$LOG_DIR" -maxdepth 1 -name '.learn_metrics_truncated_*' -mtime +1 -delete 2>/dev/null || true
+    green "Removed ${stale_count} stale learn-metrics markers"
+  fi
+}
+
 processed=0
 if [[ -f "$LOG_FILE" ]]; then
   gc_one_log_file "$LOG_FILE" "$ARCHIVE_DIR" "global log"
+  processed=$((processed + 1))
+fi
+
+if [[ -f "$WRAPPER_LOG_FILE" ]]; then
+  gc_one_log_file "$WRAPPER_LOG_FILE" "$ARCHIVE_DIR" "codex wrapper log" "codex-wrapper"
   processed=$((processed + 1))
 fi
 
@@ -204,6 +273,8 @@ for project_log in "${LOG_DIR}"/projects/*/events.jsonl; do
   gc_one_log_file "$project_log" "$(dirname "$project_log")/archive" "project log"
   processed=$((processed + 1))
 done
+
+cleanup_stale_markers
 
 if [[ "$processed" -eq 0 ]]; then
   yellow "No log files found under: ${LOG_DIR}"

--- a/scripts/gc/gc-scheduled.sh
+++ b/scripts/gc/gc-scheduled.sh
@@ -54,6 +54,9 @@ find_oversized_logs() {
     size="$(log_file_size_mb "$file")"
     [[ "$size" =~ ^[0-9]+$ && "$size" -ge "$GC_LOG_THRESHOLD_MB" ]] && printf '%s\t%s\n' "$size" "$file"
   done
+  # The trailing [[ ]] && printf leaves a nonzero status when the last file is
+  # below threshold, which kills the set -e caller mid-run.
+  return 0
 }
 
 scheduled_run_due() {

--- a/tests/test_gc_logs_rotation.sh
+++ b/tests/test_gc_logs_rotation.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# VibeGuard GC rotation tests: codex-wrapper.jsonl coverage, current-month
+# line cap, archive .gz clobber protection, and stale marker cleanup.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+PASS=0
+FAIL=0
+TOTAL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+header(){ printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+assert_contains() {
+  local output="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$output" | grep -qF -- "$expected"; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (expected to contain: $expected)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_true() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" desc="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$actual" == "$expected" ]]; then
+    green "$desc"; PASS=$((PASS + 1))
+  else
+    red "$desc (expected: $expected, actual: $actual)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+current_month() { date +%Y-%m; }
+prev_month() {
+  date -v-1m +%Y-%m 2>/dev/null || date -d "1 month ago" +%Y-%m
+}
+
+write_events() {
+  # write_events <file> <month> <count> [pad]
+  local file="$1" month="$2" count="$3" pad="${4:-}" i
+  for ((i = 1; i <= count; i++)); do
+    printf '{"ts": "%s-01T00:00:%02dZ", "hook": "test", "pad": "%s", "seq": %d}\n' \
+      "$month" $((i % 60)) "$pad" "$i" >> "$file"
+  done
+}
+
+fresh_log_dir() {
+  local dir="${TMP_ROOT}/$1"
+  mkdir -p "$dir"
+  printf '%s\n' "$dir"
+}
+
+header "codex-wrapper.jsonl is covered by log GC"
+LOG_DIR="$(fresh_log_dir wrapper)"
+write_events "${LOG_DIR}/codex-wrapper.jsonl" "$(prev_month)" 20
+write_events "${LOG_DIR}/codex-wrapper.jsonl" "$(current_month)" 5
+out="$(VIBEGUARD_LOG_DIR="$LOG_DIR" bash scripts/gc/gc-logs.sh --threshold 1)"
+assert_contains "$out" "codex wrapper log" "wrapper log is processed"
+assert_true "previous-month wrapper archive created" \
+  ls "${LOG_DIR}/archive/codex-wrapper-$(prev_month)".jsonl.gz
+assert_eq "$(grep -c '' "${LOG_DIR}/codex-wrapper.jsonl")" "5" \
+  "wrapper main file retains only current-month lines"
+
+header "current-month byte cap archives overflow"
+LOG_DIR="$(fresh_log_dir cap)"
+# 20 lines of ~260 bytes each (~5KB total) against a 1KB cap: only the newest
+# few lines fit the budget, the rest must be archived.
+pad="$(printf 'x%.0s' {1..200})"
+write_events "${LOG_DIR}/events.jsonl" "$(current_month)" 20 "$pad"
+out="$(VIBEGUARD_LOG_DIR="$LOG_DIR" VIBEGUARD_GC_CURRENT_MONTH_MAX_KB=1 \
+  bash scripts/gc/gc-logs.sh --threshold 1)"
+retained="$(grep -c '' "${LOG_DIR}/events.jsonl")"
+assert_true "main file is trimmed below the original 20 lines" \
+  test "$retained" -lt 20
+assert_true "main file still retains at least one line" \
+  test "$retained" -ge 1
+assert_true "main file stays within the byte cap" \
+  test "$(wc -c < "${LOG_DIR}/events.jsonl" | tr -d ' ')" -le 1024
+assert_contains "$(zcat < "$(ls "${LOG_DIR}/archive/events-$(current_month)-"*.jsonl.gz)" )" \
+  '"seq": 1}' "overflow archive holds the oldest lines"
+assert_eq "$(grep -c '"seq": 20}' "${LOG_DIR}/events.jsonl")" "1" \
+  "newest line stays in the main file"
+
+header "existing month .gz archive is not clobbered"
+LOG_DIR="$(fresh_log_dir clobber)"
+mkdir -p "${LOG_DIR}/archive"
+printf '{"ts": "%s-01T00:00:00Z", "hook": "old-archived"}\n' "$(prev_month)" \
+  > "${LOG_DIR}/archive/events-$(prev_month).jsonl"
+gzip "${LOG_DIR}/archive/events-$(prev_month).jsonl"
+write_events "${LOG_DIR}/events.jsonl" "$(prev_month)" 3
+write_events "${LOG_DIR}/events.jsonl" "$(current_month)" 2
+VIBEGUARD_LOG_DIR="$LOG_DIR" bash scripts/gc/gc-logs.sh --threshold 1 >/dev/null
+assert_contains "$(zcat < "${LOG_DIR}/archive/events-$(prev_month).jsonl.gz")" \
+  "old-archived" "pre-existing archive content survives a re-run"
+assert_true "late entries land in a run-stamped sibling archive" \
+  ls "${LOG_DIR}/archive/events-$(prev_month)-"*.jsonl.gz
+
+header "stale learn-metrics markers are cleaned"
+LOG_DIR="$(fresh_log_dir markers)"
+write_events "${LOG_DIR}/events.jsonl" "$(current_month)" 1
+touch "${LOG_DIR}/.learn_metrics_truncated_fresh"
+touch -mt "$(date -v-3d +%Y%m%d%H%M 2>/dev/null || date -d '3 days ago' +%Y%m%d%H%M)" \
+  "${LOG_DIR}/.learn_metrics_truncated_old"
+out="$(VIBEGUARD_LOG_DIR="$LOG_DIR" bash scripts/gc/gc-logs.sh)"
+assert_contains "$out" "Removed 1 stale learn-metrics markers" \
+  "stale marker cleanup reports the removal"
+assert_true "fresh marker is kept" test -f "${LOG_DIR}/.learn_metrics_truncated_fresh"
+assert_true "old marker is deleted" test ! -f "${LOG_DIR}/.learn_metrics_truncated_old"
+
+header "dry-run leaves everything untouched"
+LOG_DIR="$(fresh_log_dir dryrun)"
+write_events "${LOG_DIR}/events.jsonl" "$(prev_month)" 3
+touch -mt "$(date -v-3d +%Y%m%d%H%M 2>/dev/null || date -d '3 days ago' +%Y%m%d%H%M)" \
+  "${LOG_DIR}/.learn_metrics_truncated_old"
+out="$(VIBEGUARD_LOG_DIR="$LOG_DIR" bash scripts/gc/gc-logs.sh --threshold 1 --dry-run)"
+assert_contains "$out" "[DRY-RUN]" "dry-run reports planned actions"
+assert_eq "$(grep -c '' "${LOG_DIR}/events.jsonl")" "3" "dry-run keeps the main file intact"
+assert_true "dry-run keeps stale markers" test -f "${LOG_DIR}/.learn_metrics_truncated_old"
+
+echo
+echo "=============================="
+echo "Total: $TOTAL  Pass: $PASS  Fail: $FAIL"
+echo "=============================="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What/Why
A heavy-usage machine accumulated 352MB in each of `events.jsonl` and `codex-wrapper.jsonl`, plus 414MB of per-project logs and ~4800 stale marker files. Root causes fixed here:

1. **`codex-wrapper.jsonl` was outside GC coverage** — now archived with the same monthly split under a `codex-wrapper-` prefix.
2. **No bound on the current month** — a heavy month kept the main file huge until rollover. New byte cap (default 8MB via `gc.current_month_max_kb`, below the 10MB threshold) archives overflow, keeping newest lines.
3. **`gc-scheduled.sh` latent `set -e` abort** — `find_oversized_logs` ended with a failed `[[ ]] && printf`, silently killing the run after the log-archive step whenever the last project log was below threshold (reproduced; historical runs survived by luck). `gc-last-success` was never written.
4. **Archive clobber protection** — appending to a month whose `.gz` already exists now uses a run-stamped filename instead of letting `gzip -f` replace the earlier archive.
5. **Stale `.learn_metrics_truncated_*` markers** (per-session warning dedup flags) older than a day are cleaned.
6. **`codex_runner.sh`: record exit code (+signal decode) in `wrapped-hook-nonzero` diagnostics** — a real EMFILE incident produced 66 deny events with empty detail and zero forensic signal.

## Proof
- `tests/test_gc_logs_rotation.sh` — 16 new cases (wrapper coverage, byte cap, clobber protection, marker cleanup, dry-run) — all green on this branch.
- Existing suites: `test_gc_logs_concurrent` 23/23, `test_gc_config` 24/24, `test_codex_runtime` green.
- End-to-end on the affected machine: `gc-scheduled.sh --scheduled` now completes all phases and writes `gc-last-success`; main files settled at 6-8MB.
- Pre-existing on pristine `main` (not introduced here, left untouched): `test_gc_scheduled.sh` 31/32 (catch-up skip case), and a bash syntax error in `tests/codex_runtime/hook_name_resolution_tests.sh`.

## AI Role
Diagnosis and implementation by Claude Code under user direction (risk: low — bash tooling + tests, no auth/payment/secret surface).

## Review Focus
- Byte-budget loop in the archive python (newest-first retention boundary).
- `return 0` addition in `find_oversized_logs` — confirm no caller relied on its status.