### PR TITLE
fix(ci): 为 macOS 必需 CI 恢复有界余量

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   validate-and-test:
     name: CI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/docs/specs/GH614/product.md
+++ b/docs/specs/GH614/product.md
@@ -6,12 +6,13 @@ GH-614: https://github.com/majiayu000/vibeguard/issues/614
 
 ## 用户问题
 
-VibeGuard 的必需 macOS CI 与 Ubuntu 共用一个 30 分钟的 `validate-and-test`
-作业上限。PR #613 的实现未修改任何 setup 路径，但 macOS 在
-`Setup regression tests` 仍持续正常输出时，于 30 分 21 秒被 GitHub 取消；
-同一 SHA 重跑后又在 26 分 04 秒通过。近期成功样本还出现过 29 分 44 秒，
-距离上限只剩 16 秒。这会把 runner 时长波动误报为产品回归，并阻止 setup
-之后的必需检查产生证据。
+GH614 的首次修复把必需 `validate-and-test` 作业上限从 30 分钟提高到 45 分钟，
+但新的真实运行证明这仍不足。PR #727 head
+`3947abd7583ac90a93516ee8476d807c3856dfca` 的 run `30651857110`、
+macOS job `91226778977` 从 19:44:43Z 运行至 20:30:02Z，耗时 45 分 16 秒后
+被取消。前 63 个步骤全部通过，其中 `Setup regression tests` 完整通过且耗时约
+34 分钟；第 64 步 `Guard unit tests` 被取消，后续 precision、performance 与
+benchmark 步骤未运行。这是同一类总作业上限回归，因此 Issue 重开而非另建问题。
 
 ## 目标
 
@@ -30,7 +31,7 @@ VibeGuard 的必需 macOS CI 与 Ubuntu 共用一个 30 分钟的 `validate-and-
 ## Behavior Invariants
 
 1. B-001 — 在已观测的健康 macOS 时长波动范围内，必需 CI 不得再因旧的
-   30 分钟总作业上限取消；新上限仍必须是有限值。
+   45 分钟总作业上限取消；新上限仍必须是有限值。
 2. B-002 — `bash tests/test_setup.sh` 必须继续在 macOS 必需 CI 中完整执行，
    且非零退出必须使该 check 失败。
 3. B-003 — `CI (ubuntu-latest)`、`CI (macos-latest)` 与
@@ -46,12 +47,12 @@ VibeGuard 的必需 macOS CI 与 Ubuntu 共用一个 30 分钟的 `validate-and-
 
 ## 验收标准
 
-- [ ] `validate-and-test` 使用 45 分钟的有限上限，为已记录的 30 分 21 秒取消点
-      提供 14 分 39 秒余量。
+- [ ] `validate-and-test` 使用 60 分钟的有限上限，为已记录的 45 分 16 秒取消点
+      提供 14 分 44 秒余量。
 - [ ] `bash tests/test_setup.sh` 仍是 `validate-and-test` 中的精确阻塞命令。
 - [ ] Ubuntu/macOS matrix、Windows job、Self-Application job 与
       `Benchmark Report` 依赖关系保持不变。
-- [ ] 新 workflow contract 在实现前因 30 分钟旧值失败，在实现后通过。
+- [ ] 新 workflow contract 在实现前因 45 分钟旧值失败，在实现后通过。
 - [ ] 实现 head 的本地 focused/broad gate 与完整 GitHub CI 全绿。
 
 ## 边界情况清单

--- a/docs/specs/GH614/product.md
+++ b/docs/specs/GH614/product.md
@@ -9,7 +9,7 @@ GH-614: https://github.com/majiayu000/vibeguard/issues/614
 GH614 的首次修复把必需 `validate-and-test` 作业上限从 30 分钟提高到 45 分钟，
 但新的真实运行证明这仍不足。PR #727 head
 `3947abd7583ac90a93516ee8476d807c3856dfca` 的 run `30651857110`、
-macOS job `91226778977` 从 19:44:43Z 运行至 20:30:02Z，耗时 45 分 16 秒后
+macOS job `91226778977` 从 19:44:43Z 运行至 20:30:02Z，耗时 45 分 19 秒后
 被取消。前 63 个步骤全部通过，其中 `Setup regression tests` 完整通过且耗时约
 34 分钟；第 64 步 `Guard unit tests` 被取消，后续 precision、performance 与
 benchmark 步骤未运行。这是同一类总作业上限回归，因此 Issue 重开而非另建问题。
