### PR TITLE
fix(setup): post-merge corrective for GH699 scheduler rollback

### DIFF
--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -131,6 +131,73 @@ scheduler_verify_deactivated() {
   esac
 }
 
+scheduler_capture_active_state() {
+  local unit="$1" output_variable="$2"
+  local state="" state_rc=0
+  state="$(LC_ALL=C systemctl --user is-active "${unit}" 2>/dev/null)" \
+    || state_rc=$?
+  case "${state}" in
+    active)
+      printf -v "${output_variable}" '%s' 1
+      ;;
+    inactive|failed|unknown)
+      printf -v "${output_variable}" '%s' 0
+      ;;
+    *)
+      red "ERROR: cannot classify prior ${unit} active state (state=${state:-empty}, rc=${state_rc}); preserving scheduler state."
+      return 1
+      ;;
+  esac
+}
+
+scheduler_capture_enabled_state() {
+  local unit="$1" output_variable="$2"
+  local state="" state_rc=0
+  state="$(LC_ALL=C systemctl --user is-enabled "${unit}" 2>/dev/null)" \
+    || state_rc=$?
+  case "${state}" in
+    enabled)
+      printf -v "${output_variable}" '%s' persistent
+      ;;
+    enabled-runtime)
+      printf -v "${output_variable}" '%s' runtime
+      ;;
+    disabled|masked|not-found)
+      printf -v "${output_variable}" '%s' disabled
+      ;;
+    *)
+      red "ERROR: cannot classify prior ${unit} enabled state (state=${state:-empty}, rc=${state_rc}); preserving scheduler state."
+      return 1
+      ;;
+  esac
+}
+
+scheduler_restore_runtime_state() {
+  local timer_active="$1" service_active="$2" timer_enabled_mode="$3"
+  local restore_rc=0
+  case "${timer_enabled_mode}" in
+    persistent)
+      systemctl --user enable vibeguard-gc.timer >/dev/null 2>&1 \
+        || restore_rc=1
+      ;;
+    runtime)
+      systemctl --user enable --runtime vibeguard-gc.timer >/dev/null 2>&1 \
+        || restore_rc=1
+      ;;
+    disabled) ;;
+    *) return 1 ;;
+  esac
+  if [[ "${service_active}" == "1" ]]; then
+    systemctl --user start vibeguard-gc.service >/dev/null 2>&1 \
+      || restore_rc=1
+  fi
+  if [[ "${timer_active}" == "1" ]]; then
+    systemctl --user start vibeguard-gc.timer >/dev/null 2>&1 \
+      || restore_rc=1
+  fi
+  return "${restore_rc}"
+}
+
 if [[ "${REPO_DIR}" != /* || ! -d "${REPO_DIR}" ]]; then
   red "ERROR: VIBEGUARD_REPO_DIR must name an absolute VibeGuard directory."
   exit 1
@@ -179,6 +246,9 @@ fi
 # --- Remove mode ---
 if [[ "${1:-}" == "--remove" ]]; then
   REMOVE_RECEIPT=0
+  REMOVE_PRIOR_TIMER_ACTIVE=0
+  REMOVE_PRIOR_SERVICE_ACTIVE=0
+  REMOVE_PRIOR_TIMER_ENABLED_MODE=disabled
   if [[ -f "${SCHEDULER_RECEIPT}" && ! -L "${SCHEDULER_RECEIPT}" ]]; then
     IFS=$'\t' read -r _ _ service_sha timer_sha \
       <<< "${SCHEDULER_RECEIPT_PARSED}"
@@ -200,48 +270,78 @@ if [[ "${1:-}" == "--remove" ]]; then
     fi
     REMOVE_RECEIPT=1
   fi
-  echo "Removing VibeGuard systemd units..."
-  scheduler_verify_deactivated || exit 1
+  if ! scheduler_capture_active_state \
+      vibeguard-gc.timer REMOVE_PRIOR_TIMER_ACTIVE \
+    || ! scheduler_capture_active_state \
+      vibeguard-gc.service REMOVE_PRIOR_SERVICE_ACTIVE \
+    || ! scheduler_capture_enabled_state \
+      vibeguard-gc.timer REMOVE_PRIOR_TIMER_ENABLED_MODE; then
+    exit 1
+  fi
   REMOVE_BACKUP_DIR=""
   if [[ -e "${SERVICE_DEST}" || -e "${TIMER_DEST}" ]]; then
-    REMOVE_BACKUP_DIR="$(mktemp -d "${UNIT_DIR}/.vibeguard-systemd-remove.XXXXXX")"
+    if ! REMOVE_BACKUP_DIR="$(
+      mktemp -d "${UNIT_DIR}/.vibeguard-systemd-remove.XXXXXX"
+    )"; then
+      red "ERROR: failed to prepare systemd removal; scheduler state was not changed."
+      exit 1
+    fi
+  fi
+  scheduler_restore_remove_transaction() {
+    local restore_rc=0
+    if [[ -n "${REMOVE_BACKUP_DIR}" ]]; then
+      [[ ! -e "${REMOVE_BACKUP_DIR}/vibeguard-gc.service" ]] \
+        || mv -- "${REMOVE_BACKUP_DIR}/vibeguard-gc.service" \
+          "${SERVICE_DEST}" \
+        || restore_rc=1
+      [[ ! -e "${REMOVE_BACKUP_DIR}/vibeguard-gc.timer" ]] \
+        || mv -- "${REMOVE_BACKUP_DIR}/vibeguard-gc.timer" \
+          "${TIMER_DEST}" \
+        || restore_rc=1
+    fi
+    systemctl --user daemon-reload >/dev/null 2>&1 || restore_rc=1
+    scheduler_restore_runtime_state \
+      "${REMOVE_PRIOR_TIMER_ACTIVE}" \
+      "${REMOVE_PRIOR_SERVICE_ACTIVE}" \
+      "${REMOVE_PRIOR_TIMER_ENABLED_MODE}" || restore_rc=1
+    if [[ "${restore_rc}" -eq 0 && -n "${REMOVE_BACKUP_DIR}" ]]; then
+      rmdir "${REMOVE_BACKUP_DIR}" 2>/dev/null || restore_rc=1
+    fi
+    return "${restore_rc}"
+  }
+  echo "Removing VibeGuard systemd units..."
+  if ! scheduler_verify_deactivated; then
+    if ! scheduler_restore_remove_transaction; then
+      red "ERROR: failed to deactivate systemd units and restoration was incomplete; preserving units and receipt."
+    fi
+    exit 1
+  fi
+  if [[ -n "${REMOVE_BACKUP_DIR}" ]]; then
     if [[ -e "${SERVICE_DEST}" ]] \
       && ! mv -- "${SERVICE_DEST}" "${REMOVE_BACKUP_DIR}/vibeguard-gc.service"; then
-      rmdir "${REMOVE_BACKUP_DIR}" 2>/dev/null || true
-      red "ERROR: failed to stage systemd service removal; preserved units and receipt."
+      if ! scheduler_restore_remove_transaction; then
+        red "ERROR: failed to stage systemd service removal and restoration was incomplete; receipt preserved, inspect ${REMOVE_BACKUP_DIR}."
+        exit 1
+      fi
+      red "ERROR: failed to stage systemd service removal; restored units and prior scheduler state."
       exit 1
     fi
     if [[ -e "${TIMER_DEST}" ]] \
       && ! mv -- "${TIMER_DEST}" "${REMOVE_BACKUP_DIR}/vibeguard-gc.timer"; then
-      restore_rc=0
-      [[ ! -e "${REMOVE_BACKUP_DIR}/vibeguard-gc.service" ]] \
-        || mv -- "${REMOVE_BACKUP_DIR}/vibeguard-gc.service" "${SERVICE_DEST}" \
-        || restore_rc=$?
-      rmdir "${REMOVE_BACKUP_DIR}" 2>/dev/null || true
-      if [[ "${restore_rc}" -ne 0 ]]; then
-        red "ERROR: failed to stage systemd timer removal and service restoration was incomplete; receipt preserved, inspect ${REMOVE_BACKUP_DIR}."
+      if ! scheduler_restore_remove_transaction; then
+        red "ERROR: failed to stage systemd timer removal and restoration was incomplete; receipt preserved, inspect ${REMOVE_BACKUP_DIR}."
         exit 1
       fi
-      red "ERROR: failed to stage systemd timer removal; restored units and preserved receipt."
+      red "ERROR: failed to stage systemd timer removal; restored units and prior scheduler state."
       exit 1
     fi
   fi
   if ! systemctl --user daemon-reload >/dev/null 2>&1; then
-    if [[ -n "${REMOVE_BACKUP_DIR}" ]]; then
-      restore_rc=0
-      [[ ! -e "${REMOVE_BACKUP_DIR}/vibeguard-gc.service" ]] \
-        || mv -- "${REMOVE_BACKUP_DIR}/vibeguard-gc.service" "${SERVICE_DEST}" \
-        || restore_rc=$?
-      [[ ! -e "${REMOVE_BACKUP_DIR}/vibeguard-gc.timer" ]] \
-        || mv -- "${REMOVE_BACKUP_DIR}/vibeguard-gc.timer" "${TIMER_DEST}" \
-        || restore_rc=$?
-      rmdir "${REMOVE_BACKUP_DIR}" 2>/dev/null || true
-      if [[ "${restore_rc}" -ne 0 ]]; then
-        red "ERROR: systemd daemon reload failed and unit restoration was incomplete; receipt preserved, inspect ${REMOVE_BACKUP_DIR}."
-        exit 1
-      fi
+    if ! scheduler_restore_remove_transaction; then
+      red "ERROR: systemd daemon reload failed and restoration was incomplete; receipt preserved, inspect ${REMOVE_BACKUP_DIR:-systemd state}."
+      exit 1
     fi
-    red "ERROR: systemd daemon reload failed; restored units and preserved receipt."
+    red "ERROR: systemd daemon reload failed; restored units and prior scheduler state."
     exit 1
   fi
   [[ -z "${REMOVE_BACKUP_DIR}" ]] || rm -rf -- "${REMOVE_BACKUP_DIR}"
@@ -327,45 +427,7 @@ chmod +x "${REPO_DIR}/scripts/gc/gc-scheduled.sh"
 INSTALL_REFRESH=0
 PRIOR_TIMER_ACTIVE=0
 PRIOR_SERVICE_ACTIVE=0
-PRIOR_TIMER_ENABLED=0
-
-scheduler_capture_active_state() {
-  local unit="$1" output_variable="$2"
-  local state="" state_rc=0
-  state="$(LC_ALL=C systemctl --user is-active "${unit}" 2>/dev/null)" \
-    || state_rc=$?
-  case "${state}" in
-    active)
-      printf -v "${output_variable}" '%s' 1
-      ;;
-    inactive|failed|unknown)
-      printf -v "${output_variable}" '%s' 0
-      ;;
-    *)
-      red "ERROR: cannot classify prior ${unit} active state (state=${state:-empty}, rc=${state_rc}); preserving scheduler state."
-      return 1
-      ;;
-  esac
-}
-
-scheduler_capture_enabled_state() {
-  local unit="$1" output_variable="$2"
-  local state="" state_rc=0
-  state="$(LC_ALL=C systemctl --user is-enabled "${unit}" 2>/dev/null)" \
-    || state_rc=$?
-  case "${state}" in
-    enabled)
-      printf -v "${output_variable}" '%s' 1
-      ;;
-    disabled|masked|not-found)
-      printf -v "${output_variable}" '%s' 0
-      ;;
-    *)
-      red "ERROR: cannot classify prior ${unit} enabled state (state=${state:-empty}, rc=${state_rc}); preserving scheduler state."
-      return 1
-      ;;
-  esac
-}
+PRIOR_TIMER_ENABLED_MODE=disabled
 
 if [[ -n "${SCHEDULER_RECEIPT_PARSED}" ]]; then
   INSTALL_REFRESH=1
@@ -378,7 +440,7 @@ if [[ -n "${SCHEDULER_RECEIPT_PARSED}" ]]; then
     || ! scheduler_capture_active_state \
       vibeguard-gc.service PRIOR_SERVICE_ACTIVE \
     || ! scheduler_capture_enabled_state \
-      vibeguard-gc.timer PRIOR_TIMER_ENABLED; then
+      vibeguard-gc.timer PRIOR_TIMER_ENABLED_MODE; then
     rm -rf -- "${INSTALL_WORK_DIR}"
     exit 1
   fi
@@ -400,18 +462,10 @@ scheduler_restore_install_transaction() {
   fi
   systemctl --user daemon-reload >/dev/null 2>&1 || restore_rc=1
   if [[ "${INSTALL_REFRESH}" == "1" ]]; then
-    if [[ "${PRIOR_TIMER_ENABLED}" == "1" ]]; then
-      systemctl --user enable vibeguard-gc.timer >/dev/null 2>&1 \
-        || restore_rc=1
-    fi
-    if [[ "${PRIOR_SERVICE_ACTIVE}" == "1" ]]; then
-      systemctl --user start vibeguard-gc.service >/dev/null 2>&1 \
-        || restore_rc=1
-    fi
-    if [[ "${PRIOR_TIMER_ACTIVE}" == "1" ]]; then
-      systemctl --user start vibeguard-gc.timer >/dev/null 2>&1 \
-        || restore_rc=1
-    fi
+    scheduler_restore_runtime_state \
+      "${PRIOR_TIMER_ACTIVE}" \
+      "${PRIOR_SERVICE_ACTIVE}" \
+      "${PRIOR_TIMER_ENABLED_MODE}" || restore_rc=1
   fi
   return "${restore_rc}"
 }

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -382,6 +382,26 @@ elif [[ -e "${SERVICE_DEST}" || -L "${SERVICE_DEST}" \
   exit 1
 fi
 
+if [[ -z "${SCHEDULER_RECEIPT_PARSED}" ]]; then
+  FRESH_TIMER_ACTIVE=0
+  FRESH_SERVICE_ACTIVE=0
+  FRESH_TIMER_ENABLED_MODE=disabled
+  if ! scheduler_capture_active_state \
+      vibeguard-gc.timer FRESH_TIMER_ACTIVE \
+    || ! scheduler_capture_active_state \
+      vibeguard-gc.service FRESH_SERVICE_ACTIVE \
+    || ! scheduler_capture_enabled_state \
+      vibeguard-gc.timer FRESH_TIMER_ENABLED_MODE; then
+    exit 1
+  fi
+  if [[ "${FRESH_TIMER_ACTIVE}" == "1" \
+    || "${FRESH_SERVICE_ACTIVE}" == "1" \
+    || "${FRESH_TIMER_ENABLED_MODE}" != "disabled" ]]; then
+    red "ERROR: same-named systemd scheduler is active or enabled without a VibeGuard ownership receipt; preserving unowned state."
+    exit 1
+  fi
+fi
+
 echo "Installing VibeGuard systemd user units..."
 
 if [[ ! -f "${SERVICE_SRC}" ]] || [[ ! -f "${TIMER_SRC}" ]]; then
@@ -500,7 +520,16 @@ else
   green "  Unit files written to ${UNIT_DIR}/"
 fi
 
-if ! systemctl --user enable --now vibeguard-gc.timer 2>/dev/null; then
+scheduler_activate_installed_timer() {
+  if [[ "${INSTALL_REFRESH}" == "1" \
+    && "${PRIOR_TIMER_ENABLED_MODE}" == "runtime" ]]; then
+    systemctl --user enable --runtime --now vibeguard-gc.timer 2>/dev/null
+  else
+    systemctl --user enable --now vibeguard-gc.timer 2>/dev/null
+  fi
+}
+
+if ! scheduler_activate_installed_timer; then
   if ! scheduler_restore_install_transaction; then
     red "ERROR: timer activation failed and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
     exit 1

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -388,8 +388,18 @@ if ! systemctl --user enable --now vibeguard-gc.timer 2>/dev/null; then
   exit 1
 fi
 
-new_service_sha="$(scheduler_sha256_file "${SERVICE_DEST}")"
-new_timer_sha="$(scheduler_sha256_file "${TIMER_DEST}")"
+new_service_sha=""
+new_timer_sha=""
+if ! new_service_sha="$(scheduler_sha256_file "${SERVICE_DEST}")" \
+  || ! new_timer_sha="$(scheduler_sha256_file "${TIMER_DEST}")"; then
+  if ! scheduler_restore_install_transaction; then
+    red "ERROR: failed to hash installed systemd units and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
+    exit 1
+  fi
+  rm -rf -- "${INSTALL_WORK_DIR}"
+  red "ERROR: failed to hash installed systemd units; restored the previous scheduler state."
+  exit 1
+fi
 if ! scheduler_receipt_write "${new_service_sha}" "${new_timer_sha}"; then
   if ! scheduler_restore_install_transaction; then
     red "ERROR: scheduler ownership recording failed and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -114,18 +114,20 @@ scheduler_stop_and_verify_unit() {
 }
 
 scheduler_verify_deactivated() {
-  local disable_rc=0 enabled_state="" enabled_rc=0
+  local disable_rc=0 runtime_disable_rc=0 enabled_state="" enabled_rc=0
   scheduler_stop_and_verify_unit \
     vibeguard-gc.timer "vibeguard-gc.timer" || return 1
   scheduler_stop_and_verify_unit \
     vibeguard-gc.service "vibeguard-gc.service" || return 1
   systemctl --user disable vibeguard-gc.timer >/dev/null 2>&1 || disable_rc=$?
+  systemctl --user disable --runtime vibeguard-gc.timer >/dev/null 2>&1 \
+    || runtime_disable_rc=$?
   enabled_state="$(LC_ALL=C systemctl --user is-enabled vibeguard-gc.timer 2>/dev/null)" \
     || enabled_rc=$?
   case "${enabled_state}" in
     disabled|masked|not-found) ;;
     *)
-      red "ERROR: vibeguard-gc.timer is not proven disabled (disable_rc=${disable_rc}, state=${enabled_state:-empty}, rc=${enabled_rc}); preserving units and receipt."
+      red "ERROR: vibeguard-gc.timer is not proven disabled (disable_rc=${disable_rc}, runtime_disable_rc=${runtime_disable_rc}, state=${enabled_state:-empty}, rc=${enabled_rc}); preserving units and receipt."
       return 1
       ;;
   esac
@@ -476,7 +478,12 @@ if [[ "${INSTALL_REFRESH}" == "1" ]] \
   :
 elif [[ "${INSTALL_REFRESH}" == "1" ]] \
   && ! scheduler_verify_deactivated; then
+  if ! scheduler_restore_install_transaction; then
+    red "ERROR: failed to deactivate prior systemd units and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
+    exit 1
+  fi
   rm -rf -- "${INSTALL_WORK_DIR}"
+  red "ERROR: failed to deactivate prior systemd units; restored the previous scheduler state."
   exit 1
 else
   if ! mv -f -- "${STAGED_SERVICE}" "${SERVICE_DEST}" \
@@ -500,6 +507,16 @@ if ! systemctl --user enable --now vibeguard-gc.timer 2>/dev/null; then
   fi
   rm -rf -- "${INSTALL_WORK_DIR}"
   red "ERROR: Timer could not be started; restored the previous scheduler state."
+  exit 1
+fi
+if [[ "${INSTALL_REFRESH}" == "1" && "${PRIOR_SERVICE_ACTIVE}" == "1" ]] \
+  && ! systemctl --user start vibeguard-gc.service >/dev/null 2>&1; then
+  if ! scheduler_restore_install_transaction; then
+    red "ERROR: service restart failed and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
+    exit 1
+  fi
+  rm -rf -- "${INSTALL_WORK_DIR}"
+  red "ERROR: service restart failed; restored the previous scheduler state."
   exit 1
 fi
 

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -325,12 +325,63 @@ chmod 644 "${STAGED_SERVICE}" "${STAGED_TIMER}"
 chmod +x "${REPO_DIR}/scripts/gc/gc-scheduled.sh"
 
 INSTALL_REFRESH=0
+PRIOR_TIMER_ACTIVE=0
+PRIOR_SERVICE_ACTIVE=0
+PRIOR_TIMER_ENABLED=0
+
+scheduler_capture_active_state() {
+  local unit="$1" output_variable="$2"
+  local state="" state_rc=0
+  state="$(LC_ALL=C systemctl --user is-active "${unit}" 2>/dev/null)" \
+    || state_rc=$?
+  case "${state}" in
+    active)
+      printf -v "${output_variable}" '%s' 1
+      ;;
+    inactive|failed|unknown)
+      printf -v "${output_variable}" '%s' 0
+      ;;
+    *)
+      red "ERROR: cannot classify prior ${unit} active state (state=${state:-empty}, rc=${state_rc}); preserving scheduler state."
+      return 1
+      ;;
+  esac
+}
+
+scheduler_capture_enabled_state() {
+  local unit="$1" output_variable="$2"
+  local state="" state_rc=0
+  state="$(LC_ALL=C systemctl --user is-enabled "${unit}" 2>/dev/null)" \
+    || state_rc=$?
+  case "${state}" in
+    enabled)
+      printf -v "${output_variable}" '%s' 1
+      ;;
+    disabled|masked|not-found)
+      printf -v "${output_variable}" '%s' 0
+      ;;
+    *)
+      red "ERROR: cannot classify prior ${unit} enabled state (state=${state:-empty}, rc=${state_rc}); preserving scheduler state."
+      return 1
+      ;;
+  esac
+}
+
 if [[ -n "${SCHEDULER_RECEIPT_PARSED}" ]]; then
   INSTALL_REFRESH=1
   cp -p -- "${SERVICE_DEST}" "${INSTALL_WORK_DIR}/vibeguard-gc.service.backup"
   cp -p -- "${TIMER_DEST}" "${INSTALL_WORK_DIR}/vibeguard-gc.timer.backup"
   cp -p -- "${SCHEDULER_RECEIPT}" \
     "${INSTALL_WORK_DIR}/scheduler-ownership.backup"
+  if ! scheduler_capture_active_state \
+      vibeguard-gc.timer PRIOR_TIMER_ACTIVE \
+    || ! scheduler_capture_active_state \
+      vibeguard-gc.service PRIOR_SERVICE_ACTIVE \
+    || ! scheduler_capture_enabled_state \
+      vibeguard-gc.timer PRIOR_TIMER_ENABLED; then
+    rm -rf -- "${INSTALL_WORK_DIR}"
+    exit 1
+  fi
 fi
 
 scheduler_restore_install_transaction() {
@@ -349,8 +400,18 @@ scheduler_restore_install_transaction() {
   fi
   systemctl --user daemon-reload >/dev/null 2>&1 || restore_rc=1
   if [[ "${INSTALL_REFRESH}" == "1" ]]; then
-    systemctl --user enable --now vibeguard-gc.timer >/dev/null 2>&1 \
-      || restore_rc=1
+    if [[ "${PRIOR_TIMER_ENABLED}" == "1" ]]; then
+      systemctl --user enable vibeguard-gc.timer >/dev/null 2>&1 \
+        || restore_rc=1
+    fi
+    if [[ "${PRIOR_SERVICE_ACTIVE}" == "1" ]]; then
+      systemctl --user start vibeguard-gc.service >/dev/null 2>&1 \
+        || restore_rc=1
+    fi
+    if [[ "${PRIOR_TIMER_ACTIVE}" == "1" ]]; then
+      systemctl --user start vibeguard-gc.timer >/dev/null 2>&1 \
+        || restore_rc=1
+    fi
   fi
   return "${restore_rc}"
 }

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -70,19 +70,55 @@ scheduler_receipt_parse() {
   ' "$1"
 }
 
-scheduler_verify_deactivated() {
+scheduler_receipt_write() {
+  local service_sha="$1" timer_sha="$2"
+  local receipt_dir temporary parsed kind phase parsed_service parsed_timer
+  receipt_dir="$(dirname "${SCHEDULER_RECEIPT}")"
+  if [[ -L "${receipt_dir}" || (-e "${receipt_dir}" && ! -d "${receipt_dir}") ]]; then
+    return 1
+  fi
+  mkdir -p "${receipt_dir}"
+  temporary="$(mktemp "${receipt_dir}/.scheduler-ownership.XXXXXX")"
+  if ! printf 'schema=1\nkind=systemd\nphase=managed\nservice_sha256=%s\ntimer_sha256=%s\n' \
+    "${service_sha}" "${timer_sha}" > "${temporary}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  chmod 600 "${temporary}"
+  if ! mv -f -- "${temporary}" "${SCHEDULER_RECEIPT}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  parsed="$(scheduler_receipt_parse "${SCHEDULER_RECEIPT}")" || return 1
+  IFS=$'\t' read -r kind phase parsed_service parsed_timer <<< "${parsed}"
+  [[ "${kind}" == "systemd" && "${phase}" == "managed" \
+    && "${parsed_service}" == "${service_sha}" \
+    && "${parsed_timer}" == "${timer_sha}" ]]
+}
+
+scheduler_stop_and_verify_unit() {
+  local unit="$1" label="$2"
   local stop_rc=0 active_state="" active_rc=0
-  local disable_rc=0 enabled_state="" enabled_rc=0
-  systemctl --user stop vibeguard-gc.timer >/dev/null 2>&1 || stop_rc=$?
-  active_state="$(LC_ALL=C systemctl --user is-active vibeguard-gc.timer 2>/dev/null)" \
+  systemctl --user stop "${unit}" >/dev/null 2>&1 || stop_rc=$?
+  active_state="$(LC_ALL=C systemctl --user is-active "${unit}" 2>/dev/null)" \
     || active_rc=$?
   case "${active_state}" in
-    inactive|failed|unknown) ;;
+    inactive|failed|unknown)
+      return 0
+      ;;
     *)
-      red "ERROR: vibeguard-gc.timer is not proven inactive (stop_rc=${stop_rc}, state=${active_state:-empty}, rc=${active_rc}); preserving units and receipt."
+      red "ERROR: ${label} is not proven inactive (stop_rc=${stop_rc}, state=${active_state:-empty}, rc=${active_rc}); preserving units and receipt."
       return 1
       ;;
   esac
+}
+
+scheduler_verify_deactivated() {
+  local disable_rc=0 enabled_state="" enabled_rc=0
+  scheduler_stop_and_verify_unit \
+    vibeguard-gc.timer "vibeguard-gc.timer" || return 1
+  scheduler_stop_and_verify_unit \
+    vibeguard-gc.service "vibeguard-gc.service" || return 1
   systemctl --user disable vibeguard-gc.timer >/dev/null 2>&1 || disable_rc=$?
   enabled_state="$(LC_ALL=C systemctl --user is-enabled vibeguard-gc.timer 2>/dev/null)" \
     || enabled_rc=$?
@@ -238,6 +274,10 @@ if [[ -n "${SCHEDULER_RECEIPT_PARSED}" ]]; then
     red "ERROR: scheduler ownership receipt does not match current systemd files; preserving scheduler state."
     exit 1
   fi
+elif [[ -e "${SERVICE_DEST}" || -L "${SERVICE_DEST}" \
+  || -e "${TIMER_DEST}" || -L "${TIMER_DEST}" ]]; then
+  red "ERROR: existing systemd units have no valid ownership receipt; preserving scheduler state."
+  exit 1
 fi
 
 echo "Installing VibeGuard systemd user units..."
@@ -247,6 +287,10 @@ if [[ ! -f "${SERVICE_SRC}" ]] || [[ ! -f "${TIMER_SRC}" ]]; then
   exit 1
 fi
 
+if [[ -L "${UNIT_DIR}" || (-e "${UNIT_DIR}" && ! -d "${UNIT_DIR}") ]]; then
+  red "ERROR: systemd user unit directory must be a real directory: ${UNIT_DIR}"
+  exit 1
+fi
 mkdir -p "${UNIT_DIR}"
 
 for unit_dest in "${SERVICE_DEST}" "${TIMER_DEST}"; do
@@ -256,35 +300,107 @@ for unit_dest in "${SERVICE_DEST}" "${TIMER_DEST}"; do
   fi
 done
 
-# Escape values for use as sed replacement strings (|, &, and \ are metacharacters)
+# Escape values for use as sed replacement strings (|, &, and \ are metacharacters).
 _escape_sed() { printf '%s\n' "$1" | sed 's/[\\&|]/\\&/g'; }
 ESCAPED_REPO_DIR="$(_escape_sed "${REPO_DIR}")"
 ESCAPED_HOME="$(_escape_sed "${HOME}")"
 
-# Substitute placeholders and write unit files
-sed -e "s|__VIBEGUARD_DIR__|${ESCAPED_REPO_DIR}|g" \
+# Render the complete replacement before deactivating or mutating managed state.
+INSTALL_WORK_DIR="$(mktemp -d "${UNIT_DIR}/.vibeguard-systemd-install.XXXXXX")"
+STAGED_SERVICE="${INSTALL_WORK_DIR}/vibeguard-gc.service.staged"
+STAGED_TIMER="${INSTALL_WORK_DIR}/vibeguard-gc.timer.staged"
+if ! sed -e "s|__VIBEGUARD_DIR__|${ESCAPED_REPO_DIR}|g" \
     -e "s|__HOME__|${ESCAPED_HOME}|g" \
-    "${SERVICE_SRC}" > "${SERVICE_DEST}"
-
-sed -e "s|__VIBEGUARD_DIR__|${ESCAPED_REPO_DIR}|g" \
+    "${SERVICE_SRC}" > "${STAGED_SERVICE}" \
+  || ! sed -e "s|__VIBEGUARD_DIR__|${ESCAPED_REPO_DIR}|g" \
     -e "s|__HOME__|${ESCAPED_HOME}|g" \
-    "${TIMER_SRC}" > "${TIMER_DEST}"
-
-green "  Unit files written to ${UNIT_DIR}/"
+    "${TIMER_SRC}" > "${STAGED_TIMER}"; then
+  rm -rf -- "${INSTALL_WORK_DIR}"
+  red "ERROR: failed to stage systemd units; scheduler state was not changed."
+  exit 1
+fi
+chmod 644 "${STAGED_SERVICE}" "${STAGED_TIMER}"
 
 # Make GC script executable
 chmod +x "${REPO_DIR}/scripts/gc/gc-scheduled.sh"
 
-# Reload and enable
-systemctl --user daemon-reload
+INSTALL_REFRESH=0
+if [[ -n "${SCHEDULER_RECEIPT_PARSED}" ]]; then
+  INSTALL_REFRESH=1
+  cp -p -- "${SERVICE_DEST}" "${INSTALL_WORK_DIR}/vibeguard-gc.service.backup"
+  cp -p -- "${TIMER_DEST}" "${INSTALL_WORK_DIR}/vibeguard-gc.timer.backup"
+  cp -p -- "${SCHEDULER_RECEIPT}" \
+    "${INSTALL_WORK_DIR}/scheduler-ownership.backup"
+fi
 
-if systemctl --user enable --now vibeguard-gc.timer 2>/dev/null; then
-  green "  vibeguard-gc.timer enabled and started (every Sunday 3:00 AM)"
+scheduler_restore_install_transaction() {
+  local restore_rc=0
+  scheduler_verify_deactivated || restore_rc=1
+  if [[ "${INSTALL_REFRESH}" == "1" ]]; then
+    cp -p -- "${INSTALL_WORK_DIR}/vibeguard-gc.service.backup" \
+      "${SERVICE_DEST}" || restore_rc=1
+    cp -p -- "${INSTALL_WORK_DIR}/vibeguard-gc.timer.backup" \
+      "${TIMER_DEST}" || restore_rc=1
+    cp -p -- "${INSTALL_WORK_DIR}/scheduler-ownership.backup" \
+      "${SCHEDULER_RECEIPT}" || restore_rc=1
+  else
+    rm -f -- "${SERVICE_DEST}" "${TIMER_DEST}" "${SCHEDULER_RECEIPT}" \
+      || restore_rc=1
+  fi
+  systemctl --user daemon-reload >/dev/null 2>&1 || restore_rc=1
+  if [[ "${INSTALL_REFRESH}" == "1" ]]; then
+    systemctl --user enable --now vibeguard-gc.timer >/dev/null 2>&1 \
+      || restore_rc=1
+  fi
+  return "${restore_rc}"
+}
+
+if [[ "${INSTALL_REFRESH}" == "1" ]] \
+  && cmp -s "${STAGED_SERVICE}" "${SERVICE_DEST}" \
+  && cmp -s "${STAGED_TIMER}" "${TIMER_DEST}"; then
+  :
+elif [[ "${INSTALL_REFRESH}" == "1" ]] \
+  && ! scheduler_verify_deactivated; then
+  rm -rf -- "${INSTALL_WORK_DIR}"
+  exit 1
 else
-  red "ERROR: Timer installed but could not be started automatically."
-  red "Run manually: systemctl --user enable --now vibeguard-gc.timer"
+  if ! mv -f -- "${STAGED_SERVICE}" "${SERVICE_DEST}" \
+    || ! mv -f -- "${STAGED_TIMER}" "${TIMER_DEST}" \
+    || ! systemctl --user daemon-reload >/dev/null 2>&1; then
+    if ! scheduler_restore_install_transaction; then
+      red "ERROR: failed to install systemd units and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
+      exit 1
+    fi
+    rm -rf -- "${INSTALL_WORK_DIR}"
+    red "ERROR: failed to install systemd units; restored the previous scheduler state."
+    exit 1
+  fi
+  green "  Unit files written to ${UNIT_DIR}/"
+fi
+
+if ! systemctl --user enable --now vibeguard-gc.timer 2>/dev/null; then
+  if ! scheduler_restore_install_transaction; then
+    red "ERROR: timer activation failed and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
+    exit 1
+  fi
+  rm -rf -- "${INSTALL_WORK_DIR}"
+  red "ERROR: Timer could not be started; restored the previous scheduler state."
   exit 1
 fi
+
+new_service_sha="$(scheduler_sha256_file "${SERVICE_DEST}")"
+new_timer_sha="$(scheduler_sha256_file "${TIMER_DEST}")"
+if ! scheduler_receipt_write "${new_service_sha}" "${new_timer_sha}"; then
+  if ! scheduler_restore_install_transaction; then
+    red "ERROR: scheduler ownership recording failed and rollback was incomplete; inspect ${INSTALL_WORK_DIR}."
+    exit 1
+  fi
+  rm -rf -- "${INSTALL_WORK_DIR}"
+  red "ERROR: failed to record scheduler ownership; restored the previous scheduler state."
+  exit 1
+fi
+rm -rf -- "${INSTALL_WORK_DIR}"
+green "  vibeguard-gc.timer enabled and started (every Sunday 3:00 AM)"
 
 # Show timer status
 echo

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -357,6 +357,9 @@ bootstrap_acquire_owner_lock || lock_rc=$?
 if [[ "${lock_rc}" -ne 0 ]]; then
   exit "${lock_rc}"
 fi
+# Holding the single bootstrap owner lock proves no live transaction can own
+# a canonical work directory left by an earlier SIGKILL or power loss.
+bootstrap_reap_orphaned_work_directories "${DIST_ROOT}" || exit 73
 
 if [[ -e "${CURRENT_LINK}" && ! -L "${CURRENT_LINK}" ]]; then
   bootstrap_error "dist/current exists and is not a symlink; refusing to overwrite it."

--- a/scripts/setup/bootstrap_state.sh
+++ b/scripts/setup/bootstrap_state.sh
@@ -69,6 +69,48 @@ bootstrap_reap_transaction_write_temporaries() {
   done <<< "${entries}"
 }
 
+bootstrap_reap_orphaned_work_directories() {
+  local dist_root="$1" protected_work_dir="${2:-}"
+  local entries entry name candidate version nonce
+  if ! entries="$(
+    find "${dist_root}" -mindepth 1 -maxdepth 1 \
+      -name '.bootstrap-*.*' -print | LC_ALL=C sort
+  )"; then
+    bootstrap_error "could not enumerate bootstrap work directories."
+    return 1
+  fi
+  while IFS= read -r entry; do
+    [[ -n "${entry}" ]] || continue
+    name="${entry##*/}"
+    case "${name}" in
+      .bootstrap-transaction-*|.bootstrap.lock.owner.*)
+        continue
+        ;;
+    esac
+    candidate="${name#.bootstrap-}"
+    version="${candidate%.*}"
+    nonce="${candidate##*.}"
+    if [[ "${version}" == "${candidate}" \
+      || ! "${nonce}" =~ ^[[:alnum:]]{6}$ ]] \
+      || ! bootstrap_validate_version "${version}"; then
+      bootstrap_error "bootstrap work path has ambiguous ownership metadata: ${entry}"
+      return 1
+    fi
+    if [[ -L "${entry}" || ! -d "${entry}" ]]; then
+      bootstrap_error "bootstrap work path is not a real directory: ${entry}"
+      return 1
+    fi
+    if [[ -n "${protected_work_dir}" && "${entry}" == "${protected_work_dir}" ]]; then
+      continue
+    fi
+    if ! rm -rf -- "${entry}" \
+      || [[ -e "${entry}" || -L "${entry}" ]]; then
+      bootstrap_error "could not remove orphaned bootstrap work directory: ${entry}"
+      return 1
+    fi
+  done <<< "${entries}"
+}
+
 bootstrap_prepare_clean_plan() {
   local dist_root="$1" current_link="$2"
   local entries entry name version final_dir all_entries found index
@@ -76,6 +118,8 @@ bootstrap_prepare_clean_plan() {
   BOOTSTRAP_CLEAN_OWNED_VERSION_COUNT=0
   bootstrap_prepare_clean_selection "${dist_root}" "${current_link}" || return 1
   bootstrap_reap_transaction_write_temporaries "${dist_root}" || return 1
+  bootstrap_reap_orphaned_work_directories \
+    "${dist_root}" "${BOOTSTRAP_TMP:-}" || return 1
 
   if ! entries="$(
     find "${dist_root}" -mindepth 1 -maxdepth 1 \

--- a/scripts/setup/clean.sh
+++ b/scripts/setup/clean.sh
@@ -400,8 +400,8 @@ fi
 
 clean_repo_git_hooks
 clean_tracked_project_git_hooks
-clean_claude_home_installation || exit 1
-clean_codex_home_installation || exit 1
+clean_claude_home_installation
+clean_codex_home_installation
 clean_vibeguard_home
 clean_scheduled_gc
 

--- a/scripts/setup/clean.sh
+++ b/scripts/setup/clean.sh
@@ -230,7 +230,7 @@ clean_systemd_stop_and_verify_unit() {
 }
 
 clean_systemd_scheduler_deactivate() {
-  local disable_rc=0 enabled_state="" enabled_rc=0
+  local disable_rc=0 runtime_disable_rc=0 enabled_state="" enabled_rc=0
   [[ "$(uname)" == "Linux" ]] || return 0
   if ! command -v systemctl >/dev/null 2>&1; then
     red "ERROR: cannot deactivate scheduled GC: systemctl is unavailable; preserving systemd units and cleaning receipt"
@@ -241,6 +241,8 @@ clean_systemd_scheduler_deactivate() {
   clean_systemd_stop_and_verify_unit \
     vibeguard-gc.service "systemd service" || return 1
   systemctl --user disable vibeguard-gc.timer >/dev/null 2>&1 || disable_rc=$?
+  systemctl --user disable --runtime vibeguard-gc.timer >/dev/null 2>&1 \
+    || runtime_disable_rc=$?
   enabled_state="$(
     LC_ALL=C systemctl --user is-enabled vibeguard-gc.timer 2>/dev/null
   )" || enabled_rc=$?
@@ -248,8 +250,8 @@ clean_systemd_scheduler_deactivate() {
     disabled|masked|not-found)
       ;;
     *)
-      if [[ "${disable_rc}" -ne 0 ]]; then
-        red "ERROR: failed to disable scheduled GC systemd timer; timer is not proven disabled (disable_rc=${disable_rc}, state=${enabled_state:-empty}, rc=${enabled_rc}); preserving systemd units and cleaning receipt"
+      if [[ "${disable_rc}" -ne 0 || "${runtime_disable_rc}" -ne 0 ]]; then
+        red "ERROR: failed to disable scheduled GC systemd timer; timer is not proven disabled (disable_rc=${disable_rc}, runtime_disable_rc=${runtime_disable_rc}, state=${enabled_state:-empty}, rc=${enabled_rc}); preserving systemd units and cleaning receipt"
       else
         red "ERROR: scheduled GC systemd timer is not proven disabled (state=${enabled_state:-empty}, rc=${enabled_rc}); preserving systemd units and cleaning receipt"
       fi

--- a/scripts/setup/clean.sh
+++ b/scripts/setup/clean.sh
@@ -207,30 +207,39 @@ clean_launchd_scheduler_deactivate() {
   fi
 }
 
-clean_systemd_scheduler_deactivate() {
+clean_systemd_stop_and_verify_unit() {
+  local unit="$1" label="$2"
   local stop_rc=0 active_state="" active_rc=0
+  systemctl --user stop "${unit}" >/dev/null 2>&1 || stop_rc=$?
+  active_state="$(
+    LC_ALL=C systemctl --user is-active "${unit}" 2>/dev/null
+  )" || active_rc=$?
+  case "${active_state}" in
+    inactive|failed|unknown)
+      return 0
+      ;;
+    *)
+      if [[ "${stop_rc}" -ne 0 ]]; then
+        red "ERROR: failed to stop scheduled GC ${label}; ${label} is not proven inactive (stop_rc=${stop_rc}, state=${active_state:-empty}, rc=${active_rc}); preserving systemd units and cleaning receipt"
+      else
+        red "ERROR: scheduled GC ${label} is not proven inactive after stop (state=${active_state:-empty}, rc=${active_rc}); preserving systemd units and cleaning receipt"
+      fi
+      return 1
+      ;;
+  esac
+}
+
+clean_systemd_scheduler_deactivate() {
   local disable_rc=0 enabled_state="" enabled_rc=0
   [[ "$(uname)" == "Linux" ]] || return 0
   if ! command -v systemctl >/dev/null 2>&1; then
     red "ERROR: cannot deactivate scheduled GC: systemctl is unavailable; preserving systemd units and cleaning receipt"
     return 1
   fi
-  systemctl --user stop vibeguard-gc.timer >/dev/null 2>&1 || stop_rc=$?
-  active_state="$(
-    LC_ALL=C systemctl --user is-active vibeguard-gc.timer 2>/dev/null
-  )" || active_rc=$?
-  case "${active_state}" in
-    inactive|failed|unknown)
-      ;;
-    *)
-      if [[ "${stop_rc}" -ne 0 ]]; then
-        red "ERROR: failed to stop scheduled GC systemd timer; timer is not proven inactive (stop_rc=${stop_rc}, state=${active_state:-empty}, rc=${active_rc}); preserving systemd units and cleaning receipt"
-      else
-        red "ERROR: scheduled GC systemd timer is not proven inactive after stop (state=${active_state:-empty}, rc=${active_rc}); preserving systemd units and cleaning receipt"
-      fi
-      return 1
-      ;;
-  esac
+  clean_systemd_stop_and_verify_unit \
+    vibeguard-gc.timer "systemd timer" || return 1
+  clean_systemd_stop_and_verify_unit \
+    vibeguard-gc.service "systemd service" || return 1
   systemctl --user disable vibeguard-gc.timer >/dev/null 2>&1 || disable_rc=$?
   enabled_state="$(
     LC_ALL=C systemctl --user is-enabled vibeguard-gc.timer 2>/dev/null
