### PR TITLE
ci: run cargo test for vibeguard-runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,10 @@ jobs:
         shell: bash
         run: bash tests/test_behavior_eval.sh
 
+      - name: vibeguard-runtime unit tests
+        shell: bash
+        run: cargo test --release --manifest-path vibeguard-runtime/Cargo.toml
+
       - name: Rust guard regression tests
         shell: bash
         run: bash tests/test_rust_guards.sh


### PR DESCRIPTION
## What / Why

`vibeguard-runtime` is the Rust hot-path kernel every hook depends on, but CI never ran its test suite. Correctness was only covered indirectly via shell integration tests. Because hooks fail-closed on the runtime binary (`hooks/log.sh` → `exit 2`), a silent runtime regression has broad blast radius.

## Change

Add one CI step: `cargo test --release --manifest-path vibeguard-runtime/Cargo.toml`, placed next to the existing Rust guard regression tests. No runtime code change.

## Proof (this session)

- `cargo test --release --manifest-path vibeguard-runtime/Cargo.toml` → **96 unit + 13 CLI = 109 passed, 0 failed**.
- `ci.yml` re-validated as well-formed YAML after the edit.
- Diff is 4 added lines.

## AI Role

AI-authored CI config addition (low risk — gate-only, no logic change). Review focus: step placement and that Rust toolchain is available on the runners (it is — CI already runs `cargo install ast-grep`).

Closes #677