@@ -47,8 +47,8 @@ benchmark 步骤未运行。这是同一类总作业上限回归，因此 Issue 
 
 ## 验收标准
 
-- [ ] `validate-and-test` 使用 60 分钟的有限上限，为已记录的 45 分 16 秒取消点
-      提供 14 分 44 秒余量。
+- [ ] `validate-and-test` 使用 60 分钟的有限上限，为已记录的 45 分 19 秒取消点
+      提供 14 分 41 秒余量。
 - [ ] `bash tests/test_setup.sh` 仍是 `validate-and-test` 中的精确阻塞命令。
 - [ ] Ubuntu/macOS matrix、Windows job、Self-Application job 与
       `Benchmark Report` 依赖关系保持不变。

--- a/docs/specs/GH614/tasks.md
+++ b/docs/specs/GH614/tasks.md
@@ -64,6 +64,6 @@ handoff:
     human_review: pending
 ```
 
-关键决策：使用 60 分钟有限总上限，为 45 分 16 秒取消点提供 14 分 44 秒余量；
+关键决策：使用 60 分钟有限总上限，为 45 分 19 秒取消点提供 14 分 41 秒余量；
 不拆 job、不改 required context、不弱化测试。纠正分支从 `origin/main` 的
 `ce5bada07bda1ae72b5488fcf08be8982185a115` 创建；合并与最终批准保留给人类。

--- a/docs/specs/GH614/tasks.md
+++ b/docs/specs/GH614/tasks.md
@@ -11,18 +11,18 @@ GH-614: https://github.com/majiayu000/vibeguard/issues/614
 
 ## 实现任务
 
-- [ ] `SP614-T1` Owner: `/root` — 在 `tests/test_workflow_contracts.sh` 添加 timeout、稳定 check 名称、Ubuntu/macOS matrix、setup 精确命令和阻塞语义 contract。Depends on: Spec PR merged and live implementation route allowed。Covers: B-001, B-002, B-003, B-005, B-007。Done when: 旧 `timeout-minutes: 30` 上的新 contract 确定性失败，且失败原因指向缺失的 45 分钟余量。Verify: `bash tests/test_workflow_contracts.sh`。
-- [ ] `SP614-T2` Owner: `/root` — 将 `.github/workflows/ci.yml` 的 `validate-and-test.timeout-minutes` 从 30 调到 45，不改 job id、名称、matrix、步骤、命令或依赖。Depends on: SP614-T1。Covers: B-001, B-003, B-004, B-005, B-006。Done when: workflow diff 只有目标 timeout 一行，新增 contract 转绿。Verify: `git diff -- .github/workflows/ci.yml && bash tests/test_workflow_contracts.sh`。
-- [ ] `SP614-T3` Owner: `/root` — 运行 setup、workflow、文档与 broad contract 验证并记录 fresh 输出。Depends on: SP614-T2。Covers: B-002, B-004, B-006, B-007。Done when: focused/setup/quick/static 命令全部通过且 worktree 无意外产物。Verify: `bash tests/test_setup.sh && bash scripts/local-contract-check.sh --quick`。
-- [ ] `SP614-T4` Owner: `/root` + independent reviewer — 创建独立 Impl PR，获取独立 reviewer、当前 SHA 全量 CI、reviewThreads 与 SpecRail required PR gate 证据后合并。Depends on: SP614-T3。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007。Done when: gate 为 `allowed`、PR 已合并且 GH614 已关闭。Verify: `python3 checks/pr_gate.py --repo . --evidence <current-evidence> --mode required --json`。
+- [x] `SP614-T1` Owner: `/root/audit_pr727_remote` — 把现有 timeout contract 从 45 更新为 60，并在 workflow 仍为 45 时记录确定性 RED。Depends on: live duplicate evidence and SpecRail implementation route allowed。Covers: B-001, B-005, B-007。Done when: 失败原因精确指向缺失的 `timeout-minutes: 60`。Verify: `bash -n tests/test_workflow_contracts.sh && bash tests/test_workflow_contracts.sh`。
+- [x] `SP614-T2` Owner: `/root/audit_pr727_remote` — 将 `.github/workflows/ci.yml` 的 `validate-and-test.timeout-minutes` 从 45 调到 60，不改 job id、名称、matrix、步骤、命令或依赖。Depends on: SP614-T1。Covers: B-001, B-003, B-004, B-005, B-006。Done when: workflow diff 只有目标 timeout 一行，新增 contract 转绿。Verify: `git diff -- .github/workflows/ci.yml && bash tests/test_workflow_contracts.sh`。
+- [x] `SP614-T3` Owner: `/root/audit_pr727_remote` — 运行 setup、workflow、文档、索引、U-16 与 broad contract 验证并记录 fresh 输出。Depends on: SP614-T2。Covers: B-002, B-004, B-006, B-007。Done when: focused/setup/quick/static 命令全部通过且 worktree 无意外产物。Verify: `bash tests/test_setup.sh && bash scripts/local-contract-check.sh --quick`。
+- [ ] `SP614-T4` Owner: human maintainer — 审查纠正 PR，并获取当前 SHA 完整 GitHub CI、review thread 与 required PR gate 证据后决定是否合并。Depends on: SP614-T3 and explicit human confirmation。Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007。Done when: gate 为 `allowed`、人类明确批准且 PR 已合并；当前任务不得代替该确认。Verify: `python3 checks/pr_gate.py --repo . --evidence <current-evidence> --mode required --json`。
 
 ## 并行拆分
 
 实现改动只有两个相互关联文件，采用单一可写 lane：
 
-- implementation：`/root`，独占 `.github/workflows/ci.yml` 与
+- implementation：`/root/audit_pr727_remote`，独占 `.github/workflows/ci.yml` 与
   `tests/test_workflow_contracts.sh`。
-- independent_review：只读 reviewer，不拥有文件、不提交修改。
+- human_review：待维护者在 PR 上完成，不拥有本地文件、不提交实现修改。
 
 禁止两个 agent 同时写 workflow contract 或 CI YAML。
 
@@ -53,16 +53,17 @@ handoff:
     - docs/specs/GH614/tech.md
     - docs/specs/GH614/tasks.md
   runtime_pinning_snapshot: None
-  verification_owner: /root
+  verification_owner: /root/audit_pr727_remote
   stop_conditions:
-    - 新 contract 未在旧 30 分钟配置上先红
+    - 新 contract 未在旧 45 分钟配置上先红
     - 实现需要修改 setup 产品行为、fixture 或断言
     - required check 名、OS matrix、步骤命令或 benchmark 依赖发生变化
     - 任一真实 CI、独立审查、review thread 或 required PR gate 未通过
   lane_map:
-    implementation: /root
-    independent_review: read_only_reviewer
+    implementation: /root/audit_pr727_remote
+    human_review: pending
 ```
 
