### PR TITLE
spec(install): no-clone install — payload artifact + package-manager entry points (GH699)

### DIFF
--- a/docs/specs/GH699/product.md
+++ b/docs/specs/GH699/product.md
@@ -1,0 +1,60 @@
+# Product Spec — 免 clone 安装:发布产物成为唯一分发单元
+
+## Linked Issue
+
+GH-699
+
+complexity: large
+
+## 用户问题
+
+VibeGuard 当前唯一受支持的安装路径是 `git clone` 整个仓库 + `bash setup.sh`。
+运行时二进制已经从 release 下载并做 SHA-256 / attestation 校验,但 rules、
+hooks、guards、skills、templates 仍然从 git checkout 读取——**仓库本身就是安装
+介质**。对目标用户(Claude Code / Codex 用户,多数没有 Rust 工具链、也不想维护
+一份第三方 checkout)来说,这是最大的采纳门槛,也是增长 roadmap
+(`plan/2026-07-26-growth-and-architecture-roadmap.md`,WS1)判定的第一优先级。
+
+`docs/specs/install-friction-reduction.md`(2026-06-02)已经落地了它的 §3.1–§3.4
+(预编译二进制、校验、VERSION 锁定、调度器 opt-in);本 spec 承接它的 §3.5 遗留
+方向,但不做单二进制合并,而是把"安装所需的全部内容"打成一个带校验的发布产物。
+
+## 设计决策(需维护者确认)
+
+安全约束:`docs/specs/install-friction-reduction.md` §4 明确"下载路径不得把远端
+内容通过管道送进 shell"。因此 **curl | bash 一键脚本不在方案内**。选定路线是
+GH-699 评论中的方案 (a):
+
+- **包管理器作为免 clone 入口**:brew tap(macOS/Linux)与 npm 包(`bunx vibeguard`),
+  两者自带完整性模型(formula 内置 sha256 / npm 锁定 tarball 摘要)。
+- 包管理器安装的是一个薄启动器;真正的规则/hook 内容来自带 SHA-256 与
+  attestation 的 release payload 产物,复用现有校验语义。
+
+## 目标
+
+- G1:发布流水线额外产出一个 **payload 产物**(rules/hooks/guards/skills/
+  templates/schemas + 安装入口),进 `SHA256SUMS` 与 attestation,与运行时二进制
+  同 tag、同校验强度。
+- G2:`setup.sh` 支持 **payload 模式**:从解包后的 payload 目录运行时,行为与
+  git checkout 运行完全一致(profiles、languages、verify-install、doctor、clean)。
+- G3:brew formula 与 npm 包作为免 clone 入口,安装后一条命令完成部署并通过
+  `verify-install`。
+- G4:git checkout 路径保持完全兼容,降级为"开发/贡献者路径";文档相应改写。
+
+## 非目标
+
+- 不做 curl | bash 引导脚本(违反上游 spec §4 的供应链立场)。
+- 不做 Windows 原生包(hooks 依赖 bash;沿用现状 smoke-contract 级别支持)。
+- 不把 Python 可选组件(evals、docs 生成、语言 guard packs)打进 payload;它们
+  保持 checkout-only。
+- 不在本 spec 内做 Claude Code plugin marketplace 上架(依赖 payload 存在,单独
+  开 issue)。
+
+## Done-when
+
+- 一台全新 macOS/Linux 机器,不装 Rust、不 clone 仓库,通过 brew 或 bunx 一条
+  命令(加一次确认)完成安装,`verify-install` 退出码 0,新开 Claude Code /
+  Codex 会话后 hook 拦截真实生效。
+- 篡改 payload 或校验和使安装以校验错误终止,绝不静默降级。
+- 现有 clone + `setup.sh` 路径的全部 CI 门(行为评测、contract check、
+  self-application)在 payload 模式下有等价覆盖或被显式豁免并说明原因。

