### PR TITLE
fix: derive Codex W-14 writer identity from payload session_id, not wrapper PID

### DIFF
--- a/hooks/_lib/post_edit_history.sh
+++ b/hooks/_lib/post_edit_history.sh
@@ -143,6 +143,16 @@ vg_post_edit_detect_w14_overlap() {
 
   [[ -n "$recent_conflict" ]] || return 0
   IFS='|' read -r other_session other_agent other_hook other_tool <<< "$recent_conflict"
+  # Codex sessions without a payload-derived logical identity fall back to
+  # process-derived ids that can fragment within one logical thread (issue
+  # #673). A PID-difference alone is then too weak to demand a worktree.
+  if [[ "${VIBEGUARD_CLI:-}" == "codex" && "${VIBEGUARD_SESSION_SOURCE:-}" != "codex-thread" ]]; then
+    vg_post_edit_append_warning "[W-14] [info] [this-file] OBSERVATION: a possibly different session recently touched ${FILE_PATH##*/} (${other_tool} via ${other_hook}, session ${other_session}, agent ${other_agent:-unknown}) — writer identity is process-derived and low-confidence
+FIX: Confirm a second signal (another Codex thread or agent actually editing this file) before isolating; if confirmed, create a dedicated worktree
+DO NOT: Treat process-id/session differences alone as proof of another writer"
+    vg_log "post-edit-guard" "Edit" "warn" "w14 overlap low-confidence session ${other_session} agent ${other_agent:-unknown}" "$FILE_PATH"
+    return 0
+  fi
   vg_post_edit_append_warning "[W-14] [review] [this-file] OBSERVATION: another session or agent recently touched ${FILE_PATH##*/} (${other_tool} via ${other_hook}, session ${other_session}, agent ${other_agent:-unknown})"'
 FIX: Isolate via a dedicated worktree before continuing. Copy-paste:
   REPO=$(git rev-parse --show-toplevel) && SID=${VIBEGUARD_SESSION_ID:-$(date +%s)}

--- a/hooks/_lib/wrapper_env.sh
+++ b/hooks/_lib/wrapper_env.sh
@@ -65,6 +65,20 @@ vg_wrapper_env_export_line() {
   esac
 }
 
+# Derive writer identity from the Codex payload's logical session_id instead of
+# the wrapper's short-lived parent PID (issue #673). Pre/post hooks of one tool
+# call can run under different parent processes but share this payload field.
+vg_wrapper_env_codex_session() {
+  local input="$1" runtime_path logical_session
+  [[ -z "${VIBEGUARD_SESSION_ID:-}" ]] || return 0
+  [[ -n "${input}" ]] || return 0
+  runtime_path="$(vg_wrapper_env_runtime_path)" || return 0
+  logical_session="$(printf '%s' "${input}" | "${runtime_path}" codex-session-id 2>/dev/null | head -1)" || return 0
+  [[ -n "${logical_session}" ]] || return 0
+  export VIBEGUARD_SESSION_ID="${logical_session}"
+  export VIBEGUARD_SESSION_SOURCE="codex-thread"
+}
+
 vg_wrapper_env_export() {
   local cli="${1:-unknown}" runtime_path output line
   export VIBEGUARD_CLI="${VIBEGUARD_CLI:-${cli}}"

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -95,7 +95,7 @@ else
 fi
 
 WRAPPER_ENV_PATH="$(helper_path wrapper_env.sh)"
-[[ ! -f "${WRAPPER_ENV_PATH}" ]] || { source "${WRAPPER_ENV_PATH}"; vg_wrapper_env_export "codex"; }
+[[ ! -f "${WRAPPER_ENV_PATH}" ]] || { source "${WRAPPER_ENV_PATH}"; vg_wrapper_env_codex_session "${INPUT}"; vg_wrapper_env_export "codex"; }
 
 POLICY_PATH="$(helper_path policy.sh)"
 if [[ ! -f "${POLICY_PATH}" ]]; then

--- a/tests/codex_runtime/session_identity_tests.sh
+++ b/tests/codex_runtime/session_identity_tests.sh
@@ -1,0 +1,59 @@
+header "Codex writer identity stays stable across wrapper parent PIDs (issue #673)"
+
+SESSION_ID_TMP="${TMP_DIR}/session-identity"
+mkdir -p "${SESSION_ID_TMP}"
+
+cat > "${SESSION_ID_TMP}/wrapper-session-probe.sh" <<PROBE
+#!/usr/bin/env bash
+set -euo pipefail
+source "${REPO_DIR}/hooks/_lib/wrapper_env.sh"
+vg_wrapper_env_codex_session "\${1}"
+vg_wrapper_env_export "codex"
+printf 'session=%s source=%s\n' "\${VIBEGUARD_SESSION_ID:-}" "\${VIBEGUARD_SESSION_SOURCE:-}"
+PROBE
+
+# Each probe runs under a fresh short-lived intermediate bash so the wrapper
+# sees a different parent PID per invocation, modeling the fragmenting native
+# Codex process topology from issue #673.
+run_session_probe() {
+  local payload="$1"
+  VIBEGUARD_LOG_DIR="${SESSION_ID_TMP}/logs" \
+  VIBEGUARD_RUNTIME="${VIBEGUARD_RUNTIME}" \
+    bash -c "bash '${SESSION_ID_TMP}/wrapper-session-probe.sh' '${payload//\'/}'"
+}
+
+_pre_payload='{"hook_event_name":"PreToolUse","session_id":"itest-thread-1","tool_name":"Edit","tool_input":{"file_path":"src/a.rs"}}'
+_post_payload='{"hook_event_name":"PostToolUse","session_id":"itest-thread-1","tool_name":"Edit","tool_input":{"file_path":"src/a.rs"}}'
+_other_payload='{"hook_event_name":"PostToolUse","session_id":"itest-thread-2","tool_name":"Edit","tool_input":{"file_path":"src/a.rs"}}'
+_anonymous_payload='{"hook_event_name":"PostToolUse","tool_name":"Edit","tool_input":{"file_path":"src/a.rs"}}'
+
+_pre_identity="$(run_session_probe "${_pre_payload}")"
+_post_identity="$(run_session_probe "${_post_payload}")"
+_other_identity="$(run_session_probe "${_other_payload}")"
+_anonymous_identity="$(run_session_probe "${_anonymous_payload}")"
+
+assert_contains "${_pre_identity}" "session=codex-thread-" "payload session_id derives a logical codex-thread identity"
+assert_contains "${_pre_identity}" "source=codex-thread" "logical identity reports codex-thread session source"
+
+TOTAL=$((TOTAL + 1))
+if [[ "${_pre_identity}" == "${_post_identity}" ]]; then
+  green "pre and post hooks of one logical thread share one writer identity across parent PIDs"
+  PASS=$((PASS + 1))
+else
+  red "pre and post hooks of one logical thread share one writer identity across parent PIDs (pre=${_pre_identity} post=${_post_identity})"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if [[ "${_pre_identity}" != "${_other_identity}" ]]; then
+  green "different logical threads keep distinct writer identities"
+  PASS=$((PASS + 1))
+else
+  red "different logical threads keep distinct writer identities (both=${_pre_identity})"
+  FAIL=$((FAIL + 1))
+fi
+
+assert_contains "${_anonymous_identity}" "session=" "missing payload session_id still resolves a fallback session"
+assert_not_contains "${_anonymous_identity}" "source=codex-thread" "missing payload session_id does not claim logical identity"
+
+assert_contains "$(cat "${REPO_DIR}/hooks/run-hook-codex.sh")" 'vg_wrapper_env_codex_session "${INPUT}"; vg_wrapper_env_export "codex"' "run-hook-codex.sh derives logical identity before wrapper env export"

--- a/tests/hooks/test_post_edit_w14.sh
+++ b/tests/hooks/test_post_edit_w14.sh
@@ -86,6 +86,7 @@ _w14_run() {
   printf '{"tool_input":{"file_path":"%s","new_string":"value = 9\\n"}}' "$target" \
     | env VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" \
       VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_AGENT_TYPE="codex" \
+      VIBEGUARD_SESSION_SOURCE="codex-thread" \
       "$@" bash hooks/post-edit-guard.sh
 }
 
@@ -95,7 +96,7 @@ EOF
 
 _w14_result=$(
   printf '{"tool_input":{"file_path":"%s","new_string":"value = 2\\n"}}' "$_w14_rel" \
-    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_SESSION_SOURCE="codex-thread" bash hooks/post-edit-guard.sh
 )
 assert_contains "$_w14_result" "[W-14]" "W-14 detects relative/absolute matches for the same file"
 assert_contains "$_w14_result" 'BASE=${VIBEGUARD_WORKTREE_BASE:-${REPO}.wt}' "W-14 worktree hint reads configured base"
@@ -110,7 +111,7 @@ assert_contains "$_w14_shown_event" '"decision": "warn"' "First W-14 records ded
 
 _w14_repeat=$(
   printf '{"tool_input":{"file_path":"%s","new_string":"value = 3\\n"}}' "$_w14_file" \
-    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_SESSION_SOURCE="codex-thread" bash hooks/post-edit-guard.sh
 )
 assert_not_contains "$_w14_repeat" "[W-14]" "W-14 reuses cooldown across relative and absolute forms of the same file"
 _w14_suppressed_event=$(python3 -c '
@@ -130,14 +131,14 @@ raise SystemExit(0 if re.search(r"\\|\\|w14_key=[0-9a-f]{64}$", event.get("detai
 for _ in {1..801}; do printf 'value = 1\n'; done > "$_w14_file"
 _w14_mixed=$(
   printf '{"tool_input":{"file_path":"%s","new_string":"value = 4\\n"}}' "$_w14_rel" \
-    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" bash hooks/post-edit-guard.sh
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_SESSION_SOURCE="codex-thread" bash hooks/post-edit-guard.sh
 )
 assert_not_contains "$_w14_mixed" "[W-14]" "W-14 cooldown does not renew from suppressed telemetry"
 assert_contains "$_w14_mixed" "[U-16]" "W-14 cooldown preserves other post-edit warnings"
 
 _w14_disabled=$(
   printf '{"tool_input":{"file_path":"%s","new_string":"value = 5\\n"}}' "$_w14_rel" \
-    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_W14_COOLDOWN_SECONDS=0 bash hooks/post-edit-guard.sh
+    | VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_SESSION_SOURCE="codex-thread" VIBEGUARD_W14_COOLDOWN_SECONDS=0 bash hooks/post-edit-guard.sh
 )
 assert_contains "$_w14_disabled" "[W-14]" "W-14 cooldown value zero restores visible warnings"
 
@@ -213,6 +214,47 @@ rm -rf "${_w14_log_file}.lock.d"
 assert_contains "$_w14_append_failure" "[W-14]" "W-14 telemetry append failure preserves the visible warning"
 assert_contains "$_w14_append_failure" "W-14 suppressed telemetry append failed" "W-14 telemetry append failure reports its root cause"
 assert_contains "$_w14_append_failure" "VG-INTERNAL-LOG-APPEND" "W-14 final event append failure reports hook diagnostics"
+
+# Issue #673: Codex identity without a payload-derived logical session is
+# process-derived and low-confidence — W-14 downgrades to info and must not
+# demand a worktree from a PID difference alone.
+_w14_low_file="$_w14_dir/low_confidence.py"
+printf 'value = 1\n' > "$_w14_low_file"
+_w14_seed_history "$_w14_low_file" "downgrade-peer"
+_w14_low=$(
+  printf '{"tool_input":{"file_path":"%s","new_string":"value = 6\\n"}}' "$_w14_low_file" \
+    | env VIBEGUARD_LOG_DIR="$VIBEGUARD_LOG_DIR" VIBEGUARD_CLI="codex" \
+      VIBEGUARD_SESSION_ID="current-session" VIBEGUARD_AGENT_TYPE="codex" \
+      bash hooks/post-edit-guard.sh
+)
+assert_contains "$_w14_low" "[W-14] [info]" "W-14 downgrades to info without logical Codex identity"
+assert_contains "$_w14_low" "low-confidence" "W-14 downgrade names the low-confidence identity"
+assert_not_contains "$_w14_low" "git worktree add" "W-14 downgrade does not mandate a worktree"
+
+# Issue #673: a pre-edit-only history entry records intent, not a completed
+# touch — it must not count as another writer.
+_w14_pre_file="$_w14_dir/pre_intent.py"
+printf 'value = 1\n' > "$_w14_pre_file"
+python3 - "$_w14_log_file" "$_w14_pre_file" <<'PY'
+from datetime import datetime, timezone
+import json
+import sys
+
+log_file, target = sys.argv[1:]
+event = {
+    "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "session": "pre-intent-peer",
+    "hook": "pre-edit-guard",
+    "tool": "Edit",
+    "decision": "pass",
+    "agent": "peer-agent",
+    "detail": target,
+}
+with open(log_file, "w", encoding="utf-8") as handle:
+    handle.write(json.dumps(event, separators=(",", ":")) + "\n")
+PY
+_w14_pre=$(_w14_run "$_w14_pre_file")
+assert_not_contains "$_w14_pre" "[W-14]" "W-14 ignores pre-hook intent-only history entries"
 
 rm -rf "$_w14_dir"
 

--- a/tests/test_codex_runtime.sh
+++ b/tests/test_codex_runtime.sh
@@ -217,7 +217,8 @@ for codex_runtime_test in \
   "${REPO_DIR}/tests/codex_runtime/pretool_diagnostic_tests.sh" \
   "${REPO_DIR}/tests/codex_runtime/posttool_large_io_tests.sh" \
   "${REPO_DIR}/tests/codex_runtime/native_permission_patch_tests.sh" \
-  "${REPO_DIR}/tests/codex_runtime/app_server_wrapper_tests.sh"; do
+  "${REPO_DIR}/tests/codex_runtime/app_server_wrapper_tests.sh" \
+  "${REPO_DIR}/tests/codex_runtime/session_identity_tests.sh"; do
   # shellcheck source=/dev/null
   source "${codex_runtime_test}"
 done

--- a/vibeguard-runtime/src/codex_hooks.rs
+++ b/vibeguard-runtime/src/codex_hooks.rs
@@ -24,6 +24,30 @@ fn codex_event_name(data: &Value) -> &str {
         .unwrap_or("")
 }
 
+// Writer identity must come from the logical Codex session, not the wrapper's
+// short-lived parent PID (issue #673): pre/post hooks of one Edit can run under
+// different parent processes, but they share the payload's top-level session_id.
+fn codex_logical_session_id(data: &Value) -> String {
+    data.get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(crate::codex_app_server_core::session_id_for_thread)
+        .unwrap_or_default()
+}
+
+pub fn session_id(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime codex-session-id")?;
+    let data = read_json_tolerant()?;
+    println!(
+        "{}",
+        data.as_ref()
+            .map(codex_logical_session_id)
+            .unwrap_or_default()
+    );
+    Ok(())
+}
+
 fn codex_status_matcher(data: &Value) -> &str {
     data.get("tool_name").and_then(Value::as_str).unwrap_or("")
 }
@@ -413,6 +437,33 @@ mod tests {
             "PreToolUse"
         );
         assert_eq!(codex_event_name(&json!({"hook_event_name": 7})), "");
+    }
+
+    #[test]
+    fn logical_session_id_is_stable_across_pre_and_post_payloads() {
+        let pre = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "0198c5b1-thread",
+            "tool_name": "Edit"
+        });
+        let post = json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "0198c5b1-thread",
+            "tool_name": "Edit"
+        });
+        let id = codex_logical_session_id(&pre);
+        assert!(id.starts_with("codex-thread-"));
+        assert_eq!(id, codex_logical_session_id(&post));
+    }
+
+    #[test]
+    fn logical_session_id_separates_threads_and_rejects_missing_or_blank() {
+        let a = codex_logical_session_id(&json!({"session_id": "thread-a"}));
+        let b = codex_logical_session_id(&json!({"session_id": "thread-b"}));
+        assert_ne!(a, b);
+        assert_eq!(codex_logical_session_id(&json!({})), "");
+        assert_eq!(codex_logical_session_id(&json!({"session_id": "   "})), "");
+        assert_eq!(codex_logical_session_id(&json!({"session_id": 7})), "");
     }
 
     #[test]

--- a/vibeguard-runtime/src/hook_checks_history.rs
+++ b/vibeguard-runtime/src/hook_checks_history.rs
@@ -147,6 +147,14 @@ pub(crate) fn recent_overlap(
         ) {
             continue;
         }
+        // Pre-hook events record intent to edit, not a completed write; they
+        // must not count as another writer touching the file (issue #673).
+        if e.get(field::HOOK)
+            .and_then(Value::as_str)
+            .is_some_and(|hook| hook.starts_with("pre-"))
+        {
+            continue;
+        }
         let same_session = e.get(field::SESSION).and_then(Value::as_str) == Some(session);
         let other_agent = e.get("agent").and_then(Value::as_str).unwrap_or("") != agent;
         if same_session && !other_agent {
@@ -419,6 +427,29 @@ mod tests {
         )
         .expect("matching file should produce an overlap");
         assert_eq!(overlap.normalized_file, "/tmp/main.rs");
+    }
+
+    #[test]
+    fn recent_overlap_ignores_pre_hook_intent_events() {
+        let pre_only = [serde_json::json!({
+            "ts": format_unix_secs_utc(now_unix_secs()),
+            "session": "other",
+            "agent": "codex",
+            "tool": "Edit",
+            "hook": "pre-edit-guard",
+            "detail": "/tmp/main.rs"
+        })];
+        assert!(recent_overlap(&pre_only, "current", "codex", "/tmp/main.rs").is_none());
+
+        let post = [serde_json::json!({
+            "ts": format_unix_secs_utc(now_unix_secs()),
+            "session": "other",
+            "agent": "codex",
+            "tool": "Write",
+            "hook": "post-write-guard",
+            "detail": "/tmp/main.rs"
+        })];
+        assert!(recent_overlap(&post, "current", "codex", "/tmp/main.rs").is_some());
     }
 
     #[test]

--- a/vibeguard-runtime/src/hook_orchestrator_context.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_context.rs
@@ -24,6 +24,7 @@ pub(crate) struct RuntimeContext {
     pub(crate) client: String,
     pub(crate) client_variant: String,
     pub(crate) caller_evidence: String,
+    pub(crate) session_source: String,
 }
 
 #[derive(Debug)]
@@ -106,6 +107,8 @@ impl RuntimeContext {
             }
         });
 