-关键决策：使用 45 分钟有限总上限，不拆 job、不改 required context、不弱化测试；
-实现必须从 Spec PR 合并后的最新 `origin/main` 创建独立 worktree 与 Impl PR。
+关键决策：使用 60 分钟有限总上限，为 45 分 16 秒取消点提供 14 分 44 秒余量；
+不拆 job、不改 required context、不弱化测试。纠正分支从 `origin/main` 的
+`ce5bada07bda1ae72b5488fcf08be8982185a115` 创建；合并与最终批准保留给人类。

--- a/docs/specs/GH614/tech.md
+++ b/docs/specs/GH614/tech.md
@@ -13,35 +13,38 @@ GH-614: https://github.com/majiayu000/vibeguard/issues/614
 | Area | Files | Current behavior | Why relevant |
 | --- | --- | --- | --- |
 | 主 CI matrix | `.github/workflows/ci.yml:21` | `validate-and-test` 生成稳定的 Ubuntu/macOS required check | 必须保持 job id、名称表达式和 OS matrix |
-| 总作业上限 | `.github/workflows/ci.yml:24` | Ubuntu/macOS 共用 `timeout-minutes: 30` | macOS 已在 30 分 21 秒被取消 |
-| setup 覆盖 | `.github/workflows/ci.yml:239` | `bash tests/test_setup.sh` 是普通阻塞步骤 | 不能删除、跳过、弱化或改成 advisory |
-| 后续回归 | `.github/workflows/ci.yml:251` | setup 后仍有 GC、hook、stats、precision、performance 与 benchmark 检查 | 总作业取消会使后续证据全部缺失 |
-| benchmark 依赖 | `.github/workflows/ci.yml:435` | `Benchmark Report` 依赖完整 `validate-and-test` | 必须保持依赖和现有 check 拓扑 |
-| workflow contract | `tests/test_workflow_contracts.sh:588` | 已检查 performance 三步命令及阻塞语义，但不检查总超时与 setup 覆盖 | 需要增加针对 GH614 的确定性回归 |
-| spec 索引 | `docs/specs/README.md:5` | 维护 active/draft spec 入口 | GH614 在 Spec PR 中登记为 Draft |
+| 总作业上限 | `.github/workflows/ci.yml:24` | Ubuntu/macOS 共用 `timeout-minutes: 45` | macOS 已在 45 分 16 秒被取消 |
+| setup 覆盖 | `.github/workflows/ci.yml:282` | `bash tests/test_setup.sh` 是普通阻塞步骤 | 不能删除、跳过、弱化或改成 advisory |
+| 后续回归 | `.github/workflows/ci.yml:294` | setup 后仍有 GC、hook、stats、precision、performance 与 benchmark 检查 | 总作业取消会使后续证据全部缺失 |
+| benchmark 依赖 | `.github/workflows/ci.yml:485` | `Benchmark Report` 依赖完整 `validate-and-test` | 必须保持依赖和现有 check 拓扑 |
+| workflow contract | `tests/test_workflow_contracts.sh:621` | 精确固定 45 分钟、稳定名称、matrix 与 setup 阻塞语义 | 本次必须先改为 60 并在旧 workflow 上记录 RED |
+| spec 索引 | `docs/specs/README.md:5` | 维护 active/draft spec 入口 | 重开纠正期间恢复为 Draft |
 