@@ -384,12 +393,15 @@ clean_scheduled_gc() {
 
 echo "Cleaning VibeGuard installation..."
 
-ensure_setup_runtime_available >/dev/null 2>&1 || true
+if ! ensure_setup_runtime_available >/dev/null 2>&1; then
+  red "ERROR: vibeguard-runtime is required to safely remove managed high-context files"
+  exit 1
+fi
 
 clean_repo_git_hooks
 clean_tracked_project_git_hooks
-clean_claude_home_installation
-clean_codex_home_installation
+clean_claude_home_installation || exit 1
+clean_codex_home_installation || exit 1
 clean_vibeguard_home
 clean_scheduled_gc
 

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -588,13 +588,34 @@ check_claude_home_installation() {
 }
 
 clean_claude_home_installation() {
+  local md_cleanup_result="NOT_FOUND"
+  local settings_cleanup_result="SKIP"
+
   if [[ -f "${CLAUDE_DIR}/CLAUDE.md" ]]; then
-    local result
-    result=$(setup_runtime setup-md-remove "${CLAUDE_DIR}/CLAUDE.md" 2>/dev/null || echo "ERROR")
-    case "${result}" in
+    md_cleanup_result="$(
+      setup_runtime setup-md-remove "${CLAUDE_DIR}/CLAUDE.md" 2>/dev/null
+    )" || md_cleanup_result="ERROR"
+    case "${md_cleanup_result}" in
       REMOVED) yellow "Removed VibeGuard rules from ~/.claude/CLAUDE.md" ;;
       NOT_FOUND) yellow "No VibeGuard rules found in ~/.claude/CLAUDE.md" ;;
