### PR TITLE
fix: leave suppression evidence when session-temp exemption mutes churn/W-14

### DIFF
--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history.rs
@@ -20,6 +20,8 @@ const POST_EDIT_HISTORY_LINES: usize = 500;
 const W14_COOLDOWN_DEFAULT_SECONDS: &str = "3600";
 const W14_SHOWN_REASON_PREFIX: &str = "[W-14] overlap shown";
 const W14_SUPPRESSED_REASON_PREFIX: &str = "[W-14] overlap suppressed cooldown";
+const W14_TEMP_SUPPRESSED_REASON_PREFIX: &str = "[W-14] overlap suppressed session-temp";
+const CHURN_SUPPRESSED_REASON_PREFIX: &str = "[CHURN] suppressed session-temp";
 
 pub(crate) fn detect_history_warnings(
     ctx: &RuntimeContext,
@@ -39,13 +41,20 @@ pub(crate) fn detect_history_warnings(
         .collect::<Vec<_>>();
     // Session-scoped temp paths cannot have cross-session ownership conflicts
     // and long-doc scratchpad builds are not correction loops (issue #681).
-    // TODO(#691): leave a suppression trace like the cooldown path does. Doing
-    // it here would log on every temp write; the suppression point has to move
-    // inside detect_churn / detect_w14 first so only real findings are logged.
-    if !crate::hook_checks_common::is_session_temp_path(file_path) {
-        detect_churn(ctx, start, file_path, &session_events, events, warnings);
-        detect_w14(ctx, start, file_path, events, warnings);
-    }
+    // The exemption is applied inside detect_churn / detect_w14 so that a
+    // suppressed finding leaves evidence while ordinary temp writes stay
+    // silent (issue #691).
+    let session_temp = crate::hook_checks_common::is_session_temp_path(file_path);
+    detect_churn(
+        ctx,
+        start,
+        file_path,
+        session_temp,
+        &session_events,
+        events,
+        warnings,
+    );
+    detect_w14(ctx, start, file_path, session_temp, events, warnings);
     detect_w15(
         ctx, start, file_path, old_string, new_string, events, warnings,
     );
@@ -55,6 +64,7 @@ fn detect_churn(
     ctx: &RuntimeContext,
     start: Instant,
     file_path: &str,
+    session_temp: bool,
     session_events: &[Value],
     events: &[Value],
     warnings: &mut Vec<String>,
@@ -69,6 +79,27 @@ fn detect_churn(
                     .is_some_and(|detail| detail.contains(file_path))
         })
         .count();
+    // Session-temp exemption (issues #681/#691): suppress the finding but
+    // leave evidence only when churn would actually have warned, so ordinary
+    // temp writes add no log volume.
+    if session_temp {
+        if churn_count >= 5 {
+            let detail = format!("{file_path}||churn={churn_count}");
+            let detail_limit = detail.chars().count();
+            if let Err(err) = append_hook_event_with_status(
+                ctx,
+                HookKind::PostEdit,
+                decision::PASS,
+                status::SKIPPED,
+                CHURN_SUPPRESSED_REASON_PREFIX,
+                (&detail, detail_limit),
+                elapsed_ms(start),
+            ) {
+                eprintln!("VIBEGUARD: churn suppressed telemetry append failed: {err}");
+            }
+        }
+        return;
+    }
     let basename = post_edit_history_file_name(file_path);
     if churn_count >= 20 {
         let build_fail_count = count_build_failures(events);
@@ -132,6 +163,7 @@ fn detect_w14(
     ctx: &RuntimeContext,
     start: Instant,
     file_path: &str,
+    session_temp: bool,
     events: &[Value],
     warnings: &mut Vec<String>,
 ) {
@@ -144,6 +176,7 @@ fn detect_w14(
         ctx,
         start,
         file_path,
+        session_temp,
         events,
         warnings,
         now_unix_secs(),
@@ -151,10 +184,12 @@ fn detect_w14(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn detect_w14_at(
     ctx: &RuntimeContext,
     start: Instant,
     file_path: &str,
+    session_temp: bool,
     events: &[Value],
     warnings: &mut Vec<String>,
     now: u64,
@@ -164,6 +199,24 @@ fn detect_w14_at(
     let Some(overlap) = recent_overlap(events, &ctx.session_id, &agent, file_path) else {
         return;
     };
+    // Session-temp exemption (issues #681/#691): the overlap would have
+    // warned — suppress it but leave evidence, like the cooldown path.
+    if session_temp {
+        let detail = format!("{file_path}||peer={}", overlap.session);
+        let detail_limit = detail.chars().count();
+        if let Err(err) = append_hook_event_with_status(
+            ctx,
+            HookKind::PostEdit,
+            decision::PASS,
+            status::SKIPPED,
+            W14_TEMP_SUPPRESSED_REASON_PREFIX,
+            (&detail, detail_limit),
+            elapsed_ms(start),
+        ) {
+            eprintln!("VIBEGUARD: W-14 suppressed telemetry append failed: {err}");
+        }
+        return;
+    }
     let key = w14_key(&ctx.session_id, &overlap.session, &overlap.normalized_file);
     if let Some(key) = key.as_deref() {
         let eligible = cooldown_seconds > 0
@@ -508,257 +561,8 @@ fn post_edit_history_extension(file_path: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    fn test_context(log_file: std::path::PathBuf) -> RuntimeContext {
-        RuntimeContext {
-            log_root: log_file.parent().unwrap().to_path_buf(),
-            log_file,
-            project_hash: "test-project".into(),
-            session_id: "current".into(),
-            cli: "codex".into(),
-            client: "codex".into(),
-            client_variant: "codex-cli-hooks".into(),
-            caller_evidence: "explicit-test".into(),
-            session_source: "codex-thread".into(),
-        }
-    }
-
-    fn w14_shown_event(session: &str, key: &str, timestamp: u64) -> Value {
-        json!({
-            "ts": crate::time_utils::format_unix_secs_utc(timestamp),
-            "session": session,
-            "hook": "post-edit-guard",
-            "tool": "Edit",
-            "decision": "warn",
-            "status": "warn",
-            "reason": "[W-14] overlap shown session peer agent codex",
-            "detail": format!("src/main.rs||w14_key={key}"),
-        })
-    }
-
-    #[test]
-    fn delta_metadata_is_read_from_post_edit_detail() {
-        assert_eq!(
-            post_edit_delta_from_detail("src/main.rs||delta=-42"),
-            Some(-42)
-        );
-        assert_eq!(post_edit_delta_from_detail("src/main.rs||other=1"), None);
-    }
-
-    #[test]
-    fn same_file_trail_stops_at_first_other_file() {
-        let events = vec![
-            json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/a.rs||delta=9"}),
-            json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/b.rs||delta=8"}),
-            json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/a.rs||delta=5"}),
-            json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/a.rs||delta=3"}),
-        ];
-
-        let trail = same_file_edit_trail(&events, "s", "src/a.rs");
-        assert_eq!(trail.consecutive, 2);
-        assert_eq!(trail.deltas, vec![3, 5]);
-    }
-
-    #[test]
-    fn history_file_helpers_match_common_paths() {
-        assert_eq!(post_edit_history_file_name("src/main.rs"), "main.rs");
-        assert_eq!(post_edit_history_extension("docs/guide.md"), "md");
-    }
-
-    #[test]
-    fn w14_key_is_directed_and_rejects_unknown_sessions() {
-        let Some(forward) = w14_key("current", "peer", "/repo/src/main.rs") else {
-            panic!("known sessions and file should produce a key");
-        };
-        let Some(reverse) = w14_key("peer", "current", "/repo/src/main.rs") else {
-            panic!("reversed known sessions should produce a key");
-        };
-        let Some(other_file) = w14_key("current", "peer", "/repo/src/lib.rs") else {
-            panic!("a different known file should produce a key");
-        };
-
-        assert_eq!(forward.len(), 64);
-        assert!(forward.bytes().all(|byte| byte.is_ascii_hexdigit()));
-        assert_ne!(forward, reverse);
-        assert_ne!(forward, other_file);
-        assert_eq!(w14_key("unknown", "peer", "/repo/src/main.rs"), None);
-        assert_eq!(w14_key("current", "?", "/repo/src/main.rs"), None);
-    }
-
-    #[test]
-    fn w14_detail_keeps_the_full_path_and_key_at_platform_scale() {
-        let key = "a".repeat(64);
-        let path = "x".repeat(8192);
-        let detail = w14_event_detail(&path, &key);
-        let detail_limit = detail.chars().count();
-
-        assert_eq!(detail_limit, path.chars().count() + 10 + key.len());
-        assert_eq!(first_detail_path(&json!({"detail": detail})), path);
-        assert!(detail.ends_with(&format!("||w14_key={key}")));
-        assert_eq!(w14_key_from_detail(&detail), Some(key.as_str()));
-    }
-
-    #[test]
-    fn shown_evidence_obeys_time_key_and_bounded_history_contract() {
-        let now = 1_800_000_000;
-        let key = "b".repeat(64);
-        let shown = w14_shown_event("current", &key, now - 59);
-        assert!(has_recent_w14_shown(
-            std::slice::from_ref(&shown),
-            "current",
-            &key,
-            now,
-            60
-        ));
-
-        let exact_boundary = w14_shown_event("current", &key, now - 60);
-        assert!(!has_recent_w14_shown(
-            &[exact_boundary],
-            "current",
-            &key,
-            now,
-            60
-        ));
-        let future = w14_shown_event("current", &key, now + 1);
-        assert!(!has_recent_w14_shown(&[future], "current", &key, now, 60));
-        let mut invalid_timestamp = shown.clone();
-        invalid_timestamp[field::TS] = json!("not-a-timestamp");
-        assert!(!has_recent_w14_shown(
-            &[invalid_timestamp],
-            "current",
-            &key,
-            now,
-            60
-        ));
-        assert!(!has_recent_w14_shown(
-            std::slice::from_ref(&shown),
-            "other-current",
-            &key,
-            now,
-            60
-        ));
-        assert!(!has_recent_w14_shown(
-            std::slice::from_ref(&shown),
-            "current",
-            &"c".repeat(64),
-            now,
-            60
-        ));
-
-        let suppressed = json!({
-            "ts": crate::time_utils::format_unix_secs_utc(now - 1),
-            "session": "current",
-            "hook": "post-edit-guard",
-            "tool": "Edit",
-            "decision": "pass",
-            "status": "skipped",
-            "reason": "[W-14] overlap suppressed cooldown",
-            "detail": format!("src/main.rs||w14_key={key}"),
-        });
-        assert!(!has_recent_w14_shown(
-            &[suppressed],
-            "current",
-            &key,
-            now,
-            60
-        ));
-
-        let mut beyond_tail = vec![shown];
-        beyond_tail.extend((0..POST_EDIT_HISTORY_LINES).map(|index| {
-            json!({
-                "ts": crate::time_utils::format_unix_secs_utc(now - 1),
-                "session": format!("filler-{index}"),
-            })
-        }));
-        assert!(!has_recent_w14_shown(
-            &beyond_tail,
-            "current",
-            &key,
-            now,
-            60
-        ));
-    }
-
-    #[test]
-    fn suppression_requires_successful_audit_append() {
-        let called = std::cell::Cell::new(false);
-        assert_eq!(
-            suppress_after_audit(false, || {
-                called.set(true);
-                Ok::<(), ()>(())
-            }),
-            Ok(false)
-        );
-        assert!(!called.get());
-        assert_eq!(suppress_after_audit(true, || Ok::<(), ()>(())), Ok(true));
-        assert_eq!(
-            suppress_after_audit(true, || Err::<(), _>("locked")),
-            Err("locked")
-        );
-    }
-
-    #[test]
-    fn suppressed_w14_does_not_increase_prior_warn_count() {
-        let key = "d".repeat(64);
-        let events = vec![
-            w14_shown_event("current", &key, 1_800_000_000),
-            json!({
-                "session": "current",
-                "hook": "post-edit-guard",
-                "tool": "Edit",
-                "decision": "pass",
-                "status": "skipped",
-                "reason": "[W-14] overlap suppressed cooldown",
-                "detail": format!("src/main.rs||w14_key={key}"),
-            }),
-        ];
-
-        assert_eq!(
-            count_prior_warn_events_in(&events, "current", "src/main.rs"),
-            1
-        );
-    }
-
-    #[test]
-    fn shared_history_snapshot_drives_warnings_and_prior_count() {
-        let root = std::env::temp_dir().join(format!("vg-history-snapshot-{}", std::process::id()));
-        std::fs::create_dir_all(&root).unwrap();
-        let ctx = test_context(root.join("events.jsonl"));
-        let event = json!({
-            "session":"current", "hook":"post-edit-guard", "tool":"Edit",
-            "decision":"warn", "reason":"[RS-03] prior", "detail":"src/main.rs||delta=9"
-        });
-        std::fs::write(&ctx.log_file, format!("{event}\n")).unwrap();
-
-        let events = read_post_edit_history_events(&ctx).unwrap();
-        assert_eq!(
-            count_prior_warn_events(&events, "current", "src/main.rs"),
-            1
-        );
-        assert_eq!(
-            same_file_edit_trail(&events, "current", "src/main.rs").consecutive,
-            1
-        );
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn append_failure_preserves_churn_and_w15_warnings() {
-        let ctx = test_context(std::path::PathBuf::from("/not-written/events.jsonl"));
-        for label in ["[CHURN] original warning", "[W-15] original warning"] {
-            let mut warnings = Vec::new();
-            preserve_warning_after_append(&ctx, &mut warnings, label.to_string(), || {
-                Err::<(), _>(std::io::Error::other("injected append failure"))
-            });
-            assert_eq!(warnings[0], label);
-            assert!(warnings[1].contains("VG-INTERNAL-LOG-APPEND"));
-            assert!(warnings[1].contains("history telemetry append failed"));
-        }
-    }
-}
+#[path = "hook_orchestrator_post_edit_history_unit_tests.rs"]
+mod tests;
 
 #[cfg(test)]
 #[path = "hook_orchestrator_post_edit_history_tests.rs"]

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history_tests.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history_tests.rs
@@ -58,6 +58,7 @@ fn assert_churn_warning(root: &Path, count: usize, marker: &str, expected_reason
         &ctx,
         Instant::now(),
         "src/main.rs",
+        false,
         &events,
         &events,
         &mut warnings,
@@ -81,6 +82,7 @@ fn churn_thresholds_and_w15_shrinking_radius_are_behavioral() {
         &four_ctx,
         Instant::now(),
         "src/main.rs",
+        false,
         &four,
         &four,
         &mut warnings,
@@ -97,6 +99,7 @@ fn churn_thresholds_and_w15_shrinking_radius_are_behavioral() {
         &volume_ctx,
         Instant::now(),
         "src/main.rs",
+        false,
         &volume,
         &volume,
         &mut warnings,
@@ -127,6 +130,7 @@ fn churn_thresholds_and_w15_shrinking_radius_are_behavioral() {
         &critical_ctx,
         Instant::now(),
         "src/main.rs",
+        false,
         &critical,
         &critical,
         &mut critical_warnings,
@@ -203,6 +207,7 @@ fn w14_main_path_records_show_suppresses_and_restores_on_append_failure() {
         &shown_ctx,
         Instant::now(),
         &file_path,
+        false,
         std::slice::from_ref(&overlap),
         &mut shown_warnings,
         now,
@@ -238,6 +243,7 @@ fn w14_main_path_records_show_suppresses_and_restores_on_append_failure() {
         &suppressed_ctx,
         Instant::now(),
         &file_path,
+        false,
         &history,
         &mut suppressed_warnings,
         now,
@@ -261,6 +267,7 @@ fn w14_main_path_records_show_suppresses_and_restores_on_append_failure() {
         &failed_ctx,
         Instant::now(),
         &file_path,
+        false,
         &history,
         &mut restored_warnings,
         now,
@@ -288,6 +295,7 @@ fn w14_ignores_pre_hook_intent_events() {
         &ctx,
         Instant::now(),
         &file_path,
+        false,
         std::slice::from_ref(&pre_event),
         &mut warnings,
         now,
@@ -312,6 +320,7 @@ fn w14_downgrades_to_info_without_logical_codex_identity() {
         &ctx,
         Instant::now(),
         &file_path,
+        false,
         std::slice::from_ref(&overlap),
         &mut warnings,
         now,
@@ -335,5 +344,98 @@ fn full_history_reader_treats_whitespace_only_log_as_empty() {
 
     let events = read_post_edit_history_events(&ctx).unwrap();
     assert!(events.is_empty());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn session_temp_suppression_leaves_evidence_only_for_real_findings() {
+    let root = temp_root("temp-evidence");
+    let scratch = "/private/tmp/claude-x/session/scratchpad/report.html";
+    let now = now_unix_secs();
+
+    // Ordinary temp write: no finding would fire -> zero events (issue #691).
+    let quiet_ctx = review_context(root.join("quiet.jsonl"));
+    let quiet = edit_events(2, scratch);
+    let mut quiet_warnings = Vec::new();
+    detect_churn(
+        &quiet_ctx,
+        Instant::now(),
+        scratch,
+        true,
+        &quiet,
+        &quiet,
+        &mut quiet_warnings,
+    );
+    detect_w14_at(
+        &quiet_ctx,
+        Instant::now(),
+        scratch,
+        true,
+        &quiet,
+        &mut quiet_warnings,
+        now,
+        60,
+    );
+    assert!(quiet_warnings.is_empty());
+    assert!(!quiet_ctx.log_file.exists());
+
+    // Churn would have warned -> suppressed evidence, no user warning.
+    let churn_ctx = review_context(root.join("churn.jsonl"));
+    let churny = edit_events(6, scratch);
+    let mut churn_warnings = Vec::new();
+    detect_churn(
+        &churn_ctx,
+        Instant::now(),
+        scratch,
+        true,
+        &churny,
+        &churny,
+        &mut churn_warnings,
+    );
+    assert!(churn_warnings.is_empty());
+    let churn_events = read_test_events(&churn_ctx.log_file);
+    assert_eq!(churn_events.len(), 1);
+    assert_eq!(churn_events[0][field::DECISION], decision::PASS);
+    assert_eq!(churn_events[0][field::STATUS], status::SKIPPED);
+    assert_eq!(
+        churn_events[0][field::REASON],
+        CHURN_SUPPRESSED_REASON_PREFIX
+    );
+    assert!(
+        churn_events[0][field::DETAIL]
+            .as_str()
+            .unwrap()
+            .ends_with("||churn=6")
+    );
+
+    // W-14 overlap would have warned -> suppressed evidence, no user warning.
+    let w14_ctx = review_context(root.join("w14.jsonl"));
+    let overlap = overlap_event(scratch, now);
+    let mut w14_warnings = Vec::new();
+    detect_w14_at(
+        &w14_ctx,
+        Instant::now(),
+        scratch,
+        true,
+        std::slice::from_ref(&overlap),
+        &mut w14_warnings,
+        now,
+        60,
+    );
+    assert!(w14_warnings.is_empty());
+    let w14_events = read_test_events(&w14_ctx.log_file);
+    assert_eq!(w14_events.len(), 1);
+    assert_eq!(w14_events[0][field::DECISION], decision::PASS);
+    assert_eq!(w14_events[0][field::STATUS], status::SKIPPED);
+    assert_eq!(
+        w14_events[0][field::REASON],
+        W14_TEMP_SUPPRESSED_REASON_PREFIX
+    );
+    assert!(
+        w14_events[0][field::DETAIL]
+            .as_str()
+            .unwrap()
+            .ends_with("||peer=peer")
+    );
     fs::remove_dir_all(root).unwrap();
 }

--- a/vibeguard-runtime/src/hook_orchestrator_post_edit_history_unit_tests.rs
+++ b/vibeguard-runtime/src/hook_orchestrator_post_edit_history_unit_tests.rs
@@ -1,0 +1,249 @@
+use super::*;
+use serde_json::json;
+
+fn test_context(log_file: std::path::PathBuf) -> RuntimeContext {
+    RuntimeContext {
+        log_root: log_file.parent().unwrap().to_path_buf(),
+        log_file,
+        project_hash: "test-project".into(),
+        session_id: "current".into(),
+        cli: "codex".into(),
+        client: "codex".into(),
+        client_variant: "codex-cli-hooks".into(),
+        caller_evidence: "explicit-test".into(),
+        session_source: "codex-thread".into(),
+    }
+}
+
+fn w14_shown_event(session: &str, key: &str, timestamp: u64) -> Value {
+    json!({
+        "ts": crate::time_utils::format_unix_secs_utc(timestamp),
+        "session": session,
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "status": "warn",
+        "reason": "[W-14] overlap shown session peer agent codex",
+        "detail": format!("src/main.rs||w14_key={key}"),
+    })
+}
+
+#[test]
+fn delta_metadata_is_read_from_post_edit_detail() {
+    assert_eq!(
+        post_edit_delta_from_detail("src/main.rs||delta=-42"),
+        Some(-42)
+    );
+    assert_eq!(post_edit_delta_from_detail("src/main.rs||other=1"), None);
+}
+
+#[test]
+fn same_file_trail_stops_at_first_other_file() {
+    let events = vec![
+        json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/a.rs||delta=9"}),
+        json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/b.rs||delta=8"}),
+        json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/a.rs||delta=5"}),
+        json!({"session":"s","tool":"Edit","hook":"post-edit-guard","detail":"src/a.rs||delta=3"}),
+    ];
+
+    let trail = same_file_edit_trail(&events, "s", "src/a.rs");
+    assert_eq!(trail.consecutive, 2);
+    assert_eq!(trail.deltas, vec![3, 5]);
+}
+
+#[test]
+fn history_file_helpers_match_common_paths() {
+    assert_eq!(post_edit_history_file_name("src/main.rs"), "main.rs");
+    assert_eq!(post_edit_history_extension("docs/guide.md"), "md");
+}
+
+#[test]
+fn w14_key_is_directed_and_rejects_unknown_sessions() {
+    let Some(forward) = w14_key("current", "peer", "/repo/src/main.rs") else {
+        panic!("known sessions and file should produce a key");
+    };
+    let Some(reverse) = w14_key("peer", "current", "/repo/src/main.rs") else {
+        panic!("reversed known sessions should produce a key");
+    };
+    let Some(other_file) = w14_key("current", "peer", "/repo/src/lib.rs") else {
+        panic!("a different known file should produce a key");
+    };
+
+    assert_eq!(forward.len(), 64);
+    assert!(forward.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    assert_ne!(forward, reverse);
+    assert_ne!(forward, other_file);
+    assert_eq!(w14_key("unknown", "peer", "/repo/src/main.rs"), None);
+    assert_eq!(w14_key("current", "?", "/repo/src/main.rs"), None);
+}
+
+#[test]
+fn w14_detail_keeps_the_full_path_and_key_at_platform_scale() {
+    let key = "a".repeat(64);
+    let path = "x".repeat(8192);
+    let detail = w14_event_detail(&path, &key);
+    let detail_limit = detail.chars().count();
+
+    assert_eq!(detail_limit, path.chars().count() + 10 + key.len());
+    assert_eq!(first_detail_path(&json!({"detail": detail})), path);
+    assert!(detail.ends_with(&format!("||w14_key={key}")));
+    assert_eq!(w14_key_from_detail(&detail), Some(key.as_str()));
+}
+
+#[test]
+fn shown_evidence_obeys_time_key_and_bounded_history_contract() {
+    let now = 1_800_000_000;
+    let key = "b".repeat(64);
+    let shown = w14_shown_event("current", &key, now - 59);
+    assert!(has_recent_w14_shown(
+        std::slice::from_ref(&shown),
+        "current",
+        &key,
+        now,
+        60
+    ));
+
+    let exact_boundary = w14_shown_event("current", &key, now - 60);
+    assert!(!has_recent_w14_shown(
+        &[exact_boundary],
+        "current",
+        &key,
+        now,
+        60
+    ));
+    let future = w14_shown_event("current", &key, now + 1);
+    assert!(!has_recent_w14_shown(&[future], "current", &key, now, 60));
+    let mut invalid_timestamp = shown.clone();
+    invalid_timestamp[field::TS] = json!("not-a-timestamp");
+    assert!(!has_recent_w14_shown(
+        &[invalid_timestamp],
+        "current",
+        &key,
+        now,
+        60
+    ));
+    assert!(!has_recent_w14_shown(
+        std::slice::from_ref(&shown),
+        "other-current",
+        &key,
+        now,
+        60
+    ));
+    assert!(!has_recent_w14_shown(
+        std::slice::from_ref(&shown),
+        "current",
+        &"c".repeat(64),
+        now,
+        60
+    ));
+
+    let suppressed = json!({
+        "ts": crate::time_utils::format_unix_secs_utc(now - 1),
+        "session": "current",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "status": "skipped",
+        "reason": "[W-14] overlap suppressed cooldown",
+        "detail": format!("src/main.rs||w14_key={key}"),
+    });
+    assert!(!has_recent_w14_shown(
+        &[suppressed],
+        "current",
+        &key,
+        now,
+        60
+    ));
+
+    let mut beyond_tail = vec![shown];
+    beyond_tail.extend((0..POST_EDIT_HISTORY_LINES).map(|index| {
+        json!({
+            "ts": crate::time_utils::format_unix_secs_utc(now - 1),
+            "session": format!("filler-{index}"),
+        })
+    }));
+    assert!(!has_recent_w14_shown(
+        &beyond_tail,
+        "current",
+        &key,
+        now,
+        60
+    ));
+}
+
+#[test]
+fn suppression_requires_successful_audit_append() {
+    let called = std::cell::Cell::new(false);
+    assert_eq!(
+        suppress_after_audit(false, || {
+            called.set(true);
+            Ok::<(), ()>(())
+        }),
+        Ok(false)
+    );
+    assert!(!called.get());
+    assert_eq!(suppress_after_audit(true, || Ok::<(), ()>(())), Ok(true));
+    assert_eq!(
+        suppress_after_audit(true, || Err::<(), _>("locked")),
+        Err("locked")
+    );
+}
+
+#[test]
+fn suppressed_w14_does_not_increase_prior_warn_count() {
+    let key = "d".repeat(64);
+    let events = vec![
+        w14_shown_event("current", &key, 1_800_000_000),
+        json!({
+            "session": "current",
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "pass",
+            "status": "skipped",
+            "reason": "[W-14] overlap suppressed cooldown",
+            "detail": format!("src/main.rs||w14_key={key}"),
+        }),
+    ];
+
+    assert_eq!(
+        count_prior_warn_events_in(&events, "current", "src/main.rs"),
+        1
+    );
+}
+
+#[test]
+fn shared_history_snapshot_drives_warnings_and_prior_count() {
+    let root = std::env::temp_dir().join(format!("vg-history-snapshot-{}", std::process::id()));
+    std::fs::create_dir_all(&root).unwrap();
+    let ctx = test_context(root.join("events.jsonl"));
+    let event = json!({
+        "session":"current", "hook":"post-edit-guard", "tool":"Edit",
+        "decision":"warn", "reason":"[RS-03] prior", "detail":"src/main.rs||delta=9"
+    });
+    std::fs::write(&ctx.log_file, format!("{event}\n")).unwrap();
+
+    let events = read_post_edit_history_events(&ctx).unwrap();
+    assert_eq!(
+        count_prior_warn_events(&events, "current", "src/main.rs"),
+        1
+    );
+    assert_eq!(
+        same_file_edit_trail(&events, "current", "src/main.rs").consecutive,
+        1
+    );
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn append_failure_preserves_churn_and_w15_warnings() {
+    let ctx = test_context(std::path::PathBuf::from("/not-written/events.jsonl"));
+    for label in ["[CHURN] original warning", "[W-15] original warning"] {
+        let mut warnings = Vec::new();
+        preserve_warning_after_append(&ctx, &mut warnings, label.to_string(), || {
+            Err::<(), _>(std::io::Error::other("injected append failure"))
+        });
+        assert_eq!(warnings[0], label);
+        assert!(warnings[1].contains("VG-INTERNAL-LOG-APPEND"));
+        assert!(warnings[1].contains("history telemetry append failed"));
+    }
+}


### PR DESCRIPTION
## Problem

Issue #691: the #688 session-temp exemption skipped churn and W-14 silently — no event was written, so stats and FP analysis could not distinguish "guard did not fire" from "guard was exempted here". The adjacent W-14 cooldown path already writes pass/skipped evidence; the exemption broke that convention.

## Changes

Exactly the shape the issue prescribes — sink the suppression point into the detectors so evidence is written only when a finding would actually have fired:

- `detect_churn` / `detect_w14` now take a `session_temp` flag. Each first computes its finding as usual; on temp paths a would-have-warned finding becomes a `decision=pass / status=skipped` event with reason `[CHURN] suppressed session-temp` (detail carries `||churn=N`) or `[W-14] overlap suppressed session-temp` (detail carries `||peer=<session>`), and the user-visible warning is dropped.
- Ordinary temp writes with no finding produce zero events — no constant log overhead, per the issue rationale against the unconditional-append version rejected in the #688 review round.
- The inline unit tests of `hook_orchestrator_post_edit_history.rs` moved to `hook_orchestrator_post_edit_history_unit_tests.rs` (same `#[path]` pattern as the existing review-tests file): the evidence branch pushed the file past the U-16 800-line hard ceiling.

## Verification (this session)

- `cargo test` — 23 suites OK; new test `session_temp_suppression_leaves_evidence_only_for_real_findings` covers: quiet temp write -> 0 events; churn would-warn -> 1 skipped evidence; W-14 would-warn -> 1 skipped evidence; no user-visible warning in all cases
- `cargo clippy --all-targets -- -D warnings` — clean
- `tests/hooks/test_post_edit_w14.sh` — 35/35
- `tests/test_hooks.sh` — all shards

The `cli_hook_post_edit.rs:369` count assertion mentioned in the issue is unaffected: quiet temp writes log nothing, so no expected-count updates were needed.

Fixes #691.