-远端事实快照（2026-07-16）：main 分支保护要求
-`CI (ubuntu-latest)`、`CI (macos-latest)`、`CI (windows-latest)`；PR #613
-run `29484565228` 的 macOS 首次尝试在 setup 步骤于 30 分 21 秒取消，同一 SHA
-重跑在 26 分 04 秒通过。实现不得通过改名 required context 规避该事实。
+远端事实快照（2026-08-01）：PR #727 head
+`3947abd7583ac90a93516ee8476d807c3856dfca` 的 run `30651857110`、
+macOS job `91226778977` 从 `2026-07-31T19:44:43Z` 到 `20:30:02Z`，结论为
+`cancelled`。步骤 1–63 均成功（不适用的 Windows 步骤除外），约 34 分钟的
+`Setup regression tests` 已通过；第 64 步 `Guard unit tests` 被取消，后续
+precision、performance 与 benchmark 被跳过。实现不得通过改名 required context、
+跳过步骤或弱化阻塞语义规避该事实。
 
 ## 设计方案
 
 1. 在 `.github/workflows/ci.yml` 中仅把 `validate-and-test.timeout-minutes`
-   从 `30` 调整为 `45`。
+   从 `45` 调整为 `60`。
 2. 保持 `validate-and-test` job id、`CI (${{ matrix.os }})` 名称、
    `os: [ubuntu-latest, macos-latest]`、全部步骤顺序及
    `benchmark-report.needs: validate-and-test` 不变。
-3. 45 分钟相对已观测的 30 分 21 秒取消点提供 14 分 39 秒余量，也比旧上限
-   增加 50%。它仍是 fail-closed 的有限上限；正常运行的计费时长不变，只有
-   异常挂起时每个 matrix leg 的最坏上限增加 15 runner-minutes。
-4. 在 `tests/test_workflow_contracts.sh` 新增 `ci setup timeout headroom` contract：
+3. 60 分钟相对已观测的 45 分 16 秒取消点提供 14 分 44 秒余量。它仍是
+   fail-closed 的有限上限；正常运行的计费时长不变，只有异常挂起时每个 matrix
+   leg 的最坏上限增加 15 runner-minutes。
+4. 更新 `tests/test_workflow_contracts.sh` 的 `ci setup timeout headroom` contract：
    - 定位 `validate-and-test` job block；