-      *) red "Failed to clean CLAUDE.md" ;;
+      *)
+        red "Failed to clean CLAUDE.md"
+        return 1
+        ;;
+    esac
+  fi
+
+  if [[ -f "${SETTINGS_FILE}" ]]; then
+    settings_cleanup_result="$(
+      settings_remove "${SETTINGS_FILE}" 2>/dev/null
+    )" || settings_cleanup_result="ERROR"
+    case "${settings_cleanup_result}" in
+      CHANGED) yellow "Removed VibeGuard hooks from settings.json" ;;
+      SKIP) ;;
+      *)
+        red "Failed to clean VibeGuard hooks from settings.json"
+        return 1
+        ;;
     esac
   fi
 
@@ -635,14 +656,5 @@ clean_claude_home_installation() {
   if [[ -d "${HOME}/.claude/rules/vibeguard" ]]; then
     rm -rf "${HOME}/.claude/rules/vibeguard"
     yellow "Removed native rules from ~/.claude/rules/vibeguard/"
-  fi
-
-  if [[ -f "${SETTINGS_FILE}" ]]; then
-    local clean_result
-    if clean_result=$(settings_remove "${SETTINGS_FILE}" 2>/dev/null); then
-      if [[ "${clean_result}" == "CHANGED" ]]; then
-        yellow "Removed VibeGuard hooks from settings.json"
-      fi
-    fi
   fi
 }

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -489,27 +489,29 @@ check_codex_agents_hygiene() {
 }
 
 clean_codex_home_installation() {
+  local agents_md_result="NOT_FOUND"
+  local hooks_cleanup_result="SKIP"
+
   if [[ -f "${CODEX_DIR}/AGENTS.md" ]]; then
-    local agents_md_result
-    agents_md_result=$(setup_runtime setup-md-remove "${CODEX_DIR}/AGENTS.md" 2>/dev/null || echo "ERROR")
+    agents_md_result="$(
+      setup_runtime setup-md-remove "${CODEX_DIR}/AGENTS.md" 2>/dev/null
+    )" || agents_md_result="ERROR"
     case "${agents_md_result}" in
       REMOVED) yellow "Removed VibeGuard rules from ~/.codex/AGENTS.md" ;;
       NOT_FOUND) yellow "No VibeGuard rules found in ~/.codex/AGENTS.md" ;;
