### PR TITLE
docs: reconcile implemented spec and plan statuses

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,32 +7,33 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | Spec | Status | Use it for |
 |---|---|---|
 | `GH686/` | Draft | Paired with/without evaluation for prompt-injected rule target improvement and non-target regression evidence |
-| `GH687/` | Draft implementation | W-21 evidence-provenance rule plus the W-01 channel-trust step 0 |
-| `GH671/` | Draft implementation | Baseline-aware U-16 enforcement for legacy oversized files plus staged/CI changed-file checks |
-| `GH659/` | Draft | Bound wrapper/event log growth, stale learning markers, and scheduled oversized-scan status |
-| `GH661/` | Draft | Preserve wrapped-hook exit code, conventional signal decoding, and nonempty failure evidence |
-| `GH658/` | Draft | Required work-surface classification before readiness routing |
-| `GH652/` | Draft | Deterministic current-source runtime build and pinning before setup structured-report assertions |
-| `GH631/` | Draft | Explicit orphan deletion, maintainer-only sgconfig discovery, and fail-visible distribution asset inventory |
+| `GH687/` | Implemented reference | W-21 evidence-provenance rule plus the W-01 channel-trust step 0 |
+| `GH675/` | Implemented reference | Manual precision-triage capture, empty-channel visibility, and the documented feedback loop |
+| `GH671/` | Implemented reference | Baseline-aware U-16 enforcement for legacy oversized files plus staged/CI changed-file checks |
+| `GH659/` | Implemented reference | Bound wrapper/event log growth, stale learning markers, and scheduled oversized-scan status |
+| `GH661/` | Implemented reference | Preserve wrapped-hook exit code, conventional signal decoding, and nonempty failure evidence |
+| `GH658/` | Implemented reference | Required work-surface classification before readiness routing |
+| `GH652/` | Implemented reference | Deterministic current-source runtime build and pinning before setup structured-report assertions |
+| `GH631/` | Implemented reference | Explicit orphan deletion, maintainer-only sgconfig discovery, and fail-visible distribution asset inventory |
 | `GH630/` | Implemented reference | Pinned Claude eval aliases, UTC-bounded offline freshness evidence, and one shared model-resolution contract |
 | `GH629/` | Implemented reference | Fail-visible, schema-backed user runtime config validation with complete getter/template inventory |
 | `GH628/` | Implemented reference | Git-tracked Markdown personal-path detection and strict, scoped doc-path allowlist freshness |
 | `GH627/` | Implemented reference | Closed-map resolution of Codex namespaced hook names to canonical hook files without physical alias shells |
 | `GH626/` | Implemented reference | Canonical-source generation and freshness enforcement for the compact injected rule table |
