### PR TITLE
fix: close GH-683 W-19 blindspot and enforce U-32 across all profiles

### DIFF
--- a/guards/universal/check_doc_overload.sh
+++ b/guards/universal/check_doc_overload.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # VibeGuard Guard — Agent-instruction document overload detection (W-19)
 #
-# Detect three anti-patterns in agent-instruction documents (CLAUDE.md / AGENTS.md):
+# Detect four anti-patterns in the effective agent-instruction surface:
 #   1. File too long       — > 200 lines warns, > 800 lines fails in --strict
 #   2. Unpaired prohibitions — > 30 Chinese 禁止/不要 rules without paired ✅ GOOD examples
 #   3. Inline redefinition  — a canonical vibeguard rule ID from the curated
 #                              CANONICAL_IDS list below appears ≥ 3 times in one file
+#   4. Always-on rule injection — native rule files under `.claude/rules/`
+#                              (or `rules/` when the target dir is a `.claude`
+#                              home) that lack `paths:` frontmatter are injected
+#                              into every session; their aggregate line count is
+#                              part of the instruction surface even though the
+#                              doc files themselves look small (GH-683)
 #
 # The vibeguard auto-gen region (between `<!-- vibeguard-start -->` and
 # `<!-- vibeguard-end -->`) is excluded from line counting.
@@ -59,7 +65,15 @@ done < <(
     -type f -name 'AGENTS.md' -print0
 )
 
