### PR TITLE
fix(setup): make managed skill removal durable via disabled_skills

### DIFF
--- a/docs/specs/GH719/product.md
+++ b/docs/specs/GH719/product.md
@@ -1,0 +1,67 @@
+# Product Spec — 托管 skill 的持久化退出契约
+
+## Linked Issue
+
+GH-719
+
+complexity: small
+
+## 用户问题
+
+VibeGuard 把 Codex workflow skills（`plan-flow`、`fixflow`、`optflow`、
+`plan-mode`、`auto-optimize`）作为默认安装的托管副本。用户从
+`~/.codex/skills/` 删掉某个 skill 后，下一次 VibeGuard 安装或更新会静默地把它
+整个复制回来——Codex 安装器的实现是「删除目标目录后重新拷贝源树」，因此删除运行
+时副本这一动作根本无法表达一个持久的退出意图。
+
+结果是：一次与 skill 无关的 VibeGuard 更新，会重新扩张用户的 Codex skill 目录，
+而且全程没有任何提示。用户的显式删除被无声地推翻。
+
+## 目标
+
+- 让用户能够持久地禁用单个托管 skill，且该决定在后续安装/更新中继续生效。
+- 重新运行默认/core 安装器不得恢复已禁用的 skill。
+- `setup.sh --check` 必须把「有意禁用」与「缺失/损坏」区分开。
+- 重新启用必须是显式动作。
+- 安装器在恢复一个用户曾删除的托管 skill 时，必须报告该冲突并指出持久退出的方式，
+  不得静默恢复。
+
+## 非目标
+
+- 不改变 `workflows` 模块在 manifest 中的默认安装状态；本 issue 提供的是退出机制
+  （issue 列出的方案二），而不是把 workflow skills 改成 opt-in（方案一）。
+- 不引入新的 CLI 子命令来管理禁用列表；用户配置文件即是唯一来源。
+- 不改变非托管的、用户自有的 skill 目录的任何行为。
+
+## 用户可见行为
+
+用户在 `~/.vibeguard/config.json` 中记录退出意图：
+
+```json
+{
+  "version": 1,
+  "disabled_skills": ["plan-flow", "fixflow"]
+}
+```
+
+| 场景 | 行为 |
+|---|---|
+| skill 在禁用列表中，且已安装 | 安装时删除托管副本并输出 `REMOVED <skill> (disabled ...)` |
+| skill 在禁用列表中，且不存在 | 安装时输出 `SKIP <skill> (disabled ...)`，不安装 |
+| skill 被用户手工删除，但未记录退出 | 恢复它，同时输出 `RESTORING <skill>` 并指明如何持久禁用 |
+| `--check`，skill 已禁用且不存在 | `[DISABLED] <skill> skill disabled in ~/.vibeguard/config.json` |
+| `--check`，skill 已禁用但仍存在 | 同上并追加提示重跑 `setup.sh` 以移除 |
+| 从列表中移除名字后重跑安装 | skill 重新安装 |
+| `disabled_skills` 格式非法 | 安装与 `--check` 失败并报出带 JSON 路径的类型错误 |
+
+`VIBEGUARD_DISABLED_SKILLS`（逗号分隔）可临时覆盖该列表，遵循用户配置既有的
+「环境变量 > JSON 配置 > 内置默认」优先级。
+
+## 完成条件
+
+- 用户可以持久禁用单个 Codex workflow skill。
+- 默认安装器重跑不恢复被禁用的 skill。
+- `--check` 对被禁用 skill 报 `[DISABLED]` 而非 `[MISSING]`。
+- 重新启用是显式的。
+- 存在覆盖「删除/禁用 → 重装 → 仍保持禁用」的 setup 回归测试。
+- 托管 Codex skill 副本的行为与来源归属有文档说明。

--- a/docs/specs/GH719/tasks.md
+++ b/docs/specs/GH719/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — GH-719 托管 skill 的持久化退出
+
+## Implementation Tasks
+
+- [x] `SP719-T1` Owner: unassigned — 配置契约：在 `RUNTIME_CONFIG_FIELDS` 引入 `FieldKind::StringArray` 与 `disabled_skills` 声明，并同步 JSON schema、配置模板与 README 键表。Done when：schema/模板/Rust 注册表三方路径集合一致，数组类型、`maxItems`、`items.minLength` 边界均有断言，非法形状被拒。Verify: `cargo test && bash tests/test_runtime_config_schema.sh`
+- [x] `SP719-T2` Owner: unassigned — 读取通道：新增 `runtime-config-get-list` 与 `setup-state-list-tracked-under`，并把两者加入 `setup_runtime_supports()` 探测列表。Done when：配置损坏时命令非零退出而非返回空列表；旧 runtime 因缺少子命令不会被选中。Verify: `cargo test`
+- [x] `SP719-T3` Owner: unassigned — 安装与检查行为：`install_manifest_skills()` 跳过并删除被禁用的托管副本、对未记录退出的删除输出 `RESTORING` 告警；两个 target 的检查输出 `[DISABLED]` 而非 `[MISSING]`。Done when：删除→重装恢复并告警、禁用→重装删除、重复重装保持禁用、清空列表后恢复。Verify: `bash tests/test_setup.sh`
+- [x] `SP719-T4` Owner: unassigned — 文档：`templates/vibeguard-config.README.md` 补键表条目与「保持 Codex workflow skills 卸载」示例，`setup.sh` 结尾提示新环境变量。Done when：文档路径校验通过。Verify: `bash scripts/ci/validate-doc-paths.sh`
+
+## Verification
+
+- 持久性 AC：记录退出 → 重跑默认安装器 → skill 仍不存在。
+- 可见性 AC：未记录退出的删除被恢复时必须报告冲突并指明持久退出方式，不得静默。
+- 区分性 AC：`setup.sh --check` 对被禁用 skill 报 `[DISABLED]`，不报 `[MISSING]`。
+- 显式性 AC：从列表移除名字后重跑安装，skill 重新出现。
+- Fail-visible AC：`disabled_skills` 形状非法时安装与检查均带 JSON 路径失败，不退化为空列表。
+
+## Parallelization
+
+- SP719-T1 与 SP719-T2 的 runtime 侧可并行；T3 依赖两者；T4 最后。