+        let session_source = env_nonempty("VIBEGUARD_SESSION_SOURCE").unwrap_or_default();
+
         Ok(Self {
             log_root,
             log_file,
@@ -115,6 +118,7 @@ impl RuntimeContext {
             client,
             client_variant,
             caller_evidence,
+            session_source,
         })
     }
 }

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit.rs
@@ -549,6 +549,7 @@ mod tests {
             client: "codex".into(),
             client_variant: "codex-cli-hooks".into(),
             caller_evidence: "explicit-test".into(),
+            session_source: "codex-thread".into(),
         }
     }
 

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
@@ -181,7 +181,15 @@ fn detect_w14_at(
             }
         }
     }
-    warnings.push(format!("[W-14] [review] [this-file] OBSERVATION: another session or agent recently touched {} ({} via {}, session {}, agent {})\nFIX: Isolate via a dedicated worktree before continuing. Copy-paste:\n  REPO=$(git rev-parse --show-toplevel) && SID=${{VIBEGUARD_SESSION_ID:-$(date +%s)}}\n  BASE=${{VIBEGUARD_WORKTREE_BASE:-${{REPO}}.wt}}\n  case \"$BASE\" in /*) ;; *) BASE=\"${{REPO}}/${{BASE}}\" ;; esac\n  BASE=${{BASE%/}}\n  git worktree add \"$BASE/$SID\" -b \"vg/$SID\" HEAD\n  cd \"$BASE/$SID\"\nDO NOT: Continue parallel/background edits to this file without an isolated worktree", post_edit_history_file_name(file_path), overlap.tool, overlap.hook, overlap.session, if overlap.agent.is_empty() { "unknown" } else { &overlap.agent }));
+    // Codex sessions without a payload-derived logical identity fall back to
+    // process-derived ids that can fragment within one logical thread (issue
+    // #673). A PID-difference alone is then too weak to demand a worktree.
+    let low_confidence_identity = ctx.cli == "codex" && ctx.session_source != "codex-thread";
+    if low_confidence_identity {
+        warnings.push(format!("[W-14] [info] [this-file] OBSERVATION: a possibly different session recently touched {} ({} via {}, session {}, agent {}) — writer identity is process-derived and low-confidence\nFIX: Confirm a second signal (another Codex thread or agent actually editing this file) before isolating; if confirmed, create a dedicated worktree\nDO NOT: Treat process-id/session differences alone as proof of another writer", post_edit_history_file_name(file_path), overlap.tool, overlap.hook, overlap.session, if overlap.agent.is_empty() { "unknown" } else { &overlap.agent }));
+    } else {
+        warnings.push(format!("[W-14] [review] [this-file] OBSERVATION: another session or agent recently touched {} ({} via {}, session {}, agent {})\nFIX: Isolate via a dedicated worktree before continuing. Copy-paste:\n  REPO=$(git rev-parse --show-toplevel) && SID=${{VIBEGUARD_SESSION_ID:-$(date +%s)}}\n  BASE=${{VIBEGUARD_WORKTREE_BASE:-${{REPO}}.wt}}\n  case \"$BASE\" in /*) ;; *) BASE=\"${{REPO}}/${{BASE}}\" ;; esac\n  BASE=${{BASE%/}}\n  git worktree add \"$BASE/$SID\" -b \"vg/$SID\" HEAD\n  cd \"$BASE/$SID\"\nDO NOT: Continue parallel/background edits to this file without an isolated worktree", post_edit_history_file_name(file_path), overlap.tool, overlap.hook, overlap.session, if overlap.agent.is_empty() { "unknown" } else { &overlap.agent }));
+    }
     let detail = key
         .as_deref()
         .map(|key| w14_event_detail(file_path, key))