-      *) red "Failed to clean ~/.codex/AGENTS.md" ;;
+      *)
+        red "Failed to clean ~/.codex/AGENTS.md"
+        return 1
+        ;;
     esac
   fi
 
-  local skill_links source_path skill
-  skill_links="$(manifest_skill_links_for_cleanup "~/.codex/skills/")"
-  while IFS=$'\t' read -r source_path skill; do
-    [[ -n "${source_path}" && -n "${skill}" ]] || continue
-    rm -rf "${CODEX_DIR}/skills/${skill}"
-  done <<< "${skill_links}"
-  cleanup_retired_manifest_skill_links "~/.codex/skills/" "${CODEX_DIR}/skills"
-
-  # Remove only VibeGuard-managed entries from hooks.json (do not delete third-party hooks)
-  local hooks_cleanup_result
-  hooks_cleanup_result=$(setup_runtime setup-codex-hooks-remove "${REPO_DIR}" "${CODEX_DIR}/hooks.json" 2>/dev/null || echo "ERROR")
+  # Remove only VibeGuard-managed entries from hooks.json (do not delete third-party hooks).
+  # This high-context edit must succeed before wrappers or recovery payloads disappear.
+  hooks_cleanup_result="$(
+    setup_runtime setup-codex-hooks-remove \
+      "${REPO_DIR}" "${CODEX_DIR}/hooks.json" 2>/dev/null
+  )" || hooks_cleanup_result="ERROR"
   case "${hooks_cleanup_result}" in
     CHANGED)
       yellow "Removed VibeGuard hook entries from ~/.codex/hooks.json"
@@ -519,8 +521,17 @@ clean_codex_home_installation() {
       ;;
     *)
       red "Failed to clean VibeGuard entries in ~/.codex/hooks.json"
+      return 1
       ;;
   esac
+
+  local skill_links source_path skill
+  skill_links="$(manifest_skill_links_for_cleanup "~/.codex/skills/")"
+  while IFS=$'\t' read -r source_path skill; do
+    [[ -n "${source_path}" && -n "${skill}" ]] || continue
+    rm -rf "${CODEX_DIR}/skills/${skill}"
+  done <<< "${skill_links}"
+  cleanup_retired_manifest_skill_links "~/.codex/skills/" "${CODEX_DIR}/skills"
 
   rm -f "${HOME}/.vibeguard/run-hook-codex.sh"
   rm -f "${HOME}/.vibeguard/_lib/codex_diag.sh"

--- a/tests/setup/bootstrap_recovery_scheduler_tests.sh
+++ b/tests/setup/bootstrap_recovery_scheduler_tests.sh
@@ -200,6 +200,61 @@ assert_cmd "retry reaps atomically published stale lock and succeeds" env "${boo
   VIBEGUARD_TEST_RELEASE_DIR="${handoff_release}" \
   bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes
 
+orphan_work_home="${TMP_HOME}/bootstrap-orphan-work-home"
+orphan_work_dir="${orphan_work_home}/.vibeguard/dist/.bootstrap-${BOOTSTRAP_VERSION}.ABC123"
+mkdir -p "${orphan_work_dir}"
+printf 'stale partial download\n' > "${orphan_work_dir}/partial"
+assert_cmd "normal retry reaps canonical orphaned bootstrap work directory" \
+  env "${bootstrap_base_env[@]}" \
+  HOME="${orphan_work_home}" \
+  VIBEGUARD_TEST_RELEASE_DIR="${handoff_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes
+assert_cmd "normal retry leaves no orphaned bootstrap work directory" \
+  test ! -e "${orphan_work_dir}"
+orphan_clean_dir="${orphan_work_home}/.vibeguard/dist/.bootstrap-${BOOTSTRAP_VERSION}.XYZ789"
+mkdir -p "${orphan_clean_dir}"
+assert_cmd "clean retry also reaps canonical orphaned bootstrap work directory" \
+  env "${bootstrap_base_env[@]}" \
+  HOME="${orphan_work_home}" \
+  VIBEGUARD_TEST_RELEASE_DIR="${handoff_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --clean
+assert_cmd "clean retry removes orphaned work and managed payload" bash -c \
+  'test ! -e "$1" && test ! -e "$2" && test ! -L "$3"' _ \
+  "${orphan_clean_dir}" \
+  "${orphan_work_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
+  "${orphan_work_home}/.vibeguard/dist/current"
+
+ambiguous_work_home="${TMP_HOME}/bootstrap-ambiguous-work-home"
+ambiguous_work_dir="${ambiguous_work_home}/.vibeguard/dist/.bootstrap-${BOOTSTRAP_VERSION}.bad-nonce"
+mkdir -p "${ambiguous_work_dir}"
+ambiguous_work_rc=0
+env "${bootstrap_base_env[@]}" \
+  HOME="${ambiguous_work_home}" \
+  VIBEGUARD_TEST_RELEASE_DIR="${handoff_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes \
+  >/dev/null 2>&1 || ambiguous_work_rc=$?
+assert_cmd "ambiguous bootstrap work ownership fails closed" \
+  test "${ambiguous_work_rc}" -eq 73
+assert_cmd "ambiguous bootstrap work path is preserved for inspection" \
+  test -d "${ambiguous_work_dir}"
+
+symlink_work_home="${TMP_HOME}/bootstrap-symlink-work-home"
+symlink_work_target="${TMP_HOME}/bootstrap-symlink-work-target"
+symlink_work_path="${symlink_work_home}/.vibeguard/dist/.bootstrap-${BOOTSTRAP_VERSION}.DEF456"
+mkdir -p "$(dirname "${symlink_work_path}")" "${symlink_work_target}"
+ln -s "${symlink_work_target}" "${symlink_work_path}"
+symlink_work_rc=0
+env "${bootstrap_base_env[@]}" \
+  HOME="${symlink_work_home}" \
+  VIBEGUARD_TEST_RELEASE_DIR="${handoff_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes \
+  >/dev/null 2>&1 || symlink_work_rc=$?
+assert_cmd "symlink bootstrap work path fails closed" \
+  test "${symlink_work_rc}" -eq 73
+assert_cmd "symlink bootstrap work path and target are preserved" bash -c \
+  'test -L "$1" && test -d "$2"' _ \
+  "${symlink_work_path}" "${symlink_work_target}"
+
 prepared_crash_home="${TMP_HOME}/bootstrap-prepared-crash-home"
 prepared_crash_bin="${TMP_HOME}/bootstrap-prepared-crash-bin"
 prepared_crash_marker="${TMP_HOME}/bootstrap-prepared-crash.marker"

--- a/tests/setup/cleanup_failure_tests.sh
+++ b/tests/setup/cleanup_failure_tests.sh
@@ -1,0 +1,96 @@
+bootstrap_service_deactivate_home="${TMP_HOME}/bootstrap-service-deactivate-home"
+env "${bootstrap_base_env[@]}" HOME="${bootstrap_service_deactivate_home}" \
+  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes --with-scheduler \
+  >/dev/null
+touch "${bootstrap_service_deactivate_home}/.systemctl-vibeguard-gc-service-active"
+bootstrap_service_deactivate_rc=0
+env "${bootstrap_base_env[@]}" HOME="${bootstrap_service_deactivate_home}" \
+  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_SYSTEMD_SERVICE_STOP_FAIL=1 \
+  VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --clean \
+  >/dev/null 2>&1 || bootstrap_service_deactivate_rc=$?
+assert_cmd "bootstrap clean propagates active service deactivation failure" \
+  test "${bootstrap_service_deactivate_rc}" -ne 0
+assert_cmd "bootstrap service failure preserves payload, units, and receipt" bash -c \
+  'test -L "$1" && test -d "$2" && test -f "$3" && test -f "$4" && grep -qFx "phase=cleaning" "$5" && test -f "$6"' _ \
+  "${bootstrap_service_deactivate_home}/.vibeguard/dist/current" \
+  "${bootstrap_service_deactivate_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
+  "${bootstrap_service_deactivate_home}/.config/systemd/user/vibeguard-gc.service" \
+  "${bootstrap_service_deactivate_home}/.config/systemd/user/vibeguard-gc.timer" \
+  "${bootstrap_service_deactivate_home}/.vibeguard/scheduler-ownership" \
+  "${bootstrap_service_deactivate_home}/.systemctl-vibeguard-gc-service-active"
+
+cleanup_real_runtime="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+assert_cmd "cleanup failure fixtures have a real runtime delegate" \
+  test -x "${cleanup_real_runtime}"
+
+md_cleanup_failure_home="${TMP_HOME}/md-cleanup-failure-home"
+md_cleanup_failure_runtime="${TMP_HOME}/md-cleanup-failure-runtime"
+mkdir -p "${md_cleanup_failure_home}/.claude" \
+  "${md_cleanup_failure_home}/.codex" \
+  "${md_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}"
+printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
+  > "${md_cleanup_failure_home}/.claude/CLAUDE.md"
+printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
+  > "${md_cleanup_failure_home}/.codex/AGENTS.md"
+printf '#!/usr/bin/env bash\n' \
+  > "${md_cleanup_failure_home}/.vibeguard/run-hook-codex.sh"
+printf 'verified payload\n' \
+  > "${md_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+cat > "${md_cleanup_failure_runtime}" <<SH
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "setup-md-remove" \
+  && "\${2:-}" == "${md_cleanup_failure_home}/.claude/CLAUDE.md" ]]; then
+  exit 42
+fi
+exec "${cleanup_real_runtime}" "\$@"
+SH
+chmod +x "${md_cleanup_failure_runtime}"
+md_cleanup_failure_rc=0
+HOME="${md_cleanup_failure_home}" \
+  VIBEGUARD_SETUP_RUNTIME="${md_cleanup_failure_runtime}" \
+  bash "${REPO_DIR}/setup.sh" --clean >/dev/null 2>&1 \
+  || md_cleanup_failure_rc=$?
+assert_cmd "CLAUDE.md helper failure aborts clean" \
+  test "${md_cleanup_failure_rc}" -ne 0
+assert_cmd "CLAUDE.md helper failure preserves high-context files and recovery payload" bash -c \
+  'test -f "$1" && test -f "$2" && test -f "$3" && test -f "$4"' _ \
+  "${md_cleanup_failure_home}/.claude/CLAUDE.md" \
+  "${md_cleanup_failure_home}/.codex/AGENTS.md" \
+  "${md_cleanup_failure_home}/.vibeguard/run-hook-codex.sh" \
+  "${md_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+
+hooks_cleanup_failure_home="${TMP_HOME}/hooks-cleanup-failure-home"
+hooks_cleanup_failure_runtime="${TMP_HOME}/hooks-cleanup-failure-runtime"
+mkdir -p "${hooks_cleanup_failure_home}/.codex" \
+  "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}"
+printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
+  > "${hooks_cleanup_failure_home}/.codex/AGENTS.md"
+printf '{"hooks":{"PreToolUse":[]}}\n' \
+  > "${hooks_cleanup_failure_home}/.codex/hooks.json"
+printf '#!/usr/bin/env bash\n' \
+  > "${hooks_cleanup_failure_home}/.vibeguard/run-hook-codex.sh"
+printf 'verified payload\n' \
+  > "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+cat > "${hooks_cleanup_failure_runtime}" <<SH
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "setup-codex-hooks-remove" \
+  && "\${2:-}" == "${REPO_DIR}" ]]; then
+  exit 43
+fi
+exec "${cleanup_real_runtime}" "\$@"
+SH
+chmod +x "${hooks_cleanup_failure_runtime}"
+hooks_cleanup_failure_rc=0
+HOME="${hooks_cleanup_failure_home}" \
+  VIBEGUARD_SETUP_RUNTIME="${hooks_cleanup_failure_runtime}" \
+  bash "${REPO_DIR}/setup.sh" --clean >/dev/null 2>&1 \
+  || hooks_cleanup_failure_rc=$?
+assert_cmd "Codex hooks helper failure aborts clean" \
+  test "${hooks_cleanup_failure_rc}" -ne 0
+assert_cmd "Codex hooks helper failure preserves hooks, wrapper, and recovery payload" bash -c \
+  'test -f "$1" && test -f "$2" && test -f "$3"' _ \
+  "${hooks_cleanup_failure_home}/.codex/hooks.json" \
+  "${hooks_cleanup_failure_home}/.vibeguard/run-hook-codex.sh" \
+  "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"

--- a/tests/setup/cleanup_failure_tests.sh
+++ b/tests/setup/cleanup_failure_tests.sh
@@ -94,3 +94,49 @@ assert_cmd "Codex hooks helper failure preserves hooks, wrapper, and recovery pa
   "${hooks_cleanup_failure_home}/.codex/hooks.json" \
   "${hooks_cleanup_failure_home}/.vibeguard/run-hook-codex.sh" \
   "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+
