### PR TITLE
fix(specrail): make packet gate stage-aware

### DIFF
--- a/.github/workflows/workflow-check.yml
+++ b/.github/workflows/workflow-check.yml
@@ -21,6 +21,10 @@ jobs:
     name: SpecRail workflow check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      PR_IS_DRAFT: ${{ github.event.pull_request.draft || false }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -33,10 +37,6 @@ jobs:
           python-version: "3.11"
 
       - name: Check SpecRail pack and spec packets
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_IS_DRAFT: ${{ github.event.pull_request.draft || false }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
           check_args=(--repo . --all-specs --spec-stage complete)
           if [[ "${EVENT_NAME}" == "pull_request" && "${PR_IS_DRAFT}" == "true" ]]; then

--- a/.github/workflows/workflow-check.yml
+++ b/.github/workflows/workflow-check.yml
@@ -3,6 +3,12 @@ name: specrail-workflow-check
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
   push:
     branches:
       - main
@@ -27,7 +33,16 @@ jobs:
           python-version: "3.11"
 
       - name: Check SpecRail pack and spec packets
-        run: python3 checks/check_workflow.py --repo . --all-specs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_IS_DRAFT: ${{ github.event.pull_request.draft || false }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          check_args=(--repo . --all-specs --spec-stage complete)
+          if [[ "${EVENT_NAME}" == "pull_request" && "${PR_IS_DRAFT}" == "true" ]]; then
+            check_args=(--repo . --all-specs --spec-stage draft --base-ref "${BASE_SHA}")
+          fi
+          python3 checks/check_workflow.py "${check_args[@]}"
 
       - name: Run SpecRail adoption smoke tests
         run: bash tests/test_specrail_adoption.sh

--- a/AGENT_USAGE.md
+++ b/AGENT_USAGE.md
@@ -136,11 +136,28 @@ python3 checks/check_workflow.py --repo .
 python3 checks/check_workflow.py --repo . --all-specs
 ```
 
+The default packet stage is `complete`, which requires `product.md`, `tech.md`,
+and `tasks.md`. While a spec PR is still a GitHub Draft, validate its
+product/tech-only packet explicitly:
+
+```sh
+python3 checks/check_workflow.py \
+  --repo . \
+  --spec-dir docs/specs/GH<issue-number> \
+  --spec-stage draft
+```
+
+Draft mode still validates `tasks.md` when it exists. In CI, pass the PR base
+commit with `--base-ref`; the validator then rejects deletion of a `tasks.md`
+that already exists in the baseline. Ready PRs and `main` keep the default
+complete-stage requirement.
+
 `--all-specs` discovers packets from `workflow.yaml`'s
 `artifacts.spec_packet` template. The issue evidence adapter and route gate
 render their spec paths from the same artifact configuration. For a single
-packet, run the exact configured command returned by `route_gate.py` in
-`verification_commands`.
+packet, run the exact stage-specific configured command returned by
+`route_gate.py` in `verification_commands`: `write_spec` returns Draft
+validation, while implementation and later routes return Complete validation.
 
 9. Before reporting a PR as merge-ready, collect PR evidence and run:
 

--- a/checks/check_workflow.py
+++ b/checks/check_workflow.py
@@ -271,18 +271,21 @@ def git_path_exists(repo: Path, commit: str, path: Path) -> bool:
             "ls-tree",
             "-r",
             "--name-only",
+            "-z",
             commit,
             "--",
             relative_path.as_posix(),
         ],
         check=False,
         capture_output=True,
-        text=True,
     )
     if result.returncode != 0:
-        detail = result.stderr.strip() or "unknown git ls-tree failure"
+        detail = (
+            result.stderr.decode("utf-8", errors="replace").strip()
+            or "unknown git ls-tree failure"
+        )
         raise SpecRailError(f"cannot inspect baseline {commit}: {detail}")
-    return relative_path.as_posix() in result.stdout.splitlines()
+    return relative_path.as_posix().encode("utf-8") in result.stdout.split(b"\0")
 
 
 def validate_spec_packet(
@@ -340,15 +343,15 @@ def validate_spec_packet(
 
     task_path = spec_dir / "tasks.md"
     if not task_path.is_file():
-        baseline_requires_tasks = (
-            spec_stage == "draft"
-            and repo is not None
+        if task_path.exists() or task_path.is_symlink():
+            errors.append(f"{task_path}: tasks.md must be a regular file")
+        elif spec_stage == "complete":
+            errors.append(f"{spec_dir}: missing tasks.md")
+        elif (
+            repo is not None
             and base_commit is not None
             and git_path_exists(repo, base_commit, task_path)
-        )
-        if spec_stage == "complete":
-            errors.append(f"{spec_dir}: missing tasks.md")
-        elif baseline_requires_tasks:
+        ):
             errors.append(
                 f"{spec_dir}: draft validation cannot remove tasks.md "
                 f"present in baseline {base_commit}"
@@ -444,25 +447,30 @@ def discover_baseline_spec_packet_dirs(
             "-r",
             "-d",
             "--name-only",
+            "-z",
             commit,
             "--",
             spec_root.as_posix(),
         ],
         check=False,
         capture_output=True,
-        text=True,
     )
     if result.returncode != 0:
-        detail = result.stderr.strip() or "unknown git ls-tree failure"
+        detail = (
+            result.stderr.decode("utf-8", errors="replace").strip()
+            or "unknown git ls-tree failure"
+        )
         raise SpecRailError(f"cannot inspect baseline {commit}: {detail}")
 
     packet_pattern = re.compile(
-        rf"{re.escape(spec_root.as_posix())}/GH[0-9]+"
+        re.escape(spec_root.as_posix().encode("utf-8")) + rb"/GH[0-9]+"
     )
     return sorted(
         (
-            repo / PurePosixPath(raw_path)
-            for raw_path in result.stdout.splitlines()
+            repo
+            / spec_root
+            / raw_path.rsplit(b"/", 1)[-1].decode("ascii")
+            for raw_path in result.stdout.split(b"\0")
             if packet_pattern.fullmatch(raw_path)
         ),
         key=spec_packet_sort_key,

--- a/checks/check_workflow.py
+++ b/checks/check_workflow.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import re
+import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
@@ -75,6 +76,7 @@ REQUIRED_FILE_GLOBS = [
 ]
 
 VALID_AUTH_MODES = ("auto", "review")
+VALID_SPEC_STAGES = ("complete", "draft")
 
 REQUIRED_TOKENS = {
     "workflow.yaml": [
@@ -243,8 +245,59 @@ def validate_auth_mode(config: object) -> list[str]:
     return errors
 
 
-def validate_spec_packet(spec_dir: Path) -> list[str]:
+def git_commit(repo: Path, ref: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    commit = result.stdout.strip()
+    if result.returncode != 0 or not re.fullmatch(r"[0-9a-fA-F]{40,64}", commit):
+        raise SpecRailError(f"invalid --base-ref commit: {ref}")
+    return commit
+
+
+def git_path_exists(repo: Path, commit: str, path: Path) -> bool:
+    try:
+        relative_path = path.relative_to(repo)
+    except ValueError as exc:
+        raise SpecRailError(f"baseline path escapes repository: {path}") from exc
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "ls-tree",
+            "-r",
+            "--name-only",
+            commit,
+            "--",
+            relative_path.as_posix(),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "unknown git ls-tree failure"
+        raise SpecRailError(f"cannot inspect baseline {commit}: {detail}")
+    return relative_path.as_posix() in result.stdout.splitlines()
+
+
+def validate_spec_packet(
+    spec_dir: Path,
+    *,
+    spec_stage: str = "complete",
+    repo: Path | None = None,
+    base_commit: str | None = None,
+) -> list[str]:
     errors: list[str] = []
+    if spec_stage not in VALID_SPEC_STAGES:
+        raise SpecRailError(
+            f"invalid spec stage {spec_stage!r}; expected one of "
+            + ", ".join(VALID_SPEC_STAGES)
+        )
     if not spec_dir.exists():
         return [f"spec packet does not exist: {spec_dir}"]
     if not spec_dir.is_dir():
@@ -287,7 +340,19 @@ def validate_spec_packet(spec_dir: Path) -> list[str]:
 
     task_path = spec_dir / "tasks.md"
     if not task_path.is_file():
-        errors.append(f"{spec_dir}: missing tasks.md")
+        baseline_requires_tasks = (
+            spec_stage == "draft"
+            and repo is not None
+            and base_commit is not None
+            and git_path_exists(repo, base_commit, task_path)
+        )
+        if spec_stage == "complete":
+            errors.append(f"{spec_dir}: missing tasks.md")
+        elif baseline_requires_tasks:
+            errors.append(
+                f"{spec_dir}: draft validation cannot remove tasks.md "
+                f"present in baseline {base_commit}"
+            )
     else:
         resolved_task_path = resolve_path(
             task_path,
@@ -365,18 +430,66 @@ def discover_spec_packet_dirs(
     return sorted(spec_dirs, key=spec_packet_sort_key)
 
 
+def discover_baseline_spec_packet_dirs(
+    repo: Path,
+    commit: str,
+    spec_root: PurePosixPath,
+) -> list[Path]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "ls-tree",
+            "-r",
+            "-d",
+            "--name-only",
+            commit,
+            "--",
+            spec_root.as_posix(),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "unknown git ls-tree failure"
+        raise SpecRailError(f"cannot inspect baseline {commit}: {detail}")
+
+    packet_pattern = re.compile(
+        rf"{re.escape(spec_root.as_posix())}/GH[0-9]+"
+    )
+    return sorted(
+        (
+            repo / PurePosixPath(raw_path)
+            for raw_path in result.stdout.splitlines()
+            if packet_pattern.fullmatch(raw_path)
+        ),
+        key=spec_packet_sort_key,
+    )
+
+
 def select_spec_packet_dirs(
     repo: Path,
     raw_spec_dirs: list[str],
     *,
     all_specs: bool,
     spec_root: PurePosixPath | None = None,
+    base_commit: str | None = None,
 ) -> list[Path]:
     spec_dirs: list[Path] = []
     configured_root = spec_root if spec_root is not None else PurePosixPath("specs")
     resolved_root = resolve_spec_packet_root(repo, configured_root)
     if all_specs:
         spec_dirs.extend(discover_spec_packet_dirs(repo, configured_root))
+        if base_commit is not None:
+            spec_dirs.extend(
+                discover_baseline_spec_packet_dirs(
+                    repo,
+                    base_commit,
+                    configured_root,
+                )
+            )
     for raw_spec_dir in raw_spec_dirs:
         resolved_spec_dir = resolve_repo_path(
             repo,
@@ -453,6 +566,22 @@ def main() -> int:
         action="store_true",
         help="Validate every configured GH<number> spec packet under the repo",
     )
+    parser.add_argument(
+        "--spec-stage",
+        choices=VALID_SPEC_STAGES,
+        default="complete",
+        help=(
+            "Spec packet stage: complete requires tasks.md; draft allows it to "
+            "be absent but validates it when present"
+        ),
+    )
+    parser.add_argument(
+        "--base-ref",
+        help=(
+            "Optional Git baseline used in draft mode to reject removal of an "
+            "existing tasks.md"
+        ),
+    )
     args = parser.parse_args()
 
     errors: list[str] = []
@@ -464,6 +593,7 @@ def main() -> int:
             configured_spec_paths["spec_packet"]
         ).parent
         validate_spec_packet_root(repo, configured_spec_root)
+        base_commit = git_commit(repo, args.base_ref) if args.base_ref else None
         errors.extend(validate_required_files(repo))
         errors.extend(validate_required_file_globs(repo))
         errors.extend(validate_tokens(repo))
@@ -479,8 +609,16 @@ def main() -> int:
             args.spec_dir,
             all_specs=args.all_specs,
             spec_root=configured_spec_root,
+            base_commit=base_commit,
         ):
-            errors.extend(validate_spec_packet(spec_dir))
+            errors.extend(
+                validate_spec_packet(
+                    spec_dir,
+                    spec_stage=args.spec_stage,
+                    repo=repo,
+                    base_commit=base_commit,
+                )
+            )
     except SpecRailError as exc:
         errors.append(str(exc))
 

--- a/checks/route_gate.py
+++ b/checks/route_gate.py
@@ -369,9 +369,12 @@ def evaluate_route(args: argparse.Namespace) -> dict[str, Any]:
     verification_commands = ["python3 checks/check_workflow.py --repo ."]
     if args.issue:
         spec_dir = spec_packet_artifact_paths(config, args.issue, repo=repo)["spec_packet"]
+        spec_stage = "draft" if route == "write_spec" else "complete"
         verification_commands.append(
             "python3 checks/check_workflow.py --repo . --spec-dir="
             + shlex.quote(spec_dir)
+            + " --spec-stage="
+            + spec_stage
         )
 
     return {

--- a/docs/specs/GH720/product.md
+++ b/docs/specs/GH720/product.md
@@ -1,0 +1,84 @@
+# Product Spec — Draft 与 Complete 分阶段校验 SpecRail packet
+
+## Linked Issue
+
+GH-720
+
+complexity: medium
+
+## 用户问题
+
+SpecRail 当前把所有 spec packet 都当作已进入实现阶段：即使 PR 仍是 Draft，
+也强制要求 `tasks.md`。因此只包含已完成产品与技术设计、尚待形成任务计划的
+Draft spec PR 会必然红灯。维护者无法通过 PR 状态表达“设计可评审但尚不可实现”，
+已有的五个 Draft spec PR 也被同一条非阶段化检查阻断。
+
+## 目标
+
+- 让 Draft PR 能以 product + tech 的设计阶段 packet 进入评审。
+- 保持 Ready PR、`main` 和本地默认检查对完整三件套的强制要求。
+- 防止通过删除已有 `tasks.md` 或整个已有 packet 将 Complete 工作降级为 Draft。
+- 让 route gate 返回与工作阶段一致、可直接执行的验证命令。
+
+## 非目标
+
+- 不改变 readiness label、duplicate-work、PR、review、runtime ledger 或 merge gate。
+- 不批准任何具体 spec，也不改变持久化的 `automation_policy.auth_mode: review`。
+- 不为 Draft 放宽 `product.md`、`tech.md` 或已存在 `tasks.md` 的内容校验。
+- 不改变 `docs/specs/GH<number>/` 的公开路径。
+
+## Behavior Invariants
+
+1. B-001 未显式选择阶段时，packet 校验必须使用 `complete`；每个被选中的
+   `GH<number>` packet 都必须存在 `product.md`、`tech.md` 和有效的
+   `tasks.md`，缺少任一项即失败。
+2. B-002 显式选择 `draft` 时，每个新建 packet 必须存在且校验
+   `product.md` 与 `tech.md`；仅当当前和基线都没有 `tasks.md` 时，
+   `tasks.md` 才可缺省。
+3. B-003 Draft packet 一旦包含 `tasks.md`，必须执行与 Complete 相同的任务
+   计划结构校验；文件存在但为空、格式非法或 issue 关联错误均不得视为成功。
+4. B-004 提供有效 `base-ref` 时，`--all-specs` 必须校验当前工作树和基线中
+   `GH<number>` packet 的并集；基线已有 packet、当前整体删除时必须失败。
+5. B-005 基线 packet 已有 `tasks.md`、当前仅删除该文件时，Draft 校验必须失败，
+   不得把删除解释为合法的设计阶段。
+6. B-006 无法解析 `base-ref`、无法查询基线树或 packet 路径逃逸配置根时，
+   校验必须 fail-closed，并返回非零退出码及可定位错误。
+7. B-007 GitHub workflow 只能在 Draft pull request 上选择 `draft` 并传入
+   PR base SHA；Ready pull request、push、手工触发均必须选择 `complete`。
+8. B-008 pull request 在 Draft 与 Ready 之间切换时必须重新执行 workflow，
+   避免复用旧阶段的检查结果。
+9. B-009 `write_spec` route 必须返回单 packet 的 Draft 验证命令；
+   `implement` 及后续 route 必须返回 Complete 验证命令。
+10. B-010 阶段选择只改变 `tasks.md` 的阶段性必需性；现有 pack asset、状态图、
+    label、授权模式、skill lock 与 packet 内容检查必须继续执行。
+
+## 验收标准
+
+- [ ] product + tech-only 的新 Draft packet 校验通过。
+- [ ] 同一 packet 在 Complete 阶段缺少 `tasks.md` 时校验失败。
+- [ ] Draft 中存在但非法的 `tasks.md` 校验失败。
+- [ ] 删除基线 `tasks.md` 或整个基线 packet 时 `--all-specs` 校验失败。
+- [ ] 无效基线引用 fail-closed。
+- [ ] Draft/Ready 状态切换与 route 输出均有回归覆盖。
+- [ ] SpecRail adoption、workflow contract 与 broad local contract checks 通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001, B-002, B-003 |
+| 错误与失败路径 | covered: B-006 |
+| 授权/权限 | covered: B-007；阶段选择不得改变授权 gate |
+| 并发/竞态 | covered: B-007, B-008；每个事件使用自身 base/head 状态 |
+| 重试/幂等 | covered: B-008；相同树与相同阶段重复检查结果一致 |
+| 非法状态转换 | covered: B-004, B-005, B-008 |
+| 兼容/迁移 | covered: B-001, B-010 |
+| 降级/回退 | covered: B-004, B-005, B-006 |
+| 证据与审计完整性 | covered: B-004, B-006, B-007 |
+| 取消/中断 | N/A：离线校验无持久化中间状态，可从头安全重跑 |
+
+## 发布说明
+
+这是 CI/workflow 合同变更，无用户数据迁移。回滚会重新造成 Draft spec PR
+必然红灯；若需回滚，必须同时恢复旧 workflow 调用和 CLI/route 文档，不能只
+移除一侧。

--- a/docs/specs/GH720/product.md
+++ b/docs/specs/GH720/product.md
@@ -36,15 +36,18 @@ Draft spec PR 会必然红灯。维护者无法通过 PR 状态表达“设计�
    `product.md` 与 `tech.md`；仅当当前和基线都没有 `tasks.md` 时，
    `tasks.md` 才可缺省。
 3. B-003 Draft packet 一旦包含 `tasks.md`，必须执行与 Complete 相同的任务
-   计划结构校验；文件存在但为空、格式非法或 issue 关联错误均不得视为成功。
+   计划结构校验；路径是目录、悬空链接或其他非普通文件，或文件为空、格式非法、
+   issue 关联错误时，均不得视为成功。
 4. B-004 提供有效 `base-ref` 时，`--all-specs` 必须校验当前工作树和基线中
    `GH<number>` packet 的并集；基线已有 packet、当前整体删除时必须失败。
 5. B-005 基线 packet 已有 `tasks.md`、当前仅删除该文件时，Draft 校验必须失败，
    不得把删除解释为合法的设计阶段。
 6. B-006 无法解析 `base-ref`、无法查询基线树或 packet 路径逃逸配置根时，
-   校验必须 fail-closed，并返回非零退出码及可定位错误。
-7. B-007 GitHub workflow 只能在 Draft pull request 上选择 `draft` 并传入
-   PR base SHA；Ready pull request、push、手工触发均必须选择 `complete`。
+   校验必须 fail-closed，并返回非零退出码及可定位错误；合法非 ASCII 配置根
+   必须按 Git 原始路径识别，不能因 quoting 丢失基线证据。
+7. B-007 GitHub workflow 中所有 checkout-wide packet 检查（包括 adoption
+   smoke 内部检查）只能在 Draft pull request 上选择 `draft` 并传入 PR base
+   SHA；Ready pull request、push、手工触发均必须选择 `complete`。
 8. B-008 pull request 在 Draft 与 Ready 之间切换时必须重新执行 workflow，
    避免复用旧阶段的检查结果。
 9. B-009 `write_spec` route 必须返回单 packet 的 Draft 验证命令；

--- a/docs/specs/GH720/tasks.md
+++ b/docs/specs/GH720/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan — GH-720 SpecRail packet 阶段化
+
+## Linked Issue
+
+GH-720
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP720-T1` 增加 CLI stage、Draft/Complete packet 规则、fail-closed base-ref 解析及当前/基线 packet 并集。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-010. Owner: root coordinator. Dependencies: none. Done when: 新 Draft 可无 tasks，通过删除 tasks 或整个基线 packet 均失败，默认 Complete 不变。Verify: `bash tests/test_specrail_adoption.sh && python3 checks/check_workflow.py --repo . --all-specs`
+- [x] `SP720-T2` 让 GitHub workflow 按 PR Draft 状态选择 stage，并覆盖 Draft/Ready 转换事件。Covers: B-007, B-008. Owner: root coordinator. Dependencies: SP720-T1. Done when: Draft 使用 base SHA 和 Draft stage，其余事件使用 Complete，状态切换触发新 run。Verify: `bash tests/test_specrail_adoption.sh && bash tests/test_workflow_contracts.sh`
+- [x] `SP720-T3` 更新 route 输出和使用合同，保持其他 gate 与默认授权不变。Covers: B-009, B-010. Owner: root coordinator. Dependencies: SP720-T1. Done when: write_spec 输出 Draft 命令、implement 输出 Complete 命令，adoption pin 与 auth_mode 未改变。Verify: `bash tests/test_specrail_adoption.sh && bash scripts/local-contract-check.sh --quick`
+- [ ] `SP720-T4` 完成独立审查、PR CI 与离线 PR gate，修复所有阻断项后才允许合并。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010. Owner: independent reviewer + root coordinator. Dependencies: SP720-T1, SP720-T2, SP720-T3. Done when: 当前 head 的独立审查无阻断、review threads 为零、CI 全绿、`checks/pr_gate.py` allowed。Verify: `python3 checks/github_pr_evidence.py --github-repo majiayu000/vibeguard --pr <pr-number> --issue 720 --review-source independent_lane --json`
+
+## 并行拆分
+
+- 实现文件由 root coordinator 独占。
+- 独立 reviewer 为只读 lane，不拥有可写文件。
+- 后续队列诊断 lane 只读，不接触本任务分支。
+
+## 验证
+
+- `bash tests/test_specrail_adoption.sh`
+- `python3 checks/check_workflow.py --repo . --all-specs`
+- `bash tests/test_workflow_contracts.sh`
+- `bash scripts/ci/validate-workflow-contracts.sh`
+- `bash scripts/ci/validate-doc-paths.sh`
+- `bash scripts/ci/validate-doc-command-paths.sh`
+- `bash scripts/local-contract-check.sh --quick`
+- Fresh PR CI + review-thread evidence + offline PR gate
+
+## Handoff Notes
+
+- `implx auto` 仅是本次 transient authorization；不得修改持久化
+  `automation_policy.auth_mode: review`。
+- 禁止 force push、release 或绕过失败 gate。
+- 独立审查已发现并阻断过“删除整个基线 packet”绕过；该失败历史必须保留在
+  本轮证据中，修复后需用当前 head 重新审查。

--- a/docs/specs/GH720/tech.md
+++ b/docs/specs/GH720/tech.md
@@ -1,0 +1,88 @@
+# Tech Spec — SpecRail packet 阶段化与基线防降级
+
+## Linked Issue
+
+GH-720
+
+## Product Spec
+
+见 `product.md`。
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| CLI 与 packet 校验 | `checks/check_workflow.py:248`、`checks/check_workflow.py:288` | 解析 git commit、检查基线文件并校验单 packet | 阶段语义与 fail-closed 基线查询的核心 |
+| packet 发现 | `checks/check_workflow.py:395`、`checks/check_workflow.py:433` | 从配置根发现当前工作树 packet，并选择待校验集合 | 必须把基线 packet 纳入 `--all-specs` 并集，防止整目录删除绕过 |
+| route 输出 | `checks/route_gate.py:369` | 返回 route 对应的确定性验证命令 | `write_spec` 与实现阶段需要不同 stage |
+| GitHub workflow | `.github/workflows/workflow-check.yml:3`、`.github/workflows/workflow-check.yml:35` | PR/push 调用完整 packet 检查 | 依据 Draft 状态选择 stage，并在状态切换时重跑 |
+| 回归覆盖 | `tests/test_specrail_adoption.sh:61`、`tests/test_specrail_adoption.sh:210` | 校验 adopted workflow 与临时 packet 行为 | 覆盖正例、缺文件、非法任务、单文件删除、整 packet 删除和 route 命令 |
+| 使用合同 | `AGENT_USAGE.md:132` | 说明本地 workflow/route 验证 | 需要公开 Draft 与 Complete 的精确用法 |
+
+## 设计方案
+
+1. 在 `checks/check_workflow.py` 增加闭集参数
+   `--spec-stage {complete,draft}`，默认 `complete`。
+2. `validate_spec_packet()` 始终校验 product/tech；Complete 强制
+   `tasks.md`，Draft 在文件存在时仍调用原任务计划校验器。
+3. `--base-ref` 先由 `git rev-parse --verify <ref>^{commit}` 解析为确定 commit。
+   所有 git 调用使用参数数组，不经过 shell。
+4. Draft + base commit 时：
+   - 单 packet 校验用 `git ls-tree` 判断基线是否已有 `tasks.md`；
+   - `--all-specs` 额外枚举基线配置根下的直接 `GH<number>` 目录；
+   - 当前与基线 packet 做去重并集后交给同一验证函数。
+5. GitHub Actions 对 Draft PR 传 `draft + base SHA`；其余事件显式使用
+   `complete`。监听 `ready_for_review` 和 `converted_to_draft`。
+6. `route_gate.py` 仅对 `write_spec` 输出 Draft 命令，其余 route 输出
+   Complete 命令。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `check_workflow.py` 默认 stage 与 Complete 分支 | `python3 checks/check_workflow.py --repo . --all-specs`；临时缺 tasks 负例 |
+| B-002 | `validate_spec_packet()` Draft 分支 | `bash tests/test_specrail_adoption.sh` 的 product+tech-only 正例 |
+| B-003 | 复用 `validate_task_plan()` | 同一 smoke test 的非法 `tasks.md` 负例 |
+| B-004 | `discover_baseline_spec_packet_dirs()` 与选择并集 | 同一 smoke test 删除完整 `GH999` 的 `--all-specs` 负例 |
+| B-005 | `git_path_exists()` | 同一 smoke test 删除基线 `tasks.md` 负例 |
+| B-006 | `git_commit()`、`git_path_exists()`、基线目录发现 | `python3 checks/check_workflow.py --repo . --all-specs --spec-stage draft --base-ref refs/does-not-exist` 返回非零 |
+| B-007 | `.github/workflows/workflow-check.yml` stage 分支 | `bash tests/test_specrail_adoption.sh` 静态合同 + GitHub PR CI |
+| B-008 | workflow `pull_request.types` | `bash tests/test_specrail_adoption.sh` 检查两个状态事件 token |
+| B-009 | `checks/route_gate.py` | `bash tests/test_specrail_adoption.sh` 的 write_spec/implement route 断言 |
+| B-010 | 原有 validator 调用链 | `bash scripts/local-contract-check.sh --quick` |
+
+## 数据流
+
+输入来自 CLI stage、可选 base ref、配置的 packet 根及当前文件树。base ref
+先归一化为 commit，再由只读 git 查询产生基线 packet/文件存在性。当前 packet
+与基线 packet 去重排序后逐一验证，所有错误聚合为非零退出。GitHub workflow
+只负责从事件状态构造参数，不持久化新的状态。
+
+## 备选方案
+
+- 让所有 Draft PR 预先创建空 `tasks.md`：会伪造实现成熟度，并且空任务计划本身
+  不具备可验证价值。
+- 完全跳过 Draft 的 SpecRail check：会同时跳过 product/tech 和非法已有
+  `tasks.md` 的校验。
+- 只检查当前工作树中的 `tasks.md`：无法识别单文件或整个 packet 的删除降级。
+
+## 风险
+
+- Security: git ref 与路径只通过参数数组传递；配置根逃逸继续由 resolver 阻断。
+- Compatibility: 默认保持 Complete，现有本地调用不改变。
+- Performance: 仅 Draft CI 增加有界的本地 `git ls-tree` 查询，无网络调用。
+- Maintenance: stage 枚举为闭集；新增阶段必须显式扩展 CLI、workflow 与测试。
+
+## 测试计划
+
+- [ ] Unit/focused: `bash tests/test_specrail_adoption.sh`
+- [ ] Packet: `python3 checks/check_workflow.py --repo . --all-specs`
+- [ ] Workflow contracts: `bash tests/test_workflow_contracts.sh`
+- [ ] Broad local: `bash scripts/local-contract-check.sh --quick`
+- [ ] PR evidence: GitHub CI、独立 reviewer 与 `checks/pr_gate.py`
+
+## 回滚方案
+
+同一回滚中恢复 workflow 的旧调用、移除 stage/base-ref CLI 与 route 文档，并
+恢复对应测试。不得只回滚 workflow 而留下无人调用的宽松 Draft 路径，也不得
+保留 Draft workflow 却移除基线防降级检查。

--- a/docs/specs/GH720/tech.md
+++ b/docs/specs/GH720/tech.md
@@ -31,8 +31,9 @@ GH-720
    - 单 packet 校验用 `git ls-tree` 判断基线是否已有 `tasks.md`；
    - `--all-specs` 额外枚举基线配置根下的直接 `GH<number>` 目录；
    - 当前与基线 packet 做去重并集后交给同一验证函数。
-5. GitHub Actions 对 Draft PR 传 `draft + base SHA`；其余事件显式使用
-   `complete`。监听 `ready_for_review` 和 `converted_to_draft`。
+5. GitHub Actions 在 job 级共享事件类型、Draft 状态和 base SHA；主 packet
+   check 与 adoption smoke 内的 checkout-wide check 都据此选择同一阶段。
+   监听 `ready_for_review` 和 `converted_to_draft`。
 6. `route_gate.py` 仅对 `write_spec` 输出 Draft 命令，其余 route 输出
    Complete 命令。
 
@@ -42,11 +43,11 @@ GH-720
 | --- | --- | --- |
 | B-001 | `check_workflow.py` 默认 stage 与 Complete 分支 | `python3 checks/check_workflow.py --repo . --all-specs`；临时缺 tasks 负例 |
 | B-002 | `validate_spec_packet()` Draft 分支 | `bash tests/test_specrail_adoption.sh` 的 product+tech-only 正例 |
-| B-003 | 复用 `validate_task_plan()` | 同一 smoke test 的非法 `tasks.md` 负例 |
+| B-003 | 非普通路径检查 + 复用 `validate_task_plan()` | 同一 smoke test 的 `tasks.md` 目录与非法内容负例 |
 | B-004 | `discover_baseline_spec_packet_dirs()` 与选择并集 | 同一 smoke test 删除完整 `GH999` 的 `--all-specs` 负例 |
 | B-005 | `git_path_exists()` | 同一 smoke test 删除基线 `tasks.md` 负例 |
-| B-006 | `git_commit()`、`git_path_exists()`、基线目录发现 | `python3 checks/check_workflow.py --repo . --all-specs --spec-stage draft --base-ref refs/does-not-exist` 返回非零 |
-| B-007 | `.github/workflows/workflow-check.yml` stage 分支 | `bash tests/test_specrail_adoption.sh` 静态合同 + GitHub PR CI |
+| B-006 | `git_commit()`、NUL-delimited `git_path_exists()` 与基线目录发现 | smoke 中的非 ASCII git 基线路径正例；无效 base-ref 命令返回非零 |
+| B-007 | workflow job env + adoption smoke 的 stage 分支 | product+tech-only 临时 packet 下用 Draft env 运行 `bash tests/test_specrail_adoption.sh` |
 | B-008 | workflow `pull_request.types` | `bash tests/test_specrail_adoption.sh` 检查两个状态事件 token |
 | B-009 | `checks/route_gate.py` | `bash tests/test_specrail_adoption.sh` 的 write_spec/implement route 断言 |
 | B-010 | 原有 validator 调用链 | `bash scripts/local-contract-check.sh --quick` |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,6 +6,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 
 | Spec | Status | Use it for |
 |---|---|---|
+| `GH720/` | Implemented reference | Stage-aware Draft versus Complete packet validation with baseline anti-downgrade checks |
 | `GH699/` | Draft | Clone-free installation through verified release payloads and Homebrew/npm entry points |
 | `GH706/` | Draft | Privacy-safe malformed-input diagnostics and shared protocol-error versus rule-interception block counts |
 | `GH686/` | Implemented reference | Paired with/without evaluation for prompt-injected rule target improvement and non-target regression evidence (#686 / PR #696) |

--- a/tests/test_specrail_adoption.sh
+++ b/tests/test_specrail_adoption.sh
@@ -110,7 +110,12 @@ tmp = Path(sys.argv[2]).resolve()
 sys.path.insert(0, str(repo / "checks"))
 
 import check_workflow
-from check_workflow import discover_spec_packet_dirs, validate_pack_assets
+from check_workflow import (
+    discover_baseline_spec_packet_dirs,
+    discover_spec_packet_dirs,
+    git_path_exists,
+    validate_pack_assets,
+)
 import github_review_threads
 from github_evidence_common import EvidenceError
 from pr_gate import evaluate_pr_gate
@@ -235,6 +240,47 @@ if draft_result.returncode != 0:
         f"{draft_result.stdout + draft_result.stderr}"
     )
 
+task_path = draft_packet / "tasks.md"
+task_path.mkdir()
+malformed_task_result = subprocess.run(
+    draft_command,
+    check=False,
+    capture_output=True,
+    text=True,
+)
+malformed_task_output = (
+    malformed_task_result.stdout + malformed_task_result.stderr
+)
+if (
+    malformed_task_result.returncode == 0
+    or "tasks.md must be a regular file" not in malformed_task_output
+):
+    raise SystemExit(
+        "draft validation accepted a non-file tasks.md path: "
+        f"rc={malformed_task_result.returncode}, output={malformed_task_output!r}"
+    )
+task_path.rmdir()
+
+task_path.symlink_to("missing-task-plan.md")
+dangling_task_result = subprocess.run(
+    draft_command,
+    check=False,
+    capture_output=True,
+    text=True,
+)
+dangling_task_output = (
+    dangling_task_result.stdout + dangling_task_result.stderr
+)
+if (
+    dangling_task_result.returncode == 0
+    or "tasks.md must be a regular file" not in dangling_task_output
+):
+    raise SystemExit(
+        "draft validation accepted a dangling tasks.md symlink: "
+        f"rc={dangling_task_result.returncode}, output={dangling_task_output!r}"
+    )
+task_path.unlink()
+
 complete_result = subprocess.run(
     [*draft_command[:-1], "complete"],
     check=False,
@@ -248,7 +294,6 @@ if complete_result.returncode == 0 or "missing tasks.md" not in complete_output:
         f"rc={complete_result.returncode}, output={complete_output!r}"
     )
 
-task_path = draft_packet / "tasks.md"
 task_path.write_text("invalid task plan\n", encoding="utf-8")
 invalid_task_result = subprocess.run(
     draft_command,
@@ -302,6 +347,54 @@ base_commit = subprocess.run(
     capture_output=True,
     text=True,
 ).stdout.strip()
+
+unicode_repo = tmp / "unicode-baseline-repo"
+unicode_task = unicode_repo / "文档" / "GH999" / "tasks.md"
+unicode_task.parent.mkdir(parents=True)
+unicode_task.write_text("baseline task\n", encoding="utf-8")
+subprocess.run(["git", "-C", str(unicode_repo), "init"], check=True, capture_output=True)
+subprocess.run(
+    ["git", "-C", str(unicode_repo), "config", "user.name", "SpecRail Test"],
+    check=True,
+)
+subprocess.run(
+    [
+        "git",
+        "-C",
+        str(unicode_repo),
+        "config",
+        "user.email",
+        "specrail@example.invalid",
+    ],
+    check=True,
+)
+subprocess.run(
+    ["git", "-C", str(unicode_repo), "add", "文档/GH999/tasks.md"],
+    check=True,
+)
+subprocess.run(
+    ["git", "-C", str(unicode_repo), "commit", "-m", "test: unicode baseline"],
+    check=True,
+    capture_output=True,
+)
+unicode_commit = subprocess.run(
+    ["git", "-C", str(unicode_repo), "rev-parse", "HEAD"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+if not git_path_exists(unicode_repo, unicode_commit, unicode_task):
+    raise SystemExit("NUL-delimited baseline lookup lost a non-ASCII tasks.md path")
+unicode_packets = discover_baseline_spec_packet_dirs(
+    unicode_repo,
+    unicode_commit,
+    PurePosixPath("文档"),
+)
+if unicode_packets != [unicode_repo / "文档" / "GH999"]:
+    raise SystemExit(
+        f"NUL-delimited baseline packet discovery failed: {unicode_packets!r}"
+    )
+
 task_path.unlink()
 baseline_result = subprocess.run(
     [*draft_command, "--base-ref", base_commit],
@@ -602,7 +695,15 @@ if (
 PY
 
 python3 checks/check_workflow.py --repo .
-python3 checks/check_workflow.py --repo . --all-specs
+all_specs_args=(--repo . --all-specs --spec-stage complete)
+if [[ "${EVENT_NAME:-}" == "pull_request" && "${PR_IS_DRAFT:-false}" == "true" ]]; then
+  if [[ -z "${BASE_SHA:-}" ]]; then
+    echo "Draft SpecRail adoption smoke requires BASE_SHA" >&2
+    exit 1
+  fi
+  all_specs_args=(--repo . --all-specs --spec-stage draft --base-ref "${BASE_SHA}")
+fi
+python3 checks/check_workflow.py "${all_specs_args[@]}"
 python3 checks/github_pr_evidence.py --help >/dev/null
 
 python3 checks/route_gate.py \

--- a/tests/test_specrail_adoption.sh
+++ b/tests/test_specrail_adoption.sh
@@ -63,6 +63,11 @@ workflow_check_text = (
 ).read_text(encoding="utf-8")
 for token in [
     "fetch-depth: 0",
+    "ready_for_review",
+    "converted_to_draft",
+    "--spec-stage draft",
+    "--spec-stage complete",
+    "--base-ref",
     'diff_range="${BASE_SHA}...${HEAD_SHA}"',
     'diff_range="${BASE_SHA}..${HEAD_SHA}"',
     'git diff --check "${diff_range}"',
@@ -201,6 +206,148 @@ for configured_root, expected in [
             "default workflow validator did not reject configured root "
             f"{configured_root}: rc={result.returncode}, output={output!r}"
         )
+
+(cli_repo / "workflow.yaml").write_text(base_workflow_text, encoding="utf-8")
+draft_packet = cli_repo / "docs" / "specs" / "GH999"
+draft_packet.mkdir(parents=True)
+for name in ["product.md", "tech.md"]:
+    (draft_packet / name).write_text("GitHub issue: `#999`\n", encoding="utf-8")
+
+draft_command = [
+    sys.executable,
+    str(repo / "checks" / "check_workflow.py"),
+    "--repo",
+    str(cli_repo),
+    "--spec-dir",
+    "docs/specs/GH999",
+    "--spec-stage",
+    "draft",
+]
+draft_result = subprocess.run(
+    draft_command,
+    check=False,
+    capture_output=True,
+    text=True,
+)
+if draft_result.returncode != 0:
+    raise SystemExit(
+        "draft packet without tasks.md was rejected: "
+        f"{draft_result.stdout + draft_result.stderr}"
+    )
+
+complete_result = subprocess.run(
+    [*draft_command[:-1], "complete"],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+complete_output = complete_result.stdout + complete_result.stderr
+if complete_result.returncode == 0 or "missing tasks.md" not in complete_output:
+    raise SystemExit(
+        "complete packet without tasks.md was not rejected: "
+        f"rc={complete_result.returncode}, output={complete_output!r}"
+    )
+
+task_path = draft_packet / "tasks.md"
+task_path.write_text("invalid task plan\n", encoding="utf-8")
+invalid_task_result = subprocess.run(
+    draft_command,
+    check=False,
+    capture_output=True,
+    text=True,
+)
+invalid_task_output = invalid_task_result.stdout + invalid_task_result.stderr
+if (
+    invalid_task_result.returncode == 0
+    or "no task checklist items found" not in invalid_task_output
+):
+    raise SystemExit(
+        "draft validation ignored malformed tasks.md: "
+        f"rc={invalid_task_result.returncode}, output={invalid_task_output!r}"
+    )
+
+task_path.write_text(
+    "- [ ] `SP999-T1` Owner: agent; Done when: staged; Verify: focused test\n",
+    encoding="utf-8",
+)
+subprocess.run(["git", "-C", str(cli_repo), "init"], check=True, capture_output=True)
+subprocess.run(
+    ["git", "-C", str(cli_repo), "config", "user.name", "SpecRail Test"],
+    check=True,
+)
+subprocess.run(
+    ["git", "-C", str(cli_repo), "config", "user.email", "specrail@example.invalid"],
+    check=True,
+)
+subprocess.run(
+    [
+        "git",
+        "-C",
+        str(cli_repo),
+        "add",
+        "docs/specs/GH999/product.md",
+        "docs/specs/GH999/tech.md",
+        "docs/specs/GH999/tasks.md",
+    ],
+    check=True,
+)
+subprocess.run(
+    ["git", "-C", str(cli_repo), "commit", "-m", "test: complete packet baseline"],
+    check=True,
+    capture_output=True,
+)
+base_commit = subprocess.run(
+    ["git", "-C", str(cli_repo), "rev-parse", "HEAD"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+task_path.unlink()
+baseline_result = subprocess.run(
+    [*draft_command, "--base-ref", base_commit],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+baseline_output = baseline_result.stdout + baseline_result.stderr
+if (
+    baseline_result.returncode == 0
+    or "draft validation cannot remove tasks.md" not in baseline_output
+):
+    raise SystemExit(
+        "draft validation allowed a complete baseline packet downgrade: "
+        f"rc={baseline_result.returncode}, output={baseline_output!r}"
+    )
+
+shutil.rmtree(draft_packet)
+deleted_packet_result = subprocess.run(
+    [
+        sys.executable,
+        str(repo / "checks" / "check_workflow.py"),
+        "--repo",
+        str(cli_repo),
+        "--all-specs",
+        "--spec-stage",
+        "draft",
+        "--base-ref",
+        base_commit,
+    ],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+deleted_packet_output = (
+    deleted_packet_result.stdout + deleted_packet_result.stderr
+)
+if (
+    deleted_packet_result.returncode == 0
+    or "spec packet does not exist" not in deleted_packet_output
+    or "GH999" not in deleted_packet_output
+):
+    raise SystemExit(
+        "draft all-spec validation allowed a baseline packet deletion: "
+        f"rc={deleted_packet_result.returncode}, output={deleted_packet_output!r}"
+    )
 
 
 def review_threads_payload(nodes, *, total_count, has_next_page, end_cursor):
@@ -411,6 +558,47 @@ for artifact_prefix in ["docs/specs", "docs/specs/."]:
         "satisfied", []
     ):
         raise SystemExit(f"normalized product path missing: {payload!r}")
+    complete_command = (
+        "python3 checks/check_workflow.py --repo . "
+        "--spec-dir=docs/specs/GH595 --spec-stage=complete"
+    )
+    if complete_command not in payload.get("verification_commands", []):
+        raise SystemExit(
+            f"implement route did not require complete packet validation: {payload!r}"
+        )
+
+write_spec_result = subprocess.run(
+    [
+        sys.executable,
+        str(repo / "checks" / "route_gate.py"),
+        "--repo",
+        str(route_repo),
+        "--route",
+        "write_spec",
+        "--issue",
+        "595",
+        "--state",
+        "ready_to_spec",
+        "--json",
+    ],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+write_spec_payload = json.loads(write_spec_result.stdout)
+draft_verification = (
+    "python3 checks/check_workflow.py --repo . "
+    "--spec-dir=docs/specs/GH595 --spec-stage=draft"
+)
+if (
+    write_spec_result.returncode != 0
+    or write_spec_payload.get("decision") != "allowed"
+    or draft_verification not in write_spec_payload.get("verification_commands", [])
+):
+    raise SystemExit(
+        f"write_spec route did not emit draft packet validation: "
+        f"{write_spec_payload!r}"
+    )
 PY
 
 python3 checks/check_workflow.py --repo .


### PR DESCRIPTION
# Summary

让 SpecRail packet gate 区分 Draft 与 Complete：Draft 允许 product+tech-only，但继续校验已有 tasks，并通过 base SHA 阻止删除既有 tasks 或整个 packet。Ready PR、main 和本地默认验证保持完整三件套要求。

## Linked Work

- Fixes #720
- Spec packet: `docs/specs/GH720/`

## Readiness Gate

- [x] #720 已标记 `ready_to_implement`。
- [x] product/tech/tasks 完整并已通过 Complete packet check。
- [x] 不涉及安全私密披露。

## Review Gate

- [x] native independent reviewer 已完成 first pass；首次发现整 packet 删除绕过，修复后最终复审无阻断。
- [x] `implx auto` 是本轮 final review/merge 的显式授权；仍须所有机器 gate 通过。
- [x] writable ownership 仅 root coordinator；reviewer lane 只读。

## Merge Gate

- [x] PR head SHA: `5f9b0200a4a9a299ab8bdacd10a5b555c9d551a3`。
- [ ] CI/check rollup 已完成且通过。
- [ ] review threads 已确认全部解决。
- [x] native reviewer lane: `/root/gate_reviewer`。
- [ ] merge state 为 clean。
- [x] human merge authorization: 当前会话 `implx auto`。
- [ ] fresh `github_pr_evidence.py` 结果为完整证据。
- [ ] offline `pr_gate.py` decision 为 `allowed`。

## Verification

- [x] `bash tests/test_specrail_adoption.sh`
- [x] `python3 checks/check_workflow.py --repo . --all-specs`
- [x] `bash tests/test_manifest_contract.sh`
- [x] `bash tests/test_workflow_contracts.sh`
- [x] `bash scripts/ci/validate-workflow-contracts.sh`
- [x] `bash scripts/ci/validate-skill-format.sh`
- [x] `bash scripts/ci/validate-doc-paths.sh`
- [x] `bash scripts/ci/validate-doc-command-paths.sh`
- [x] `bash scripts/local-contract-check.sh --quick`
- [x] 无效 base ref fail-closed；删除整个基线 packet 负例 fail-closed。

## 配对 Prompt 规则评测

- [x] 本 PR 未新增或修改 prompt 注入的原生规则。

## Release Notes

- [x] 非 release；不发布 release。

## Agent Disclosure

- [x] Agent assisted; full diff received an independent reviewer-lane review.