@@ -512,6 +520,7 @@ mod tests {
             client: "codex".into(),
             client_variant: "codex-cli-hooks".into(),
             caller_evidence: "explicit-test".into(),
+            session_source: "codex-thread".into(),
         }
     }
 

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history_tests.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history_tests.rs
@@ -24,6 +24,7 @@ fn review_context(log_file: std::path::PathBuf) -> RuntimeContext {
         client: "codex".into(),
         client_variant: "codex-cli-hooks".into(),
         caller_evidence: "explicit-test".into(),
+        session_source: "codex-thread".into(),
     }
 }
 
@@ -270,6 +271,59 @@ fn w14_main_path_records_show_suppresses_and_restores_on_append_failure() {
     assert!(restored_warnings[0].contains("session peer"));
     assert!(!failed_ctx.log_file.exists());
     assert!(blocking_parent.is_file());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn w14_ignores_pre_hook_intent_events() {
+    let root = temp_root("w14-pre-intent");
+    let file_path = root.join("src/main.rs").to_string_lossy().to_string();
+    let now = now_unix_secs();
+    let mut pre_event = overlap_event(&file_path, now);
+    pre_event["hook"] = json!("pre-edit-guard");
+
+    let ctx = review_context(root.join("events.jsonl"));
+    let mut warnings = Vec::new();
+    detect_w14_at(
+        &ctx,
+        Instant::now(),
+        &file_path,
+        std::slice::from_ref(&pre_event),
+        &mut warnings,
+        now,
+        60,
+    );
+    assert!(warnings.is_empty());
+    assert!(!ctx.log_file.exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn w14_downgrades_to_info_without_logical_codex_identity() {
+    let root = temp_root("w14-low-confidence");
+    let file_path = root.join("src/main.rs").to_string_lossy().to_string();
+    let now = now_unix_secs();
+    let overlap = overlap_event(&file_path, now);
+
+    let mut ctx = review_context(root.join("events.jsonl"));
+    ctx.session_source = String::new();
+    let mut warnings = Vec::new();
+    detect_w14_at(
+        &ctx,
+        Instant::now(),
+        &file_path,
+        std::slice::from_ref(&overlap),
+        &mut warnings,
+        now,
+        60,
+    );
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("[W-14] [info]"));
+    assert!(warnings[0].contains("low-confidence"));
+    assert!(!warnings[0].contains("git worktree add"));
+    let events = read_test_events(&ctx.log_file);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0][field::DECISION], decision::WARN);
     fs::remove_dir_all(root).unwrap();
 }
 