-   - 要求稳定名称、Ubuntu/macOS matrix 与 `timeout-minutes: 45`；
+   - 要求稳定名称、Ubuntu/macOS matrix 与 `timeout-minutes: 60`；
    - 定位 `Setup regression tests` step，要求精确命令
      `bash tests/test_setup.sh` 且不存在 `continue-on-error`；
    - 不把 GitHub 历史运行时长写成脆弱的动态测试输入。
-5. contract 必须先在旧值 `30` 上红，再进行 workflow 一行实现，确保测试真正
+5. contract 必须先在旧值 `45` 上红，再进行 workflow 一行实现，确保测试真正
    证明缺失行为而不是事后装饰。
 
 ## Product-to-Test Mapping
@@ -52,20 +55,20 @@ run `29484565228` 的 macOS 首次尝试在 setup 步骤于 30 分 21 秒取消�
 | B-002 | setup step block | contract 检查精确命令与无 `continue-on-error`；`bash tests/test_setup.sh` |
 | B-003 | job name 与 OS matrix | contract 检查 `CI (${{ matrix.os }})` 和两个 OS；读取 main branch protection evidence |
 | B-004 | 既有步骤与 benchmark 依赖不变 | `git diff -- .github/workflows/ci.yml` 只出现 timeout 一行；完整 CI rollup |
-| B-005 | 有限 45 分钟上限 | contract 精确要求 `timeout-minutes: 45`，不得删除或设为无界 |
+| B-005 | 有限 60 分钟上限 | contract 精确要求 `timeout-minutes: 60`，不得删除或设为无界 |
 | B-006 | 非目标 job/latency contract | `git diff --check`；`bash tests/test_hook_perf_contract.sh`；workflow diff review |
 | B-007 | workflow contract | 红态 fixture/旧值运行失败证据；绿态 `bash tests/test_workflow_contracts.sh` |
 
 ## 数据流
 
 GitHub 事件触发 `validate-and-test` → matrix 生成 Ubuntu/macOS 两个稳定 check →
-每个 leg 继承 45 分钟有限总上限 → 按原顺序执行全部阻塞步骤（含 setup）→ 两个
+每个 leg 继承 60 分钟有限总上限 → 按原顺序执行全部阻塞步骤（含 setup）→ 两个
 leg 成功后才触发 `Benchmark Report`。没有新增持久化、外部写入、secret 或网络接口。
 
 ## 备选方案
 
-- 只重跑超时 job：已证明同一 SHA 可能在 30 分 21 秒失败、26 分 04 秒通过，
-  重跑不能消除错误状态与人工等待，因此拒绝。
+- 只重跑超时 job：45 分 16 秒的真实取消已证明当前边界不足；重跑不能消除错误
+  状态与人工等待，因此拒绝。
 - 拆分独立 macOS setup job：能隔离长步骤，但会引入新的 check 名、branch
   protection 迁移、依赖聚合和额外 runner 启动；对当前 P0 修复风险过高，后续可在
   有独立成本/拓扑 spec 时评估。
@@ -78,8 +81,8 @@ leg 成功后才触发 `Benchmark Report`。没有新增持久化、外部写入
 
 - Security: 不新增权限、secret 或外部调用；required checks 仍由现有分支保护约束。
 - Compatibility: required check 名、job id、matrix 和 benchmark 依赖保持不变。
-- Performance: 正常运行耗时不变；异常挂起的最坏上限从 30 增至 45 分钟。
-- Maintenance: contract 固定 45 分钟策略值；未来调整必须同步 spec 与测试，避免
+- Performance: 正常运行耗时不变；异常挂起的最坏上限从 45 增至 60 分钟。
+- Maintenance: contract 固定 60 分钟策略值；未来调整必须同步 spec 与测试，避免
   静默回退到无余量配置。
 
 ## 测试计划
@@ -96,6 +99,7 @@ leg 成功后才触发 `Benchmark Report`。没有新增持久化、外部写入
 
 ## 回滚方案
 