--- a/docs/specs/GH699/tasks.md
+++ b/docs/specs/GH699/tasks.md
@@ -1,0 +1,22 @@
+# Tasks — GH-699 免 clone 安装
+
+## Implementation Tasks
+
+- [ ] `SP699-T1` Owner: unassigned — payload manifest 与打包脚本:新增 `scripts/release/payload-manifest.txt` 与打包 step,产出 `vibeguard-payload-<version>.tar.gz` 并进 `SHA256SUMS` / attestation。 Done when: 本地以任意 tag 版本可复现打包,manifest 路径全部存在断言通过。 Verify: `bash scripts/local-contract-check.sh --quick`
+- [ ] `SP699-T2` Owner: unassigned — `setup.sh` payload 模式:运行根探测 + 两处白名单差异(无源码回退;checkout-only 子命令显式 not-applicable)。 Done when: 解包 payload 后 `bash setup.sh --yes` 与 `bash setup.sh verify-install` 行为与 checkout 一致。 Verify: `bash setup.sh verify-install`
+- [ ] `SP699-T3` Owner: unassigned — bootstrap 共享内核:在 `scripts/setup/` 下新增 `bootstrap.sh`(下载 payload、校验、原子切换 dist/current、exec setup)。 Done when: 篡改 payload 或校验和时以校验错误终止且不落盘安装。 Verify: `bash tests/test_setup.sh`
+- [ ] `SP699-T4` Owner: unassigned — release workflow 集成:payload 构建、VERSION==tag 断言、macOS+Ubuntu 免 clone smoke(下载产物→安装→verify-install)。 Done when: tag 演练 run 全绿且 release 页出现 payload 资产。 Verify: `gh run view <release-run>`
+- [ ] `SP699-T5` Owner: unassigned — brew tap:`majiayu000/homebrew-vibeguard` formula + release 自动 bump。 Done when: `brew install majiayu000/vibeguard/vibeguard && vibeguard --yes` 后 `verify-install` 退出码 0。 Verify: `bash setup.sh verify-install`
+- [ ] `SP699-T6` Owner: unassigned — npm 启动器:`vibeguard` 包,无 postinstall 副作用,`bunx vibeguard init` 走 bootstrap。 Done when: 干净机器 `bunx vibeguard init` 完成安装并通过 verify-install。 Verify: `bash setup.sh verify-install`
+- [ ] `SP699-T7` Owner: unassigned — 文档:README 安装节、`docs/how/quickstart.md`、`docs/how/team-rollout.md` 改写为免 clone 默认 + checkout 开发者路径。 Done when: 文档路径校验通过且首屏安装命令为包管理器入口。 Verify: `bash scripts/ci/validate-doc-paths.sh`
+
+## Verification
+
+- 免 clone AC:全新环境,brew 或 bunx 单命令安装,`verify-install` 退出 0,新会话 hook 拦截生效。
+- 供应链 AC:payload/校验和被篡改 → 安装终止;`--require-provenance` 在 attestation 不可用时 fail-closed。
+- 兼容 AC:checkout 路径全部现有 CI 门保持绿;payload 与 checkout 的 hook 内容 byte-identical(manifest+SHA 断言)。
+
+## Parallelization
+
+- SP699-T1 / SP699-T2 可并行(打包侧与安装侧接口是 manifest + 标记文件)。
+- SP699-T3 依赖 T1、T2;T4 依赖 T1–T3;T5 / T6 依赖 T4 后可并行;T7 最后。