-| `GH644/` | Draft | Deterministic stdin and complete child-error evidence for runtime-policy expected-error integration tests |
-| `GH615/` | Draft | Reminder-aware pre-write escalation counting, same-session Grep/Glob recovery, and actionable block guidance |
-| `GH623/` | Draft | Behavior-preserving decomposition of the oversized self-application CI harness into ordered focused test domains |
-| `GH621/` | Draft | Behavior-preserving extraction of install-time runtime acquisition, provenance, and source fallback from the oversized setup entrypoint |
+| `GH644/` | Implemented reference | Deterministic stdin and complete child-error evidence for runtime-policy expected-error integration tests |
+| `GH615/` | Implemented reference | Reminder-aware pre-write escalation counting, same-session Grep/Glob recovery, and actionable block guidance |
+| `GH623/` | Implemented reference | Behavior-preserving decomposition of the oversized self-application CI harness into ordered focused test domains |
+| `GH621/` | Implemented reference | Behavior-preserving extraction of install-time runtime acquisition, provenance, and source fallback from the oversized setup entrypoint |
 | `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
-| `GH618/` | Draft | Manifest-driven compliance language scope, guard-pack reporting, and fail-visible config handling |
-| `GH614/` | Draft | Bounded macOS CI timeout headroom while preserving required check names and blocking setup coverage |
+| `GH618/` | Implemented reference | Manifest-driven compliance language scope, guard-pack reporting, and fail-visible config handling |
+| `GH614/` | Implemented reference | Bounded macOS CI timeout headroom while preserving required check names and blocking setup coverage |
 | `GH581/` | Implemented reference | Rust coverage ratchets from a latest-head clean measurement through risk-ordered, independently reviewed tranches to the enforced 80% gate |
-| `GH588/` | Draft | Scheduled GC execution freshness, platform-correct wrapper/internal log evidence, and preserved setup-check mode semantics |
-| `GH589/` | Draft | Repo-scoped code-slop self-scan precision for Rust CLI stdout and line-scoped detector pattern sources |
-| `GH590/` | Draft | Directed session-pair W-14 cooldown, fail-open bounded history, schema-valid suppression telemetry, and runtime config distribution |
-| `GH595/` | Draft implementation | SpecRail repository adoption, configured VibeGuard overrides, offline PR/runtime gates, target-local evidence, and preserved human merge boundaries |
+| `GH588/` | Implemented reference | Scheduled GC execution freshness, platform-correct wrapper/internal log evidence, and preserved setup-check mode semantics |
+| `GH589/` | Implemented reference | Repo-scoped code-slop self-scan precision for Rust CLI stdout and line-scoped detector pattern sources |
+| `GH590/` | Implemented reference | Directed session-pair W-14 cooldown, fail-open bounded history, schema-valid suppression telemetry, and runtime config distribution |
+| `GH595/` | Implemented reference | SpecRail repository adoption, configured VibeGuard overrides, offline PR/runtime gates, target-local evidence, and preserved human merge boundaries |
 | `GH556/` | Implemented reference | Weekly health report for rule trigger counts, precision risk, unclassified backlog, idle asset detection, and opt-in scheduling |
-| `GH566/` | Draft | Codex unmanaged stale `PreToolUse` hook detection, explicit repair, and setup-test fixture isolation |
+| `GH566/` | Implemented reference | Codex unmanaged stale `PreToolUse` hook detection, explicit repair, and setup-test fixture isolation |
 | `install-friction-reduction.md` | Implemented reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
 | `learn-first-class-signal-inbox.md` | Draft | Learn signal inbox, signal classification, triage state, adoption compiler, and outcome evaluator planning |
 | `rust-only-production-path.md` | Implemented reference | Python-free production path, Rust runtime boundaries, and remaining validation expectations |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -24,7 +24,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | `GH615/` | Implemented reference | Reminder-aware pre-write escalation counting, same-session Grep/Glob recovery, and actionable block guidance |
 | `GH623/` | Implemented reference | Behavior-preserving decomposition of the oversized self-application CI harness into ordered focused test domains |
 | `GH621/` | Implemented reference | Behavior-preserving extraction of install-time runtime acquisition, provenance, and source fallback from the oversized setup entrypoint |
-| `codex-app-observability-plugin.md` | Draft implementation | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
+| `codex-app-observability-plugin.md` | Implemented reference | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
 | `GH618/` | Implemented reference | Manifest-driven compliance language scope, guard-pack reporting, and fail-visible config handling |
 | `GH614/` | Implemented reference | Bounded macOS CI timeout headroom while preserving required check names and blocking setup coverage |
 | `GH581/` | Implemented reference | Rust coverage ratchets from a latest-head clean measurement through risk-ordered, independently reviewed tranches to the enforced 80% gate |
@@ -35,7 +35,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | `GH556/` | Implemented reference | Weekly health report for rule trigger counts, precision risk, unclassified backlog, idle asset detection, and opt-in scheduling |
 | `GH566/` | Implemented reference | Codex unmanaged stale `PreToolUse` hook detection, explicit repair, and setup-test fixture isolation |
 | `install-friction-reduction.md` | Implemented reference | Prebuilt runtime binaries, release checksums, source-build fallback, and scheduler opt-in behavior |
-| `learn-first-class-signal-inbox.md` | Draft | Learn signal inbox, signal classification, triage state, adoption compiler, and outcome evaluator planning |
+| `learn-first-class-signal-inbox.md` | Implemented reference | Learn signal inbox, signal classification, triage state, adoption compiler, and outcome evaluator planning |
 | `rust-only-production-path.md` | Implemented reference | Python-free production path, Rust runtime boundaries, and remaining validation expectations |
 
 ## Reading Rules

--- a/docs/specs/codex-app-observability-plugin.md
+++ b/docs/specs/codex-app-observability-plugin.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft implementation for the repo-local VibeGuard Codex plugin.
+Implemented reference for the repo-local VibeGuard Codex plugin (GH-423, PR #424).
 
 ## Problem
 

--- a/docs/specs/learn-first-class-signal-inbox.md
+++ b/docs/specs/learn-first-class-signal-inbox.md
@@ -1,6 +1,6 @@
 # Spec: Make Learn a first-class signal inbox
 
-- Status: Draft
+- Status: Implemented
 - Date: 2026-06-25
 - Owner: @majiayu000
 - Readiness: plan_first

--- a/plan/README.md
+++ b/plan/README.md
@@ -11,9 +11,9 @@ Keep `plan/` as the workflow output directory. Historical or completed files sta
 | Class | Meaning | Files |
 |---|---|---|
 | Active execution plan | Current multi-step work where remaining steps may still be actionable after checking linked issues and main branch | None currently |
-| Completed record | Historical execution evidence or implemented plan record; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `2026-06-05_22-28-rust-only-production-path.md`, `spec-96-prompt-contract-schema.md`, `spec-app-server-runtime-policy-gate.md`, `spec-codebase-audit-remediation.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md` |
+| Completed record | Historical execution evidence or implemented plan record; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `2026-06-05_22-28-rust-only-production-path.md`, `spec-96-prompt-contract-schema.md`, `spec-app-server-runtime-policy-gate.md`, `spec-codebase-audit-remediation.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md`, `spec-test-file-size-decomposition.md` |
 | Historical convergence plan | Older architecture plan; verify current code and newer specs before acting | `2026-04-19_00-15-39-main-architecture-convergence.md` |
-| Draft spec | Candidate work that needs issue and code-state verification before implementation | `spec-test-file-size-decomposition.md`, `full-english-localization-spec.md` |
+| Draft spec | Candidate work that needs issue and code-state verification before implementation | `full-english-localization-spec.md` |
 | Snapshot or signal report | Evidence artifact for another plan or issue; do not implement directly without an owning spec | `w20-rust-only-production-path-snapshot.md`, `signal-report-legacy-vibeguard-mcp-cleanup.md` |
 
 ## File Status Index
@@ -30,7 +30,7 @@ Keep `plan/` as the workflow output directory. Historical or completed files sta
 | `spec-codebase-audit-remediation.md` | Completed record | Use as remediation history; create a fresh issue for any remaining work. |
 | `spec-posttool-malformed-input-fail-visible.md` | Completed record | Use as fail-visible behavior context; current tests are authoritative. |
 | `spec-runtime-config-contract-clarity.md` | Completed record | Use as config-contract history; current schema and setup tests are authoritative. |
-| `spec-test-file-size-decomposition.md` | Draft spec | Verify current file-size pressure and open a GitHub issue before implementation. |
+| `spec-test-file-size-decomposition.md` | Completed record | Use as GH375/PR407 decomposition history; current file sizes and aggregate tests are authoritative. |
 | `w20-rust-only-production-path-snapshot.md` | Snapshot or signal report | Treat as evidence for W-20 runtime drift decisions, not backlog. |
 
 ## Reading Rules

--- a/plan/spec-test-file-size-decomposition.md
+++ b/plan/spec-test-file-size-decomposition.md
@@ -1,6 +1,6 @@
 # Spec: Decompose oversized test and runtime support files
 
-- Status: Draft
+- Status: Implemented
 - Date: 2026-06-04
 - Owner: @majiayu000
 - Issue: https://github.com/majiayu000/vibeguard/issues/375


### PR DESCRIPTION
## 问题

spec/plan 索引仍把多项已经完成的工作标为 `Draft` / `Draft implementation`，会把历史实现证据误当成可执行 backlog。

## 对账规则

仅在存在鲜态完成证据时升级状态：

- GitHub Issue 为 `closed/completed`；
- 存在 merged implementation PR；
- 对计划拆分项额外核对当前目标文件已满足硬上限。

## 改动

- 将现有 GH spec 中 18 项已完成工作改为 `Implemented reference`，并登记 GH675。
- Codex observability plugin：Issue #423 completed，PR #424 merged，改为 implemented reference。
- Learn signal inbox：#526–#531 全部 completed，PR #532–#536 已实现，改为 implemented reference。
- 文件拆分计划：#375 completed、PR #407 merged，当前列出的目标文件均低于 800 行，改为 completed record。
- 保留 GH686 为 `Draft`：PR #693 只合并了 spec，SP686-T1..T12 尚未实现。
- 保留 full-English localization 为 Draft：没有当前 GitHub Issue 或实现授权。

## 验证

- `python3 checks/check_workflow.py --repo . --all-specs` — passed
- `bash scripts/ci/validate-doc-paths.sh` — 171 files validated
- `bash scripts/ci/validate-doc-command-paths.sh` — 126 command paths validated
- `git diff --check` — passed