--- a/vibeguard-runtime/src/hook_orchestrator_post_write.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_write.rs
@@ -155,6 +155,7 @@ mod tests {
             client: "codex".to_string(),
             client_variant: "codex-cli-hooks".to_string(),
             caller_evidence: "test".to_string(),
+            session_source: "codex-thread".to_string(),
         }
     }
 

--- a/vibeguard-runtime/src/log_query.rs
+++ b/vibeguard-runtime/src/log_query.rs
@@ -203,6 +203,14 @@ fn recent_overlap(
         ) {
             continue;
         }
+        // Pre-hook events record intent to edit, not a completed write; they
+        // must not count as another writer touching the file (issue #673).
+        if e.get(field::HOOK)
+            .and_then(Value::as_str)
+            .is_some_and(|hook| hook.starts_with("pre-"))
+        {
+            continue;
+        }
         let detail_path = first_detail_path(e);
         if detail_path != file_path && normalize_path(detail_path) != normalized_file {
             continue;
@@ -521,6 +529,31 @@ mod tests {
         ];
 
         assert_eq!(count_warn_events(&events, "src/lib.rs"), 3);
+    }
+
+    #[test]
+    fn recent_overlap_ignores_pre_hook_intent_events() {
+        let now = now_unix_secs();
+        let ts = crate::time_utils::format_unix_secs_utc(now);
+        let pre_only = [json!({
+            "ts": ts,
+            "session": "other",
+            "agent": "codex",
+            "tool": "Edit",
+            "hook": "pre-edit-guard",
+            "detail": "/tmp/main.rs"
+        })];
+        assert!(recent_overlap(&pre_only, "current", "codex", "/tmp/main.rs", now).is_none());
+
+        let post = [json!({
+            "ts": ts,
+            "session": "other",
+            "agent": "codex",
+            "tool": "Write",
+            "hook": "post-write-guard",
+            "detail": "/tmp/main.rs"
+        })];
+        assert!(recent_overlap(&post, "current", "codex", "/tmp/main.rs", now).is_some());
     }
 
     #[test]

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -186,6 +186,11 @@ static COMMANDS: &[Command] = &[
         handler: codex_hooks::event_name,
     },
     Command {
+        name: "codex-session-id",
+        usage: "  — derive a stable logical session id from Codex hook stdin",
+        handler: codex_hooks::session_id,
+    },
+    Command {
         name: "codex-status-detail",
         usage: "  — extract Codex hook status detail from stdin",
         handler: codex_hooks::status_detail,


### PR DESCRIPTION
## What/Why

Fixes #673. VibeGuard's native Codex hook wrapper anchored writer identity to the wrapper's short-lived parent PID, so the pre/post hooks of one `apply_patch` Edit could receive different `session_id` values. W-14 then treated the edit's own pre-hook event as another writer and demanded a dedicated worktree.

The Codex hook payload already carries a stable top-level `session_id` (verified against codex-cli 0.145.0 binary field tables). This PR makes that logical identity the primary writer identity and keeps PID derivation only as a low-confidence fallback.

## Changes

- **runtime**: new `codex-session-id` command parses hook stdin JSON and derives a stable id via the existing `session_id_for_thread` semantics (same model the app-server path already uses). JSON is parsed by the runtime, not bash regex, so `tool_input` content can never shadow the top-level field.
- **wrapper**: `run-hook-codex.sh` resolves the logical identity before `wrapper-env` and exports `VIBEGUARD_SESSION_SOURCE=codex-thread`.
- **evidence**: `recent_overlap` (Rust orchestrator + log-query shell fallback) no longer counts `pre-*` hook events as completed file touches — intent to edit is not a write.
- **downgrade**: Codex sessions without logical identity get an info-level W-14 without the mandatory worktree copy-paste; a PID difference alone cannot prove another writer. Claude-path behavior is unchanged.

## Acceptance criteria from #673

- [x] Same logical thread + different wrapper parent PIDs keeps one stable writer identity (`session_identity_tests.sh`)
- [x] One Edit's pre/post hooks cannot trigger W-14 against each other (pre-hook exclusion + stable identity)
- [x] Two adjacent edits by one logical thread do not trigger W-14 (stable identity)
- [x] Different logical threads sharing a parent process still trigger W-14 (distinct thread ids → distinct sessions)
- [x] Pre-edit-only history entries are not completed touches (Rust + shell tests)
- [x] Missing logical identity does not produce a mandatory worktree action (downgrade tests)
- [x] Native-hook regression tests avoid hard-coding `VIBEGUARD_SESSION_ID` (probe derives it from payloads)

## Proof (fresh, this session)

- `cargo test`: 23 suites all ok (incl. 321 bin tests, 6 new)
- `tests/hooks/test_post_edit_w14.sh`: 29/29 (2 new downgrade + 1 pre-intent case)
- `tests/codex_runtime/session_identity_tests.sh`: 7/7
- `tests/test_hooks.sh`: 36/36; w15/churn/basic/suppression/log_session/post_write/pre_edit suites all pass
- Note: `tests/test_codex_runtime.sh` aborts on macOS bash 3.2 at the pre-existing `hook_name_resolution_tests.sh` (baseline fails identically); the new shard runs clean standalone and in CI bash.

## AI Role

Entire change AI-generated (Claude). Risk: medium — touches hook identity and W-14 messaging, no auth/payment/secret surface. Review focus: (1) downgrade condition scope (`cli==codex && source!=codex-thread`), (2) whether excluding `pre-*` events from overlap evidence loses any signal you care about.