+rm_cleanup_failure_home="${TMP_HOME}/rm-cleanup-failure-home"
+rm_cleanup_failure_bin="${TMP_HOME}/rm-cleanup-failure-bin"
+rm_cleanup_failure_runtime="${TMP_HOME}/rm-cleanup-failure-runtime"
+rm_cleanup_failure_skill="${rm_cleanup_failure_home}/.codex/skills/vibeguard"
+rm_cleanup_real="$(command -v rm)"
+mkdir -p "${rm_cleanup_failure_home}/.vibeguard/_lib" \
+  "${rm_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
+  "${rm_cleanup_failure_skill}" "${rm_cleanup_failure_bin}"
+printf 'managed skill\n' > "${rm_cleanup_failure_skill}/SKILL.md"
+printf '#!/usr/bin/env bash\n' \
+  > "${rm_cleanup_failure_home}/.vibeguard/run-hook-codex.sh"
+printf '#!/usr/bin/env bash\n' \
+  > "${rm_cleanup_failure_home}/.vibeguard/_lib/codex_diag.sh"
+printf 'verified payload\n' \
+  > "${rm_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+cat > "${rm_cleanup_failure_runtime}" <<SH
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "setup-codex-hooks-remove" ]]; then
+  printf 'SKIP\n'
+  exit 0
+fi
+exec "${cleanup_real_runtime}" "\$@"
+SH
+cat > "${rm_cleanup_failure_bin}/rm" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [[ "\${arg}" == "${rm_cleanup_failure_skill}" ]]; then
+    exit 44
+  fi
+done
+exec "${rm_cleanup_real}" "\$@"
+SH
+chmod +x "${rm_cleanup_failure_runtime}" "${rm_cleanup_failure_bin}/rm"
+rm_cleanup_failure_rc=0
+HOME="${rm_cleanup_failure_home}" \
+  PATH="${rm_cleanup_failure_bin}:${PATH}" \
+  VIBEGUARD_SETUP_RUNTIME="${rm_cleanup_failure_runtime}" \
+  bash "${REPO_DIR}/setup.sh" --clean >/dev/null 2>&1 \
+  || rm_cleanup_failure_rc=$?
+assert_cmd "managed skill removal failure aborts clean" \
+  test "${rm_cleanup_failure_rc}" -ne 0
+assert_cmd "managed skill removal failure preserves skill and recovery payload" bash -c \
+  'test -f "$1" && test -f "$2"' _ \
+  "${rm_cleanup_failure_skill}/SKILL.md" \
+  "${rm_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"

--- a/tests/setup/install_core_flow_tests.sh
+++ b/tests/setup/install_core_flow_tests.sh
@@ -19,7 +19,31 @@ SH
 cat > "${standalone_systemd_bin}/systemctl" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${VIBEGUARD_TEST_SYSTEMCTL_LOG}"
-exit 0
+[[ "${1:-}" == "--user" ]] && shift
+case "${1:-}" in
+  stop|disable|daemon-reload|list-timers)
+    exit 0
+    ;;
+  is-active)
+    printf 'inactive\n'
+    exit 3
+    ;;
+  is-enabled)
+    printf 'disabled\n'
+    exit 1
+    ;;
+  enable)
+    if [[ "${VIBEGUARD_TEST_SYSTEMD_ENABLE_FAIL_ONCE:-0}" == "1" \
+      && ! -e "${VIBEGUARD_TEST_SYSTEMD_FAIL_MARKER}" ]]; then
+      : > "${VIBEGUARD_TEST_SYSTEMD_FAIL_MARKER}"
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
 SH
 chmod +x "${standalone_systemd_bin}/uname" "${standalone_systemd_bin}/systemctl"
 
@@ -38,11 +62,23 @@ assert_cmd "fresh standalone install writes both systemd units" bash -c \
   "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer"
 
 standalone_fresh_receipt="${standalone_fresh_home}/.vibeguard/scheduler-ownership"
-mkdir -p "$(dirname "${standalone_fresh_receipt}")"
-printf 'schema=1\nkind=systemd\nphase=managed\nservice_sha256=%s\ntimer_sha256=%s\n' \
-  "$(shasum -a 256 "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" | awk '{print $1}')" \
-  "$(shasum -a 256 "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" | awk '{print $1}')" \
-  > "${standalone_fresh_receipt}"
+standalone_fresh_service_sha="$(
+  shasum -a 256 \
+    "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" \
+    | awk '{print $1}'
+)"
+standalone_fresh_timer_sha="$(
+  shasum -a 256 \
+    "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" \
+    | awk '{print $1}'
+)"
+assert_cmd "fresh standalone install records exact systemd ownership" bash -c \
+  'grep -qFx "phase=managed" "$3" \
+    && grep -qFx "service_sha256=$1" "$3" \
+    && grep -qFx "timer_sha256=$2" "$3"' _ \
+  "${standalone_fresh_service_sha}" \
+  "${standalone_fresh_timer_sha}" \
+  "${standalone_fresh_receipt}"
 : > "${standalone_fresh_log}"
 assert_cmd "documented systemd installer preserves valid-owned refresh behavior" \
   env HOME="${standalone_fresh_home}" \
@@ -51,6 +87,8 @@ assert_cmd "documented systemd installer preserves valid-owned refresh behavior"
   bash "${REPO_DIR}/scripts/install-systemd.sh"
 assert_cmd "valid-owned standalone refresh still invokes systemd" \
   test -s "${standalone_fresh_log}"
+
+source "${REPO_DIR}/tests/setup/systemd_refresh_transaction_tests.sh"
 
 standalone_malformed_home="${TMP_HOME}/standalone-systemd-malformed-home"
 standalone_malformed_dir="${standalone_malformed_home}/.config/systemd/user"
@@ -159,6 +197,21 @@ cat > "${systemd_remove_bin}/systemctl" <<'SH'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--user" ]] && shift
 case "${VIBEGUARD_TEST_SYSTEMD_REMOVE_MODE:-success}:${1:-}" in
+  service-active:stop)
+    [[ "${2:-}" == "vibeguard-gc.service" ]] && exit 9
+    exit 0
+    ;;
+  service-active:is-active)
+    if [[ "${2:-}" == "vibeguard-gc.service" ]]; then
+      printf 'active\n'
+      exit 0
+    fi
+    printf 'inactive\n'
+    exit 3
+    ;;
+  service-active:*)
+    exit 0
+    ;;
   success:stop|success:disable|success:daemon-reload) exit 0 ;;
   success:is-active) printf 'inactive\n'; exit 3 ;;
   success:is-enabled) printf 'disabled\n'; exit 1 ;;
@@ -207,6 +260,30 @@ assert_cmd "failed systemd deactivation preserves units and ownership receipt" b
   "${systemd_remove_failure_dir}/vibeguard-gc.service" \
   "${systemd_remove_failure_dir}/vibeguard-gc.timer" \
   "${systemd_remove_failure_receipt}"
+
+systemd_service_failure_home="${TMP_HOME}/systemd-service-failure-home"
+systemd_service_failure_dir="${systemd_service_failure_home}/.config/systemd/user"
+systemd_service_failure_receipt="${systemd_service_failure_home}/.vibeguard/scheduler-ownership"
+mkdir -p "${systemd_service_failure_dir}" \
+  "$(dirname "${systemd_service_failure_receipt}")"
+printf '[Service]\n' > "${systemd_service_failure_dir}/vibeguard-gc.service"
+printf '[Timer]\n' > "${systemd_service_failure_dir}/vibeguard-gc.timer"
+printf 'schema=1\nkind=systemd\nphase=managed\nservice_sha256=%s\ntimer_sha256=%s\n' \
+  "$(shasum -a 256 "${systemd_service_failure_dir}/vibeguard-gc.service" | awk '{print $1}')" \
+  "$(shasum -a 256 "${systemd_service_failure_dir}/vibeguard-gc.timer" | awk '{print $1}')" \
+  > "${systemd_service_failure_receipt}"
+systemd_service_failure_rc=0
+HOME="${systemd_service_failure_home}" PATH="${systemd_remove_bin}:${PATH}" \
+  VIBEGUARD_TEST_SYSTEMD_REMOVE_MODE=service-active \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" --remove >/dev/null 2>&1 \
+  || systemd_service_failure_rc=$?
+assert_cmd "systemd remover fails when oneshot service inactivity is not proven" \
+  test "${systemd_service_failure_rc}" -ne 0
+assert_cmd "active service preserves standalone units and ownership receipt" bash -c \
+  'test -f "$1" && test -f "$2" && test -f "$3"' _ \
+  "${systemd_service_failure_dir}/vibeguard-gc.service" \
+  "${systemd_service_failure_dir}/vibeguard-gc.timer" \
+  "${systemd_service_failure_receipt}"
 
 systemd_reload_failure_home="${TMP_HOME}/systemd-reload-failure-home"
 systemd_reload_failure_dir="${systemd_reload_failure_home}/.config/systemd/user"

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -174,6 +174,31 @@ assert_cmd "systemd clean removes files only after inactive and disabled postcon
   "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-service-active" \
   "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-enabled"
 
+runtime_clean_home="${TMP_HOME}/scheduler-runtime-clean-home"
+runtime_clean_dir="${runtime_clean_home}/.config/systemd/user"
+runtime_clean_receipt="${runtime_clean_home}/.vibeguard/scheduler-ownership"
+runtime_clean_enabled="${runtime_clean_home}/.systemctl-vibeguard-gc-enabled-runtime"
+mkdir -p "${runtime_clean_dir}" "$(dirname "${runtime_clean_receipt}")"
+printf '%s\n' '[Service]' 'ExecStart=/usr/local/bin/managed-gc' \
+  > "${runtime_clean_dir}/vibeguard-gc.service"
+printf '%s\n' '[Timer]' 'OnCalendar=daily' \
+  > "${runtime_clean_dir}/vibeguard-gc.timer"
+printf 'schema=1\nkind=systemd\nphase=managed\nservice_sha256=%s\ntimer_sha256=%s\n' \
+  "$(shasum -a 256 "${runtime_clean_dir}/vibeguard-gc.service" | awk '{print $1}')" \
+  "$(shasum -a 256 "${runtime_clean_dir}/vibeguard-gc.timer" | awk '{print $1}')" \
+  > "${runtime_clean_receipt}"
+touch "${runtime_clean_home}/.systemctl-vibeguard-gc-active" \
+  "${runtime_clean_home}/.systemctl-vibeguard-gc-service-active" \
+  "${runtime_clean_enabled}"
+HOME="${runtime_clean_home}" VIBEGUARD_TEST_UNAME=Linux \
+  bash "${REPO_DIR}/setup.sh" --clean >/dev/null
+assert_cmd "systemd clean removes runtime-enabled timer state and owned files" bash -c \
+  'test ! -e "$1" && test ! -e "$2" && test ! -e "$3" \
+    && test ! -e "$4"' _ \
+  "${runtime_clean_dir}/vibeguard-gc.service" \
+  "${runtime_clean_dir}/vibeguard-gc.timer" \
+  "${runtime_clean_receipt}" "${runtime_clean_enabled}"
+
 bootstrap_deactivate_home="${TMP_HOME}/bootstrap-scheduler-deactivate-home"
 env "${bootstrap_base_env[@]}" HOME="${bootstrap_deactivate_home}" \
   VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -76,12 +76,14 @@ rm -f "${HOME}/.systemctl-vibeguard-gc-active"
 rm -f "${HOME}/.systemctl-vibeguard-gc-enabled"
 
 for scheduler_deactivate_case in \
-  stop_failure active_after_stop disable_failure enabled_after_disable; do
+  stop_failure active_after_stop service_stop_failure \
+  service_active_after_stop disable_failure enabled_after_disable; do
   scheduler_deactivate_home="${TMP_HOME}/scheduler-deactivate-${scheduler_deactivate_case}-home"
   scheduler_deactivate_dir="${scheduler_deactivate_home}/.config/systemd/user"
   scheduler_deactivate_service="${scheduler_deactivate_dir}/vibeguard-gc.service"
   scheduler_deactivate_timer="${scheduler_deactivate_dir}/vibeguard-gc.timer"
   scheduler_deactivate_receipt="${scheduler_deactivate_home}/.vibeguard/scheduler-ownership"
+  scheduler_deactivate_service_active="${scheduler_deactivate_home}/.systemctl-vibeguard-gc-service-active"
   mkdir -p "${scheduler_deactivate_dir}" "$(dirname "${scheduler_deactivate_receipt}")"
   printf '%s\n' '[Service]' 'ExecStart=/usr/local/bin/managed-gc' \
     > "${scheduler_deactivate_service}"
@@ -101,6 +103,16 @@ for scheduler_deactivate_case in \
     active_after_stop)
       scheduler_deactivate_env+=(VIBEGUARD_TEST_SYSTEMD_STILL_ACTIVE=1)
       scheduler_deactivate_error="is not proven inactive after stop"
+      ;;
+    service_stop_failure)
+      touch "${scheduler_deactivate_service_active}"
+      scheduler_deactivate_env+=(VIBEGUARD_TEST_SYSTEMD_SERVICE_STOP_FAIL=1)
+      scheduler_deactivate_error="failed to stop scheduled GC systemd service"
+      ;;
+    service_active_after_stop)
+      touch "${scheduler_deactivate_service_active}"
+      scheduler_deactivate_env+=(VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE=1)
+      scheduler_deactivate_error="systemd service is not proven inactive after stop"
       ;;
     disable_failure)
       scheduler_deactivate_env+=(VIBEGUARD_TEST_SYSTEMD_DISABLE_FAIL=1)
@@ -127,6 +139,12 @@ for scheduler_deactivate_case in \
     'test -f "$1" && test -f "$2" && grep -qFx "phase=cleaning" "$3"' _ \
     "${scheduler_deactivate_service}" "${scheduler_deactivate_timer}" \
     "${scheduler_deactivate_receipt}"
+  case "${scheduler_deactivate_case}" in
+    service_stop_failure|service_active_after_stop)
+      assert_cmd "systemd ${scheduler_deactivate_case} preserves active service evidence" \
+        test -f "${scheduler_deactivate_service_active}"
+      ;;
+  esac
 done
 
 scheduler_deactivate_success_home="${TMP_HOME}/scheduler-deactivate-success-home"
@@ -143,15 +161,17 @@ printf 'schema=1\nkind=systemd\nphase=managed\nservice_sha256=%s\ntimer_sha256=%
   "$(shasum -a 256 "${scheduler_deactivate_success_dir}/vibeguard-gc.timer" | awk '{print $1}')" \
   > "${scheduler_deactivate_success_receipt}"
 touch "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-active"
+touch "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-service-active"
 touch "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-enabled"
 HOME="${scheduler_deactivate_success_home}" VIBEGUARD_TEST_UNAME=Linux \
   bash "${REPO_DIR}/setup.sh" --clean >/dev/null
 assert_cmd "systemd clean removes files only after inactive and disabled postconditions" bash -c \