--- a/docs/specs/GH719/tech.md
+++ b/docs/specs/GH719/tech.md
@@ -1,0 +1,95 @@
+# Tech Spec — 托管 skill 的持久化退出契约
+
+## Linked Issue
+
+GH-719
+
+## 现状
+
+`scripts/setup/lib.sh:install_manifest_skills()` 遍历 manifest 声明的 skill
+链接，对每一个调用目标专属的安装函数。Codex 侧的
+`install_codex_skill_copy()` 先 `rm -rf` 目标再拷贝源树，Claude 侧建立符号链接。
+两条路径都不查询任何用户意图，也不区分「从未安装」与「装过但被删除」。
+
+`~/.vibeguard/config.json` 已有一套集中式契约：字段在
+`vibeguard-runtime/src/runtime_config_validation.rs` 的 `RUNTIME_CONFIG_FIELDS`
+注册表中声明，未声明的字段直接被拒绝（`config_unknown_field`），并与
+`schemas/vibeguard-runtime-config.schema.json`、
+`templates/vibeguard-config.json.example` 由
+`tests/test_runtime_config_schema.sh` 和
+`runtime_config_validation_tests.rs` 双向锁定。
+
+## 变更
+
+### 1. 配置字段（runtime）
+
+`RUNTIME_CONFIG_FIELDS` 新增 `disabled_skills`，类型为新引入的
+`FieldKind::StringArray { maximum_items: 256 }`。校验规则：必须是数组，条目必须是
+去空白后非空的字符串，超过上限报 `config_range_error`。同步更新 JSON schema
+（`type: array` / `maxItems: 256` / `items.type: string` / `items.minLength: 1`）、
+配置模板与 `templates/vibeguard-config.README.md` 的键表。
+
+新增读取命令 `runtime-config-get-list <env-name> <json-path>`，逐行输出条目。它
+复用 `loaded_runtime_config()`，因此整份配置在读取任何值之前已被校验：**配置损坏
+时命令非零退出，而不是退化成空列表**。空列表会静默推翻用户的退出意图，正是本
+issue 要修的缺陷类别（U-29）。
+
+### 2. 安装状态查询（runtime）
+
+新增 `setup-state-list-tracked-under <state-file> <dest-dir>`，输出 install-state
+中位于该目录下的所有被跟踪路径（不限 install type）。托管 skill 副本是逐文件记录
+的，因此「VibeGuard 是否装过这个 skill」等价于「该 skill 目录下是否有被跟踪路径」。
+既有的 `setup-state-list-symlinks-under` 只覆盖 symlink，无法回答 Codex 侧的拷贝。
+
+### 3. 安装与检查（shell）
+
+`scripts/setup/lib.sh` 新增：
+
+- `disabled_skills()` — 调用 `runtime-config-get-list`，结果缓存在
+  `_VG_DISABLED_SKILLS_CACHE`。读取失败时返回非零并打印错误，调用方随之失败。
+- `skill_is_disabled <name>`
+- `remove_disabled_skill <dest> <name> <dest-dir>` — 删除前用 `pwd -P` 校验目标的
+  父目录确实是托管 skills 目录，拒绝越界删除。
+- `report_skill_restore <dest> <name>` — 目标缺失但 install-state 中有跟踪记录时，
+  输出 `RESTORING` 告警并指明如何持久禁用。
+
+`install_manifest_skills()` 在循环前先解析一次禁用列表（让配置错误尽早失败），
+循环内先处理禁用分支（删除 + SKIP），再对未禁用的 skill 调用
+`report_skill_restore` 后安装。
+
+`scripts/lib/install-state.sh` 新增 `state_is_tracked_path()` 包装。
+
+两个 target 的检查函数（`check_codex_home_installation`、
+`check_claude_home_installation`）在各自的 skill 循环内插入禁用分支，输出
+`[DISABLED]` 而非落到 `[MISSING]`。
+
+### 4. 运行时能力探测
+
+`setup_runtime_supports()` 的子命令探测列表加入
+`setup-state-list-tracked-under` 与 `runtime-config-get-list`，避免选中一个缺少
+新命令的旧 runtime 后在安装中途失败（U-26）。
+
+## 影响文件
+
+| 文件 | 变更 |
+|---|---|
+| `vibeguard-runtime/src/runtime_config_validation.rs` | `StringArray` 字段类型 + `disabled_skills` 声明 |
+| `vibeguard-runtime/src/runtime_config.rs` | `runtime_config_get_list` |
+| `vibeguard-runtime/src/setup_install_state.rs` | `list_tracked_under` |
+| `vibeguard-runtime/src/main.rs` | 两个新命令注册 |
+| `scripts/setup/lib.sh` | 禁用列表读取、跳过/删除/恢复告警、探测列表 |
+| `scripts/lib/install-state.sh` | `state_is_tracked_path` |
+| `scripts/setup/targets/codex-home.sh` | `[DISABLED]` 检查分支 |
+| `scripts/setup/targets/claude-home.sh` | `[DISABLED]` 检查分支 |
+| `scripts/setup/install.sh` | 结尾环境变量说明 |
+| `schemas/vibeguard-runtime-config.schema.json` | `disabled_skills` |
+| `templates/vibeguard-config.json.example` | `disabled_skills: []` |
+| `templates/vibeguard-config.README.md` | 键表 + 使用示例 |
+
+## 验证
+
+| 层 | 命令 | 覆盖 |
+|---|---|---|
+| runtime 单测 | `cargo test` | `StringArray` 校验、schema/模板/注册表三方一致、非法形状拒绝 |
+| schema 契约 | `bash tests/test_runtime_config_schema.sh` | 数组类型、maxItems、minLength 边界 |
+| setup 回归 | `bash tests/test_setup.sh` | 删除→重装恢复并告警；禁用→重装删除；重复重装保持禁用；`--check` 报 DISABLED 不报 MISSING；清空列表后恢复；非法配置显式失败 |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,6 +11,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | `GH699/` | Draft | Clone-free installation through verified release payloads and Homebrew/npm entry points |
 | `GH700/` | Draft | Public reproducible effectiveness benchmarks with provenance, ground truth, precision, and latency contracts |
 | `GH706/` | Draft | Privacy-safe malformed-input diagnostics and shared protocol-error versus rule-interception block counts |