-若 45 分钟上限造成不可接受的异常成本，回滚 workflow 与对应 contract 提交，恢复
-30 分钟；回滚前必须重新打开 GH614 或建立替代 Issue，因为已知的 macOS 健康运行
-仍会再次逼近或越过 30 分钟。禁止只删除 contract、保留未证明的配置。
+若 60 分钟上限造成不可接受的异常成本，整体回滚本次 workflow、contract 与 spec
+提交以恢复 45 分钟，并保持 GH614 打开或建立明确的替代 Issue，因为 45 分钟已被
+真实运行越过。禁止只删除 contract、保留未证明的配置；任何替代方案仍须保留全部
+阻塞步骤、required check 名称和 benchmark 依赖。

--- a/docs/specs/GH614/tech.md
+++ b/docs/specs/GH614/tech.md
@@ -13,7 +13,7 @@ GH-614: https://github.com/majiayu000/vibeguard/issues/614
 | Area | Files | Current behavior | Why relevant |
 | --- | --- | --- | --- |
 | 主 CI matrix | `.github/workflows/ci.yml:21` | `validate-and-test` 生成稳定的 Ubuntu/macOS required check | 必须保持 job id、名称表达式和 OS matrix |
-| 总作业上限 | `.github/workflows/ci.yml:24` | Ubuntu/macOS 共用 `timeout-minutes: 45` | macOS 已在 45 分 16 秒被取消 |
+| 总作业上限 | `.github/workflows/ci.yml:24` | Ubuntu/macOS 共用 `timeout-minutes: 45` | macOS 已在 45 分 19 秒被取消 |
 | setup 覆盖 | `.github/workflows/ci.yml:282` | `bash tests/test_setup.sh` 是普通阻塞步骤 | 不能删除、跳过、弱化或改成 advisory |
 | 后续回归 | `.github/workflows/ci.yml:294` | setup 后仍有 GC、hook、stats、precision、performance 与 benchmark 检查 | 总作业取消会使后续证据全部缺失 |
 | benchmark 依赖 | `.github/workflows/ci.yml:485` | `Benchmark Report` 依赖完整 `validate-and-test` | 必须保持依赖和现有 check 拓扑 |
@@ -35,7 +35,7 @@ precision、performance 与 benchmark 被跳过。实现不得通过改名 requi
 2. 保持 `validate-and-test` job id、`CI (${{ matrix.os }})` 名称、
    `os: [ubuntu-latest, macos-latest]`、全部步骤顺序及
    `benchmark-report.needs: validate-and-test` 不变。
-3. 60 分钟相对已观测的 45 分 16 秒取消点提供 14 分 44 秒余量。它仍是
+3. 60 分钟相对已观测的 45 分 19 秒取消点提供 14 分 41 秒余量。它仍是
    fail-closed 的有限上限；正常运行的计费时长不变，只有异常挂起时每个 matrix
    leg 的最坏上限增加 15 runner-minutes。
 4. 更新 `tests/test_workflow_contracts.sh` 的 `ci setup timeout headroom` contract：
@@ -67,7 +67,7 @@ leg 成功后才触发 `Benchmark Report`。没有新增持久化、外部写入
 
 ## 备选方案
 
-- 只重跑超时 job：45 分 16 秒的真实取消已证明当前边界不足；重跑不能消除错误
+- 只重跑超时 job：45 分 19 秒的真实取消已证明当前边界不足；重跑不能消除错误
   状态与人工等待，因此拒绝。
 - 拆分独立 macOS setup job：能隔离长步骤，但会引入新的 check 名、branch
   protection 迁移、依赖聚合和额外 runner 启动；对当前 P0 修复风险过高，后续可在

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -37,7 +37,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | `GH621/` | Implemented reference | Behavior-preserving extraction of install-time runtime acquisition, provenance, and source fallback from the oversized setup entrypoint |
 | `codex-app-observability-plugin.md` | Implemented reference | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
 | `GH618/` | Implemented reference | Manifest-driven compliance language scope, guard-pack reporting, and fail-visible config handling |