-  'test ! -e "$1" && test ! -e "$2" && test ! -e "$3" && test ! -e "$4" && test ! -e "$5"' _ \
+  'test ! -e "$1" && test ! -e "$2" && test ! -e "$3" && test ! -e "$4" && test ! -e "$5" && test ! -e "$6"' _ \
   "${scheduler_deactivate_success_dir}/vibeguard-gc.service" \
   "${scheduler_deactivate_success_dir}/vibeguard-gc.timer" \
   "${scheduler_deactivate_success_receipt}" \
   "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-active" \
+  "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-service-active" \
   "${scheduler_deactivate_success_home}/.systemctl-vibeguard-gc-enabled"
 
 bootstrap_deactivate_home="${TMP_HOME}/bootstrap-scheduler-deactivate-home"
@@ -500,6 +520,8 @@ HOME="${launchd_clean_home}" VIBEGUARD_TEST_UNAME=Darwin \
 assert_cmd "launchd clean retry removes receipt after confirming absence" bash -c \
   'test ! -e "$1" && test ! -e "$2"' _ \
   "${launchd_clean_plist}" "${launchd_clean_receipt}"
+
+source "${REPO_DIR}/tests/setup/cleanup_failure_tests.sh"
 
 bash "${REPO_DIR}/setup.sh" --yes --profile full >/dev/null
 

--- a/tests/setup/systemctl_stub.sh
+++ b/tests/setup/systemctl_stub.sh
@@ -2,13 +2,21 @@
 active_state="${HOME}/.systemctl-vibeguard-gc-active"
 service_active_state="${HOME}/.systemctl-vibeguard-gc-service-active"
 enabled_state="${HOME}/.systemctl-vibeguard-gc-enabled"
+runtime_enabled_state="${HOME}/.systemctl-vibeguard-gc-enabled-runtime"
 [[ "${1:-}" == "--user" ]] && shift
 case "${1:-}" in
   daemon-reload) exit 0 ;;
   enable)
-    [[ "${2:-}" == "--now" && "${3:-}" == "vibeguard-gc.timer" ]] || exit 0
     [[ "${VIBEGUARD_TEST_SYSTEMD_ENABLE_FAIL:-0}" == "1" ]] && exit 1
-    touch "$active_state" "$enabled_state"
+    if [[ "${2:-}" == "--runtime" \
+      && "${3:-}" == "vibeguard-gc.timer" ]]; then
+      touch "$runtime_enabled_state"
+    elif [[ "${2:-}" == "--now" \
+      && "${3:-}" == "vibeguard-gc.timer" ]]; then
+      touch "$active_state" "$enabled_state"
+    elif [[ "${2:-}" == "vibeguard-gc.timer" ]]; then
+      touch "$enabled_state"
+    fi
     ;;
   start)
     [[ "${2:-}" == "vibeguard-gc.timer" ]] && touch "$active_state"
@@ -28,7 +36,13 @@ case "${1:-}" in
     ;;
   disable)
     [[ "${VIBEGUARD_TEST_SYSTEMD_DISABLE_FAIL:-0}" == "1" ]] && exit 1
-    [[ "${VIBEGUARD_TEST_SYSTEMD_STILL_ENABLED:-0}" == "1" ]] || rm -f "$enabled_state"
+    if [[ "${2:-}" == "--runtime" ]]; then
+      [[ "${VIBEGUARD_TEST_SYSTEMD_RUNTIME_STILL_ENABLED:-0}" == "1" ]] \
+        || rm -f "$runtime_enabled_state"
+    else
+      [[ "${VIBEGUARD_TEST_SYSTEMD_STILL_ENABLED:-0}" == "1" ]] \
+        || rm -f "$enabled_state"
+    fi
     ;;
   is-active)
     if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$active_state" ]]; then
@@ -40,6 +54,9 @@ case "${1:-}" in
     printf 'inactive\n'; exit 3
     ;;
   is-enabled)
+    if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$runtime_enabled_state" ]]; then
+      printf 'enabled-runtime\n'; exit 0
+    fi
     if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$enabled_state" ]]; then
       printf 'enabled\n'; exit 0
     fi

--- a/tests/setup/systemctl_stub.sh
+++ b/tests/setup/systemctl_stub.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+active_state="${HOME}/.systemctl-vibeguard-gc-active"
+service_active_state="${HOME}/.systemctl-vibeguard-gc-service-active"
+enabled_state="${HOME}/.systemctl-vibeguard-gc-enabled"
+[[ "${1:-}" == "--user" ]] && shift
+case "${1:-}" in
+  daemon-reload) exit 0 ;;
+  enable)
+    [[ "${2:-}" == "--now" && "${3:-}" == "vibeguard-gc.timer" ]] || exit 0
+    [[ "${VIBEGUARD_TEST_SYSTEMD_ENABLE_FAIL:-0}" == "1" ]] && exit 1
+    touch "$active_state" "$enabled_state"
+    ;;
+  start)
+    [[ "${2:-}" == "vibeguard-gc.timer" ]] && touch "$active_state"
+    ;;
+  stop)
+    case "${2:-}" in
+      vibeguard-gc.timer)
+        [[ "${VIBEGUARD_TEST_SYSTEMD_STOP_FAIL:-0}" == "1" ]] && exit 1
+        [[ "${VIBEGUARD_TEST_SYSTEMD_STILL_ACTIVE:-0}" == "1" ]] || rm -f "$active_state"
+        ;;
+      vibeguard-gc.service)
+        [[ "${VIBEGUARD_TEST_SYSTEMD_SERVICE_STOP_FAIL:-0}" == "1" ]] && exit 1
+        [[ "${VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE:-0}" == "1" ]] \
+          || rm -f "$service_active_state"
+        ;;
+    esac
+    ;;
+  disable)
+    [[ "${VIBEGUARD_TEST_SYSTEMD_DISABLE_FAIL:-0}" == "1" ]] && exit 1
+    [[ "${VIBEGUARD_TEST_SYSTEMD_STILL_ENABLED:-0}" == "1" ]] || rm -f "$enabled_state"
+    ;;
+  is-active)
+    if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$active_state" ]]; then
+      printf 'active\n'; exit 0
+    fi
+    if [[ "${2:-}" == "vibeguard-gc.service" && -f "$service_active_state" ]]; then
+      printf 'active\n'; exit 0
+    fi
+    printf 'inactive\n'; exit 3
+    ;;
+  is-enabled)
+    if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$enabled_state" ]]; then
+      printf 'enabled\n'; exit 0
+    fi
+    printf 'disabled\n'; exit 1
+    ;;
+  status)
+    [[ "${2:-}" == "vibeguard-gc.timer" && -f "$active_state" ]] && exit 0
+    exit 3
+    ;;
+  list-timers)
+    if [[ -f "$active_state" ]]; then
+      printf 'NEXT LEFT LAST PASSED UNIT ACTIVATES\n'
+      printf 'Sun 03:00 - - - vibeguard-gc.timer vibeguard-gc.service\n'
+    fi
+    ;;
+  *) exit 0 ;;
+esac

--- a/tests/setup/systemd_refresh_transaction_tests.sh
+++ b/tests/setup/systemd_refresh_transaction_tests.sh
@@ -116,14 +116,20 @@ case "${1:-}" in
     if [[ "${2:-}" == "vibeguard-gc.timer" ]]; then
       rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}"
     elif [[ "${2:-}" == "vibeguard-gc.service" ]]; then
-      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE}"
+      if [[ "${VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE_ONCE:-0}" == "1" \
+        && ! -e "${VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE_MARKER}" ]]; then
+        touch "${VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE_MARKER}"
+      else
+        rm -f -- "${VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE}"
+      fi
     fi
     exit 0
     ;;
   disable)
-    rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
-    if [[ -n "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME:-}" ]]; then
+    if [[ "${2:-}" == "--runtime" ]]; then
       rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME}"
+    else
+      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
     fi
     exit 0
     ;;
@@ -343,6 +349,72 @@ assert_cmd "runtime-enabled refresh restores units and receipt byte-for-byte" ba
 assert_cmd "runtime-enabled refresh restores runtime enablement exactly" bash -c \
   'test -e "$1" && test ! -e "$2"' _ \
   "${runtime_refresh_enabled_runtime}" "${runtime_refresh_enabled}"
+
+successful_service_home="${TMP_HOME}/standalone-systemd-successful-service-refresh-home"
+successful_service_active="${successful_service_home}/.systemctl-vibeguard-gc-active"
+successful_service_service_active="${successful_service_home}/.systemctl-vibeguard-gc-service-active"
+successful_service_enabled="${successful_service_home}/.systemctl-vibeguard-gc-enabled"
+successful_service_enabled_runtime="${successful_service_home}/.systemctl-vibeguard-gc-enabled-runtime"
+successful_service_activated="${successful_service_home}/.systemctl-vibeguard-gc-activated"
+mkdir -p "${successful_service_home}"
+env HOME="${successful_service_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${successful_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${successful_service_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${successful_service_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${successful_service_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${successful_service_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${successful_service_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+touch "${successful_service_service_active}"
+rm -f -- "${successful_service_activated}"
+env HOME="${successful_service_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${successful_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${successful_service_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${successful_service_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${successful_service_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${successful_service_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${successful_service_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+assert_cmd "successful refresh restarts a previously active service" \
+  test -e "${successful_service_service_active}"
+
+deactivation_rollback_home="${TMP_HOME}/standalone-systemd-deactivation-rollback-home"
+deactivation_rollback_active="${deactivation_rollback_home}/.systemctl-vibeguard-gc-active"
+deactivation_rollback_service_active="${deactivation_rollback_home}/.systemctl-vibeguard-gc-service-active"
+deactivation_rollback_enabled="${deactivation_rollback_home}/.systemctl-vibeguard-gc-enabled"
+deactivation_rollback_enabled_runtime="${deactivation_rollback_home}/.systemctl-vibeguard-gc-enabled-runtime"
+deactivation_rollback_activated="${deactivation_rollback_home}/.systemctl-vibeguard-gc-activated"
+deactivation_rollback_still_active_marker="${deactivation_rollback_home}/.systemctl-service-still-active-once"
+mkdir -p "${deactivation_rollback_home}"
+env HOME="${deactivation_rollback_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${deactivation_rollback_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${deactivation_rollback_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${deactivation_rollback_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${deactivation_rollback_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${deactivation_rollback_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${deactivation_rollback_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+touch "${deactivation_rollback_service_active}"
+deactivation_rollback_rc=0
+env HOME="${deactivation_rollback_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${deactivation_rollback_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${deactivation_rollback_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${deactivation_rollback_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${deactivation_rollback_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${deactivation_rollback_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${deactivation_rollback_home}/not-this-run" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE_ONCE=1 \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_STILL_ACTIVE_MARKER="${deactivation_rollback_still_active_marker}" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null 2>&1 \
+  || deactivation_rollback_rc=$?
+assert_cmd "partial deactivation failure returns nonzero" \
+  test "${deactivation_rollback_rc}" -ne 0
+assert_cmd "partial deactivation rollback restores timer, service, and enablement" bash -c \
+  'test -e "$1" && test -e "$2" && test -e "$3"' _ \
+  "${deactivation_rollback_active}" "${deactivation_rollback_service_active}" \
+  "${deactivation_rollback_enabled}"
 
 remove_rollback_home="${TMP_HOME}/standalone-systemd-remove-rollback-home"
 remove_rollback_service="${remove_rollback_home}/.config/systemd/user/vibeguard-gc.service"

--- a/tests/setup/systemd_refresh_transaction_tests.sh
+++ b/tests/setup/systemd_refresh_transaction_tests.sh
@@ -1,0 +1,66 @@
+standalone_alt_repo="${TMP_HOME}/standalone-systemd-alt-repo"
+mkdir -p "${standalone_alt_repo}/scripts/gc"
+printf '#!/usr/bin/env bash\nexit 0\n' \
+  > "${standalone_alt_repo}/scripts/gc/gc-scheduled.sh"
+chmod +x "${standalone_alt_repo}/scripts/gc/gc-scheduled.sh"
+: > "${standalone_fresh_log}"
+assert_cmd "standalone refresh supports changed rendered repository path" \
+  env HOME="${standalone_fresh_home}" \
+  PATH="${standalone_systemd_bin}:${PATH}" \
+  VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+  VIBEGUARD_TEST_SYSTEMCTL_LOG="${standalone_fresh_log}" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh"
+standalone_refreshed_service_sha="$(
+  shasum -a 256 \
+    "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" \
+    | awk '{print $1}'
+)"
+standalone_refreshed_timer_sha="$(
+  shasum -a 256 \
+    "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" \
+    | awk '{print $1}'
+)"
+assert_cmd "changed-path refresh updates units and exact receipt hashes" bash -c \
+  'grep -qF "$4" "$1" \
+    && grep -qFx "service_sha256=$5" "$3" \
+    && grep -qFx "timer_sha256=$6" "$3"' _ \
+  "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" \
+  "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" \
+  "${standalone_fresh_receipt}" "${standalone_alt_repo}" \
+  "${standalone_refreshed_service_sha}" \
+  "${standalone_refreshed_timer_sha}"
+assert_cmd "next standalone run accepts refreshed ownership receipt" \
+  env HOME="${standalone_fresh_home}" \
+  PATH="${standalone_systemd_bin}:${PATH}" \
+  VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+  VIBEGUARD_TEST_SYSTEMCTL_LOG="${standalone_fresh_log}" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh"
+
+standalone_rollback_repo="${TMP_HOME}/standalone-systemd-rollback-repo"
+standalone_rollback_marker="${TMP_HOME}/standalone-systemd-enable-failed-once"
+mkdir -p "${standalone_rollback_repo}/scripts/gc"
+printf '#!/usr/bin/env bash\nexit 0\n' \
+  > "${standalone_rollback_repo}/scripts/gc/gc-scheduled.sh"
+chmod +x "${standalone_rollback_repo}/scripts/gc/gc-scheduled.sh"
+standalone_refresh_before="$(
+  shasum -a 256 \
+    "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" \
+    "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" \
+    "${standalone_fresh_receipt}"
+)"
+standalone_refresh_fail_rc=0
+env HOME="${standalone_fresh_home}" \
+  PATH="${standalone_systemd_bin}:${PATH}" \
+  VIBEGUARD_REPO_DIR="${standalone_rollback_repo}" \
+  VIBEGUARD_TEST_SYSTEMCTL_LOG="${standalone_fresh_log}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLE_FAIL_ONCE=1 \
+  VIBEGUARD_TEST_SYSTEMD_FAIL_MARKER="${standalone_rollback_marker}" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null 2>&1 \
+  || standalone_refresh_fail_rc=$?
+assert_cmd "failed standalone activation returns nonzero after rollback" \
+  test "${standalone_refresh_fail_rc}" -ne 0
+assert_cmd "failed standalone refresh restores units and receipt byte-for-byte" bash -c \
+  'test "$(shasum -a 256 "$1" "$2" "$3")" = "$4"' _ \
+  "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" \
+  "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" \
+  "${standalone_fresh_receipt}" "${standalone_refresh_before}"