+| `GH719/` | Draft | Persistent per-skill opt-out for managed Codex/Claude skill copies, with reported rather than silent restores |
 | `GH686/` | Implemented reference | Paired with/without evaluation for prompt-injected rule target improvement and non-target regression evidence (#686 / PR #696) |
 | `GH687/` | Implemented reference | W-21 evidence-provenance rule plus the W-01 channel-trust step 0 |
 | `GH675/` | Implemented reference | Manual precision-triage capture, empty-channel visibility, and the documented feedback loop |

--- a/schemas/vibeguard-runtime-config.schema.json
+++ b/schemas/vibeguard-runtime-config.schema.json
@@ -88,6 +88,16 @@
       "maximum": 1000000,
       "default": 5
     },
+    "disabled_skills": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": [],
+      "description": "Managed skill directory names to skip on install and remove if already installed."
+    },
     "learn": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -24,6 +24,10 @@
 
 STATE_VERSION=1
 STATE_FILE="${HOME}/.vibeguard/install-state.json"
+# Snapshot of the inventory from the previous install. state_init resets
+# STATE_FILE, so without this the installer cannot tell "never installed" from
+# "installed by VibeGuard and since deleted by the user" (GH719).
+STATE_PREVIOUS_FILE="${HOME}/.vibeguard/install-state.previous.json"
 INSTALL_STATE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 state_runtime_path() {
@@ -70,6 +74,12 @@ state_runtime() {
 # Initialize or load state
 state_init() {
   local profile="${1:-core}" languages="${2:-}"
+  # Preserve the outgoing inventory before it is reset (see STATE_PREVIOUS_FILE).
+  if [[ -f "$STATE_FILE" ]]; then
+    cp -f "$STATE_FILE" "$STATE_PREVIOUS_FILE" 2>/dev/null || rm -f "$STATE_PREVIOUS_FILE"
+  else
+    rm -f "$STATE_PREVIOUS_FILE"
+  fi
   state_runtime setup-state-init "$STATE_FILE" "$profile" "$languages"
 }
 
@@ -119,6 +129,18 @@ state_list() {
   state_runtime setup-state-list "$STATE_FILE"
 }
 
+# True when the path itself, or anything under it, was installed by VibeGuard —
+# either in this run or in the install whose inventory state_init preserved.
+state_is_tracked_path() {
+  local path="$1" state_source tracked
+  for state_source in "$STATE_PREVIOUS_FILE" "$STATE_FILE"; do
+    [[ -f "$state_source" ]] || continue
+    tracked="$(state_runtime setup-state-list-tracked-under "$state_source" "$path" 2>/dev/null)" || continue
+    [[ -n "${tracked//[[:space:]]/}" ]] && return 0
+  done
+  return 1
+}
+
 state_list_tracked_symlinks_under() {
   local dest_dir="$1"
   [[ -f "$STATE_FILE" ]] || return 0
@@ -134,5 +156,5 @@ state_list_project_hooks() {
 
 # Remove state file (used by clean.sh)
 state_clean() {
-  rm -f "$STATE_FILE"
+  rm -f "$STATE_FILE" "$STATE_PREVIOUS_FILE"
 }

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -91,6 +91,8 @@ setup_runtime_supports() {
     setup-codex-hooks-check-stale \
     setup-codex-hooks-prune-stale-unmanaged \
     setup-codex-hooks-check-timeouts \
+    setup-state-list-tracked-under \
+    runtime-config-get-list \
     runtime-config-validate; do
     probe_out="$("${runtime}" "${command}" 2>&1 || true)"
     if printf '%s\n' "${probe_out}" | grep -q "Unknown command"; then
@@ -555,15 +557,84 @@ cleanup_retired_manifest_skill_links() {
   done < <(state_list_tracked_symlinks_under "${dest_dir}")
 }
 
+# Skills the user has persistently opted out of, one per line (GH719).
+#
+# Source of truth is "disabled_skills" in ~/.vibeguard/config.json, overridable
+# via VIBEGUARD_DISABLED_SKILLS. A malformed config fails the caller instead of
+# reading as "nothing is disabled", which would silently reverse an opt-out.
+disabled_skills() {
+  if [[ -n "${_VG_DISABLED_SKILLS_CACHE+x}" ]]; then
+    printf '%s' "${_VG_DISABLED_SKILLS_CACHE}"
+    return 0
+  fi
+  local output
+  if ! output="$(setup_runtime runtime-config-get-list VIBEGUARD_DISABLED_SKILLS disabled_skills 2>&1)"; then
+    red "  ERROR: cannot read disabled_skills from ~/.vibeguard/config.json" >&2
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && red "  ${line}" >&2
+    done <<< "${output}"
+    return 1
+  fi
+  _VG_DISABLED_SKILLS_CACHE="${output}"
+  printf '%s' "${_VG_DISABLED_SKILLS_CACHE}"
+}
+
+skill_is_disabled() {
+  local skill="$1" disabled entry
+  disabled="$(disabled_skills)" || return 2
+  while IFS= read -r entry; do
+    [[ "${entry}" == "${skill}" ]] && return 0
+  done <<< "${disabled}"
+  return 1
+}
+
+# Remove a VibeGuard-managed skill the user has since disabled.
+remove_disabled_skill() {
+  local dest="$1" skill="$2" dest_dir="$3"
+  local dest_parent dest_parent_abs dest_dir_abs
+  [[ -e "${dest}" || -L "${dest}" ]] || return 0
+
+  # Never delete outside the managed skills directory.
+  dest_parent="$(dirname "${dest}")"
+  [[ -d "${dest_parent}" && -d "${dest_dir}" ]] || return 0
+  dest_parent_abs="$(cd "${dest_parent}" && pwd -P)"
+  dest_dir_abs="$(cd "${dest_dir}" && pwd -P)"
+  if [[ "${dest_parent_abs}" != "${dest_dir_abs}" ]]; then
+    red "  ERROR: refusing to remove disabled skill outside ${dest_dir}: ${dest}"
+    return 1
+  fi
+
+  rm -rf "${dest}"
+  yellow "  REMOVED ${skill} (disabled in ~/.vibeguard/config.json)"
+}
+
+# Report — rather than silently perform — the restore of a managed skill the
+# user deleted without recording a persistent opt-out (GH719).
+report_skill_restore() {
+  local dest="$1" skill="$2"
+  [[ -e "${dest}" || -L "${dest}" ]] && return 0
+  declare -F state_is_tracked_path >/dev/null || return 0
+  state_is_tracked_path "${dest}" || return 0
+  yellow "  RESTORING ${skill}: previously installed by VibeGuard and since deleted."
+  yellow "    To keep it removed, add \"${skill}\" to \"disabled_skills\" in ~/.vibeguard/config.json."
+}
+
 install_manifest_skills() {
   local target_uri="$1" dest_dir="$2" install_fn="$3"
   local skill_links source_path skill
 
   mkdir -p "${dest_dir}"
   skill_links="$(manifest_skill_links_checked "${target_uri}")" || return 1
+  disabled_skills >/dev/null || return 1
   while IFS=$'\t' read -r source_path skill; do
     [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    if skill_is_disabled "${skill}"; then
+      remove_disabled_skill "${dest_dir}/${skill}" "${skill}" "${dest_dir}" || return 1
+      yellow "  SKIP ${skill} (disabled in ~/.vibeguard/config.json)"
+      continue
+    fi
     if [[ -d "${REPO_DIR}/${source_path}" ]]; then
+      report_skill_restore "${dest_dir}/${skill}" "${skill}"
       "${install_fn}" "${REPO_DIR}/${source_path}" "${dest_dir}/${skill}" "${source_path}" "${skill}" || return 1
     else
       yellow "  SKIP ${skill} (source not found: ${source_path})"

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -430,9 +430,18 @@ check_claude_home_installation() {
 
   local link skill_links source_path skill
   skill_links="$(manifest_skill_links_checked "~/.claude/skills/")" || return 1
+  disabled_skills >/dev/null || return 1
   while IFS=$'\t' read -r source_path skill; do
     [[ -n "${source_path}" && -n "${skill}" ]] || continue
     link="${CLAUDE_DIR}/skills/${skill}"
+    if skill_is_disabled "${skill}"; then
+      if [[ -e "${link}" || -L "${link}" ]]; then
+        yellow "[DISABLED] ${skill} skill disabled in ~/.vibeguard/config.json but still present; re-run setup.sh to remove it"
+      else
+        green "[DISABLED] ${skill} skill disabled in ~/.vibeguard/config.json"
+      fi
+      continue
+    fi
     _check_claude_skill_symlink "${link}" "$(_claude_source_path "${source_path}")" "${skill}"
   done <<< "${skill_links}"
 

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -158,9 +158,18 @@ check_codex_home_installation() {
 
   local link skill_links source_path skill
   skill_links="$(manifest_skill_links_checked "~/.codex/skills/")" || return 1
+  disabled_skills >/dev/null || return 1
   while IFS=$'\t' read -r source_path skill; do
     [[ -n "${source_path}" && -n "${skill}" ]] || continue
     link="${CODEX_DIR}/skills/${skill}"
+    if skill_is_disabled "${skill}"; then
+      if [[ -e "${link}" || -L "${link}" ]]; then
+        yellow "[DISABLED] ${skill} skill disabled in ~/.vibeguard/config.json but still present; re-run setup.sh to remove it"
+      else
+        green "[DISABLED] ${skill} skill disabled in ~/.vibeguard/config.json"
+      fi
+      continue
+    fi
     if [[ -d "${link}" && ! -L "${link}" ]]; then
       if diff -qr "$(_codex_source_path "${source_path}")" "${link}" >/dev/null 2>&1; then
         green "[OK] ${skill} skill copied to ~/.codex/skills/"

--- a/templates/vibeguard-config.README.md
+++ b/templates/vibeguard-config.README.md
@@ -27,6 +27,22 @@ weaken unrelated hook behavior.
 | _(env only)_ | `VIBEGUARD_W14_SKIP_TEMP` | unset | Set to exactly `0` to keep W-14 **and** churn active on system temp roots (`/tmp`, `/private/tmp`, `/var/folders`). By default those paths are exempt because a session-scoped scratchpad cannot have cross-session write conflicts. Repository paths are never exempt, including a repo-local `scratchpad/` directory. |
 | `paralysis.threshold` | `VG_PARALYSIS_THRESHOLD` | `7` | W-13 read-only-action streak before paralysis warning. |
 | `write_mode` | `VIBEGUARD_WRITE_MODE` | `warn` | `warn` = advisory; `block` = hard reject new source files without prior search. |
+| `disabled_skills` | `VIBEGUARD_DISABLED_SKILLS` | `[]` | Managed skill directory names to keep uninstalled. `setup.sh` skips them, removes any copy it previously installed, and `setup.sh --check` reports them as `[DISABLED]` instead of `[MISSING]`. Env var form is comma-separated. |
+
+## Example: keep Codex workflow skills uninstalled
+
+Deleting `~/.codex/skills/plan-flow` by hand is not durable — the next install
+restores it (and says so). Record the opt-out instead:
+
+```json
+{
+  "version": 1,
+  "disabled_skills": ["plan-flow", "fixflow"]
+}
+```
+
+Re-running `setup.sh` then removes those skills and leaves them removed.
+Re-enabling is explicit: drop the name from the list and re-run `setup.sh`.
 
 ## Example: raise U-16 for a Rust-heavy machine
 

--- a/templates/vibeguard-config.json.example
+++ b/templates/vibeguard-config.json.example
@@ -19,5 +19,6 @@
   "write_escalate_threshold": 5,
   "learn": {
     "metrics_tail_bytes": 5242880
-  }
+  },
+  "disabled_skills": []
 }

--- a/tests/setup/install_flow_tests.sh
+++ b/tests/setup/install_flow_tests.sh
@@ -3,3 +3,59 @@
 source "${REPO_DIR}/tests/setup/install_core_flow_tests.sh"
 # shellcheck source=setup/install_scheduler_health_tests.sh
 source "${REPO_DIR}/tests/setup/install_scheduler_health_tests.sh"
+
+header "GH719 persistent skill opt-out"
+gh719_home="${TMP_HOME}/gh719-home"
+gh719_config="${gh719_home}/.vibeguard/config.json"
+mkdir -p "${gh719_home}"
+
+gh719_set_disabled() {
+  python3 - "${gh719_config}" "$@" <<'PY'
+import json, sys
+path, names = sys.argv[1], sys.argv[2:]
+with open(path, encoding="utf-8") as handle:
+    config = json.load(handle)
+config["disabled_skills"] = list(names)
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(config, handle, indent=2)
+PY
+}
+
+HOME="${gh719_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core >/dev/null 2>&1
+assert_cmd "workflow skill installed by default" test -d "${gh719_home}/.codex/skills/plan-flow"
+
+# Deleting only the runtime copy is not durable: the installer restores it, but
+# must report the conflict and point at the persistent opt-out.
+rm -rf "${gh719_home}/.codex/skills/plan-flow"
+gh719_restore_out="$(HOME="${gh719_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core 2>&1)"
+assert_contains "${gh719_restore_out}" "RESTORING plan-flow" "reinstall reports restoring a deleted managed skill"
+assert_contains "${gh719_restore_out}" "disabled_skills" "restore report names the persistent opt-out"
+assert_cmd "deleted skill is restored when no opt-out is recorded" test -d "${gh719_home}/.codex/skills/plan-flow"
+
+# Recording the opt-out removes the managed copy.
+gh719_set_disabled plan-flow
+gh719_disable_out="$(HOME="${gh719_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core 2>&1)"
+assert_contains "${gh719_disable_out}" "REMOVED plan-flow" "reinstall removes a newly disabled skill"
+assert_cmd "disabled skill is gone after reinstall" test ! -e "${gh719_home}/.codex/skills/plan-flow"
+assert_cmd "non-disabled skills are unaffected" test -d "${gh719_home}/.codex/skills/fixflow"
+
+# ...and it stays removed across further installs.
+gh719_repeat_out="$(HOME="${gh719_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core 2>&1)"
+assert_contains "${gh719_repeat_out}" "SKIP plan-flow (disabled" "repeat reinstall skips the disabled skill"
+assert_not_contains "${gh719_repeat_out}" "RESTORING plan-flow" "repeat reinstall does not restore the disabled skill"
+assert_cmd "disabled skill stays gone across reinstalls" test ! -e "${gh719_home}/.codex/skills/plan-flow"
+
+gh719_check_out="$(HOME="${gh719_home}" bash "${REPO_DIR}/setup.sh" --check 2>&1)"
+assert_contains "${gh719_check_out}" "[DISABLED] plan-flow" "--check reports the skill as disabled"
+assert_not_contains "${gh719_check_out}" "[MISSING] plan-flow" "--check does not report a disabled skill as missing"
+
+# Re-enabling is explicit.
+gh719_set_disabled
+HOME="${gh719_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core >/dev/null 2>&1
+assert_cmd "clearing the opt-out re-enables the skill" test -d "${gh719_home}/.codex/skills/plan-flow"
+
+# A malformed opt-out list fails visibly instead of reading as "nothing disabled".
+printf '%s\n' '{"version":1,"disabled_skills":"plan-flow"}' > "${gh719_config}"
+gh719_malformed_out="$(HOME="${gh719_home}" VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes --profile core 2>&1 || true)"
+assert_contains "${gh719_malformed_out}" "disabled_skills" "malformed disabled_skills is reported by path"
+assert_contains "${gh719_malformed_out}" "config_type_error" "malformed disabled_skills fails with a typed config error"

--- a/tests/test_runtime_config_schema.sh
+++ b/tests/test_runtime_config_schema.sh
@@ -27,7 +27,7 @@ numeric_contract = {
     "write_escalate_threshold": (0, 1_000_000),
     "learn.metrics_tail_bytes": (1, 268_435_456),
 }
-expected_paths = {"version", "write_mode", *numeric_contract}
+expected_paths = {"version", "write_mode", "disabled_skills", *numeric_contract}
 
 
 def leaf_paths(node, prefix=""):
@@ -97,7 +97,18 @@ def validate(node, contract, path="$"):
             return [f"{path}: type"]
         if "enum" in contract and node not in contract["enum"]:
             return [f"{path}: enum"]
+        if len(node) < contract.get("minLength", 0):
+            return [f"{path}: range"]
         return []
+    if expected_type == "array":
+        if not isinstance(node, list):
+            return [f"{path}: type"]
+        if "maxItems" in contract and len(node) > contract["maxItems"]:
+            return [f"{path}: range"]
+        errors = []
+        for index, item in enumerate(node):
+            errors.extend(validate(item, contract["items"], f"{path}[{index}]"))
+        return errors
     return [f"{path}: unsupported_schema_type"]
 
 
@@ -156,6 +167,16 @@ assert_invalid("invalid write mode", {"write_mode": "invalid"}, "enum")
 assert_invalid("numeric string", {"u16": {"limit": "800"}}, "type")
 assert_invalid("boolean integer", {"paralysis": {"threshold": True}}, "type")
 assert_invalid("non-integral number", {"paralysis": {"threshold": 1.5}}, "type")
+assert_valid("empty disabled skills", {"disabled_skills": []})
+assert_valid("disabled skills list", {"disabled_skills": ["plan-flow", "fixflow"]})
+assert_invalid("disabled skills scalar", {"disabled_skills": "plan-flow"}, "type")
+assert_invalid("disabled skills non-string entry", {"disabled_skills": [1]}, "type")
+assert_invalid("disabled skills empty entry", {"disabled_skills": [""]}, "range")
+assert_invalid(
+    "disabled skills over max items",
+    {"disabled_skills": [f"skill-{index}" for index in range(257)]},
+    "range",
+)
 
 mutated_schema = copy.deepcopy(schema)
 del mutated_schema["properties"]["write_escalate_threshold"]

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -312,6 +312,11 @@ static COMMANDS: &[Command] = &[
         handler: runtime_config::runtime_config_get_str,
     },
     Command {
+        name: "runtime-config-get-list",
+        usage: "<env-name> <json-path>  — read a string array from runtime config, one entry per line",
+        handler: runtime_config::runtime_config_get_list,
+    },
+    Command {
         name: "wrapper-env",
         usage: "[cli]  — precompute hook wrapper log and session environment",
         handler: wrapper_env::run,
@@ -455,6 +460,11 @@ static COMMANDS: &[Command] = &[
         name: "setup-state-list-symlinks-under",
         usage: "<state-file> <dest-dir>  — list tracked symlinks under a directory",
         handler: setup_install_state::list_tracked_symlinks_under,
+    },
+    Command {
+        name: "setup-state-list-tracked-under",
+        usage: "<state-file> <dest-dir>  — list tracked paths of any type under a directory",
+        handler: setup_install_state::list_tracked_under,
     },
     Command {
         name: "setup-state-list-project-hooks",

--- a/vibeguard-runtime/src/runtime_config.rs
+++ b/vibeguard-runtime/src/runtime_config.rs
@@ -56,6 +56,53 @@ pub fn runtime_config_get_str(args: &[String]) -> HandlerResult {
     Ok(())
 }
 
+/// Print one entry per line for a declared string-array field.
+///
+/// The whole config is validated before any value is read, so a malformed file
+/// exits non-zero here instead of degrading into an empty list — an empty list
+/// would silently reverse an explicit user opt-out (GH719).
+pub fn runtime_config_get_list(args: &[String]) -> HandlerResult {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime runtime-config-get-list <env-name> <json-path>".into(),
+        );
+    }
+
+    for entry in resolve_runtime_config_list(&args[0], &args[1])? {
+        println!("{entry}");
+    }
+    Ok(())
+}
+
+fn resolve_runtime_config_list(
+    env_name: &str,
+    json_path: &str,
+) -> Result<Vec<String>, RuntimeConfigError> {
+    let config = loaded_runtime_config()?;
+    if let Some(raw) = std::env::var(env_name).ok().filter(|v| !v.is_empty()) {
+        return Ok(raw
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(str::to_string)
+            .collect());
+    }
+
+    let Some(items) = config
+        .and_then(|value| value_at_path(value, json_path))
+        .and_then(Value::as_array)
+    else {
+        return Ok(Vec::new());
+    };
+
+    Ok(items
+        .iter()
+        .filter_map(Value::as_str)
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+        .collect())
+}
+
 pub(crate) fn runtime_config_int_value(
     env_name: &str,
     json_path: &str,

--- a/vibeguard-runtime/src/runtime_config_validation.rs
+++ b/vibeguard-runtime/src/runtime_config_validation.rs
@@ -116,9 +116,7 @@ const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
     },
     RuntimeConfigField {
         path: "disabled_skills",
-        kind: FieldKind::StringArray {
-            maximum_items: 256,
-        },
+        kind: FieldKind::StringArray { maximum_items: 256 },
     },
 ];
 

--- a/vibeguard-runtime/src/runtime_config_validation.rs
+++ b/vibeguard-runtime/src/runtime_config_validation.rs
@@ -30,6 +30,7 @@ pub enum RuntimeConfigDecision {
 enum FieldKind {
     Integer { minimum: u64, maximum: u64 },
     StringEnum { allowed: &'static [&'static str] },
+    StringArray { maximum_items: usize },
     Version,
 }
 
@@ -111,6 +112,12 @@ const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
         kind: FieldKind::Integer {
             minimum: 1,
             maximum: 268_435_456,
+        },
+    },
+    RuntimeConfigField {
+        path: "disabled_skills",
+        kind: FieldKind::StringArray {
+            maximum_items: 256,
         },
     },
 ];
@@ -313,6 +320,38 @@ fn validate_field(
                     &format!("allowed={}", allowed.join("|")),
                     CONFIG_PARSE_ERROR,
                 ));
+            }
+        }
+        FieldKind::StringArray { maximum_items } => {
+            let items = value.as_array().ok_or_else(|| {
+                config_error(
+                    file_path,
+                    display_path,
+                    "config_type_error",
+                    "type=array",
+                    CONFIG_PARSE_ERROR,
+                )
+            })?;
+            if items.len() > maximum_items {
+                return Err(config_error(
+                    file_path,
+                    display_path,
+                    "config_range_error",
+                    &format!("array_max_items={maximum_items}"),
+                    CONFIG_PARSE_ERROR,
+                ));
+            }
+            for (index, item) in items.iter().enumerate() {
+                let is_nonempty_string = item.as_str().is_some_and(|text| !text.trim().is_empty());
+                if !is_nonempty_string {
+                    return Err(config_error(
+                        file_path,
+                        &format!("{display_path}[{index}]"),
+                        "config_type_error",
+                        "type=nonempty_string",
+                        CONFIG_PARSE_ERROR,
+                    ));
+                }
             }
         }
         FieldKind::Version => {

--- a/vibeguard-runtime/src/runtime_config_validation_tests.rs
+++ b/vibeguard-runtime/src/runtime_config_validation_tests.rs
@@ -82,6 +82,24 @@ fn runtime_config_inventory_matches_schema_and_template() {
                     .collect::<Vec<_>>();
                 assert_eq!(schema_allowed, allowed, "{} enum", field.path);
             }
+            FieldKind::StringArray { maximum_items } => {
+                assert_eq!(schema_field["type"], "array", "{} type", field.path);
+                assert_eq!(
+                    schema_field["maxItems"], maximum_items,
+                    "{} maxItems",
+                    field.path
+                );
+                assert_eq!(
+                    schema_field["items"]["type"], "string",
+                    "{} item type",
+                    field.path
+                );
+                assert_eq!(
+                    schema_field["items"]["minLength"], 1,
+                    "{} item minLength",
+                    field.path
+                );
+            }
             FieldKind::Version => {
                 assert_eq!(schema_field["type"], "integer", "version type");
                 assert_eq!(schema_field["const"], 1, "supported version");
@@ -102,6 +120,9 @@ fn runtime_config_semantics_reject_unknown_type_enum_range_and_version() {
             json!({"learn": {"metrics_tail_bytes": 0}}),
             "config_range_error",
         ),
+        (json!({"disabled_skills": "plan-flow"}), "config_type_error"),
+        (json!({"disabled_skills": [1]}), "config_type_error"),
+        (json!({"disabled_skills": [" "]}), "config_type_error"),
         (json!({"version": 2}), "config_version_error"),
     ] {
         let error = validate_runtime_config_value(Path::new("config.json"), &value)

--- a/vibeguard-runtime/src/setup_install_state.rs
+++ b/vibeguard-runtime/src/setup_install_state.rs
@@ -253,7 +253,8 @@ pub fn list_tracked_symlinks_under(args: &[String]) -> SetupResult<()> {
 pub fn list_tracked_under(args: &[String]) -> SetupResult<()> {
     if args.len() != 2 {
         return Err(
-            "Usage: vibeguard-runtime setup-state-list-tracked-under <state-file> <dest-dir>".into(),
+            "Usage: vibeguard-runtime setup-state-list-tracked-under <state-file> <dest-dir>"
+                .into(),
         );
     }
     let state_file = Path::new(&args[0]);

--- a/vibeguard-runtime/src/setup_install_state.rs
+++ b/vibeguard-runtime/src/setup_install_state.rs
@@ -245,6 +245,49 @@ pub fn list_tracked_symlinks_under(args: &[String]) -> SetupResult<()> {
     Ok(())
 }
 
+/// Print every tracked path at or under `dest-dir`, regardless of install type.
+///
+/// Managed skill copies are recorded file-by-file, so "did VibeGuard ever
+/// install this skill?" is answered by whether any tracked path lives under the
+/// skill directory (GH719).
+pub fn list_tracked_under(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-state-list-tracked-under <state-file> <dest-dir>".into(),
+        );
+    }
+    let state_file = Path::new(&args[0]);
+    if !state_file.exists() {
+        return Ok(());
+    }
+    let state = match read_state(state_file) {
+        Ok(state) => state,
+        Err(_) => return Ok(()),
+    };
+    if state
+        .get("version")
+        .and_then(Value::as_i64)
+        .unwrap_or(STATE_VERSION)
+        != STATE_VERSION
+    {
+        eprintln!("WARN: unsupported install-state version; skipping tracked path lookup");
+        return Ok(());
+    }
+    let dest_dir = setup_absolute_path(&expand_home(&args[1]));
+    let files = state
+        .get("files")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for dest in files.keys() {
+        let expanded = setup_absolute_path(&expand_home(dest));
+        if expanded == dest_dir || expanded.starts_with(&dest_dir) {
+            println!("{}", expanded.display());
+        }
+    }
+    Ok(())
+}
+
 pub fn list_project_hooks(args: &[String]) -> SetupResult<()> {
     if args.len() != 1 {
         return Err("Usage: vibeguard-runtime setup-state-list-project-hooks <state-file>".into());


### PR DESCRIPTION
Closes #719

## Problem

Deleting a managed skill from `~/.codex/skills/` was silently reversed by the next
install. The Codex installer removes the destination and re-copies the source tree,
so deleting the runtime copy could never express a durable opt-out — an unrelated
VibeGuard update would quietly re-expand the user's Codex skill catalog.

## Change

`disabled_skills` in `~/.vibeguard/config.json` is the persistent opt-out:

| Situation | Behavior |
|---|---|
| Disabled and installed | install removes the managed copy, prints `REMOVED` |
| Disabled and absent | install prints `SKIP`, does not install |
| Deleted without an opt-out | restored, but prints `RESTORING` naming the opt-out |
| `--check`, disabled | `[DISABLED] …` instead of `[MISSING] …` |
| Name dropped from the list | skill is reinstalled — re-enabling is explicit |
| Malformed `disabled_skills` | install and `--check` fail with a typed config error |

`VIBEGUARD_DISABLED_SKILLS` (comma-separated) overrides it, matching the existing
env > JSON > default precedence.

## Design notes

- The field joins the existing centralized registry via a new `FieldKind::StringArray`,
  so the JSON schema, config template, and Rust field inventory stay locked together by
  the contract tests that already exist. The schema test grew array support and boundary
  assertions (`maxItems`, `items.minLength`).
- Reads go through the validated config path. A malformed config exits non-zero instead
  of degrading to an empty list — an empty list would itself silently reverse a user's
  opt-out, which is the exact defect class this issue reports (U-29).
- `state_init` resets the tracked-file inventory, so it now preserves the outgoing
  inventory to `install-state.previous.json`. Without it the installer cannot tell
  "never installed" from "installed and since deleted", and the `RESTORING` report can
  never fire.
- Both new runtime subcommands were added to `setup_runtime_supports()` so an older
  runtime is not selected and then failed mid-install (U-26).

## Verification

- `cargo test` — all suites pass, including 3 new rejection assertions for malformed
  `disabled_skills` shapes and the schema/template/registry three-way inventory check.
- `bash tests/test_runtime_config_schema.sh` — array type, `maxItems`, `minLength` boundaries.
- `bash tests/test_setup.sh` — 16 new assertions covering delete→restore-with-warning,
  disable→remove, repeat-reinstall stays disabled, `[DISABLED]` vs `[MISSING]`, explicit
  re-enable, and fail-visible malformed config.
- `bash scripts/ci/validate-doc-paths.sh`, `validate-doc-command-paths.sh`.