-if [[ ${#DOC_FILES[@]} -eq 0 ]]; then
+# Always-on native rule surface: `.claude/rules/` under a project dir, or
+# `rules/` when the target dir is itself a `.claude` home (~/.claude).
+RULES_DIRS=()
+[[ -d "${TARGET_DIR}/.claude/rules" ]] && RULES_DIRS+=("${TARGET_DIR}/.claude/rules")
+if [[ "$(basename "$(cd "${TARGET_DIR}" && pwd)")" == ".claude" && -d "${TARGET_DIR}/rules" ]]; then
+  RULES_DIRS+=("${TARGET_DIR}/rules")
+fi
+
+if [[ ${#DOC_FILES[@]} -eq 0 && ${#RULES_DIRS[@]} -eq 0 ]]; then
   exit 0
 fi
 
@@ -87,10 +101,22 @@ CANONICAL_IDS=(
   "W${DASH}15" "W${DASH}16" "W${DASH}17"
 )
 
+# A rule file is path-scoped (loaded on demand) only when its YAML frontmatter
+# declares a `paths:` key; everything else is injected into every session.
+_rule_is_path_scoped() {
+  awk '
+    NR == 1 { if ($0 != "---") exit; next }
+    /^---[[:space:]]*$/ { exit }
+    /^paths:/ { found = 1; exit }
+    NR > 40 { exit }
+    END { exit(found ? 0 : 1) }
+  ' "$1"
+}
+
 echo "Doc Overload Check (W-19): ${TARGET_DIR}"
 echo "---"
 
-for file in "${DOC_FILES[@]}"; do
+for file in ${DOC_FILES[@]+"${DOC_FILES[@]}"}; do
   # Strip the vibeguard auto-gen region so line counts reflect user-authored content
   CONTENT=$(awk '
     /<!-- vibeguard-start -->/ { skip = 1; next }
@@ -121,6 +147,33 @@ for file in "${DOC_FILES[@]}"; do
     fi
   done
 done
+
+# Check 4: aggregate size of always-on native rule files (no `paths:` frontmatter)
+if [[ ${#RULES_DIRS[@]} -gt 0 ]]; then
+  ALWAYS_ON_TOTAL=0
+  ALWAYS_ON_COUNT=0
+  ALWAYS_ON_DETAIL=""
+  while IFS= read -r -d '' rule_file; do
+    _rule_is_path_scoped "$rule_file" && continue
+    RULE_LINES=$(wc -l < "$rule_file" | tr -d ' ')
+    ALWAYS_ON_TOTAL=$((ALWAYS_ON_TOTAL + RULE_LINES))
+    ALWAYS_ON_COUNT=$((ALWAYS_ON_COUNT + 1))
+    ALWAYS_ON_DETAIL="${ALWAYS_ON_DETAIL}${RULE_LINES}	${rule_file}
+"
+  done < <(find -L "${RULES_DIRS[@]}" -type f -name '*.md' -print0 2>/dev/null)
+
+  if [[ "$ALWAYS_ON_TOTAL" -gt "$WARN_LINES" ]]; then
+    TOP_RULES=$(printf '%s' "$ALWAYS_ON_DETAIL" | sort -rn | head -3 \
+      | awk -F '	' '{ printf "%s (%s lines); ", $2, $1 }')
+    RULE_MSG="always-on native rules inject ${ALWAYS_ON_TOTAL} lines across ${ALWAYS_ON_COUNT} files without paths: frontmatter"
+    RULE_FIX="Fix: add paths: frontmatter to scope rules to file types, or demote long-tail rules to skills/on-demand references"
+    if [[ "$ALWAYS_ON_TOTAL" -gt "$FAIL_LINES" ]]; then
+      fail "${RULE_MSG} (limit ${FAIL_LINES}). Largest: ${TOP_RULES}${RULE_FIX}"
+    else
+      warn "${RULE_MSG} (target ≤${WARN_LINES}). Largest: ${TOP_RULES}${RULE_FIX}"
+    fi
+  fi
+fi
 
 echo "---"
 if [[ "$WARNINGS" -eq 0 && "$FAILURES" -eq 0 ]]; then

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -16,7 +16,7 @@ AI coded agent hooks script, automatically triggered before and after the operat
 | `post-edit-guard.sh` | PostToolUse(Edit) | Detect quality problems after editing: unwrap, console.log, hard-coded path, Go error discard, oversized diff, repeated editing of the same file (churn), W-15 consecutive same-file edit loop. | native |
 | `post-write-guard.sh` | PostToolUse(Write) | Detect duplicate definitions and files with the same name after creating a new file. | native |
 | `analysis-paralysis-guard.sh` | PostToolUse(Read|Glob|Grep) | Detect excessive exploration without progress and prompt the agent to act. | unsupported |
-| `count_active_constraints.sh` | SessionStart | Count effective task constraints loaded into agent context and enforce the U-32 live-context budget in strict profile. | unsupported |
+| `count_active_constraints.sh` | SessionStart | Count effective task constraints loaded into agent context; warn over the U-32 budget in core/full profiles and hard-block in strict profile. | unsupported |
 | `post-build-check.sh` | PostToolUse(Edit/Write) | Automatically run the build check corresponding to the language after editing. | native |
 | `skills-loader.sh` | Manual optional | Optional first read prompt script; not registered to hooks by default. | unsupported |
 | `stop-guard.sh` | Stop | Record uncommitted source code changes as a non-blocking Stop signal. | native |

--- a/hooks/count_active_constraints.sh
+++ b/hooks/count_active_constraints.sh
@@ -2,7 +2,8 @@
 # VibeGuard SessionStart/UserPromptSubmit Hook — U-32 live constraint budget
 #
 # Counts the effective constraints that can enter the current agent context.
-# >15 emits an advisory, >30 becomes a hard block when strict mode is enabled.
+# >15 emits an advisory; >30 emits a warning under core/full profiles and a
+# hard block under the strict profile (override via VIBEGUARD_U32_STRICT).
 
 set -euo pipefail
 
@@ -56,9 +57,21 @@ fi
 
 MESSAGE="VIBEGUARD U-32 ${STATUS}: effective task constraints=${TOTAL} (warn>${WARN_THRESHOLD}, block>${BLOCK_THRESHOLD}). Split low-frequency rules into path-scoped files, skills, or hooks before adding more persistent instructions. Top sources: ${SUMMARY}"
 
+# Hard-block semantics are opt-in: default follows the installed profile so
+# core/full users get the budget signal as context instead of a failed hook.
+_vg_u32_strict_default() {
+  local state_file="${VIBEGUARD_HOME:-${HOME}/.vibeguard}/install-state.json"
+  local profile=""
+  if [[ -f "${state_file}" ]]; then
+    profile=$(grep -o '"profile"[[:space:]]*:[[:space:]]*"[a-z]*"' "${state_file}" 2>/dev/null \
+      | tail -1 | grep -o '"[a-z]*"$' | tr -d '"' || true)
+  fi
+  if [[ "${profile}" == "strict" ]]; then printf '1'; else printf '0'; fi
+}
+
 if [[ "${STATUS}" == "block" ]]; then
   vg_log "count-active-constraints" "${HOOK_EVENT}" "block" "constraints=${TOTAL}" "${SUMMARY}"
-  if [[ "${VIBEGUARD_U32_STRICT:-1}" == "1" ]]; then
+  if [[ "${VIBEGUARD_U32_STRICT:-$(_vg_u32_strict_default)}" == "1" ]]; then
     printf '%s\n' "[BLOCKED] ${MESSAGE}" >&2
     exit 2
   fi

--- a/hooks/manifest.json
+++ b/hooks/manifest.json
@@ -183,13 +183,13 @@
       "install_targets": [],
       "config_exposure": {"disabled_hook": true},
       "trigger": "SessionStart",
-      "responsibilities": "Count effective task constraints loaded into agent context and enforce the U-32 live-context budget in strict profile.",
+      "responsibilities": "Count effective task constraints loaded into agent context; warn over the U-32 budget in core/full profiles and hard-block in strict profile.",
       "decision_types": ["pass", "warn", "block"],
       "claude": {
         "enabled": true,
         "event": "SessionStart",
         "matchers": [null],
-        "profiles": ["strict"]
+        "profiles": ["core", "full", "strict"]
       },
       "codex": {"enabled": false, "support": "unsupported", "reason": "Not part of the default Codex native enforcement layer"}
     },

--- a/rules/claude-rules/common/workflow.md
+++ b/rules/claude-rules/common/workflow.md
@@ -299,6 +299,7 @@ Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when t
 | Lines outside vibeguard auto-gen region | > 200 | > 800 |
 | Chinese prohibition keywords (counted by the guard) | > 30 (warn only) | — |
 | Inline mentions of any single canonical rule ID (U-17, U-26..U-32, W-01..W-17) | ≥ 3 (likely redefining canonical text) | — |
+| Aggregate lines of always-on native rule files under `.claude/rules/` (no `paths:` frontmatter) | > 200 | > 800 |
 
 The vibeguard auto-gen region (between `<!-- vibeguard-start -->` and `<!-- vibeguard-end -->`) is excluded from line counting because it is owned by `setup.sh`.
 

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -21,6 +21,7 @@ hook_no_ci_env=(
   JENKINS_URL=
   GITLAB_CI=false
   TF_BUILD=false
+  VIBEGUARD_HOME=
 )
 
 make_home() {
@@ -148,6 +149,18 @@ JSON
 assert_contains "${hook_warn_out}" "hookSpecificOutput" "hook emits additional context on warning"
 assert_contains "${hook_warn_out}" "effective task constraints=16" "hook warning includes constraint count"
 
+# GH-683: without a strict profile, exceeding the block budget must surface as
+# injected context (exit 0), not a failed hook — core/full users still see it.
+hook_softblock_out="$(env "${hook_no_ci_env[@]}" HOME="${BLOCK_HOME}" VIBEGUARD_PROJECT_ROOT="${BLOCK_REPO}" VIBEGUARD_LOG_DIR="${TMP_ROOT}/logs-softblock" bash "${HOOK}" <<'JSON'
+{"hook_event_name":"SessionStart"}
+JSON
+)"
+assert_contains "${hook_softblock_out}" "hookSpecificOutput" "non-strict profile surfaces block budget as context"
+assert_contains "${hook_softblock_out}" "VIBEGUARD U-32 block" "non-strict block context names the U-32 status"
+
+mkdir -p "${BLOCK_HOME}/.vibeguard"
+printf '{\n  "profile": "strict"\n}\n' > "${BLOCK_HOME}/.vibeguard/install-state.json"
+
 hook_block_err="${TMP_ROOT}/hook-block.err"
 set +e
 env "${hook_no_ci_env[@]}" HOME="${BLOCK_HOME}" VIBEGUARD_PROJECT_ROOT="${BLOCK_REPO}" VIBEGUARD_LOG_DIR="${TMP_ROOT}/logs-block" bash "${HOOK}" <<'JSON' 2>"${hook_block_err}" >/dev/null
@@ -163,6 +176,13 @@ else
   red "hook blocks when strict budget exceeds 30"
   FAIL=$((FAIL + 1))
 fi
+
+# Explicit env override still wins over the installed profile.
+hook_override_out="$(env "${hook_no_ci_env[@]}" HOME="${BLOCK_HOME}" VIBEGUARD_U32_STRICT=0 VIBEGUARD_PROJECT_ROOT="${BLOCK_REPO}" VIBEGUARD_LOG_DIR="${TMP_ROOT}/logs-override" bash "${HOOK}" <<'JSON'
+{"hook_event_name":"SessionStart"}
+JSON
+)"
+assert_contains "${hook_override_out}" "hookSpecificOutput" "VIBEGUARD_U32_STRICT=0 downgrades strict block to context"
 
 header "GH-541 rule-delivery budget (compact core default vs full-tree opt-in)"
 # The default (core/minimal) Claude profile injects only the compact L1-L7 +

--- a/tests/unit/test_check_doc_overload.sh
+++ b/tests/unit/test_check_doc_overload.sh
@@ -129,6 +129,46 @@ mkdir -p "$TMP/packages/api"
 run_case "nested AGENTS.md is inspected" 0 "packages/api/AGENTS.md" "$TMP"
 rm -rf "$TMP"
 
+# --- Case 11: always-on rules under a .claude home (> 200 aggregate lines) warn ---
+TMP=$(mktemp -d)
+mkdir -p "$TMP/.claude/rules/vibeguard/common"
+{ echo "# Rules"; for i in $(seq 1 250); do echo "- rule line $i"; done; } \
+  > "$TMP/.claude/rules/vibeguard/common/big.md"
+run_case "always-on native rules over budget warn (.claude home)" 0 \
+  "always-on native rules inject" "$TMP/.claude"
+rm -rf "$TMP"
+
+# --- Case 12: path-scoped rules (paths: frontmatter) are excluded ---
+TMP=$(mktemp -d)
+mkdir -p "$TMP/.claude/rules/vibeguard/rust"
+{
+  echo "---"
+  echo "paths: **/*.rs,**/Cargo.toml"
+  echo "---"
+  echo "# Rust Rules"
+  for i in $(seq 1 300); do echo "- rust rule $i"; done
+} > "$TMP/.claude/rules/vibeguard/rust/quality.md"
+run_case "path-scoped rules are excluded from injection surface" 0 "OK" "$TMP/.claude"
+rm -rf "$TMP"
+
+# --- Case 13: always-on rules > 800 aggregate lines fail in --strict ---
+TMP=$(mktemp -d)
+mkdir -p "$TMP/.claude/rules/vibeguard/common"
+{ echo "# Rules"; for i in $(seq 1 900); do echo "- rule line $i"; done; } \
+  > "$TMP/.claude/rules/vibeguard/common/huge.md"
+run_case "always-on rules over hard limit fail strict" 1 \
+  "always-on native rules inject" --strict "$TMP/.claude"
+rm -rf "$TMP"
+
+# --- Case 14: a project-level rules/ source tree is not an injection surface ---
+TMP=$(mktemp -d)
+mkdir -p "$TMP/rules/claude-rules/common"
+echo "# Project" > "$TMP/CLAUDE.md"
+{ echo "# Canonical source"; for i in $(seq 1 900); do echo "- line $i"; done; } \
+  > "$TMP/rules/claude-rules/common/security.md"
+run_case "canonical rules/ source tree in a project is not counted" 0 "OK" "$TMP"
+rm -rf "$TMP"
+
 echo
 echo "=============================="
 TOTAL=$((PASS + FAIL))

--- a/vibeguard-runtime/src/codex_app_server_policy.rs
+++ b/vibeguard-runtime/src/codex_app_server_policy.rs
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn core_profile_excludes_strict_only_count_active_constraints() {
+    fn core_profile_runs_count_active_constraints() {
         let repo = temp_policy_dir("core_count_active_constraints");
         if let Err(err) = fs::write(repo.join(".vibeguard.json"), r#"{"profile":"core"}"#) {
             panic!("project config should be written: {err}");
@@ -304,7 +304,8 @@ mod tests {
         );
 
         assert!(
-            matches!(decision, HookPolicyDecision::Skip(reason) if reason.contains("profile=core excludes count-active-constraints"))
+            !matches!(decision, HookPolicyDecision::Skip(_)),
+            "count_active_constraints should run under core profile, got: {decision:?}"
         );
         if let Err(err) = fs::remove_dir_all(&repo) {
             panic!("temp policy dir should be removed: {err}");

--- a/vibeguard-runtime/tests/runtime_policy_cli.rs
+++ b/vibeguard-runtime/tests/runtime_policy_cli.rs
@@ -244,22 +244,19 @@ fn runtime_policy_check_reports_project_utf8_errors_as_config_parse_errors() {
 }
 
 #[test]
-fn runtime_policy_check_uses_shared_profile_filtering_for_strict_only_hooks() {
-    let repo = unique_temp_dir("strict_only");
+fn runtime_policy_check_runs_count_active_constraints_under_core_profile() {
+    let repo = unique_temp_dir("core_count_active_constraints");
     write_policy(&repo, r#"{"profile":"core"}"#);
 
     let output = run_runtime_policy(&repo, "count_active_constraints.sh");
 
-    assert_eq!(output.status.code(), Some(10));
+    assert_eq!(output.status.code(), Some(0));
     let value = policy_json(&output);
-    assert_eq!(value["decision"], "skip");
-    assert_eq!(value["profile"], "core");
     assert!(
-        value["reason"]
-            .as_str()
-            .unwrap_or("")
-            .contains("profile=core excludes count-active-constraints")
+        value["decision"] != "skip",
+        "count_active_constraints should run under core profile, got: {value}"
     );
+    assert_eq!(value["profile"], "core");
     let _ = fs::remove_dir_all(repo);
 }
 


### PR DESCRIPTION
## Problem

Issue #683: the effective instruction surface was 231 constraints, almost 8× the U-32 block threshold. Two enforcement gaps allowed it:

1. **W-19 guard ignored always-on native rule injection.** `guards/universal/check_doc_overload.sh` only counted `CLAUDE.md` / `AGENTS.md` lines, so the ~1700 lines under `.claude/rules/vibeguard/` were invisible.
2. **U-32 budget hook was strict-only.** `count_active_constraints.sh` only ran in the strict profile, meaning the default `core` / `full` installs had no runtime feedback on constraint overload.

## Changes

- `guards/universal/check_doc_overload.sh`: detect always-on rule files under `.claude/rules/` that lack `paths:` frontmatter; aggregate line count >200 warns, >800 fails under `--strict`.
- `hooks/count_active_constraints.sh`: run in `core` / `full` / `strict` profiles; only strict hard-blocks by default, core/full downgrade the block to injected context. `VIBEGUARD_U32_STRICT=0/1` overrides.
- `hooks/manifest.json`, `hooks/CLAUDE.md`: update profile list and responsibility text.
- `rules/claude-rules/common/workflow.md`: add the new aggregate-line threshold to the W-19 detection table.
- Tests added for always-on rule detection, path-scoped exclusion, strict failure, and profile-aware blocking.

## Verification

```bash
bash tests/unit/test_check_doc_overload.sh          # 14/14 pass
bash tests/hooks/test_count_active_constraints.sh   # 27/27 pass
bash tests/test_hooks.sh                            # 36/36 pass
bash tests/test_setup.sh                            # 536/536 pass
```

Also ran `scripts/ci/validate-{guards,hooks,hooks-manifest,rules,canonical-rule-language,generated-rule-docs,hook-behavior-docs,manifest-contract}.sh` locally — all OK.

Fixes #683.