--- a/tests/setup/systemd_refresh_transaction_tests.sh
+++ b/tests/setup/systemd_refresh_transaction_tests.sh
@@ -77,11 +77,27 @@ cat > "${post_activation_hash_bin}/systemctl" <<'SH'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--user" ]] && shift
 case "${1:-}" in
-  daemon-reload|list-timers)
+  daemon-reload)
+    if [[ "${VIBEGUARD_TEST_SYSTEMD_DAEMON_RELOAD_FAIL_ONCE:-0}" == "1" \
+      && ! -e "${VIBEGUARD_TEST_SYSTEMD_DAEMON_RELOAD_FAIL_MARKER}" ]]; then
+      touch "${VIBEGUARD_TEST_SYSTEMD_DAEMON_RELOAD_FAIL_MARKER}"
+      exit 91
+    fi
+    exit 0
+    ;;
+  list-timers)
     exit 0
     ;;
   enable)
+    if [[ "${2:-}" == "--runtime" ]]; then
+      touch "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME}"
+      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
+      exit 0
+    fi
     touch "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
+    if [[ -n "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME:-}" ]]; then
+      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME}"
+    fi
     if [[ "${2:-}" == "--now" ]]; then
       touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}" \
         "${VIBEGUARD_TEST_HASH_ACTIVATED}"
@@ -91,15 +107,24 @@ case "${1:-}" in
   start)
     if [[ "${2:-}" == "vibeguard-gc.timer" ]]; then
       touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}"
+    elif [[ "${2:-}" == "vibeguard-gc.service" ]]; then
+      touch "${VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE}"
     fi
     exit 0
     ;;
   stop)
-    rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}"
+    if [[ "${2:-}" == "vibeguard-gc.timer" ]]; then
+      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}"
+    elif [[ "${2:-}" == "vibeguard-gc.service" ]]; then
+      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE}"
+    fi
     exit 0
     ;;
   disable)
     rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
+    if [[ -n "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME:-}" ]]; then
+      rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME}"
+    fi
     exit 0
     ;;
   is-active)
@@ -108,10 +133,20 @@ case "${1:-}" in
       printf 'active\n'
       exit 0
     fi
+    if [[ "${2:-}" == "vibeguard-gc.service" \
+      && -e "${VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE}" ]]; then
+      printf 'active\n'
+      exit 0
+    fi
     printf 'inactive\n'
     exit 3
     ;;
   is-enabled)
+    if [[ -n "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME:-}" \
+      && -e "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME}" ]]; then
+      printf 'enabled-runtime\n'
+      exit 0
+    fi
     if [[ -e "${VIBEGUARD_TEST_SYSTEMD_ENABLED}" ]]; then
       printf 'enabled\n'
       exit 0
@@ -259,3 +294,100 @@ assert_cmd "inactive disabled refresh restores units and receipt byte-for-byte" 
 assert_cmd "inactive disabled refresh does not activate or enable timer" bash -c \
   'test ! -e "$1" && test ! -e "$2"' _ \
   "${refresh_hash_active}" "${refresh_hash_enabled}"
+
+runtime_refresh_home="${TMP_HOME}/standalone-systemd-runtime-refresh-home"
+runtime_refresh_service="${runtime_refresh_home}/.config/systemd/user/vibeguard-gc.service"
+runtime_refresh_timer="${runtime_refresh_home}/.config/systemd/user/vibeguard-gc.timer"
+runtime_refresh_receipt="${runtime_refresh_home}/.vibeguard/scheduler-ownership"
+runtime_refresh_active="${runtime_refresh_home}/.systemctl-vibeguard-gc-active"
+runtime_refresh_service_active="${runtime_refresh_home}/.systemctl-vibeguard-gc-service-active"
+runtime_refresh_enabled="${runtime_refresh_home}/.systemctl-vibeguard-gc-enabled"
+runtime_refresh_enabled_runtime="${runtime_refresh_home}/.systemctl-vibeguard-gc-enabled-runtime"
+runtime_refresh_activated="${runtime_refresh_home}/.systemctl-vibeguard-gc-activated"
+mkdir -p "${runtime_refresh_home}"
+env HOME="${runtime_refresh_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${runtime_refresh_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${runtime_refresh_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${runtime_refresh_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${runtime_refresh_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${runtime_refresh_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${runtime_refresh_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+rm -f -- "${runtime_refresh_enabled}" "${runtime_refresh_activated}"
+touch "${runtime_refresh_enabled_runtime}"
+runtime_refresh_before="$(
+  shasum -a 256 \
+    "${runtime_refresh_service}" "${runtime_refresh_timer}" \
+    "${runtime_refresh_receipt}"
+)"
+runtime_refresh_rc=0
+runtime_refresh_out="$(
+  env HOME="${runtime_refresh_home}" "${post_activation_hash_env[@]}" \
+    VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+    VIBEGUARD_TEST_SYSTEMD_ACTIVE="${runtime_refresh_active}" \
+    VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${runtime_refresh_service_active}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED="${runtime_refresh_enabled}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${runtime_refresh_enabled_runtime}" \
+    VIBEGUARD_TEST_HASH_ACTIVATED="${runtime_refresh_activated}" \
+    VIBEGUARD_TEST_HASH_FAIL_PATH="${runtime_refresh_timer}" \
+    bash "${REPO_DIR}/scripts/install-systemd.sh" 2>&1
+)" || runtime_refresh_rc=$?
+assert_cmd "runtime-enabled refresh reaches the intentional hash failure" \
+  grep -qF "failed to hash installed systemd units" <<< "${runtime_refresh_out}"
+assert_cmd "runtime-enabled refresh hash failure returns nonzero" \
+  test "${runtime_refresh_rc}" -ne 0
+assert_cmd "runtime-enabled refresh restores units and receipt byte-for-byte" bash -c \
+  'test "$(shasum -a 256 "$1" "$2" "$3")" = "$4"' _ \
+  "${runtime_refresh_service}" "${runtime_refresh_timer}" \
+  "${runtime_refresh_receipt}" "${runtime_refresh_before}"
+assert_cmd "runtime-enabled refresh restores runtime enablement exactly" bash -c \
+  'test -e "$1" && test ! -e "$2"' _ \
+  "${runtime_refresh_enabled_runtime}" "${runtime_refresh_enabled}"
+
+remove_rollback_home="${TMP_HOME}/standalone-systemd-remove-rollback-home"
+remove_rollback_service="${remove_rollback_home}/.config/systemd/user/vibeguard-gc.service"
+remove_rollback_timer="${remove_rollback_home}/.config/systemd/user/vibeguard-gc.timer"
+remove_rollback_receipt="${remove_rollback_home}/.vibeguard/scheduler-ownership"
+remove_rollback_active="${remove_rollback_home}/.systemctl-vibeguard-gc-active"
+remove_rollback_service_active="${remove_rollback_home}/.systemctl-vibeguard-gc-service-active"
+remove_rollback_enabled="${remove_rollback_home}/.systemctl-vibeguard-gc-enabled"
+remove_rollback_enabled_runtime="${remove_rollback_home}/.systemctl-vibeguard-gc-enabled-runtime"
+remove_rollback_activated="${remove_rollback_home}/.systemctl-vibeguard-gc-activated"
+remove_rollback_reload_marker="${remove_rollback_home}/.systemctl-daemon-reload-failed"
+mkdir -p "${remove_rollback_home}"
+env HOME="${remove_rollback_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${remove_rollback_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${remove_rollback_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${remove_rollback_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${remove_rollback_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${remove_rollback_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${remove_rollback_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+touch "${remove_rollback_service_active}"
+remove_rollback_before="$(
+  shasum -a 256 \
+    "${remove_rollback_service}" "${remove_rollback_timer}" \
+    "${remove_rollback_receipt}"
+)"
+remove_rollback_rc=0
+env HOME="${remove_rollback_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${remove_rollback_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${remove_rollback_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${remove_rollback_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${remove_rollback_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${remove_rollback_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${remove_rollback_home}/not-this-run" \
+  VIBEGUARD_TEST_SYSTEMD_DAEMON_RELOAD_FAIL_ONCE=1 \
+  VIBEGUARD_TEST_SYSTEMD_DAEMON_RELOAD_FAIL_MARKER="${remove_rollback_reload_marker}" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" --remove >/dev/null 2>&1 \
+  || remove_rollback_rc=$?
+assert_cmd "remove daemon-reload failure returns nonzero" \
+  test "${remove_rollback_rc}" -ne 0
+assert_cmd "remove rollback restores units and receipt byte-for-byte" bash -c \
+  'test "$(shasum -a 256 "$1" "$2" "$3")" = "$4"' _ \
+  "${remove_rollback_service}" "${remove_rollback_timer}" \
+  "${remove_rollback_receipt}" "${remove_rollback_before}"
+assert_cmd "remove rollback restores timer, service, and enablement state" bash -c \
+  'test -e "$1" && test -e "$2" && test -e "$3"' _ \
+  "${remove_rollback_active}" "${remove_rollback_service_active}" \
+  "${remove_rollback_enabled}"

--- a/tests/setup/systemd_refresh_transaction_tests.sh
+++ b/tests/setup/systemd_refresh_transaction_tests.sh
@@ -92,6 +92,10 @@ case "${1:-}" in
     if [[ "${2:-}" == "--runtime" ]]; then
       touch "${VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME}"
       rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
+      if [[ "${3:-}" == "--now" ]]; then
+        touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}" \
+          "${VIBEGUARD_TEST_HASH_ACTIVATED}"
+      fi
       exit 0
     fi
     touch "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
@@ -349,6 +353,72 @@ assert_cmd "runtime-enabled refresh restores units and receipt byte-for-byte" ba
 assert_cmd "runtime-enabled refresh restores runtime enablement exactly" bash -c \
   'test -e "$1" && test ! -e "$2"' _ \
   "${runtime_refresh_enabled_runtime}" "${runtime_refresh_enabled}"
