### PR TITLE
docs(plan): add growth and architecture roadmap draft spec

### DIFF
--- a/plan/2026-07-26-growth-and-architecture-roadmap.md
+++ b/plan/2026-07-26-growth-and-architecture-roadmap.md
@@ -1,0 +1,119 @@
+# Growth and Architecture Roadmap (Draft Spec)
+
+Status: Draft spec — verify priority and open a GitHub issue per workstream before implementation.
+Date: 2026-07-26
+
+## Problem
+
+VibeGuard's defense stack (Rust runtime hooks, 126 layered rules, static guards,
+paired with/without eval, precision tracking, cross-session learning) is ahead of
+comparable tooling, but adoption does not reflect that. The bottlenecks are
+positioning, distribution friction, and unproven-to-outsiders effectiveness —
+not missing capability.
+
+## Goal
+
+Make VibeGuard the default guardrail layer for AI coding agents: installable in
+under one minute, valuable in the first session, and backed by published,
+reproducible effectiveness numbers.
+
+## Non-goals
+
+- Rewriting the runtime or rule engine; both are adequate.
+- Adding new rule surface area before the distribution and evidence gaps close.
+- SaaS/hosted offering; everything below stays local-first.
+
+## Workstreams (priority order)
+
+### WS1 — One-command install
+
+Today the supported path is `git clone` + `setup.sh`, which makes the repository
+the installation medium. Target end state:
+
+- Single command install: `brew install vibeguard` and/or `npx vibeguard init`
+  (or `bunx`), plus Claude Code plugin-marketplace listing.
+- The release binary (already built, checksummed, provenance-attested) becomes
+  the distribution unit; rules/hooks ship inside it or are fetched on first run.
+- The git checkout remains the development source only.
+
+Done-when: a fresh machine goes from nothing to a verified install (equivalent
+of `setup.sh verify-install` passing) with one command and no repository clone.
+
+### WS2 — Public effectiveness benchmark
+
+The paired with/without side-effect gate (GH686, PR #696) is the foundation.
+Target end state:
+
+- A reproducible `vibeguard bench` that injects representative failure classes
+  (invented APIs, duplicate modules, swallowed exceptions, dangerous shell/git
+  ops, unverified "done" claims) and reports interception rate, false-positive
+  rate, and hook latency.
+- Headline numbers published in README and regenerated in CI per release.
+
+Done-when: README shows a benchmark table any user can reproduce with one
+command from a released binary.
+
+### WS3 — Repositioning: agent firewall, not a two-tool rule pack
+
+- Narrative shifts from "rules for Claude Code and Codex" to "the firewall
+  between AI coding agents and your codebase".
+- Adapter surface documented so additional hosts (Cursor CLI, Gemini CLI,
+  opencode) can be added without touching the rule/guard core; ship at least
+  one new host adapter to prove the seam.
+- README first screen reduced to: one-line positioning, a 30-second intercept
+  demo GIF, the one-command install, the benchmark table. Operational detail
+  (provenance modes, fallbacks, doctor internals) moves under `docs/`.
+
+Done-when: a first-time visitor can understand, install, and see a real
+interception within five minutes without reading past the first screen.
+
+### WS4 — Rule packs as an ecosystem
+
+- Stabilize the pack format (`packs/` + `schemas/`) as a published contract.
+- `vibeguard add <pack>` installs a third-party pack; core packs stay curated
+  with precision data attached.
+- Precision tracking gates defaults: rules below a precision floor ship as
+  warnings, not blocks (protects against the number-one uninstall reason:
+  false-positive fatigue).
+
+Done-when: an external contributor can author, publish, and install a pack
+without modifying this repository.
+
+### WS5 — Visible weekly value
+
+- The opt-in weekly report (PR #572) becomes the default retention surface:
+  "this week VibeGuard blocked N dangerous ops, caught M invented APIs" with a
+  shareable summary.
+
+Done-when: a default install produces a weekly summary without extra setup.
+
+### WS6 — Tiered semantic defense (differentiation moat)
+
+Layered detection depth, each tier opt-in above the last:
+
+- L1 (exists): regex/AST guards, microsecond budget.
+- L2: semantic checks via a small local/cheap model — "does this API exist in
+  this project's dependencies", "was this test assertion weakened".
+- L3 (exists in part as W-rules): session-level behavior detection — repeated
+  failed fixes, completion claims without verification — moving from rule text
+  to runtime enforcement signals.
+- Cross-session learning closes the loop: corrections observed in practice
+  become candidate rules with tracked precision.
+
+Done-when: L2 ships behind a flag with measured latency and precision, and at
+least two W-rules are enforced from runtime signals rather than prompt text.
+
+## Sequencing
+
+WS1 and WS3 unblock adoption and ship first (WS3's README cut is cheap and can
+land with WS1). WS2 lands next and feeds launch material. WS4–WS6 follow;
+none of them pay off while installation still requires cloning the repository.
+
+## Risks
+
+- False-positive fatigue: every workstream that adds detection must attach
+  precision data before enabling blocking defaults (WS4 floor applies globally).
+- Scope creep: WS6 L2 must hold a hard latency budget or it degrades the
+  core promise (fast hooks).
+- Windows remains smoke-contract only; WS1 packaging should not promise more
+  than CI verifies.

--- a/plan/README.md
+++ b/plan/README.md
@@ -13,7 +13,7 @@ Keep `plan/` as the workflow output directory. Historical or completed files sta
 | Active execution plan | Current multi-step work where remaining steps may still be actionable after checking linked issues and main branch | None currently |
 | Completed record | Historical execution evidence or implemented plan record; use for context, not new scope | `2026-05-01_18-56-41-vibeguard-audit-remediation.md`, `2026-06-05_22-28-rust-only-production-path.md`, `spec-96-prompt-contract-schema.md`, `spec-app-server-runtime-policy-gate.md`, `spec-codebase-audit-remediation.md`, `spec-posttool-malformed-input-fail-visible.md`, `spec-runtime-config-contract-clarity.md`, `spec-test-file-size-decomposition.md` |
 | Historical convergence plan | Older architecture plan; verify current code and newer specs before acting | `2026-04-19_00-15-39-main-architecture-convergence.md` |
-| Draft spec | Candidate work that needs issue and code-state verification before implementation | `full-english-localization-spec.md` |
+| Draft spec | Candidate work that needs issue and code-state verification before implementation | `full-english-localization-spec.md`, `2026-07-26-growth-and-architecture-roadmap.md` |
 | Snapshot or signal report | Evidence artifact for another plan or issue; do not implement directly without an owning spec | `w20-rust-only-production-path-snapshot.md`, `signal-report-legacy-vibeguard-mcp-cleanup.md` |
 
 ## File Status Index
@@ -23,6 +23,7 @@ Keep `plan/` as the workflow output directory. Historical or completed files sta
 | `2026-04-19_00-15-39-main-architecture-convergence.md` | Historical convergence plan | Use as architecture context only after checking current code and newer specs. |
 | `2026-05-01_18-56-41-vibeguard-audit-remediation.md` | Completed record | Use as audit evidence; do not reopen items without a new issue. |
 | `2026-06-05_22-28-rust-only-production-path.md` | Completed record | Use as implementation context for the Rust-only production path. |
+| `2026-07-26-growth-and-architecture-roadmap.md` | Draft spec | Verify workstream priority and open one GitHub issue per workstream before implementation. |
 | `full-english-localization-spec.md` | Draft spec | Verify current product priority and open a GitHub issue before implementation. |
 | `signal-report-legacy-vibeguard-mcp-cleanup.md` | Snapshot or signal report | Treat as evidence for another owner; do not implement directly. |
 | `spec-96-prompt-contract-schema.md` | Completed record | Use as prompt-contract history; current schema and tests are authoritative. |


### PR DESCRIPTION
## Summary

Adds a draft-spec roadmap capturing the strategy discussion on how to grow VibeGuard into the leading guardrail layer for AI coding agents. Six prioritized workstreams:

1. **WS1 — One-command install**: release binary becomes the distribution unit; repo clone no longer required.
2. **WS2 — Public effectiveness benchmark**: build on the paired with/without gate (GH686) to publish reproducible interception/FP/latency numbers.
3. **WS3 — Repositioning**: agent firewall narrative, host adapter seam, README first-screen cut.
4. **WS4 — Rule packs as an ecosystem**: published pack contract, precision-gated defaults.
5. **WS5 — Visible weekly value**: weekly report as default retention surface.
6. **WS6 — Tiered semantic defense**: L2 semantic checks + runtime-enforced W-rules.

Registered in `plan/README.md` as a draft spec; each workstream needs its own GitHub issue before implementation.

Docs-only change; no runtime/rule behavior touched.