--- a/docs/specs/GH699/tech.md
+++ b/docs/specs/GH699/tech.md
@@ -1,0 +1,111 @@
+# Tech Spec — 免 clone 安装:payload 产物 + 包管理器入口
+
+## Linked Issue
+
+GH-699
+
+## 现状(本会话核实)
+
+- `.github/workflows/release.yml` 在 tag push 时构建 4 个平台的
+  `vibeguard-runtime` 二进制,连同 `SHA256SUMS` 与 attestation 上传 release。
+- `scripts/setup/install.sh` 从 release 下载二进制并做 SHA-256 /
+  attestation 校验,失败时回退 cargo 源码构建;但 rules/hooks/guards/skills/
+  templates 全部以 `$REPO_ROOT`(即 git checkout)为源拷贝到
+  `~/.vibeguard/installed/`。
+- `vibeguard-runtime/VERSION` 是 release 版本的单一事实源(当前 `1.1.12`),CI
+  断言其与 tag 一致。
+- `setup.sh` 是安装/校验/清理的唯一入口,内部委托 `scripts/setup/` 下的模块。
+
+## 方案
+
+### 1. payload 产物(release 侧)
+
+`.github/workflows/release.yml` 新增一个 job step:把安装所需内容打成
+
+```
+vibeguard-payload-<version>.tar.gz
+```
+
+内容为 git archive 的一个白名单子集(单一来源清单文件,新增
+`scripts/release/payload-manifest.txt`):
+
+- `rules/` `hooks/` `guards/` `skills/` `templates/` `schemas/` `agents/`
+  `workflows/` `claude-md/` `context-profiles/` `packs/`
+- `setup.sh` + `scripts/setup/` + `scripts/doctors/` + `scripts/hook-health.sh`
+  + `scripts/project-init.sh` + 其余 setup 运行期依赖的脚本(以 manifest 为准,
+  CI 校验 manifest 中路径全部存在)
+- `vibeguard-runtime/VERSION`(payload 与二进制版本自洽的依据)
+- `LICENSE` `CHANGELOG.md`
+
+产物条目追加进现有 `SHA256SUMS`,并纳入现有 attestation 覆盖范围。排除测试、
+eval、docs、site、plan 等开发面——payload 是安装介质,不是仓库镜像。
+
+### 2. `setup.sh` payload 模式(安装侧)
+
+- `setup.sh` 启动时探测运行根:存在 `.git` → checkout 模式(现状不变);存在
+  payload 标记文件(打包时写入 `PAYLOAD_MANIFEST_SHA`)→ payload 模式。
+- payload 模式差异仅两点:
+  1. 跳过"未发布 main 回退 cargo 构建"分支——payload 永远对应一个已发布 tag,
+     二进制资产必然存在;下载失败即失败,不做源码回退。
+  2. `verify-dev-repo` 等仅对 checkout 有意义的子命令显式报
+     `not applicable in payload mode` 并退出非零,而不是误报 BROKEN。
+- 其余逻辑(profiles、languages、hook 部署、`verify-install`、doctor、clean)
+  不分叉,同一套代码跑两种根。**禁止**为 payload 模式复制一份并行安装逻辑。
+
+### 3. 免 clone 入口
+
+**bootstrap 子命令(共享内核)**
+
+在 `scripts/setup/` 下新增 bootstrap 脚本 `bootstrap.sh`(brew/npm 共用,不接受管道输入):
+
+1. 读取入口自带的 pinned version(brew formula / npm 包版本即 payload 版本);
+2. 下载 `vibeguard-payload-<version>.tar.gz` + `SHA256SUMS`(`gh` 优先,回退
+   `curl -fsSL`,与 `scripts/setup/install.sh` 现有下载器同源复用);
+3. SHA-256 校验失败即终止;可用时执行 attestation 校验,语义与现状一致
+   (`verified-provenance` / `checksum-only`);
+4. 解包到 `~/.vibeguard/dist/<version>/`,原子切换 `~/.vibeguard/dist/current`
+   符号链接;
+5. exec `~/.vibeguard/dist/current/setup.sh "$@"`(payload 模式)。
+
+**brew tap**
+
+- 新仓库 `majiayu000/homebrew-vibeguard`,formula 直接以 payload tarball 为
+  source(`url` + `sha256` 内置于 formula,brew 自身完成校验),安装出一个
+  `vibeguard` 命令 = bootstrap 的薄封装(此时步骤 2–3 已由 brew 完成,直接
+  4–5)。
+- formula 由 release workflow 在发 tag 时自动 bump(PR 到 tap 仓库)。
+
+**npm 包**
+
+- 包名 `vibeguard`,无 postinstall 副作用;`bunx vibeguard init` 显式触发
+  bootstrap 全流程。包内只有启动器脚本与 pinned version,不内嵌 payload。
+
+### 4. CI / 契约
+
+- release workflow 新增断言:payload 内 `vibeguard-runtime/VERSION` == tag;
+  manifest 中路径全部存在;payload 解包后 `bash setup.sh verify-install` 的
+  smoke 在 macOS + Ubuntu runner 上通过(不 clone,只用 release 产物)。
+- `scripts/local-contract-check.sh` 增加 payload manifest 存在性 + 标记文件
+  生成的确定性测试。
+- 行为评测门继续跑在 checkout 上(payload 是其子集,hook 内容 byte-identical,
+  由 manifest + SHA 断言保证,无需重复跑一遍)。
+
+## 安全
+
+- 沿用 `docs/specs/install-friction-reduction.md` §4:不管道执行远端内容;
+  payload 校验失败即终止,无未校验回退;attestation 语义(
+  `verified-provenance` / `checksum-only` / `--require-provenance` fail-closed)
+  原样适用于 payload 产物。
+- brew/npm 入口各自叠加其生态的完整性模型(formula sha256、npm tarball 摘要),
+  与 release 侧校验形成双层。
+- SEC-13:bootstrap 与 payload 模式不得静默改写 `~/.claude/settings.json` /
+  `AGENTS.md` 之外新增任何高上下文面;写入面与现有 `setup.sh` 完全一致。
+
+## 风险
+
+- payload 白名单漏文件 → 安装物残缺。缓解:manifest 单一事实源 + release
+  smoke(AC 里必须真装真验)。
+- brew tap 自动 bump 依赖跨仓库 token。缓解:tap PR 用 fine-grained token,
+  失败只影响 brew 渠道,不阻塞 release 本体。
+- 双模式漂移(checkout 与 payload 行为分叉)。缓解:同一 `setup.sh` 代码路径 +
+  差异点白名单化(仅上述两处),新增差异需改本 spec。


### PR DESCRIPTION
Refs #699. Spec packet `docs/specs/GH699/{product,tech,tasks}.md` for WS1 of the growth roadmap (`plan/2026-07-26-growth-and-architecture-roadmap.md`).

## Key decisions proposed
- **No curl|bash**: keeps the supply-chain stance from `docs/specs/install-friction-reduction.md` §4. No-clone entry points are brew tap + npm launcher (option (a) from the issue thread) on top of a checksummed/attested release payload artifact.
- **Payload artifact**: `vibeguard-payload-<version>.tar.gz` — whitelist manifest of rules/hooks/guards/skills/templates/schemas + setup entry, added to existing `SHA256SUMS` + attestation.
- **Single code path**: `setup.sh` gains a payload-mode root detection with exactly two whitelisted behavior differences (no cargo fallback; checkout-only subcommands report not-applicable). No parallel install logic.
- 7 implementation tasks (SP699-T1..T7) with dependencies and parallelization lanes.

## Verification
- `python3 checks/check_workflow.py --repo . --all-specs` — SpecRail check passed
- `bash scripts/ci/validate-doc-paths.sh` — 174 files OK
- `bash scripts/ci/validate-doc-command-paths.sh` — 126 command paths OK

Spec-only; no runtime behavior touched. Implementation starts after this packet is approved and #699 is promoted to ready_to_implement.