-| `GH614/` | Implemented reference | Bounded macOS CI timeout headroom while preserving required check names and blocking setup coverage |
+| `GH614/` | Draft | Reopened macOS CI headroom correction from 45 to 60 minutes while preserving required check names and blocking setup coverage |
 | `GH611/` | Implemented reference | Stable multi-sample hook P95 latency gate replacing the flaky 3-sample max collapse |
 | `GH608/` | Implemented reference | Correct default `VIBEGUARD_DIR` resolution for standalone compliance-check runs |
 | `GH605/` | Implemented reference | Rust test-path classifier recognition of `*_tests.rs` for RS-03 precision |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -37,7 +37,7 @@ This directory holds maintainer-facing specs. Most files here are implementation
 | `GH621/` | Implemented reference | Behavior-preserving extraction of install-time runtime acquisition, provenance, and source fallback from the oversized setup entrypoint |
 | `codex-app-observability-plugin.md` | Implemented reference | Codex App plugin packaging, dashboard generation, observability commands, and plugin privacy boundaries |
 | `GH618/` | Implemented reference | Manifest-driven compliance language scope, guard-pack reporting, and fail-visible config handling |
-| `GH614/` | Draft | Reopened macOS CI headroom correction from 45 to 60 minutes while preserving required check names and blocking setup coverage |
+| `GH614/` | Implemented reference | macOS CI headroom correction from 45 to 60 minutes, with required check names and blocking setup coverage preserved |
 | `GH611/` | Implemented reference | Stable multi-sample hook P95 latency gate replacing the flaky 3-sample max collapse |
 | `GH608/` | Implemented reference | Correct default `VIBEGUARD_DIR` resolution for standalone compliance-check runs |
 | `GH605/` | Implemented reference | Rust test-path classifier recognition of `*_tests.rs` for RS-03 precision |

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -636,7 +636,7 @@ def validate(workflow: str) -> None:
     job_lines = job.splitlines()
     required_lines = {
         "stable required check name": "    name: CI (${{ matrix.os }})",
-        "finite timeout headroom": "    timeout-minutes: 45",
+        "finite timeout headroom": "    timeout-minutes: 60",
         "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
     }
     for description, line in required_lines.items():


### PR DESCRIPTION
## 背景

GH614 首次修复把 `validate-and-test` 上限从 30 分钟提高到 45 分钟，但 PR #727 head `3947abd7583ac90a93516ee8476d807c3856dfca` 的 run `30651857110` / macOS job `91226778977` 仍在 45 分 19 秒后被取消。前 63 个步骤通过（含约 34 分钟的完整 setup 回归），第 64 步 `Guard unit tests` 被取消，后续 precision、performance 与 benchmark 未运行。

## 修复

- 先把 workflow contract 的精确期望从 45 改为 60，并在旧 workflow 上记录 RED：缺少 `timeout-minutes: 60`
- 仅把 `validate-and-test.timeout-minutes` 从 45 调整为 60
- 保持 job id、`CI (${{ matrix.os }})` 名称、Ubuntu/macOS matrix、全部步骤顺序与命令、setup 阻塞语义及 `Benchmark Report` 依赖不变
- 将 GH614 spec packet/index 恢复为 Draft，记录本次重开纠正

60 分钟相对 45 分 19 秒取消点提供 14 分 41 秒余量，仍是 fail-closed 的有限上限。正常运行耗时不变；只有异常挂起时每个 matrix leg 的最坏上限增加 15 runner-minutes。

## RED → GREEN

- RED：`bash -n tests/test_workflow_contracts.sh` = 0；旧 45 分钟配置上的 `bash tests/test_workflow_contracts.sh` = 1，唯一新增失败为缺少 `timeout-minutes: 60`
- GREEN：workflow contract 25/25
- 完整隔离 setup：1000/1000
- `bash scripts/local-contract-check.sh --quick`：全部通过
- docs/index/path/command、SpecRail workflow、diff check 与 U-16：全部通过（`U16_BASELINE_OK`）

## 回滚

若 60 分钟异常成本不可接受，应整体回滚 workflow、contract 与 spec 提交恢复 45 分钟，并保持 GH614 打开或创建明确替代 Issue；45 分钟已被真实运行越过，不能只删除 contract 或弱化/跳过测试。

Fixes #614

> Merge gate: merge only after the exact head has green required CI contexts and zero current review threads. This PR preserves blocking setup coverage and the existing required-check topology.