+
+runtime_success_home="${TMP_HOME}/standalone-systemd-runtime-success-home"
+runtime_success_active="${runtime_success_home}/.systemctl-vibeguard-gc-active"
+runtime_success_service_active="${runtime_success_home}/.systemctl-vibeguard-gc-service-active"
+runtime_success_enabled="${runtime_success_home}/.systemctl-vibeguard-gc-enabled"
+runtime_success_enabled_runtime="${runtime_success_home}/.systemctl-vibeguard-gc-enabled-runtime"
+runtime_success_activated="${runtime_success_home}/.systemctl-vibeguard-gc-activated"
+mkdir -p "${runtime_success_home}"
+env HOME="${runtime_success_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${runtime_success_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${runtime_success_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${runtime_success_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${runtime_success_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${runtime_success_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${runtime_success_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+rm -f -- "${runtime_success_enabled}" "${runtime_success_activated}"
+touch "${runtime_success_enabled_runtime}"
+env HOME="${runtime_success_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${runtime_success_active}" \
+  VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${runtime_success_service_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${runtime_success_enabled}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${runtime_success_enabled_runtime}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${runtime_success_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${runtime_success_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+assert_cmd "successful runtime-enabled refresh stays runtime-only and active" bash -c \
+  'test -e "$1" && test ! -e "$2" && test -e "$3"' _ \
+  "${runtime_success_enabled_runtime}" "${runtime_success_enabled}" \
+  "${runtime_success_active}"
+
+fresh_unowned_home="${TMP_HOME}/standalone-systemd-fresh-unowned-home"
+fresh_unowned_service="${fresh_unowned_home}/.config/systemd/user/vibeguard-gc.service"
+fresh_unowned_timer="${fresh_unowned_home}/.config/systemd/user/vibeguard-gc.timer"
+fresh_unowned_receipt="${fresh_unowned_home}/.vibeguard/scheduler-ownership"
+fresh_unowned_active="${fresh_unowned_home}/.systemctl-vibeguard-gc-active"
+fresh_unowned_service_active="${fresh_unowned_home}/.systemctl-vibeguard-gc-service-active"
+fresh_unowned_enabled="${fresh_unowned_home}/.systemctl-vibeguard-gc-enabled"
+fresh_unowned_enabled_runtime="${fresh_unowned_home}/.systemctl-vibeguard-gc-enabled-runtime"
+fresh_unowned_activated="${fresh_unowned_home}/.systemctl-vibeguard-gc-activated"
+mkdir -p "${fresh_unowned_home}"
+touch "${fresh_unowned_active}" "${fresh_unowned_service_active}" \
+  "${fresh_unowned_enabled_runtime}"
+fresh_unowned_rc=0
+fresh_unowned_out="$(
+  env HOME="${fresh_unowned_home}" "${post_activation_hash_env[@]}" \
+    VIBEGUARD_TEST_SYSTEMD_ACTIVE="${fresh_unowned_active}" \
+    VIBEGUARD_TEST_SYSTEMD_SERVICE_ACTIVE="${fresh_unowned_service_active}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED="${fresh_unowned_enabled}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED_RUNTIME="${fresh_unowned_enabled_runtime}" \
+    VIBEGUARD_TEST_HASH_ACTIVATED="${fresh_unowned_activated}" \
+    VIBEGUARD_TEST_HASH_FAIL_PATH="${fresh_unowned_home}/not-this-run" \
+    bash "${REPO_DIR}/scripts/install-systemd.sh" 2>&1
+)" || fresh_unowned_rc=$?
+assert_cmd "fresh install rejects active or enabled same-named unowned state" \
+  test "${fresh_unowned_rc}" -ne 0
+assert_contains "${fresh_unowned_out}" \
+  "active or enabled without a VibeGuard ownership receipt" \
+  "fresh unowned rejection explains the ownership boundary"
+assert_cmd "fresh unowned rejection preserves state and creates no local ownership" bash -c \
+  'test -e "$1" && test -e "$2" && test -e "$3" \
+    && test ! -e "$4" && test ! -e "$5" && test ! -e "$6"' _ \
+  "${fresh_unowned_active}" "${fresh_unowned_service_active}" \
+  "${fresh_unowned_enabled_runtime}" "${fresh_unowned_service}" \
+  "${fresh_unowned_timer}" "${fresh_unowned_receipt}"
 
 successful_service_home="${TMP_HOME}/standalone-systemd-successful-service-refresh-home"
 successful_service_active="${successful_service_home}/.systemctl-vibeguard-gc-active"

--- a/tests/setup/systemd_refresh_transaction_tests.sh
+++ b/tests/setup/systemd_refresh_transaction_tests.sh
@@ -64,3 +64,159 @@ assert_cmd "failed standalone refresh restores units and receipt byte-for-byte" 
   "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.service" \
   "${standalone_fresh_home}/.config/systemd/user/vibeguard-gc.timer" \
   "${standalone_fresh_receipt}" "${standalone_refresh_before}"
+
+post_activation_hash_bin="${TMP_HOME}/standalone-systemd-post-activation-hash-bin"
+post_activation_real_sha256sum="$(command -v sha256sum || true)"
+post_activation_real_shasum="$(command -v shasum)"
+mkdir -p "${post_activation_hash_bin}"
+cat > "${post_activation_hash_bin}/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Linux
+SH
+cat > "${post_activation_hash_bin}/systemctl" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--user" ]] && shift
+case "${1:-}" in
+  daemon-reload|list-timers)
+    exit 0
+    ;;
+  enable)
+    touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}" \
+      "${VIBEGUARD_TEST_SYSTEMD_ENABLED}" \
+      "${VIBEGUARD_TEST_HASH_ACTIVATED}"
+    exit 0
+    ;;
+  stop)
+    rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}"
+    exit 0
+    ;;
+  disable)
+    rm -f -- "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
+    exit 0
+    ;;
+  is-active)
+    if [[ "${2:-}" == "vibeguard-gc.timer" \
+      && -e "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}" ]]; then
+      printf 'active\n'
+      exit 0
+    fi
+    printf 'inactive\n'
+    exit 3
+    ;;
+  is-enabled)
+    if [[ -e "${VIBEGUARD_TEST_SYSTEMD_ENABLED}" ]]; then
+      printf 'enabled\n'
+      exit 0
+    fi
+    printf 'disabled\n'
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+cat > "${post_activation_hash_bin}/sha256sum" <<'SH'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="${arg}"; done
+if [[ -e "${VIBEGUARD_TEST_HASH_ACTIVATED}" \
+  && "${last}" == "${VIBEGUARD_TEST_HASH_FAIL_PATH}" ]]; then
+  exit 91
+fi
+if [[ -n "${VIBEGUARD_TEST_REAL_SHA256SUM}" ]]; then
+  exec "${VIBEGUARD_TEST_REAL_SHA256SUM}" "$@"
+fi
+exec "${VIBEGUARD_TEST_REAL_SHASUM}" -a 256 "$@"
+SH
+cat > "${post_activation_hash_bin}/shasum" <<'SH'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="${arg}"; done
+if [[ -e "${VIBEGUARD_TEST_HASH_ACTIVATED}" \
+  && "${last}" == "${VIBEGUARD_TEST_HASH_FAIL_PATH}" ]]; then
+  exit 91
+fi
+exec "${VIBEGUARD_TEST_REAL_SHASUM}" "$@"
+SH
+chmod +x \
+  "${post_activation_hash_bin}/uname" \
+  "${post_activation_hash_bin}/systemctl" \
+  "${post_activation_hash_bin}/sha256sum" \
+  "${post_activation_hash_bin}/shasum"
+
+post_activation_hash_env=(
+  PATH="${post_activation_hash_bin}:${PATH}"
+  VIBEGUARD_TEST_REAL_SHA256SUM="${post_activation_real_sha256sum}"
+  VIBEGUARD_TEST_REAL_SHASUM="${post_activation_real_shasum}"
+)
+
+fresh_hash_home="${TMP_HOME}/standalone-systemd-fresh-hash-failure-home"
+fresh_hash_service="${fresh_hash_home}/.config/systemd/user/vibeguard-gc.service"
+fresh_hash_timer="${fresh_hash_home}/.config/systemd/user/vibeguard-gc.timer"
+fresh_hash_receipt="${fresh_hash_home}/.vibeguard/scheduler-ownership"
+fresh_hash_active="${fresh_hash_home}/.systemctl-vibeguard-gc-active"
+fresh_hash_enabled="${fresh_hash_home}/.systemctl-vibeguard-gc-enabled"
+fresh_hash_activated="${fresh_hash_home}/.systemctl-vibeguard-gc-activated"
+mkdir -p "${fresh_hash_home}"
+fresh_hash_rc=0
+fresh_hash_out="$(
+  env HOME="${fresh_hash_home}" "${post_activation_hash_env[@]}" \
+    VIBEGUARD_TEST_SYSTEMD_ACTIVE="${fresh_hash_active}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED="${fresh_hash_enabled}" \
+    VIBEGUARD_TEST_HASH_ACTIVATED="${fresh_hash_activated}" \
+    VIBEGUARD_TEST_HASH_FAIL_PATH="${fresh_hash_service}" \
+    bash "${REPO_DIR}/scripts/install-systemd.sh" 2>&1
+)" || fresh_hash_rc=$?
+assert_cmd "fresh post-activation hash failure returns nonzero" \
+  test "${fresh_hash_rc}" -ne 0
+assert_contains "${fresh_hash_out}" \
+  "failed to hash installed systemd units; restored the previous scheduler state" \
+  "fresh post-activation hash failure reports successful rollback"
+assert_cmd "fresh hash rollback removes units and receipt and deactivates scheduler" bash -c \
+  'test ! -e "$1" && test ! -e "$2" && test ! -e "$3" \
+    && test ! -e "$4" && test ! -e "$5"' _ \
+  "${fresh_hash_service}" "${fresh_hash_timer}" "${fresh_hash_receipt}" \
+  "${fresh_hash_active}" "${fresh_hash_enabled}"
+
+refresh_hash_home="${TMP_HOME}/standalone-systemd-refresh-hash-failure-home"
+refresh_hash_service="${refresh_hash_home}/.config/systemd/user/vibeguard-gc.service"
+refresh_hash_timer="${refresh_hash_home}/.config/systemd/user/vibeguard-gc.timer"
+refresh_hash_receipt="${refresh_hash_home}/.vibeguard/scheduler-ownership"
+refresh_hash_active="${refresh_hash_home}/.systemctl-vibeguard-gc-active"
+refresh_hash_enabled="${refresh_hash_home}/.systemctl-vibeguard-gc-enabled"
+refresh_hash_activated="${refresh_hash_home}/.systemctl-vibeguard-gc-activated"
+mkdir -p "${refresh_hash_home}"
+env HOME="${refresh_hash_home}" "${post_activation_hash_env[@]}" \
+  VIBEGUARD_TEST_SYSTEMD_ACTIVE="${refresh_hash_active}" \
+  VIBEGUARD_TEST_SYSTEMD_ENABLED="${refresh_hash_enabled}" \
+  VIBEGUARD_TEST_HASH_ACTIVATED="${refresh_hash_activated}" \
+  VIBEGUARD_TEST_HASH_FAIL_PATH="${refresh_hash_home}/not-this-run" \
+  bash "${REPO_DIR}/scripts/install-systemd.sh" >/dev/null
+rm -f -- "${refresh_hash_activated}"
+refresh_hash_before="$(
+  shasum -a 256 \
+    "${refresh_hash_service}" "${refresh_hash_timer}" "${refresh_hash_receipt}"
+)"
+refresh_hash_rc=0
+refresh_hash_out="$(
+  env HOME="${refresh_hash_home}" "${post_activation_hash_env[@]}" \
+    VIBEGUARD_REPO_DIR="${standalone_alt_repo}" \
+    VIBEGUARD_TEST_SYSTEMD_ACTIVE="${refresh_hash_active}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED="${refresh_hash_enabled}" \
+    VIBEGUARD_TEST_HASH_ACTIVATED="${refresh_hash_activated}" \
+    VIBEGUARD_TEST_HASH_FAIL_PATH="${refresh_hash_timer}" \
+    bash "${REPO_DIR}/scripts/install-systemd.sh" 2>&1
+)" || refresh_hash_rc=$?
+assert_cmd "refresh post-activation hash failure returns nonzero" \
+  test "${refresh_hash_rc}" -ne 0
+assert_contains "${refresh_hash_out}" \
+  "failed to hash installed systemd units; restored the previous scheduler state" \
+  "refresh post-activation hash failure reports successful rollback"
+assert_cmd "refresh hash rollback restores units and receipt byte-for-byte" bash -c \
+  'test "$(shasum -a 256 "$1" "$2" "$3")" = "$4"' _ \
+  "${refresh_hash_service}" "${refresh_hash_timer}" \
+  "${refresh_hash_receipt}" "${refresh_hash_before}"
+assert_cmd "refresh hash rollback restores prior active and enabled state" bash -c \
+  'test -e "$1" && test -e "$2"' _ \
+  "${refresh_hash_active}" "${refresh_hash_enabled}"

--- a/tests/setup/systemd_refresh_transaction_tests.sh
+++ b/tests/setup/systemd_refresh_transaction_tests.sh
@@ -81,9 +81,17 @@ case "${1:-}" in
     exit 0
     ;;
   enable)
-    touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}" \
-      "${VIBEGUARD_TEST_SYSTEMD_ENABLED}" \
-      "${VIBEGUARD_TEST_HASH_ACTIVATED}"
+    touch "${VIBEGUARD_TEST_SYSTEMD_ENABLED}"
+    if [[ "${2:-}" == "--now" ]]; then
+      touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}" \
+        "${VIBEGUARD_TEST_HASH_ACTIVATED}"
+    fi
+    exit 0
+    ;;
+  start)
+    if [[ "${2:-}" == "vibeguard-gc.timer" ]]; then
+      touch "${VIBEGUARD_TEST_SYSTEMD_ACTIVE}"
+    fi
     exit 0
     ;;
   stop)
@@ -219,4 +227,35 @@ assert_cmd "refresh hash rollback restores units and receipt byte-for-byte" bash
   "${refresh_hash_receipt}" "${refresh_hash_before}"
 assert_cmd "refresh hash rollback restores prior active and enabled state" bash -c \
   'test -e "$1" && test -e "$2"' _ \
+  "${refresh_hash_active}" "${refresh_hash_enabled}"
+
+rm -f -- \
+  "${refresh_hash_active}" \
+  "${refresh_hash_enabled}" \
+  "${refresh_hash_activated}"
+inactive_refresh_before="$(
+  shasum -a 256 \
+    "${refresh_hash_service}" "${refresh_hash_timer}" "${refresh_hash_receipt}"
+)"
+inactive_refresh_rc=0
+inactive_refresh_out="$(
+  env HOME="${refresh_hash_home}" "${post_activation_hash_env[@]}" \
+    VIBEGUARD_REPO_DIR="${standalone_rollback_repo}" \
+    VIBEGUARD_TEST_SYSTEMD_ACTIVE="${refresh_hash_active}" \
+    VIBEGUARD_TEST_SYSTEMD_ENABLED="${refresh_hash_enabled}" \
+    VIBEGUARD_TEST_HASH_ACTIVATED="${refresh_hash_activated}" \
+    VIBEGUARD_TEST_HASH_FAIL_PATH="${refresh_hash_timer}" \
+    bash "${REPO_DIR}/scripts/install-systemd.sh" 2>&1
+)" || inactive_refresh_rc=$?
+assert_cmd "inactive disabled refresh hash failure returns nonzero" \
+  test "${inactive_refresh_rc}" -ne 0
+assert_contains "${inactive_refresh_out}" \
+  "failed to hash installed systemd units; restored the previous scheduler state" \
+  "inactive disabled refresh reports successful rollback"
+assert_cmd "inactive disabled refresh restores units and receipt byte-for-byte" bash -c \
+  'test "$(shasum -a 256 "$1" "$2" "$3")" = "$4"' _ \
+  "${refresh_hash_service}" "${refresh_hash_timer}" \
+  "${refresh_hash_receipt}" "${inactive_refresh_before}"
+assert_cmd "inactive disabled refresh does not activate or enable timer" bash -c \
+  'test ! -e "$1" && test ! -e "$2"' _ \
   "${refresh_hash_active}" "${refresh_hash_enabled}"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -499,54 +499,7 @@ EOF
 esac
 SH
 chmod +x "${TMP_HOME}/bin/launchctl"
-cat > "${TMP_HOME}/bin/systemctl" <<'SH'
-#!/usr/bin/env bash
-active_state="${HOME}/.systemctl-vibeguard-gc-active"
-enabled_state="${HOME}/.systemctl-vibeguard-gc-enabled"
-[[ "${1:-}" == "--user" ]] && shift
-case "${1:-}" in
-  daemon-reload) exit 0 ;;
-  enable)
-    [[ "${2:-}" == "--now" && "${3:-}" == "vibeguard-gc.timer" ]] || exit 0
-    [[ "${VIBEGUARD_TEST_SYSTEMD_ENABLE_FAIL:-0}" == "1" ]] && exit 1
-    touch "$active_state" "$enabled_state"
-    ;;
-  start)
-    [[ "${2:-}" == "vibeguard-gc.timer" ]] && touch "$active_state"
-    ;;
-  stop)
-    [[ "${VIBEGUARD_TEST_SYSTEMD_STOP_FAIL:-0}" == "1" ]] && exit 1
-    [[ "${VIBEGUARD_TEST_SYSTEMD_STILL_ACTIVE:-0}" == "1" ]] || rm -f "$active_state"
-    ;;
-  disable)
-    [[ "${VIBEGUARD_TEST_SYSTEMD_DISABLE_FAIL:-0}" == "1" ]] && exit 1
-    [[ "${VIBEGUARD_TEST_SYSTEMD_STILL_ENABLED:-0}" == "1" ]] || rm -f "$enabled_state"
-    ;;
-  is-active)
-    if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$active_state" ]]; then
-      printf 'active\n'; exit 0
-    fi
-    printf 'inactive\n'; exit 3
-    ;;
-  is-enabled)
-    if [[ "${2:-}" == "vibeguard-gc.timer" && -f "$enabled_state" ]]; then
-      printf 'enabled\n'; exit 0
-    fi
-    printf 'disabled\n'; exit 1
-    ;;
-  status)
-    [[ "${2:-}" == "vibeguard-gc.timer" && -f "$active_state" ]] && exit 0
-    exit 3
-    ;;
-  list-timers)
-    if [[ -f "$active_state" ]]; then
-      printf 'NEXT LEFT LAST PASSED UNIT ACTIVATES\n'
-      printf 'Sun 03:00 - - - vibeguard-gc.timer vibeguard-gc.service\n'
-    fi
-    ;;
-  *) exit 0 ;;
-esac
-SH
+cp "${REPO_DIR}/tests/setup/systemctl_stub.sh" "${TMP_HOME}/bin/systemctl"
 chmod +x "${TMP_HOME}/bin/systemctl"
 cat > "${TMP_HOME}/bin/gh" <<'SH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Post-merge corrective

- Roll back fresh and refresh systemd installs when post-activation unit hashing fails.
- Restore the exact prior timer active/enabled and service active state after refresh or removal rollback.
- Preserve `enabled-runtime` timer state with `systemctl --user enable --runtime`.
- Keep cleanup failures explicit by running managed Claude/Codex cleanup outside conditional contexts.
- Keep rollback failures explicit and preserve recovery evidence.

Refs #699. Issue #699 intentionally remains open; this PR does not close it.

## Verification

- Focused systemd transaction: 30/30 passed
- Focused cleanup failure propagation: 2/2 passed
- Focused runtime-enabled cleanup: passed
- Clean isolated exact-head clone `bash tests/test_setup.sh`: 1000/1000 passed
- Clean isolated exact-head clone `bash tests/test_health_report.sh`: 45/45 passed
- Clean isolated exact-head clone `bash tests/test_payload.sh`: 43/43 passed
- `bash -n` and `git diff --check`: passed
- Latest `origin/main` was merged normally to include the health-report fixture repair.
- Current-head CI and connector review are pending.

## Source

- Exact head: `4042cfbbf8010822f02cb71dcb654fab172f94df`
- SpecRail was not used.
