### PR TITLE
ci(release): add real no-clone install smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
         shell: bash
         run: bash tests/test_release_workflow.sh
 
+      - name: Validate no-clone release smoke contract
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash tests/test_no_clone_release_smoke.sh
+
       - name: Payload regression tests
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -684,11 +684,12 @@ jobs:
 
           release_json="$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}")"
           if ! jq -e --arg tag "${TAG_NAME}" --argjson id "${RELEASE_ID}" '
-            .id == $id and .draft == true and .tag_name == $tag
+            .id == $id and (.draft == true or .draft == false) and .tag_name == $tag
           ' <<< "${release_json}" >/dev/null; then
-            echo "ERROR: final publication target is not the expected draft release" >&2
+            echo "ERROR: final publication target is not the expected release" >&2
             exit 1
           fi
+          initially_public="$(jq -r '.draft == false' <<< "${release_json}")"
 
           audit_dir="${RUNNER_TEMP}/vibeguard-final-release-audit"
           mkdir -p "${audit_dir}"
@@ -752,6 +753,7 @@ jobs:
             echo "ERROR: release tag ${TAG_NAME} moved before publication; draft remains unpublished" >&2
             exit 1
           fi
+          [[ "${initially_public}" != "true" ]] || exit 0
 
           # The PATCH is an ambiguous commit point: GitHub may have applied the
           # draft-to-public transition even when the acknowledgement is lost,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,11 +158,13 @@ jobs:
         with:
           subject-path: dist/${{ matrix.target }}/vibeguard-runtime-${{ matrix.target }}
 
-  publish-release:
-    name: Publish release assets
+  stage-release:
+    name: Stage release assets
     runs-on: ubuntu-latest
     needs: build-runtime
     timeout-minutes: 10
+    outputs:
+      release_id: ${{ steps.stage-release.outputs.release_id }}
     permissions:
       contents: write
       id-token: write
@@ -248,14 +250,28 @@ jobs:
         with:
           subject-path: dist/vibeguard-payload-*.tar.gz
 
-      - name: Publish GitHub Release
+      - name: Stage draft GitHub Release
+        id: stage-release
         env:
           EVENT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+          set -euo pipefail
+          release_created=0
+          cleanup_failed_draft() {
+            status=$?
+            if [[ "${status}" -ne 0 && "${release_created}" == "1" ]]; then
+              if ! gh release delete "${TAG_NAME}" --repo "${GH_REPO}" --yes; then
+                echo "ERROR: failed to delete incomplete draft release ${TAG_NAME}" >&2
+              fi
+            fi
+            exit "${status}"
+          }
+          trap cleanup_failed_draft EXIT
+
+          if gh release view "${TAG_NAME}" --repo "${GH_REPO}" >/dev/null 2>&1; then
             echo "ERROR: release ${TAG_NAME} already exists; refusing to mutate release assets" >&2
             exit 1
           fi
@@ -264,15 +280,38 @@ jobs:
             echo "ERROR: release tag ${TAG_NAME} moved from event commit ${EVENT_SHA} to ${remote_tag_commit}" >&2
             exit 1
           fi
-          gh release create "${TAG_NAME}" dist/vibeguard-runtime-* dist/vibeguard-payload-* dist/SHA256SUMS \
+          gh release create "${TAG_NAME}" \
+            --repo "${GH_REPO}" \
+            --draft \
             --verify-tag \
             --target "${EVENT_SHA}" \
             --title "${TAG_NAME}" \
             --notes "VibeGuard runtime binaries, install payload, release manifest, and dependency metadata for ${TAG_NAME}."
+          release_created=1
+          gh release upload "${TAG_NAME}" \
+            --repo "${GH_REPO}" \
+            dist/vibeguard-runtime-* dist/vibeguard-payload-* dist/SHA256SUMS
+
+          release_json="$(gh release view "${TAG_NAME}" --repo "${GH_REPO}" \
+            --json databaseId,isDraft,tagName)"
+          release_id="$(jq -er --arg tag "${TAG_NAME}" '
+            select(.isDraft == true and .tagName == $tag) | .databaseId
+          ' <<< "${release_json}")"
+          if [[ ! "${release_id}" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: staged release did not return an exact numeric release id" >&2
+            exit 1
+          fi
+          staged_tag_commit="$(gh api "repos/${GH_REPO}/commits/${TAG_NAME}" --jq .sha)"
+          if [[ "${staged_tag_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: release tag ${TAG_NAME} moved while staging draft assets" >&2
+            exit 1
+          fi
+          printf 'release_id=%s\n' "${release_id}" >> "${GITHUB_OUTPUT}"
+          trap - EXIT
 
   no-clone-smoke:
     name: No-clone install smoke (${{ matrix.os }})
-    needs: publish-release
+    needs: stage-release
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     permissions:
@@ -296,6 +335,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RELEASE_ID: ${{ needs.stage-release.outputs.release_id }}
         run: |
           set -euo pipefail
           umask 077
@@ -305,12 +345,25 @@ jobs:
             echo "ERROR: event and signer workflow digests must be exact lowercase commit SHAs" >&2
             exit 1
           fi
+          if [[ ! "${GH_REPO}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ \
+            || ! "${RELEASE_ID}" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: repository identity and staged release id must be exact trusted inputs" >&2
+            exit 1
+          fi
           VERSION="${TAG_NAME#v}"
           ASSET="vibeguard-payload-${VERSION}.tar.gz"
           DOWNLOAD_DIR="${RUNNER_TEMP}/vibeguard-release"
           SEED_DIR="${RUNNER_TEMP}/vibeguard-bootstrap-seed"
           FRESH_HOME="${RUNNER_TEMP}/vibeguard-fresh-home"
           mkdir -p "${DOWNLOAD_DIR}" "${SEED_DIR}" "${FRESH_HOME}"
+
+          release_json="$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}")"
+          if ! jq -e --arg tag "${TAG_NAME}" --argjson id "${RELEASE_ID}" '
+            .id == $id and .draft == true and .tag_name == $tag
+          ' <<< "${release_json}" >/dev/null; then
+            echo "ERROR: no-clone smoke is not bound to the expected draft release" >&2
+            exit 1
+          fi
 
           tag_commit="$(gh api "repos/${GH_REPO}/commits/${TAG_NAME}" --jq .sha)"
           if [[ "${tag_commit}" != "${EVENT_SHA}" ]]; then
@@ -453,6 +506,20 @@ jobs:
             fi
           done
 
+          # The canonical source keeps an upstream default for ordinary installs.
+          # This release smoke replaces that single trusted default with an explicit
+          # repository input after the payload has passed checksum and attestation.
+          ruby - "${SEED_DIR}/scripts/setup/bootstrap.sh" <<'RUBY'
+          path = ARGV.fetch(0)
+          text = File.binread(path)
+          pattern = /^RELEASE_REPO="[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+"$/
+          matches = text.scan(pattern)
+          raise "bootstrap must expose exactly one release repository default" unless matches.length == 1
+          replacement = 'RELEASE_REPO="${VIBEGUARD_RELEASE_REPO:?VIBEGUARD_RELEASE_REPO must be set}"'
+          text.sub!(pattern, replacement)
+          File.binwrite(path, text)
+          RUBY
+
           # Audit the bootstrap's independent release download without replacing it:
           # the wrapper validates repository/tag arguments, calls the real gh binary,
           # and retains only the downloaded payload plus non-secret identity evidence.
@@ -508,6 +575,7 @@ jobs:
           export VIBEGUARD_SMOKE_REAL_GH="${REAL_GH}"
 
           HOME="${FRESH_HOME}" PATH="${AUDIT_BIN}:${PATH}" \
+            VIBEGUARD_RELEASE_REPO="${GH_REPO}" \
             bash "${SEED_DIR}/scripts/setup/bootstrap.sh" \
             --version "${VERSION}" --require-provenance -- --yes --require-provenance
           test "$(grep -Fxc -- "repo=${GH_REPO}" "${AUDIT_DIR}/download.identity")" = "1"
@@ -542,3 +610,114 @@ jobs:
           fi
           test -x "${FRESH_HOME}/.vibeguard/installed/bin/vibeguard-runtime"
           test -d "${FRESH_HOME}/.vibeguard/installed/rules/claude-rules"
+
+  publish-release:
+    name: Publish release assets
+    runs-on: ubuntu-latest
+    needs:
+      - stage-release
+      - no-clone-smoke
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      attestations: read
+
+    steps:
+      - name: Finalize and publish verified draft
+        env:
+          EVENT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RELEASE_ID: ${{ needs.stage-release.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          umask 077
+
+          if [[ ${#EVENT_SHA} -ne 40 || "${EVENT_SHA}" == *[!0-9a-f]* \
+            || ${#WORKFLOW_SHA} -ne 40 || "${WORKFLOW_SHA}" == *[!0-9a-f]* \
+            || ! "${GH_REPO}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ \
+            || ! "${RELEASE_ID}" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: final release identities are malformed" >&2
+            exit 1
+          fi
+
+          release_json="$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}")"
+          if ! jq -e --arg tag "${TAG_NAME}" --argjson id "${RELEASE_ID}" '
+            .id == $id and .draft == true and .tag_name == $tag
+          ' <<< "${release_json}" >/dev/null; then
+            echo "ERROR: final publication target is not the expected draft release" >&2
+            exit 1
+          fi
+
+          audit_dir="${RUNNER_TEMP}/vibeguard-final-release-audit"
+          mkdir -p "${audit_dir}"
+          gh release download "${TAG_NAME}" --repo "${GH_REPO}" --dir "${audit_dir}"
+          expected_assets=(
+            SHA256SUMS
+            "vibeguard-payload-${TAG_NAME#v}.tar.gz"
+            vibeguard-runtime-aarch64-apple-darwin
+            vibeguard-runtime-aarch64-unknown-linux-musl
+            vibeguard-runtime-dependency-metadata.json
+            vibeguard-runtime-releases.json
+            vibeguard-runtime-x86_64-apple-darwin
+            vibeguard-runtime-x86_64-unknown-linux-musl
+          )
+          mapfile -t actual_assets < <(find "${audit_dir}" -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort)
+          mapfile -t sorted_expected < <(printf '%s\n' "${expected_assets[@]}" | LC_ALL=C sort)
+          if [[ "${actual_assets[*]}" != "${sorted_expected[*]}" ]]; then
+            echo "ERROR: staged draft assets do not match the exact release set" >&2
+            exit 1
+          fi
+
+          (
+            cd "${audit_dir}"
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum --check --strict SHA256SUMS
+            else
+              shasum -a 256 --check SHA256SUMS
+            fi
+          )
+
+          attested_assets=(
+            "${audit_dir}/SHA256SUMS"
+            "${audit_dir}/vibeguard-payload-${TAG_NAME#v}.tar.gz"
+            "${audit_dir}/vibeguard-runtime-aarch64-apple-darwin"
+            "${audit_dir}/vibeguard-runtime-aarch64-unknown-linux-musl"
+            "${audit_dir}/vibeguard-runtime-releases.json"
+            "${audit_dir}/vibeguard-runtime-x86_64-apple-darwin"
+            "${audit_dir}/vibeguard-runtime-x86_64-unknown-linux-musl"
+          )
+          for asset in "${attested_assets[@]}"; do
+            gh attestation verify "${asset}" \
+              --repo "${GH_REPO}" \
+              --signer-workflow "github.com/${GH_REPO}/.github/workflows/release.yml" \
+              --signer-digest "${WORKFLOW_SHA}" \
+              --source-ref "refs/tags/${TAG_NAME}" \
+              --source-digest "${EVENT_SHA}" \
+              --deny-self-hosted-runners
+          done
+
+          marker_commit="$(
+            tar -xOf "${audit_dir}/vibeguard-payload-${TAG_NAME#v}.tar.gz" .vibeguard-payload \
+              | awk -F= '$1 == "git_commit" { count += 1; commit = $2 } END { if (count == 1) print commit; else exit 1 }'
+          )"
+          if [[ "${marker_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: staged payload marker does not match event commit ${EVENT_SHA}" >&2
+            exit 1
+          fi
+
+          final_tag_commit="$(gh api "repos/${GH_REPO}/commits/${TAG_NAME}" --jq .sha)"
+          if [[ "${final_tag_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: release tag ${TAG_NAME} moved before publication; draft remains unpublished" >&2
+            exit 1
+          fi
+
+          publish_json="$(gh api --method PATCH "repos/${GH_REPO}/releases/${RELEASE_ID}" \
+            -F draft=false -f make_latest=true)"
+          if ! jq -e --argjson id "${RELEASE_ID}" '.id == $id and .draft == false' \
+            <<< "${publish_json}" >/dev/null; then
+            echo "ERROR: GitHub did not confirm the single draft-to-public transition" >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,14 +538,20 @@ jobs:
             shift
             repo=""
             destination=""
+            payload_requested=0
             while [[ $# -gt 0 ]]; do
               case "$1" in
                 --repo) [[ $# -ge 2 ]] || exit 64; repo="$2"; shift 2 ;;
                 --repo=*) repo="${1#*=}"; shift ;;
                 --dir) [[ $# -ge 2 ]] || exit 64; destination="$2"; shift 2 ;;
                 --dir=*) destination="${1#*=}"; shift ;;
-                --pattern) [[ $# -ge 2 ]] || exit 64; shift 2 ;;
-                --pattern=*) shift ;;
+                --pattern)
+                  [[ $# -ge 2 ]] || exit 64
+                  [[ "$2" != "${VIBEGUARD_SMOKE_EXPECTED_ASSET}" ]] || payload_requested=1
+                  shift 2 ;;
+                --pattern=*)
+                  [[ "${1#*=}" != "${VIBEGUARD_SMOKE_EXPECTED_ASSET}" ]] || payload_requested=1
+                  shift ;;
                 *) echo "ERROR: unexpected bootstrap gh release download argument: $1" >&2; exit 64 ;;
               esac
             done
@@ -553,6 +559,15 @@ jobs:
               || "${tag}" != "${VIBEGUARD_SMOKE_EXPECTED_TAG}" ]]; then
               echo "ERROR: bootstrap requested ${repo}@${tag}, expected ${VIBEGUARD_SMOKE_EXPECTED_REPO}@${VIBEGUARD_SMOKE_EXPECTED_TAG}" >&2
               exit 1
+            fi
+            if [[ "${payload_requested}" != "1" ]]; then
+              # Setup downloads the runtime binary, SHA256SUMS, and the runtime
+              # release manifest from the same release. Those downloads must keep
+              # the real gh exit status, otherwise setup falls back to an
+              # unauthenticated curl that cannot read a still-draft release.
+              printf 'repo=%s\ntag=%s\n' "${repo}" "${tag}" \
+                >> "${VIBEGUARD_SMOKE_AUDIT_DIR}/runtime-download.identity"
+              exec "${VIBEGUARD_SMOKE_REAL_GH}" "${original_args[@]}"
             fi
             "${VIBEGUARD_SMOKE_REAL_GH}" "${original_args[@]}"
             downloaded="${destination}/${VIBEGUARD_SMOKE_EXPECTED_ASSET}"
@@ -576,6 +591,7 @@ jobs:
 
           HOME="${FRESH_HOME}" PATH="${AUDIT_BIN}:${PATH}" \
             VIBEGUARD_RELEASE_REPO="${GH_REPO}" \
+            VIBEGUARD_RUNTIME_RELEASE_REPO="${GH_REPO}" \
             bash "${SEED_DIR}/scripts/setup/bootstrap.sh" \
             --version "${VERSION}" --require-provenance -- --yes --require-provenance
           test "$(grep -Fxc -- "repo=${GH_REPO}" "${AUDIT_DIR}/download.identity")" = "1"
@@ -593,6 +609,29 @@ jobs:
             echo "ERROR: bootstrap payload marker does not match event commit ${EVENT_SHA}" >&2
             exit 1
           fi
+          runtime_provenance="${FRESH_HOME}/.vibeguard/installed/runtime-provenance"
+          if [[ ! -f "${runtime_provenance}" || -L "${runtime_provenance}" ]]; then
+            echo "ERROR: no-clone install did not record runtime provenance evidence" >&2
+            exit 1
+          fi
+          installed_runtime_repo="$(
+            awk -F= '$1 == "release_repo" { count += 1; repo = $2 } END { if (count == 1) print repo; else exit 1 }' \
+              "${runtime_provenance}"
+          )"
+          if [[ "${installed_runtime_repo}" != "${GH_REPO}" ]]; then
+            echo "ERROR: installed runtime came from ${installed_runtime_repo}, expected ${GH_REPO}" >&2
+            exit 1
+          fi
+          installed_runtime_tag="$(
+            awk -F= '$1 == "tag" { count += 1; tag = $2 } END { if (count == 1) print tag; else exit 1 }' \
+              "${runtime_provenance}"
+          )"
+          if [[ "${installed_runtime_tag}" != "${TAG_NAME}" ]]; then
+            echo "ERROR: installed runtime came from ${installed_runtime_tag}, expected ${TAG_NAME}" >&2
+            exit 1
+          fi
+          test "$(grep -Fxc -- "repo=${GH_REPO}" "${AUDIT_DIR}/runtime-download.identity")" -ge 1
+          test "$(grep -Fxc -- "tag=${TAG_NAME}" "${AUDIT_DIR}/runtime-download.identity")" -ge 1
           HOME="${FRESH_HOME}" bash \
             "${FRESH_HOME}/.vibeguard/dist/current/setup.sh" verify-install
           installed_marker_commit="$(
@@ -714,10 +753,34 @@ jobs:
             exit 1
           fi
 
+          # The PATCH is an ambiguous commit point: GitHub may have applied the
+          # draft-to-public transition even when the acknowledgement is lost,
+          # truncated, or unparseable. Never decide the job status from the
+          # acknowledgement alone; reconcile against the exact release id.
+          publish_rc=0
           publish_json="$(gh api --method PATCH "repos/${GH_REPO}/releases/${RELEASE_ID}" \
-            -F draft=false -f make_latest=true)"
-          if ! jq -e --argjson id "${RELEASE_ID}" '.id == $id and .draft == false' \
-            <<< "${publish_json}" >/dev/null; then
-            echo "ERROR: GitHub did not confirm the single draft-to-public transition" >&2
-            exit 1
+            -F draft=false -f make_latest=true)" || publish_rc=$?
+          if [[ "${publish_rc}" -ne 0 ]] \
+            || ! jq -e --argjson id "${RELEASE_ID}" '.id == $id and .draft == false' \
+              <<< "${publish_json}" >/dev/null; then
+            echo "NOTE: publication acknowledgement was unusable; reconciling release ${RELEASE_ID}" >&2
+            reconcile_rc=0
+            reconcile_json="$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}")" || reconcile_rc=$?
+            if [[ "${reconcile_rc}" -ne 0 ]]; then
+              echo "ERROR: publication state of release ${RELEASE_ID} could not be read" >&2
+              exit 1
+            fi
+            if jq -e --arg tag "${TAG_NAME}" --argjson id "${RELEASE_ID}" '
+              .id == $id and .draft == false and .tag_name == $tag
+            ' <<< "${reconcile_json}" >/dev/null; then
+              echo "NOTE: release ${RELEASE_ID} is already public; the lost acknowledgement was benign" >&2
+            elif jq -e --arg tag "${TAG_NAME}" --argjson id "${RELEASE_ID}" '
+              .id == $id and .draft == true and .tag_name == $tag
+            ' <<< "${reconcile_json}" >/dev/null; then
+              echo "ERROR: draft-to-public transition did not commit; release ${RELEASE_ID} is still a draft" >&2
+              exit 1
+            else
+              echo "ERROR: release ${RELEASE_ID} is in an unexpected state after the publish attempt" >&2
+              exit 1
+            fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,15 @@ jobs:
 
       - name: Assert tag commit is on main
         env:
+          EVENT_SHA: ${{ github.sha }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           git fetch --no-tags origin main
           tag_commit="$(git rev-list -n 1 "${TAG_NAME}")"
+          if [[ "${tag_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: release tag ${TAG_NAME} moved from event commit ${EVENT_SHA} to ${tag_commit}" >&2
+            exit 1
+          fi
           if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
             echo "ERROR: release tag ${TAG_NAME} (${tag_commit}) is not reachable from origin/main" >&2
             exit 1
@@ -188,10 +193,28 @@ jobs:
 
       - name: Build payload artifact
         env:
+          EVENT_SHA: ${{ github.sha }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          bash scripts/release/build-payload.sh --version "${TAG_NAME#v}" --output dist
+          bash scripts/release/build-payload.sh \
+            --version "${TAG_NAME#v}" \
+            --output dist \
+            --ref "${EVENT_SHA}"
           tar -tzf "dist/vibeguard-payload-${TAG_NAME#v}.tar.gz" | sed 's#^\./##' | grep -qx '.vibeguard-payload'
+          marker_commit="$(
+            tar -xOf "dist/vibeguard-payload-${TAG_NAME#v}.tar.gz" .vibeguard-payload \
+              | awk -F= '
+                  $1 == "git_commit" { count += 1; commit = $2 }
+                  END { if (count == 1) print commit; else exit 1 }
+                '
+          )" || {
+            echo "ERROR: payload marker must contain exactly one git_commit" >&2
+            exit 1
+          }
+          if [[ "${marker_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: payload marker commit ${marker_commit} does not match event commit ${EVENT_SHA}" >&2
+            exit 1
+          fi
 
       - name: Generate checksums
         run: |
@@ -227,6 +250,7 @@ jobs:
 
       - name: Publish GitHub Release
         env:
+          EVENT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
@@ -235,7 +259,14 @@ jobs:
             echo "ERROR: release ${TAG_NAME} already exists; refusing to mutate release assets" >&2
             exit 1
           fi
+          remote_tag_commit="$(gh api "repos/${GH_REPO}/commits/${TAG_NAME}" --jq .sha)"
+          if [[ "${remote_tag_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: release tag ${TAG_NAME} moved from event commit ${EVENT_SHA} to ${remote_tag_commit}" >&2
+            exit 1
+          fi
           gh release create "${TAG_NAME}" dist/vibeguard-runtime-* dist/vibeguard-payload-* dist/SHA256SUMS \
+            --verify-tag \
+            --target "${EVENT_SHA}" \
             --title "${TAG_NAME}" \
             --notes "VibeGuard runtime binaries, install payload, release manifest, and dependency metadata for ${TAG_NAME}."
 
@@ -260,19 +291,32 @@ jobs:
       # immutable release is sufficient installation media on a fresh HOME.
       - name: Install and verify from immutable release
         env:
+          EVENT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           umask 077
 
+          if [[ ${#EVENT_SHA} -ne 40 || "${EVENT_SHA}" == *[!0-9a-f]* \
+            || ${#WORKFLOW_SHA} -ne 40 || "${WORKFLOW_SHA}" == *[!0-9a-f]* ]]; then
+            echo "ERROR: event and signer workflow digests must be exact lowercase commit SHAs" >&2
+            exit 1
+          fi
           VERSION="${TAG_NAME#v}"
           ASSET="vibeguard-payload-${VERSION}.tar.gz"
           DOWNLOAD_DIR="${RUNNER_TEMP}/vibeguard-release"
           SEED_DIR="${RUNNER_TEMP}/vibeguard-bootstrap-seed"
           FRESH_HOME="${RUNNER_TEMP}/vibeguard-fresh-home"
           mkdir -p "${DOWNLOAD_DIR}" "${SEED_DIR}" "${FRESH_HOME}"
+
+          tag_commit="$(gh api "repos/${GH_REPO}/commits/${TAG_NAME}" --jq .sha)"
+          if [[ "${tag_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: release tag ${TAG_NAME} does not resolve to event commit ${EVENT_SHA}" >&2
+            exit 1
+          fi
 
           download_ok=0
           for attempt in 1 2 3 4; do
@@ -328,8 +372,25 @@ jobs:
           gh attestation verify "${DOWNLOAD_DIR}/${ASSET}" \
             --repo "${GH_REPO}" \
             --signer-workflow "github.com/${GH_REPO}/.github/workflows/release.yml" \
+            --signer-digest "${WORKFLOW_SHA}" \
             --source-ref "refs/tags/${TAG_NAME}" \
+            --source-digest "${EVENT_SHA}" \
             --deny-self-hosted-runners
+
+          marker_commit="$(
+            tar -xOf "${DOWNLOAD_DIR}/${ASSET}" .vibeguard-payload \
+              | awk -F= '
+                  $1 == "git_commit" { count += 1; commit = $2 }
+                  END { if (count == 1) print commit; else exit 1 }
+                '
+          )" || {
+            echo "ERROR: payload marker must contain exactly one git_commit" >&2
+            exit 1
+          }
+          if [[ "${marker_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: payload marker commit ${marker_commit} does not match event commit ${EVENT_SHA}" >&2
+            exit 1
+          fi
 
           archive_names="${RUNNER_TEMP}/vibeguard-payload-names"
           archive_types="${RUNNER_TEMP}/vibeguard-payload-types"
@@ -346,6 +407,16 @@ jobs:
             END { exit bad }
           ' "${archive_names}"; then
             echo "ERROR: payload contains an unsafe archive path" >&2
+            exit 1
+          fi
+          if ! awk '
+            {
+              type = substr($1, 1, 1)
+              if (type != "-" && type != "d") bad = 1
+            }
+            END { exit bad }
+          ' "${archive_types}"; then
+            echo "ERROR: payload contains a link or special archive entry" >&2
             exit 1
           fi
 
@@ -382,9 +453,92 @@ jobs:
             fi
           done
 
-          HOME="${FRESH_HOME}" bash "${SEED_DIR}/scripts/setup/bootstrap.sh" \
+          # Audit the bootstrap's independent release download without replacing it:
+          # the wrapper validates repository/tag arguments, calls the real gh binary,
+          # and retains only the downloaded payload plus non-secret identity evidence.
+          REAL_GH="$(command -v gh)"
+          AUDIT_BIN="${RUNNER_TEMP}/vibeguard-bootstrap-audit-bin"
+          AUDIT_DIR="${RUNNER_TEMP}/vibeguard-bootstrap-audit"
+          mkdir -p "${AUDIT_BIN}" "${AUDIT_DIR}"
+          cat > "${AUDIT_BIN}/gh" <<'GH_AUDIT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
+            original_args=("$@")
+            shift 2
+            tag="${1:-}"
+            [[ -n "${tag}" ]] || { echo "ERROR: bootstrap gh download omitted tag" >&2; exit 64; }
+            shift
+            repo=""
+            destination=""
+            while [[ $# -gt 0 ]]; do
+              case "$1" in
+                --repo) [[ $# -ge 2 ]] || exit 64; repo="$2"; shift 2 ;;
+                --repo=*) repo="${1#*=}"; shift ;;
+                --dir) [[ $# -ge 2 ]] || exit 64; destination="$2"; shift 2 ;;
+                --dir=*) destination="${1#*=}"; shift ;;
+                --pattern) [[ $# -ge 2 ]] || exit 64; shift 2 ;;
+                --pattern=*) shift ;;
+                *) echo "ERROR: unexpected bootstrap gh release download argument: $1" >&2; exit 64 ;;
+              esac
+            done
+            if [[ "${repo}" != "${VIBEGUARD_SMOKE_EXPECTED_REPO}" \
+              || "${tag}" != "${VIBEGUARD_SMOKE_EXPECTED_TAG}" ]]; then
+              echo "ERROR: bootstrap requested ${repo}@${tag}, expected ${VIBEGUARD_SMOKE_EXPECTED_REPO}@${VIBEGUARD_SMOKE_EXPECTED_TAG}" >&2
+              exit 1
+            fi
+            "${VIBEGUARD_SMOKE_REAL_GH}" "${original_args[@]}"
+            downloaded="${destination}/${VIBEGUARD_SMOKE_EXPECTED_ASSET}"
+            if [[ ! -f "${downloaded}" || -L "${downloaded}" ]]; then
+              echo "ERROR: bootstrap gh download did not produce the expected regular payload" >&2
+              exit 1
+            fi
+            cp "${downloaded}" "${VIBEGUARD_SMOKE_AUDIT_DIR}/payload.tar.gz"
+            printf 'repo=%s\ntag=%s\n' "${repo}" "${tag}" \
+              > "${VIBEGUARD_SMOKE_AUDIT_DIR}/download.identity"
+            exit 0
+          fi
+          exec "${VIBEGUARD_SMOKE_REAL_GH}" "$@"
+          GH_AUDIT
+          chmod 0755 "${AUDIT_BIN}/gh"
+          export VIBEGUARD_SMOKE_AUDIT_DIR="${AUDIT_DIR}"
+          export VIBEGUARD_SMOKE_EXPECTED_ASSET="${ASSET}"
+          export VIBEGUARD_SMOKE_EXPECTED_REPO="${GH_REPO}"
+          export VIBEGUARD_SMOKE_EXPECTED_TAG="${TAG_NAME}"
+          export VIBEGUARD_SMOKE_REAL_GH="${REAL_GH}"
+
+          HOME="${FRESH_HOME}" PATH="${AUDIT_BIN}:${PATH}" \
+            bash "${SEED_DIR}/scripts/setup/bootstrap.sh" \
             --version "${VERSION}" --require-provenance -- --yes --require-provenance
+          test "$(grep -Fxc -- "repo=${GH_REPO}" "${AUDIT_DIR}/download.identity")" = "1"
+          test "$(grep -Fxc -- "tag=${TAG_NAME}" "${AUDIT_DIR}/download.identity")" = "1"
+          secondary_sha="$(sha256_file "${AUDIT_DIR}/payload.tar.gz")"
+          if [[ "${secondary_sha}" != "${actual}" ]]; then
+            echo "ERROR: bootstrap downloaded a different payload than the attested smoke payload" >&2
+            exit 1
+          fi
+          secondary_marker_commit="$(
+            tar -xOf "${AUDIT_DIR}/payload.tar.gz" .vibeguard-payload \
+              | awk -F= '$1 == "git_commit" { count += 1; commit = $2 } END { if (count == 1) print commit; else exit 1 }'
+          )"
+          if [[ "${secondary_marker_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: bootstrap payload marker does not match event commit ${EVENT_SHA}" >&2
+            exit 1
+          fi
           HOME="${FRESH_HOME}" bash \
             "${FRESH_HOME}/.vibeguard/dist/current/setup.sh" verify-install
+          installed_marker_commit="$(
+            awk -F= '$1 == "git_commit" { count += 1; commit = $2 } END { if (count == 1) print commit; else exit 1 }' \
+              "${FRESH_HOME}/.vibeguard/dist/current/.vibeguard-payload"
+          )"
+          if [[ "${installed_marker_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: installed payload marker does not match event commit ${EVENT_SHA}" >&2
+            exit 1
+          fi
+          final_tag_commit="$(gh api "repos/${GH_REPO}/commits/${TAG_NAME}" --jq .sha)"
+          if [[ "${final_tag_commit}" != "${EVENT_SHA}" ]]; then
+            echo "ERROR: release tag ${TAG_NAME} moved during no-clone verification" >&2
+            exit 1
+          fi
           test -x "${FRESH_HOME}/.vibeguard/installed/bin/vibeguard-runtime"
           test -d "${FRESH_HOME}/.vibeguard/installed/rules/claude-rules"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,3 +238,153 @@ jobs:
           gh release create "${TAG_NAME}" dist/vibeguard-runtime-* dist/vibeguard-payload-* dist/SHA256SUMS \
             --title "${TAG_NAME}" \
             --notes "VibeGuard runtime binaries, install payload, release manifest, and dependency metadata for ${TAG_NAME}."
+
+  no-clone-smoke:
+    name: No-clone install smoke (${{ matrix.os }})
+    needs: publish-release
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      attestations: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+          - os: ubuntu-latest
+
+    steps:
+      # Intentionally no actions/checkout step: this job proves that the
+      # immutable release is sufficient installation media on a fresh HOME.
+      - name: Install and verify from immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          umask 077
+
+          VERSION="${TAG_NAME#v}"
+          ASSET="vibeguard-payload-${VERSION}.tar.gz"
+          DOWNLOAD_DIR="${RUNNER_TEMP}/vibeguard-release"
+          SEED_DIR="${RUNNER_TEMP}/vibeguard-bootstrap-seed"
+          FRESH_HOME="${RUNNER_TEMP}/vibeguard-fresh-home"
+          mkdir -p "${DOWNLOAD_DIR}" "${SEED_DIR}" "${FRESH_HOME}"
+
+          download_ok=0
+          for attempt in 1 2 3 4; do
+            if gh release download "${TAG_NAME}" \
+              --repo "${GH_REPO}" \
+              --pattern "${ASSET}" \
+              --pattern SHA256SUMS \
+              --dir "${DOWNLOAD_DIR}"; then
+              download_ok=1
+              break
+            fi
+            rm -f -- "${DOWNLOAD_DIR}/${ASSET}" "${DOWNLOAD_DIR}/SHA256SUMS"
+            sleep 5
+          done
+          if [[ "${download_ok}" != "1" ]]; then
+            echo "ERROR: release assets did not become readable after bounded retries" >&2
+            exit 1
+          fi
+          if [[ ! -f "${DOWNLOAD_DIR}/${ASSET}" \
+            || -L "${DOWNLOAD_DIR}/${ASSET}" \
+            || ! -f "${DOWNLOAD_DIR}/SHA256SUMS" \
+            || -L "${DOWNLOAD_DIR}/SHA256SUMS" ]]; then
+            echo "ERROR: release download did not produce regular payload and checksum files" >&2
+            exit 1
+          fi
+
+          expected="$(
+            awk -v file="${ASSET}" '
+              ($2 == file || $2 == "*" file) { count += 1; digest = $1 }
+              END { if (count == 1) print digest; else exit 1 }
+            ' "${DOWNLOAD_DIR}/SHA256SUMS"
+          )" || {
+            echo "ERROR: SHA256SUMS must contain exactly one payload entry" >&2
+            exit 1
+          }
+          if [[ ${#expected} -ne 64 || "${expected}" == *[!0-9a-f]* ]]; then
+            echo "ERROR: SHA256SUMS contains an invalid payload digest" >&2
+            exit 1
+          fi
+          sha256_file() {
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$1" | awk '{print $1}'
+            else
+              shasum -a 256 "$1" | awk '{print $1}'
+            fi
+          }
+          actual="$(sha256_file "${DOWNLOAD_DIR}/${ASSET}")"
+          if [[ "${actual}" != "${expected}" ]]; then
+            echo "ERROR: payload checksum verification failed" >&2
+            exit 1
+          fi
+
+          gh attestation verify "${DOWNLOAD_DIR}/${ASSET}" \
+            --repo "${GH_REPO}" \
+            --signer-workflow "github.com/${GH_REPO}/.github/workflows/release.yml" \
+            --source-ref "refs/tags/${TAG_NAME}" \
+            --deny-self-hosted-runners
+
+          archive_names="${RUNNER_TEMP}/vibeguard-payload-names"
+          archive_types="${RUNNER_TEMP}/vibeguard-payload-types"
+          LC_ALL=C tar -tzf "${DOWNLOAD_DIR}/${ASSET}" > "${archive_names}"
+          LC_ALL=C tar -tvzf "${DOWNLOAD_DIR}/${ASSET}" > "${archive_types}"
+          if ! awk '
+            {
+              name = $0
+              normalized = name
+              sub(/\/$/, "", normalized)
+              if (name == "" || normalized == "" || name ~ /^\// \
+                || name ~ /(^|\/)\.\.?($|\/)/ || name ~ /\/\//) bad = 1
+            }
+            END { exit bad }
+          ' "${archive_names}"; then
+            echo "ERROR: payload contains an unsafe archive path" >&2
+            exit 1
+          fi
+
+          bootstrap_files=(
+            scripts/setup/bootstrap.sh
+            scripts/setup/bootstrap-lib.sh
+            scripts/setup/bootstrap_identity.sh
+            scripts/setup/bootstrap_birth_token.jxa
+            scripts/setup/bootstrap_process.sh
+            scripts/setup/bootstrap_termination.sh
+            scripts/setup/bootstrap_lease_terminal.sh
+            scripts/setup/bootstrap_lease_retirement.sh
+            scripts/setup/bootstrap_state.sh
+          )
+          for member in "${bootstrap_files[@]}"; do
+            if [[ "$(grep -Fxc -- "${member}" "${archive_names}")" != "1" ]]; then
+              echo "ERROR: payload must contain exactly one regular ${member}" >&2
+              exit 1
+            fi
+            if ! awk -v file="${member}" '
+              $NF == file { count += 1; regular = substr($1, 1, 1) == "-" }
+              END { exit !(count == 1 && regular) }
+            ' "${archive_types}"; then
+              echo "ERROR: payload bootstrap member is not a unique regular file: ${member}" >&2
+              exit 1
+            fi
+          done
+          tar -xzf "${DOWNLOAD_DIR}/${ASSET}" -C "${SEED_DIR}" \
+            "${bootstrap_files[@]}"
+          for member in "${bootstrap_files[@]}"; do
+            if [[ ! -f "${SEED_DIR}/${member}" || -L "${SEED_DIR}/${member}" ]]; then
+              echo "ERROR: extracted bootstrap member is not a regular file: ${member}" >&2
+              exit 1
+            fi
+          done
+
+          HOME="${FRESH_HOME}" bash "${SEED_DIR}/scripts/setup/bootstrap.sh" \
+            --version "${VERSION}" --require-provenance -- --yes --require-provenance
+          HOME="${FRESH_HOME}" bash \
+            "${FRESH_HOME}/.vibeguard/dist/current/setup.sh" verify-install
+          test -x "${FRESH_HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+          test -d "${FRESH_HOME}/.vibeguard/installed/rules/claude-rules"

--- a/tests/helpers/release_workflow_contract.rb
+++ b/tests/helpers/release_workflow_contract.rb
@@ -1,0 +1,275 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+
+module ReleaseWorkflowContract
+  module_function
+
+  SMOKE_STEP = "Install and verify from immutable release"
+  STAGE_STEP = "Stage draft GitHub Release"
+  PUBLISH_STEP = "Finalize and publish verified draft"
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+
+  def exact_hash(actual, expected, label)
+    assert(actual == expected, "#{label} must equal #{expected.inspect}, got #{actual.inspect}")
+  end
+
+  def reachable(node, label)
+    assert(!node.key?("if"), "#{label} must not define if")
+    assert(!node["continue-on-error"], "#{label} must propagate failure")
+  end
+
+  def one_step(job, name)
+    matches = job.fetch("steps").select { |step| step["name"] == name }
+    assert(matches.length == 1, "expected exactly one #{name.inspect} step")
+    matches.fetch(0)
+  end
+
+  def require_fragments(script, fragments, label)
+    fragments.each do |fragment|
+      assert(script.include?(fragment), "#{label} is missing #{fragment.inspect}")
+    end
+  end
+
+  def require_order(script, fragments, label)
+    positions = fragments.map do |fragment|
+      position = script.index(fragment)
+      assert(position, "#{label} is missing #{fragment.inspect}")
+      position
+    end
+    assert(positions.each_cons(2).all? { |left, right| left < right },
+           "#{label} operations are out of order: #{fragments.inspect}")
+  end
+
+  def load_jobs(workflow_path)
+    YAML.load_file(workflow_path).fetch("jobs")
+  end
+
+  def validate(workflow_path, ci_path)
+    validate_jobs(load_jobs(workflow_path), load_jobs(ci_path))
+  end
+
+  def validate_jobs(jobs, ci_jobs)
+    stage = jobs.fetch("stage-release")
+    smoke = jobs.fetch("no-clone-smoke")
+    publish = jobs.fetch("publish-release")
+
+    validate_stage(stage)
+    validate_smoke(smoke)
+    validate_publish(publish)
+    validate_ci_jobs(ci_jobs)
+  end
+
+  def validate_stage(job)
+    reachable(job, "stage-release job")
+    assert(job.fetch("needs") == "build-runtime", "stage-release must depend on build-runtime")
+    exact_hash(job.fetch("permissions"), {
+      "contents" => "write", "id-token" => "write", "attestations" => "write"
+    }, "stage-release permissions")
+    exact_hash(job.fetch("outputs"), {
+      "release_id" => "${{ steps.stage-release.outputs.release_id }}"
+    }, "stage-release outputs")
+
+    step = one_step(job, STAGE_STEP)
+    reachable(step, STAGE_STEP)
+    assert(step.fetch("id") == "stage-release", "stage step id must be stage-release")
+    exact_hash(step.fetch("env"), {
+      "EVENT_SHA" => "${{ github.sha }}",
+      "GH_TOKEN" => "${{ github.token }}",
+      "GH_REPO" => "${{ github.repository }}",
+      "TAG_NAME" => "${{ github.ref_name }}"
+    }, "stage step env")
+    script = step.fetch("run")
+    require_fragments(script, [
+      "trap cleanup_failed_draft EXIT",
+      "gh release delete",
+      "--draft",
+      "gh release upload",
+      "release_id=%s",
+      'staged_tag_commit="$(gh api'
+    ], STAGE_STEP)
+    assert(!script.include?("draft=false"), "stage step must never publish a release")
+  end
+
+  def validate_smoke(job)
+    reachable(job, "no-clone-smoke job")
+    assert(job.fetch("needs") == "stage-release", "smoke must depend on stage-release")
+    exact_hash(job.fetch("permissions"), {
+      "contents" => "read", "attestations" => "read"
+    }, "no-clone-smoke permissions")
+    oses = job.dig("strategy", "matrix", "include").map { |entry| entry.fetch("os") }
+    assert(oses.sort == ["macos-14", "ubuntu-latest"], "smoke matrix must cover macOS and Ubuntu")
+    assert(job.fetch("steps").none? { |step| step["uses"].to_s.start_with?("actions/checkout@") },
+           "smoke must not checkout source")
+
+    step = one_step(job, SMOKE_STEP)
+    reachable(step, SMOKE_STEP)
+    exact_hash(step.fetch("env"), {
+      "EVENT_SHA" => "${{ github.sha }}",
+      "GH_TOKEN" => "${{ github.token }}",
+      "GH_REPO" => "${{ github.repository }}",
+      "TAG_NAME" => "${{ github.ref_name }}",
+      "WORKFLOW_SHA" => "${{ github.workflow_sha }}",
+      "RELEASE_ID" => "${{ needs.stage-release.outputs.release_id }}"
+    }, "smoke step env")
+    script = step.fetch("run")
+    require_fragments(script, [
+      ".draft == true",
+      'VIBEGUARD_RELEASE_REPO="${GH_REPO}"',
+      'secondary_sha="$(sha256_file',
+      'secondary_marker_commit="$(' ,
+      'final_tag_commit="$(gh api'
+    ], SMOKE_STEP)
+    require_order(script, [
+      'tag_commit="$(gh api',
+      'gh release download "${TAG_NAME}"',
+      'secondary_sha="$(sha256_file',
+      'secondary_marker_commit="$(' ,
+      'final_tag_commit="$(gh api'
+    ], SMOKE_STEP)
+  end
+
+  def validate_publish(job)
+    reachable(job, "publish-release job")
+    assert(job.fetch("needs") == ["stage-release", "no-clone-smoke"],
+           "publish-release must depend on staging and both smoke matrix results")
+    exact_hash(job.fetch("permissions"), {
+      "contents" => "write", "attestations" => "read"
+    }, "publish-release permissions")
+
+    step = one_step(job, PUBLISH_STEP)
+    reachable(step, PUBLISH_STEP)
+    exact_hash(step.fetch("env"), {
+      "EVENT_SHA" => "${{ github.sha }}",
+      "GH_TOKEN" => "${{ github.token }}",
+      "GH_REPO" => "${{ github.repository }}",
+      "TAG_NAME" => "${{ github.ref_name }}",
+      "WORKFLOW_SHA" => "${{ github.workflow_sha }}",
+      "RELEASE_ID" => "${{ needs.stage-release.outputs.release_id }}"
+    }, "publish step env")
+    script = step.fetch("run")
+    require_fragments(script, [
+      ".draft == true",
+      "expected_assets=(",
+      "sha256sum --check --strict SHA256SUMS",
+      "gh attestation verify",
+      'marker_commit="$(' ,
+      'final_tag_commit="$(gh api',
+      "gh api --method PATCH",
+      "-F draft=false"
+    ], PUBLISH_STEP)
+    require_order(script, [
+      'release_json="$(gh api',
+      'gh release download "${TAG_NAME}"',
+      "sha256sum --check --strict SHA256SUMS",
+      "gh attestation verify",
+      'marker_commit="$(' ,
+      'final_tag_commit="$(gh api',
+      "gh api --method PATCH"
+    ], PUBLISH_STEP)
+  end
+
+  def validate_ci_jobs(jobs)
+    job = jobs.fetch("validate-and-test")
+    reachable(job, "validate-and-test job")
+    step = one_step(job, "Validate no-clone release smoke contract")
+    assert(!step["continue-on-error"], "CI no-clone contract step must propagate failure")
+    assert(step.fetch("run") == "bash tests/test_no_clone_release_smoke.sh",
+           "CI must execute the no-clone contract test")
+    assert(step.fetch("if") == "runner.os != 'Windows'", "CI contract must run on both Unix matrices")
+  end
+
+  def self_test(workflow_path, ci_path)
+    jobs = load_jobs(workflow_path)
+    ci_jobs = load_jobs(ci_path)
+    mutations = {
+      "disabled smoke job" => lambda { |copy, _ci| copy.fetch("no-clone-smoke")["if"] = "${{ false }}" },
+      "extra smoke permission" => lambda do |copy, _ci|
+        copy.fetch("no-clone-smoke").fetch("permissions")["id-token"] = "write"
+      end,
+      "wrong event expression" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP).fetch("env")["EVENT_SHA"] =
+          "${{ github.ref_name }}"
+      end,
+      "wrong workflow expression" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP).fetch("env")["WORKFLOW_SHA"] =
+          "${{ github.sha }}"
+      end,
+      "wrong repository expression" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP).fetch("env")["GH_REPO"] =
+          "${{ github.event.repository.full_name }}"
+      end,
+      "wrong tag expression" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP).fetch("env")["TAG_NAME"] =
+          "${{ github.ref }}"
+      end,
+      "disabled CI job" => lambda { |_copy, ci| ci.fetch("validate-and-test")["if"] = "${{ false }}" },
+      "removed secondary digest check" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP)["run"]
+          .sub!('secondary_sha="$(sha256_file', 'digest_check_removed="$(sha256_file')
+      end,
+      "removed secondary marker check" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP)["run"]
+          .sub!('secondary_marker_commit="$(' , 'marker_check_removed="$(')
+      end,
+      "removed final smoke tag check" => lambda do |copy, _ci|
+        one_step(copy.fetch("no-clone-smoke"), SMOKE_STEP)["run"]
+          .sub!('final_tag_commit="$(gh api', 'tag_check_removed="$(gh api')
+      end,
+      "publish missing smoke dependency" => lambda do |copy, _ci|
+        copy.fetch("publish-release")["needs"] = ["stage-release"]
+      end,
+      "removed final publish tag check" => lambda do |copy, _ci|
+        one_step(copy.fetch("publish-release"), PUBLISH_STEP)["run"]
+          .sub!('final_tag_commit="$(gh api', 'tag_check_removed="$(gh api')
+      end,
+      "publish before final tag check" => lambda do |copy, _ci|
+        script = one_step(copy.fetch("publish-release"), PUBLISH_STEP).fetch("run")
+        patch = script.index("gh api --method PATCH")
+        final = script.index('final_tag_commit="$(gh api')
+        script[patch, 2], script[final, 2] = script[final, 2], script[patch, 2]
+      end
+    }
+
+    mutations.each do |name, mutation|
+      jobs_copy = Marshal.load(Marshal.dump(jobs))
+      ci_copy = Marshal.load(Marshal.dump(ci_jobs))
+      mutation.call(jobs_copy, ci_copy)
+      begin
+        validate_jobs(jobs_copy, ci_copy)
+      rescue StandardError
+        next
+      end
+      raise "contract false-greened mutation: #{name}"
+    end
+  end
+
+  def extract(workflow_path, step_name, output_path)
+    jobs = load_jobs(workflow_path)
+    step = jobs.values.flat_map { |job| job.fetch("steps", []) }
+      .select { |candidate| candidate["name"] == step_name }
+    assert(step.length == 1, "expected one #{step_name.inspect} step")
+    File.binwrite(output_path, step.fetch(0).fetch("run"))
+  end
+end
+
+command = ARGV.shift
+case command
+when "validate"
+  ReleaseWorkflowContract.validate(ARGV.fetch(0), ARGV.fetch(1))
+when "extract-smoke"
+  ReleaseWorkflowContract.extract(ARGV.fetch(0), ReleaseWorkflowContract::SMOKE_STEP, ARGV.fetch(1))
+when "extract-stage"
+  ReleaseWorkflowContract.extract(ARGV.fetch(0), ReleaseWorkflowContract::STAGE_STEP, ARGV.fetch(1))
+when "extract-publish"
+  ReleaseWorkflowContract.extract(ARGV.fetch(0), ReleaseWorkflowContract::PUBLISH_STEP, ARGV.fetch(1))
+when "self-test"
+  ReleaseWorkflowContract.self_test(ARGV.fetch(0), ARGV.fetch(1))
+else
+  warn "usage: #{$PROGRAM_NAME} {validate,self-test} WORKFLOW CI | extract-{smoke,stage,publish} WORKFLOW OUTPUT"
+  exit 64
+end

--- a/tests/helpers/test_staged_release_protocol.sh
+++ b/tests/helpers/test_staged_release_protocol.sh
@@ -99,21 +99,82 @@ if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
   exit 0
 fi
 if [[ "${1:-}" == "attestation" && "${2:-}" == "verify" ]]; then
+  shift 2
+  subject="${1:-}"
+  [[ -n "${subject}" && "${subject}" != -* ]] || exit 64
+  shift
+  repo="" signer="" signer_digest="" source_ref="" source_digest="" deny=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) [[ $# -ge 2 ]] || exit 64; repo="$2"; shift 2 ;;
+      --signer-workflow) [[ $# -ge 2 ]] || exit 64; signer="$2"; shift 2 ;;
+      --signer-digest) [[ $# -ge 2 ]] || exit 64; signer_digest="$2"; shift 2 ;;
+      --source-ref) [[ $# -ge 2 ]] || exit 64; source_ref="$2"; shift 2 ;;
+      --source-digest) [[ $# -ge 2 ]] || exit 64; source_digest="$2"; shift 2 ;;
+      --deny-self-hosted-runners) deny=1; shift ;;
+      *) exit 64 ;;
+    esac
+  done
+  # A stub that ignores arguments would false-green a provenance regression:
+  # require the complete pinned identity that the workflow advertises.
+  if [[ "${repo}" != "${GH_REPO}" \
+    || "${signer}" != "github.com/${GH_REPO}/.github/workflows/release.yml" \
+    || "${signer_digest}" != "${WORKFLOW_SHA}" \
+    || "${source_ref}" != "refs/tags/${TAG_NAME}" \
+    || "${source_digest}" != "${EVENT_SHA}" \
+    || "${deny}" != "1" ]]; then
+    echo "ERROR: attestation verify omitted the pinned signer identity" >&2
+    exit 64
+  fi
   printf 'verify-attestation\n' >> "${GH_STUB_LOG}"
   [[ "${GH_STUB_ATTEST_FAIL:-0}" != "1" ]]
   exit
 fi
 if [[ "${1:-}" == "api" ]]; then
-  if [[ " $* " == *" --method PATCH "* ]]; then
+  shift
+  method="GET" endpoint="" draft_value="" make_latest_value=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --method) [[ $# -ge 2 ]] || exit 64; method="$2"; shift 2 ;;
+      --jq) [[ $# -ge 2 ]] || exit 64; shift 2 ;;
+      -F|-f)
+        [[ $# -ge 2 ]] || exit 64
+        case "$2" in
+          draft=*) draft_value="${2#draft=}" ;;
+          make_latest=*) make_latest_value="${2#make_latest=}" ;;
+          *) exit 64 ;;
+        esac
+        shift 2 ;;
+      -*) exit 64 ;;
+      *) [[ -z "${endpoint}" ]] || exit 64; endpoint="$1"; shift ;;
+    esac
+  done
+  if [[ "${method}" == "PATCH" ]]; then
+    if [[ "${endpoint}" != "repos/${GH_REPO}/releases/${RELEASE_ID}" \
+      || "${draft_value}" != "false" \
+      || "${make_latest_value}" != "true" ]]; then
+      echo "ERROR: publish PATCH did not target the staged draft release" >&2
+      exit 64
+    fi
     printf 'publish-transition\n' >> "${GH_STUB_LOG}"
+    # An applied PATCH whose acknowledgement is lost is the ambiguous commit
+    # point the publish job must reconcile instead of failing outright.
+    if [[ "${GH_STUB_PATCH_LOSE_ACK:-0}" == "1" ]]; then
+      exit 1
+    fi
     printf '{"id":%s,"draft":false}\n' "${RELEASE_ID}"
     exit 0
   fi
-  endpoint="${2:-}"
+  [[ "${method}" == "GET" ]] || exit 64
   case "${endpoint}" in
     "repos/${GH_REPO}/commits/${TAG_NAME}") printf '%s\n' "${GH_STUB_TAG_SHA}" ;;
     "repos/${GH_REPO}/releases/${RELEASE_ID}")
-      printf '{"id":%s,"draft":true,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
+      patch_seen="$(grep -c '^publish-transition$' "${GH_STUB_LOG}" || true)"
+      if [[ "${patch_seen}" -gt 0 && "${GH_STUB_PATCH_COMMITTED:-1}" == "1" ]]; then
+        printf '{"id":%s,"draft":false,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
+      else
+        printf '{"id":%s,"draft":true,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
+      fi
       ;;
     *) exit 64 ;;
   esac
@@ -173,3 +234,52 @@ if (
   exit 1
 fi
 test "$(grep -c '^delete-draft$' "${GH_LOG}")" -eq 1
+
+# An applied PATCH whose acknowledgement is lost must reconcile to success
+# against the exact release id, without a second publish transition.
+: > "${GH_LOG}"
+env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" GH_STUB_PATCH_LOSE_ACK=1 \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-lost-ack" bash "${PUBLISH_SCRIPT}" >/dev/null 2>&1
+test "$(grep -c '^publish-transition$' "${GH_LOG}")" -eq 1
+
+# A PATCH that never committed must stay a failure, not be reconciled away.
+: > "${GH_LOG}"
+if env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" GH_STUB_PATCH_LOSE_ACK=1 \
+  GH_STUB_PATCH_COMMITTED=0 \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-uncommitted" bash "${PUBLISH_SCRIPT}" >/dev/null 2>&1; then
+  exit 1
+fi
+
+# Negative mutation: publishing another release id must fail closed.
+WRONG_RELEASE_SCRIPT="${TMP_ROOT}/publish-wrong-release.sh"
+ruby - "${PUBLISH_SCRIPT}" "${WRONG_RELEASE_SCRIPT}" <<'RUBY'
+text = File.binread(ARGV.fetch(0))
+old = 'gh api --method PATCH "repos/${GH_REPO}/releases/${RELEASE_ID}"'
+new = 'gh api --method PATCH "repos/${GH_REPO}/releases/999999"'
+raise "publish PATCH endpoint missing" unless text.sub!(old, new)
+File.binwrite(ARGV.fetch(1), text)
+RUBY
+: > "${GH_LOG}"
+if env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-wrong-release" \
+  bash "${WRONG_RELEASE_SCRIPT}" >/dev/null 2>&1; then
+  exit 1
+fi
+test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0
+
+# Negative mutation: dropping the pinned provenance identity must fail closed.
+LOOSE_ATTEST_SCRIPT="${TMP_ROOT}/publish-loose-attestation.sh"
+ruby - "${PUBLISH_SCRIPT}" "${LOOSE_ATTEST_SCRIPT}" <<'RUBY'
+text = File.binread(ARGV.fetch(0))
+pattern = /gh attestation verify "\$\{asset\}".*?--deny-self-hosted-runners\n/m
+replacement = %Q{gh attestation verify "${asset}" --repo "${GH_REPO}"\n}
+raise "pinned attestation identity missing" unless text.sub!(pattern, replacement)
+File.binwrite(ARGV.fetch(1), text)
+RUBY
+: > "${GH_LOG}"
+if env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-loose-attestation" \
+  bash "${LOOSE_ATTEST_SCRIPT}" >/dev/null 2>&1; then
+  exit 1
+fi
+test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0

--- a/tests/helpers/test_staged_release_protocol.sh
+++ b/tests/helpers/test_staged_release_protocol.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Executable fixture for the draft -> verify -> publish release protocol.
+
+set -euo pipefail
+
+WORKFLOW="${1:?release workflow path required}"
+CONTRACT_HELPER="${2:?workflow contract helper required}"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-staged-release.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+STAGE_SCRIPT="${TMP_ROOT}/stage.sh"
+PUBLISH_SCRIPT="${TMP_ROOT}/publish.sh"
+ruby "${CONTRACT_HELPER}" extract-stage "${WORKFLOW}" "${STAGE_SCRIPT}"
+ruby "${CONTRACT_HELPER}" extract-publish "${WORKFLOW}" "${PUBLISH_SCRIPT}"
+
+EVENT_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+WORKFLOW_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+GH_REPO="fork-owner/renamed-vibeguard"
+TAG_NAME="v1.2.3"
+RELEASE_ID="4242"
+FIXTURE_ROOT="${TMP_ROOT}/fixture"
+DIST="${FIXTURE_ROOT}/dist"
+STUB_BIN="${FIXTURE_ROOT}/bin"
+GH_LOG="${FIXTURE_ROOT}/gh.log"
+mkdir -p "${DIST}" "${STUB_BIN}"
+
+for target in \
+  aarch64-apple-darwin \
+  aarch64-unknown-linux-musl \
+  x86_64-apple-darwin \
+  x86_64-unknown-linux-musl
+do
+  printf 'runtime=%s\n' "${target}" > "${DIST}/vibeguard-runtime-${target}"
+done
+printf '{"dependencies":[]}\n' > "${DIST}/vibeguard-runtime-dependency-metadata.json"
+printf '{"release":"fixture"}\n' > "${DIST}/vibeguard-runtime-releases.json"
+
+PAYLOAD_ROOT="${FIXTURE_ROOT}/payload"
+mkdir -p "${PAYLOAD_ROOT}"
+printf 'version=1.2.3\nmanifest_sha256=%064d\ngit_commit=%s\n' \
+  0 "${EVENT_SHA}" > "${PAYLOAD_ROOT}/.vibeguard-payload"
+tar -czf "${DIST}/vibeguard-payload-1.2.3.tar.gz" -C "${PAYLOAD_ROOT}" .vibeguard-payload
+(
+  cd "${DIST}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum vibeguard-runtime-aarch64-apple-darwin \
+      vibeguard-runtime-aarch64-unknown-linux-musl \
+      vibeguard-runtime-dependency-metadata.json \
+      vibeguard-runtime-x86_64-apple-darwin \
+      vibeguard-runtime-x86_64-unknown-linux-musl \
+      vibeguard-payload-1.2.3.tar.gz > SHA256SUMS
+  else
+    shasum -a 256 vibeguard-runtime-aarch64-apple-darwin \
+      vibeguard-runtime-aarch64-unknown-linux-musl \
+      vibeguard-runtime-dependency-metadata.json \
+      vibeguard-runtime-x86_64-apple-darwin \
+      vibeguard-runtime-x86_64-unknown-linux-musl \
+      vibeguard-payload-1.2.3.tar.gz > SHA256SUMS
+  fi
+)
+
+cat > "${STUB_BIN}/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
+  if [[ " $* " == *" --json "* ]]; then
+    printf '{"databaseId":%s,"isDraft":true,"tagName":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
+    exit 0
+  fi
+  exit 1
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "create" ]]; then
+  printf 'create-draft\n' >> "${GH_STUB_LOG}"
+  [[ " $* " == *" --draft "* ]]
+  exit 0
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "upload" ]]; then
+  printf 'upload-assets\n' >> "${GH_STUB_LOG}"
+  [[ "${GH_STUB_UPLOAD_FAIL:-0}" != "1" ]]
+  exit
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "delete" ]]; then
+  printf 'delete-draft\n' >> "${GH_STUB_LOG}"
+  exit 0
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
+  destination=""
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dir) destination="$2"; shift 2 ;;
+      --repo) shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  mkdir -p "${destination}"
+  cp "${GH_STUB_ASSET_DIR}"/* "${destination}/"
+  printf 'download-draft\n' >> "${GH_STUB_LOG}"
+  exit 0
+fi
+if [[ "${1:-}" == "attestation" && "${2:-}" == "verify" ]]; then
+  printf 'verify-attestation\n' >> "${GH_STUB_LOG}"
+  [[ "${GH_STUB_ATTEST_FAIL:-0}" != "1" ]]
+  exit
+fi
+if [[ "${1:-}" == "api" ]]; then
+  if [[ " $* " == *" --method PATCH "* ]]; then
+    printf 'publish-transition\n' >> "${GH_STUB_LOG}"
+    printf '{"id":%s,"draft":false}\n' "${RELEASE_ID}"
+    exit 0
+  fi
+  endpoint="${2:-}"
+  case "${endpoint}" in
+    "repos/${GH_REPO}/commits/${TAG_NAME}") printf '%s\n' "${GH_STUB_TAG_SHA}" ;;
+    "repos/${GH_REPO}/releases/${RELEASE_ID}")
+      printf '{"id":%s,"draft":true,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
+      ;;
+    *) exit 64 ;;
+  esac
+  exit 0
+fi
+exit 64
+GH_STUB
+chmod 0755 "${STUB_BIN}/gh"
+
+run_env=(
+  "EVENT_SHA=${EVENT_SHA}"
+  "WORKFLOW_SHA=${WORKFLOW_SHA}"
+  "GH_REPO=${GH_REPO}"
+  "TAG_NAME=${TAG_NAME}"
+  "RELEASE_ID=${RELEASE_ID}"
+  "GH_TOKEN=fixture-token"
+  "GH_STUB_LOG=${GH_LOG}"
+  "GH_STUB_ASSET_DIR=${DIST}"
+  "PATH=${STUB_BIN}:${PATH}"
+)
+
+: > "${GH_LOG}"
+(
+  cd "${FIXTURE_ROOT}"
+  env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" \
+    GITHUB_OUTPUT="${FIXTURE_ROOT}/github-output" bash "${STAGE_SCRIPT}"
+)
+grep -qx 'release_id=4242' "${FIXTURE_ROOT}/github-output"
+test "$(grep -c '^create-draft$' "${GH_LOG}")" -eq 1
+test "$(grep -c '^upload-assets$' "${GH_LOG}")" -eq 1
+test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0
+
+env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-success" bash "${PUBLISH_SCRIPT}"
+test "$(grep -c '^publish-transition$' "${GH_LOG}")" -eq 1
+
+: > "${GH_LOG}"
+if env "${run_env[@]}" GH_STUB_TAG_SHA="cccccccccccccccccccccccccccccccccccccccc" \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-drift" bash "${PUBLISH_SCRIPT}" >/dev/null 2>&1; then
+  exit 1
+fi
+test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0
+
+: > "${GH_LOG}"
+if env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" GH_STUB_ATTEST_FAIL=1 \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-attestation" bash "${PUBLISH_SCRIPT}" >/dev/null 2>&1; then
+  exit 1
+fi
+test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0
+
+: > "${GH_LOG}"
+if (
+  cd "${FIXTURE_ROOT}"
+  env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" GH_STUB_UPLOAD_FAIL=1 \
+    GITHUB_OUTPUT="${FIXTURE_ROOT}/failed-output" bash "${STAGE_SCRIPT}" >/dev/null 2>&1
+); then
+  exit 1
+fi
+test "$(grep -c '^delete-draft$' "${GH_LOG}")" -eq 1

--- a/tests/helpers/test_staged_release_protocol.sh
+++ b/tests/helpers/test_staged_release_protocol.sh
@@ -170,7 +170,8 @@ if [[ "${1:-}" == "api" ]]; then
     "repos/${GH_REPO}/commits/${TAG_NAME}") printf '%s\n' "${GH_STUB_TAG_SHA}" ;;
     "repos/${GH_REPO}/releases/${RELEASE_ID}")
       patch_seen="$(grep -c '^publish-transition$' "${GH_STUB_LOG}" || true)"
-      if [[ "${patch_seen}" -gt 0 && "${GH_STUB_PATCH_COMMITTED:-1}" == "1" ]]; then
+      if [[ "${GH_STUB_RELEASE_PUBLIC:-0}" == "1" \
+        || ( "${patch_seen}" -gt 0 && "${GH_STUB_PATCH_COMMITTED:-1}" == "1" ) ]]; then
         printf '{"id":%s,"draft":false,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
       else
         printf '{"id":%s,"draft":true,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
@@ -207,6 +208,12 @@ test "$(grep -c '^create-draft$' "${GH_LOG}")" -eq 1
 test "$(grep -c '^upload-assets$' "${GH_LOG}")" -eq 1
 test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0
 
+: > "${GH_LOG}"
+env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" GH_STUB_RELEASE_PUBLIC=1 \
+  RUNNER_TEMP="${FIXTURE_ROOT}/runner-already-public" bash "${PUBLISH_SCRIPT}"
+test "$(grep -c '^publish-transition$' "${GH_LOG}" || true)" -eq 0
+
+: > "${GH_LOG}"
 env "${run_env[@]}" GH_STUB_TAG_SHA="${EVENT_SHA}" \
   RUNNER_TEMP="${FIXTURE_ROOT}/runner-success" bash "${PUBLISH_SCRIPT}"
 test "$(grep -c '^publish-transition$' "${GH_LOG}")" -eq 1

--- a/tests/test_no_clone_release_smoke.sh
+++ b/tests/test_no_clone_release_smoke.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="${REPO_DIR}/.github/workflows/release.yml"
 CI_WORKFLOW="${REPO_DIR}/.github/workflows/ci.yml"
+CONTRACT_HELPER="${REPO_DIR}/tests/helpers/release_workflow_contract.rb"
+PROTOCOL_FIXTURE="${REPO_DIR}/tests/helpers/test_staged_release_protocol.sh"
 PASS=0
 FAIL=0
 
@@ -43,53 +45,18 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-no-clone-smoke.XXXXXX")"
 trap 'rm -rf "${TMP_ROOT}"' EXIT
 JOB_SCRIPT="${TMP_ROOT}/no-clone-smoke.sh"
 
-# Parse the workflow as YAML. This deliberately rejects a disabled security
-# step and extracts the executable run body rather than scanning comments.
 extract_smoke_script() {
   local workflow="$1" output="$2"
-  ruby - "${workflow}" "${output}" <<'RUBY'
-require "yaml"
-
-document = YAML.load_file(ARGV.fetch(0))
-jobs = document.fetch("jobs")
-job = jobs.fetch("no-clone-smoke")
-raise "smoke must depend on publish-release" unless job.fetch("needs") == "publish-release"
-raise "smoke contents permission must be read" unless job.dig("permissions", "contents") == "read"
-raise "smoke attestations permission must be read" unless job.dig("permissions", "attestations") == "read"
-oses = job.dig("strategy", "matrix", "include").map { |entry| entry.fetch("os") }
-raise "smoke matrix must cover macOS and Ubuntu" unless oses.sort == ["macos-14", "ubuntu-latest"]
-steps = job.fetch("steps")
-raise "smoke must not checkout source" if steps.any? { |step| step["uses"].to_s.start_with?("actions/checkout@") }
-matches = steps.select { |step| step["name"] == "Install and verify from immutable release" }
-raise "expected exactly one immutable release smoke step" unless matches.length == 1
-step = matches.fetch(0)
-raise "immutable release smoke step must be reachable" if step.key?("if")
-raise "immutable release smoke step must not ignore failure" if step["continue-on-error"]
-run = step.fetch("run")
-raise "immutable release smoke step is empty" if run.strip.empty?
-File.binwrite(ARGV.fetch(1), run)
-RUBY
+  ruby "${CONTRACT_HELPER}" extract-smoke "${workflow}" "${output}"
 }
 
-validate_ci_invocation() {
-  ruby - "${CI_WORKFLOW}" <<'RUBY'
-require "yaml"
-
-document = YAML.load_file(ARGV.fetch(0))
-steps = document.fetch("jobs").fetch("validate-and-test").fetch("steps")
-matches = steps.select { |step| step["name"] == "Validate no-clone release smoke contract" }
-raise "expected one CI no-clone contract step" unless matches.length == 1
-step = matches.fetch(0)
-raise "CI no-clone contract must execute the test" unless step["run"] == "bash tests/test_no_clone_release_smoke.sh"
-raise "CI no-clone contract must propagate failure" if step["continue-on-error"]
-raise "CI no-clone contract must run on both Unix matrices" unless step["if"] == "runner.os != 'Windows'"
-RUBY
-}
-
-expect_success "release smoke is a reachable structured YAML step" \
+expect_success "release workflow has exact structured jobs, permissions, expressions, and dependencies" \
+  ruby "${CONTRACT_HELPER}" validate "${WORKFLOW}" "${CI_WORKFLOW}"
+expect_success "release smoke is extracted from the parsed workflow AST" \
   extract_smoke_script "${WORKFLOW}" "${JOB_SCRIPT}"
 expect_success "extracted release smoke is valid Bash" bash -n "${JOB_SCRIPT}"
-expect_success "CI structurally invokes the executable contract on Unix" validate_ci_invocation
+expect_success "draft staging, final verification, one publish transition, and failure cleanup execute" \
+  bash "${PROTOCOL_FIXTURE}" "${WORKFLOW}" "${CONTRACT_HELPER}"
 
 make_payload_fixture() {
   local root="$1" marker_commit="$2" bootstrap_repo="$3" checksum_mode="$4" archive_mode="$5"
@@ -114,6 +81,7 @@ SETUP
   cat > "${payload_root}/scripts/setup/bootstrap.sh" <<BOOTSTRAP
 #!/usr/bin/env bash
 set -euo pipefail
+RELEASE_REPO="${bootstrap_repo}"
 version=""
 while [[ \$# -gt 0 ]]; do
   case "\$1" in
@@ -127,11 +95,11 @@ tag="v\${version}"
 asset="vibeguard-payload-\${version}.tar.gz"
 download="\${RUNNER_TEMP}/fixture-bootstrap-download"
 mkdir -p "\${download}"
-gh release download "\${tag}" --repo "${bootstrap_repo}" \
+gh release download "\${tag}" --repo "\${RELEASE_REPO}" \
   --pattern "\${asset}" --pattern SHA256SUMS --dir "\${download}"
 gh attestation verify "\${download}/\${asset}" \
-  --repo "${bootstrap_repo}" \
-  --signer-workflow "github.com/${bootstrap_repo}/.github/workflows/release.yml" \
+  --repo "\${RELEASE_REPO}" \
+  --signer-workflow "github.com/\${RELEASE_REPO}/.github/workflows/release.yml" \
   --source-ref "refs/tags/\${tag}" --deny-self-hosted-runners
 final="\${HOME}/.vibeguard/dist/\${version}"
 mkdir -p "\${final}"
@@ -165,6 +133,8 @@ BOOTSTRAP
   if [[ "${archive_mode}" == "unsafe-link" ]]; then
     ln -s setup.sh "${payload_root}/unsafe-link"
     members+=(unsafe-link)
+  elif [[ "${archive_mode}" == "changed-content" ]]; then
+    printf '# distinct second download\n' >> "${payload_root}/setup.sh"
   fi
   tar -czf "${asset}" -C "${payload_root}" "${members[@]}"
 
@@ -183,8 +153,22 @@ make_gh_stub() {
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${1:-}" == "api" ]]; then
-  printf '%s\n' "${GH_STUB_API_SHA}"
-  exit 0
+  endpoint="${2:-}"
+  if [[ "${endpoint}" == "repos/${GH_REPO}/releases/${RELEASE_ID}" ]]; then
+    printf '{"id":%s,"draft":true,"tag_name":"%s"}\n' "${RELEASE_ID}" "${TAG_NAME}"
+    exit 0
+  fi
+  if [[ "${endpoint}" == "repos/${GH_REPO}/commits/${TAG_NAME}" ]]; then
+    api_count="$(grep -c '^api-tag$' "${GH_STUB_LOG}" || true)"
+    printf 'api-tag\n' >> "${GH_STUB_LOG}"
+    if [[ "${api_count}" -eq 0 ]]; then
+      printf '%s\n' "${GH_STUB_API_SHA_FIRST}"
+    else
+      printf '%s\n' "${GH_STUB_API_SHA_FINAL}"
+    fi
+    exit 0
+  fi
+  exit 64
 fi
 if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
   shift 2
@@ -205,8 +189,16 @@ if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
   done
   [[ "${repo}" == "${GH_REPO}" && "${tag}" == "${TAG_NAME}" && -n "${destination}" ]] || exit 1
   mkdir -p "${destination}"
-  cp "${GH_STUB_PAYLOAD}" "${destination}/${GH_STUB_PAYLOAD##*/}"
-  cp "${GH_STUB_SUMS}" "${destination}/SHA256SUMS"
+  download_count="$(grep -c '^download$' "${GH_STUB_LOG}" || true)"
+  if [[ "${download_count}" -eq 0 ]]; then
+    payload="${GH_STUB_PAYLOAD}"
+    sums="${GH_STUB_SUMS}"
+  else
+    payload="${GH_STUB_SECOND_PAYLOAD}"
+    sums="${GH_STUB_SECOND_SUMS}"
+  fi
+  cp "${payload}" "${destination}/vibeguard-payload-1.2.3.tar.gz"
+  cp "${sums}" "${destination}/SHA256SUMS"
   printf 'download\n' >> "${GH_STUB_LOG}"
   exit 0
 fi
@@ -249,6 +241,9 @@ GH_STUB
 
 run_fixture() {
   local fixture_root="$1" script="$2" verify_exit="${3:-0}"
+  local release_repo="${4:-majiayu000/vibeguard}"
+  local final_api_sha="${5:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+  local second_root="${6:-${fixture_root}}"
   local runner="${fixture_root}/runner"
   local stub_bin="${fixture_root}/stub-bin"
   rm -rf "${runner}" "${stub_bin}"
@@ -259,13 +254,17 @@ run_fixture() {
   if ! env \
     EVENT_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
     WORKFLOW_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
-    GH_REPO="majiayu000/vibeguard" \
+    GH_REPO="${release_repo}" \
     TAG_NAME="v1.2.3" \
+    RELEASE_ID="4242" \
     GH_TOKEN="fixture-token" \
     RUNNER_TEMP="${runner}" \
-    GH_STUB_API_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    GH_STUB_API_SHA_FIRST="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    GH_STUB_API_SHA_FINAL="${final_api_sha}" \
     GH_STUB_PAYLOAD="${fixture_root}/vibeguard-payload-1.2.3.tar.gz" \
     GH_STUB_SUMS="${fixture_root}/SHA256SUMS" \
+    GH_STUB_SECOND_PAYLOAD="${second_root}/vibeguard-payload-1.2.3.tar.gz" \
+    GH_STUB_SECOND_SUMS="${second_root}/SHA256SUMS" \
     GH_STUB_LOG="${fixture_root}/gh.log" \
     FIXTURE_VERIFY_EXIT="${verify_exit}" \
     PATH="${stub_bin}:${PATH}" \
@@ -285,6 +284,9 @@ make_payload_fixture "${GOOD}" \
 expect_success "exact release smoke executes checksum, provenance, secondary download, install, and verify" \
   run_fixture "${GOOD}" "${JOB_SCRIPT}"
 
+expect_success "fork or renamed repository uses one trusted identity for both downloads" \
+  run_fixture "${GOOD}" "${JOB_SCRIPT}" 0 fork-owner/renamed-vibeguard
+
 WRONG_SUM="${TMP_ROOT}/wrong-sum"
 mkdir -p "${WRONG_SUM}"
 make_payload_fixture "${WRONG_SUM}" \
@@ -300,13 +302,15 @@ make_payload_fixture "${WRONG_MARKER}" \
 expect_failure "payload marker from another commit fails closed" \
   run_fixture "${WRONG_MARKER}" "${JOB_SCRIPT}"
 
-WRONG_REPO="${TMP_ROOT}/wrong-repo"
-mkdir -p "${WRONG_REPO}"
-make_payload_fixture "${WRONG_REPO}" \
-  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
-  other/repository correct safe
-expect_failure "bootstrap secondary download from another repository fails closed" \
-  run_fixture "${WRONG_REPO}" "${JOB_SCRIPT}"
+WRONG_REPO_SCRIPT="${TMP_ROOT}/wrong-repository-parameter.sh"
+ruby - "${JOB_SCRIPT}" "${WRONG_REPO_SCRIPT}" <<'RUBY'
+text = File.binread(ARGV.fetch(0))
+old = 'VIBEGUARD_RELEASE_REPO="${GH_REPO}"'
+raise "trusted repository argument missing" unless text.sub!(old, 'VIBEGUARD_RELEASE_REPO="other/repository"')
+File.binwrite(ARGV.fetch(1), text)
+RUBY
+expect_failure "bootstrap cannot perform its second download from another repository" \
+  run_fixture "${GOOD}" "${WRONG_REPO_SCRIPT}"
 
 UNSAFE="${TMP_ROOT}/unsafe"
 mkdir -p "${UNSAFE}"
@@ -318,6 +322,19 @@ expect_failure "link or special archive entry fails before execution" \
 
 expect_failure "verify-install nonzero status propagates" \
   run_fixture "${GOOD}" "${JOB_SCRIPT}" 17
+
+expect_failure "tag movement during staged smoke fails before publication" \
+  run_fixture "${GOOD}" "${JOB_SCRIPT}" 0 majiayu000/vibeguard \
+    cccccccccccccccccccccccccccccccccccccccc
+
+SECOND_PAYLOAD="${TMP_ROOT}/second-payload"
+mkdir -p "${SECOND_PAYLOAD}"
+make_payload_fixture "${SECOND_PAYLOAD}" \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  majiayu000/vibeguard correct changed-content
+expect_failure "independent second-download digest drift fails closed" \
+  run_fixture "${GOOD}" "${JOB_SCRIPT}" 0 majiayu000/vibeguard \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "${SECOND_PAYLOAD}"
 
 WRONG_DIGEST_SCRIPT="${TMP_ROOT}/wrong-source-digest.sh"
 ruby - "${JOB_SCRIPT}" "${WRONG_DIGEST_SCRIPT}" <<'RUBY'
@@ -339,17 +356,8 @@ RUBY
 expect_failure "commented or inert attestation cannot satisfy the executable contract" \
   run_fixture "${GOOD}" "${INERT_SCRIPT}"
 
-DISABLED_WORKFLOW="${TMP_ROOT}/disabled-workflow.yml"
-ruby - "${WORKFLOW}" "${DISABLED_WORKFLOW}" <<'RUBY'
-require "yaml"
-document = YAML.load_file(ARGV.fetch(0))
-step = document.fetch("jobs").fetch("no-clone-smoke").fetch("steps")
-  .find { |candidate| candidate["name"] == "Install and verify from immutable release" }
-step["if"] = "${{ false }}"
-File.write(ARGV.fetch(1), YAML.dump(document))
-RUBY
-expect_failure "structural validator rejects an unreachable smoke step" \
-  extract_smoke_script "${DISABLED_WORKFLOW}" "${TMP_ROOT}/disabled.sh" 2>/dev/null
+expect_success "structured contract rejects reachability, permission, expression, dependency, and final-check mutations" \
+  ruby "${CONTRACT_HELPER}" self-test "${WORKFLOW}" "${CI_WORKFLOW}"
 
 printf '%s passed, %s failed\n' "${PASS}" "${FAIL}"
 test "${FAIL}" -eq 0

--- a/tests/test_no_clone_release_smoke.sh
+++ b/tests/test_no_clone_release_smoke.sh
@@ -1,69 +1,355 @@
 #!/usr/bin/env bash
-# Contract tests for the release-backed, no-checkout GH699 smoke job.
+# Structural and executable contract tests for the release-backed GH699 smoke.
 
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="${REPO_DIR}/.github/workflows/release.yml"
-
+CI_WORKFLOW="${REPO_DIR}/.github/workflows/ci.yml"
 PASS=0
 FAIL=0
 
-check_contains() {
-  local description="$1" pattern="$2"
-  if grep -Fq -- "${pattern}" "${JOB_FILE}"; then
-    printf 'PASS: %s\n' "${description}"
-    PASS=$((PASS + 1))
-  else
-    printf 'FAIL: %s\n' "${description}" >&2
-    FAIL=$((FAIL + 1))
-  fi
+pass() {
+  printf 'PASS: %s\n' "$1"
+  PASS=$((PASS + 1))
 }
 
-check_absent() {
-  local description="$1" pattern="$2"
-  if grep -Fq -- "${pattern}" "${JOB_FILE}"; then
-    printf 'FAIL: %s\n' "${description}" >&2
-    FAIL=$((FAIL + 1))
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+expect_success() {
+  local description="$1"
+  shift
+  if "$@"; then pass "${description}"; else fail "${description}"; fi
+}
+
+expect_failure() {
+  local description="$1"
+  shift
+  if "$@"; then fail "${description}"; else pass "${description}"; fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
   else
-    printf 'PASS: %s\n' "${description}"
-    PASS=$((PASS + 1))
+    shasum -a 256 "$1" | awk '{print $1}'
   fi
 }
 
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-no-clone-smoke.XXXXXX")"
 trap 'rm -rf "${TMP_ROOT}"' EXIT
-JOB_FILE="${TMP_ROOT}/job.yml"
+JOB_SCRIPT="${TMP_ROOT}/no-clone-smoke.sh"
 
-awk '
-  /^  no-clone-smoke:/ { capture = 1 }
-  capture { print }
-' "${WORKFLOW}" > "${JOB_FILE}"
+# Parse the workflow as YAML. This deliberately rejects a disabled security
+# step and extracts the executable run body rather than scanning comments.
+extract_smoke_script() {
+  local workflow="$1" output="$2"
+  ruby - "${workflow}" "${output}" <<'RUBY'
+require "yaml"
 
-if [[ ! -s "${JOB_FILE}" ]]; then
-  printf 'FAIL: release workflow has no no-clone-smoke job\n' >&2
-  exit 1
+document = YAML.load_file(ARGV.fetch(0))
+jobs = document.fetch("jobs")
+job = jobs.fetch("no-clone-smoke")
+raise "smoke must depend on publish-release" unless job.fetch("needs") == "publish-release"
+raise "smoke contents permission must be read" unless job.dig("permissions", "contents") == "read"
+raise "smoke attestations permission must be read" unless job.dig("permissions", "attestations") == "read"
+oses = job.dig("strategy", "matrix", "include").map { |entry| entry.fetch("os") }
+raise "smoke matrix must cover macOS and Ubuntu" unless oses.sort == ["macos-14", "ubuntu-latest"]
+steps = job.fetch("steps")
+raise "smoke must not checkout source" if steps.any? { |step| step["uses"].to_s.start_with?("actions/checkout@") }
+matches = steps.select { |step| step["name"] == "Install and verify from immutable release" }
+raise "expected exactly one immutable release smoke step" unless matches.length == 1
+step = matches.fetch(0)
+raise "immutable release smoke step must be reachable" if step.key?("if")
+raise "immutable release smoke step must not ignore failure" if step["continue-on-error"]
+run = step.fetch("run")
+raise "immutable release smoke step is empty" if run.strip.empty?
+File.binwrite(ARGV.fetch(1), run)
+RUBY
+}
+
+validate_ci_invocation() {
+  ruby - "${CI_WORKFLOW}" <<'RUBY'
+require "yaml"
+
+document = YAML.load_file(ARGV.fetch(0))
+steps = document.fetch("jobs").fetch("validate-and-test").fetch("steps")
+matches = steps.select { |step| step["name"] == "Validate no-clone release smoke contract" }
+raise "expected one CI no-clone contract step" unless matches.length == 1
+step = matches.fetch(0)
+raise "CI no-clone contract must execute the test" unless step["run"] == "bash tests/test_no_clone_release_smoke.sh"
+raise "CI no-clone contract must propagate failure" if step["continue-on-error"]
+raise "CI no-clone contract must run on both Unix matrices" unless step["if"] == "runner.os != 'Windows'"
+RUBY
+}
+
+expect_success "release smoke is a reachable structured YAML step" \
+  extract_smoke_script "${WORKFLOW}" "${JOB_SCRIPT}"
+expect_success "extracted release smoke is valid Bash" bash -n "${JOB_SCRIPT}"
+expect_success "CI structurally invokes the executable contract on Unix" validate_ci_invocation
+
+make_payload_fixture() {
+  local root="$1" marker_commit="$2" bootstrap_repo="$3" checksum_mode="$4" archive_mode="$5"
+  local payload_root="${root}/payload-root"
+  local asset="${root}/vibeguard-payload-1.2.3.tar.gz"
+  mkdir -p "${payload_root}/scripts/setup"
+
+  printf 'version=1.2.3\nmanifest_sha256=%064d\ngit_commit=%s\n' \
+    0 "${marker_commit}" > "${payload_root}/.vibeguard-payload"
+  cat > "${payload_root}/setup.sh" <<'SETUP'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "verify-install" ]]; then
+  exit "${FIXTURE_VERIFY_EXIT:-0}"
 fi
+mkdir -p "${HOME}/.vibeguard/installed/bin" "${HOME}/.vibeguard/installed/rules/claude-rules"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+chmod 0755 "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+SETUP
+  chmod 0755 "${payload_root}/setup.sh"
 
-check_contains "smoke waits for immutable release publication" "needs: publish-release"
-check_contains "smoke runs on macOS" "os: macos-14"
-check_contains "smoke runs on Linux" "os: ubuntu-latest"
-check_contains "smoke receives only read access to release contents" "contents: read"
-check_contains "smoke downloads the exact pinned payload" 'vibeguard-payload-${VERSION}.tar.gz'
-check_contains "smoke downloads release assets with gh" 'gh release download "${TAG_NAME}"'
-check_contains "checksum manifest requires one exact asset row" "count == 1"
-check_contains "payload digest is computed before execution" 'actual="$(sha256_file "${DOWNLOAD_DIR}/${ASSET}")"'
-check_contains "checksum mismatch fails visibly" "payload checksum verification failed"
-check_contains "payload attestation is mandatory" 'gh attestation verify "${DOWNLOAD_DIR}/${ASSET}"'
-check_contains "attestation signer is pinned to release workflow" "--signer-workflow"
-check_contains "attestation source is pinned to exact tag" '--source-ref "refs/tags/${TAG_NAME}"'
-check_contains "bootstrap seed accepts regular archive members only" 'substr($1, 1, 1) == "-"'
-check_contains "bootstrap enforces payload provenance" '--version "${VERSION}" --require-provenance -- --yes --require-provenance'
-check_contains "installed release runs canonical verification" 'setup.sh" verify-install'
-check_absent "fresh-machine job never checks out the repository" "actions/checkout@"
-check_absent "fresh-machine job never pipes curl into a shell" "curl | bash"
-check_absent "fresh-machine job never pipes curl into sh" "curl | sh"
-check_absent "fresh-machine job never prints the GitHub token" 'echo ${GH_TOKEN}'
+  cat > "${payload_root}/scripts/setup/bootstrap.sh" <<BOOTSTRAP
+#!/usr/bin/env bash
+set -euo pipefail
+version=""
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --version) version="\${2#v}"; shift 2 ;;
+    --require-provenance) shift ;;
+    --) break ;;
+    *) shift ;;
+  esac
+done
+tag="v\${version}"
+asset="vibeguard-payload-\${version}.tar.gz"
+download="\${RUNNER_TEMP}/fixture-bootstrap-download"
+mkdir -p "\${download}"
+gh release download "\${tag}" --repo "${bootstrap_repo}" \
+  --pattern "\${asset}" --pattern SHA256SUMS --dir "\${download}"
+gh attestation verify "\${download}/\${asset}" \
+  --repo "${bootstrap_repo}" \
+  --signer-workflow "github.com/${bootstrap_repo}/.github/workflows/release.yml" \
+  --source-ref "refs/tags/\${tag}" --deny-self-hosted-runners
+final="\${HOME}/.vibeguard/dist/\${version}"
+mkdir -p "\${final}"
+tar -xzf "\${download}/\${asset}" -C "\${final}"
+ln -s "\${version}" "\${HOME}/.vibeguard/dist/current"
+HOME="\${HOME}" bash "\${final}/setup.sh" --yes --require-provenance
+BOOTSTRAP
+  chmod 0755 "${payload_root}/scripts/setup/bootstrap.sh"
+
+  local helper
+  for helper in \
+    bootstrap-lib.sh bootstrap_identity.sh bootstrap_birth_token.jxa \
+    bootstrap_process.sh bootstrap_termination.sh bootstrap_lease_terminal.sh \
+    bootstrap_lease_retirement.sh bootstrap_state.sh; do
+    printf '# fixture helper\n' > "${payload_root}/scripts/setup/${helper}"
+  done
+
+  local -a members=(
+    .vibeguard-payload
+    setup.sh
+    scripts/setup/bootstrap.sh
+    scripts/setup/bootstrap-lib.sh
+    scripts/setup/bootstrap_identity.sh
+    scripts/setup/bootstrap_birth_token.jxa
+    scripts/setup/bootstrap_process.sh
+    scripts/setup/bootstrap_termination.sh
+    scripts/setup/bootstrap_lease_terminal.sh
+    scripts/setup/bootstrap_lease_retirement.sh
+    scripts/setup/bootstrap_state.sh
+  )
+  if [[ "${archive_mode}" == "unsafe-link" ]]; then
+    ln -s setup.sh "${payload_root}/unsafe-link"
+    members+=(unsafe-link)
+  fi
+  tar -czf "${asset}" -C "${payload_root}" "${members[@]}"
+
+  local digest
+  digest="$(sha256_file "${asset}")"
+  if [[ "${checksum_mode}" == "wrong" ]]; then
+    digest="0000000000000000000000000000000000000000000000000000000000000000"
+  fi
+  printf '%s  %s\n' "${digest}" "${asset##*/}" > "${root}/SHA256SUMS"
+}
+
+make_gh_stub() {
+  local bin_dir="$1"
+  mkdir -p "${bin_dir}"
+  cat > "${bin_dir}/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "api" ]]; then
+  printf '%s\n' "${GH_STUB_API_SHA}"
+  exit 0
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
+  shift 2
+  tag="${1:-}"
+  shift
+  repo=""
+  destination=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --repo=*) repo="${1#*=}"; shift ;;
+      --dir) destination="$2"; shift 2 ;;
+      --dir=*) destination="${1#*=}"; shift ;;
+      --pattern) shift 2 ;;
+      --pattern=*) shift ;;
+      *) exit 64 ;;
+    esac
+  done
+  [[ "${repo}" == "${GH_REPO}" && "${tag}" == "${TAG_NAME}" && -n "${destination}" ]] || exit 1
+  mkdir -p "${destination}"
+  cp "${GH_STUB_PAYLOAD}" "${destination}/${GH_STUB_PAYLOAD##*/}"
+  cp "${GH_STUB_SUMS}" "${destination}/SHA256SUMS"
+  printf 'download\n' >> "${GH_STUB_LOG}"
+  exit 0
+fi
+if [[ "${1:-}" == "attestation" && "${2:-}" == "verify" ]]; then
+  for argument in "$@"; do
+    [[ "${argument}" == "--help" ]] && exit 0
+  done
+  repo="" signer="" signer_digest="" source_ref="" source_digest=""
+  shift 2
+  [[ $# -gt 0 ]] || exit 64
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --signer-workflow) signer="$2"; shift 2 ;;
+      --signer-digest) signer_digest="$2"; shift 2 ;;
+      --source-ref) source_ref="$2"; shift 2 ;;
+      --source-digest) source_digest="$2"; shift 2 ;;
+      --deny-self-hosted-runners) shift ;;
+      *) exit 64 ;;
+    esac
+  done
+  [[ "${repo}" == "${GH_REPO}" \
+    && "${signer}" == "github.com/${GH_REPO}/.github/workflows/release.yml" \
+    && "${source_ref}" == "refs/tags/${TAG_NAME}" ]] || exit 1
+  if [[ "${source_digest}" == "${EVENT_SHA}" && "${signer_digest}" == "${WORKFLOW_SHA}" ]]; then
+    printf 'attest-exact\n' >> "${GH_STUB_LOG}"
+  else
+    printf 'attest-loose\n' >> "${GH_STUB_LOG}"
+  fi
+  exit 0
+fi
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  exit 0
+fi
+exit 64
+GH_STUB
+  chmod 0755 "${bin_dir}/gh"
+}
+
+run_fixture() {
+  local fixture_root="$1" script="$2" verify_exit="${3:-0}"
+  local runner="${fixture_root}/runner"
+  local stub_bin="${fixture_root}/stub-bin"
+  rm -rf "${runner}" "${stub_bin}"
+  mkdir -p "${runner}"
+  make_gh_stub "${stub_bin}"
+  : > "${fixture_root}/gh.log"
+
+  if ! env \
+    EVENT_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    WORKFLOW_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+    GH_REPO="majiayu000/vibeguard" \
+    TAG_NAME="v1.2.3" \
+    GH_TOKEN="fixture-token" \
+    RUNNER_TEMP="${runner}" \
+    GH_STUB_API_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    GH_STUB_PAYLOAD="${fixture_root}/vibeguard-payload-1.2.3.tar.gz" \
+    GH_STUB_SUMS="${fixture_root}/SHA256SUMS" \
+    GH_STUB_LOG="${fixture_root}/gh.log" \
+    FIXTURE_VERIFY_EXIT="${verify_exit}" \
+    PATH="${stub_bin}:${PATH}" \
+    bash "${script}" > "${fixture_root}/run.log" 2>&1; then
+    return 1
+  fi
+  [[ "$(grep -c '^download$' "${fixture_root}/gh.log" || true)" -eq 2 ]] || return 1
+  [[ "$(grep -c '^attest-exact$' "${fixture_root}/gh.log" || true)" -eq 1 ]] || return 1
+  [[ "$(grep -c '^attest-loose$' "${fixture_root}/gh.log" || true)" -eq 1 ]] || return 1
+}
+
+GOOD="${TMP_ROOT}/good"
+mkdir -p "${GOOD}"
+make_payload_fixture "${GOOD}" \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  majiayu000/vibeguard correct safe
+expect_success "exact release smoke executes checksum, provenance, secondary download, install, and verify" \
+  run_fixture "${GOOD}" "${JOB_SCRIPT}"
+
+WRONG_SUM="${TMP_ROOT}/wrong-sum"
+mkdir -p "${WRONG_SUM}"
+make_payload_fixture "${WRONG_SUM}" \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  majiayu000/vibeguard wrong safe
+expect_failure "checksum mutation fails closed" run_fixture "${WRONG_SUM}" "${JOB_SCRIPT}"
+
+WRONG_MARKER="${TMP_ROOT}/wrong-marker"
+mkdir -p "${WRONG_MARKER}"
+make_payload_fixture "${WRONG_MARKER}" \
+  cccccccccccccccccccccccccccccccccccccccc \
+  majiayu000/vibeguard correct safe
+expect_failure "payload marker from another commit fails closed" \
+  run_fixture "${WRONG_MARKER}" "${JOB_SCRIPT}"
+
+WRONG_REPO="${TMP_ROOT}/wrong-repo"
+mkdir -p "${WRONG_REPO}"
+make_payload_fixture "${WRONG_REPO}" \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  other/repository correct safe
+expect_failure "bootstrap secondary download from another repository fails closed" \
+  run_fixture "${WRONG_REPO}" "${JOB_SCRIPT}"
+
+UNSAFE="${TMP_ROOT}/unsafe"
+mkdir -p "${UNSAFE}"
+make_payload_fixture "${UNSAFE}" \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  majiayu000/vibeguard correct unsafe-link
+expect_failure "link or special archive entry fails before execution" \
+  run_fixture "${UNSAFE}" "${JOB_SCRIPT}"
+
+expect_failure "verify-install nonzero status propagates" \
+  run_fixture "${GOOD}" "${JOB_SCRIPT}" 17
+
+WRONG_DIGEST_SCRIPT="${TMP_ROOT}/wrong-source-digest.sh"
+ruby - "${JOB_SCRIPT}" "${WRONG_DIGEST_SCRIPT}" <<'RUBY'
+text = File.binread(ARGV.fetch(0))
+old = '--source-digest "${EVENT_SHA}"'
+raise "source digest binding missing" unless text.sub!(old, '--source-digest "${WORKFLOW_SHA}"')
+File.binwrite(ARGV.fetch(1), text)
+RUBY
+expect_failure "wrong provenance source identity is rejected by executable fixture" \
+  run_fixture "${GOOD}" "${WRONG_DIGEST_SCRIPT}"
+
+INERT_SCRIPT="${TMP_ROOT}/inert-attestation.sh"
+ruby - "${JOB_SCRIPT}" "${INERT_SCRIPT}" <<'RUBY'
+text = File.binread(ARGV.fetch(0))
+pattern = /gh attestation verify "\$\{DOWNLOAD_DIR\}\/\$\{ASSET\}" .*?--deny-self-hosted-runners\n/m
+raise "active attestation command missing" unless text.sub!(pattern, ": # attestation deliberately disabled\n")
+File.binwrite(ARGV.fetch(1), text)
+RUBY
+expect_failure "commented or inert attestation cannot satisfy the executable contract" \
+  run_fixture "${GOOD}" "${INERT_SCRIPT}"
+
+DISABLED_WORKFLOW="${TMP_ROOT}/disabled-workflow.yml"
+ruby - "${WORKFLOW}" "${DISABLED_WORKFLOW}" <<'RUBY'
+require "yaml"
+document = YAML.load_file(ARGV.fetch(0))
+step = document.fetch("jobs").fetch("no-clone-smoke").fetch("steps")
+  .find { |candidate| candidate["name"] == "Install and verify from immutable release" }
+step["if"] = "${{ false }}"
+File.write(ARGV.fetch(1), YAML.dump(document))
+RUBY
+expect_failure "structural validator rejects an unreachable smoke step" \
+  extract_smoke_script "${DISABLED_WORKFLOW}" "${TMP_ROOT}/disabled.sh" 2>/dev/null
 
 printf '%s passed, %s failed\n' "${PASS}" "${FAIL}"
 test "${FAIL}" -eq 0

--- a/tests/test_no_clone_release_smoke.sh
+++ b/tests/test_no_clone_release_smoke.sh
@@ -73,8 +73,22 @@ if [[ "${1:-}" == "verify-install" ]]; then
   exit "${FIXTURE_VERIFY_EXIT:-0}"
 fi
 mkdir -p "${HOME}/.vibeguard/installed/bin" "${HOME}/.vibeguard/installed/rules/claude-rules"
-printf '#!/usr/bin/env bash\nexit 0\n' > "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+# Mirror production runtime acquisition: the payload setup performs its own
+# release download for the runtime binary, from the runtime release repository.
+runtime_repo="${VIBEGUARD_RUNTIME_RELEASE_REPO:-majiayu000/vibeguard}"
+runtime_dir="$(mktemp -d "${HOME}/.vibeguard/runtime-download.XXXXXX")"
+gh release download "v1.2.3" \
+  --repo "${runtime_repo}" \
+  --pattern "vibeguard-runtime-fixture-target" \
+  --pattern "SHA256SUMS" \
+  --dir "${runtime_dir}"
+[[ -f "${runtime_dir}/vibeguard-runtime-fixture-target" ]]
+cp "${runtime_dir}/vibeguard-runtime-fixture-target" \
+  "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
 chmod 0755 "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+rm -rf "${runtime_dir}"
+printf 'status=verified-provenance\nrelease_repo=%s\ntag=v1.2.3\ntarget=fixture-target\n' \
+  "${runtime_repo}" > "${HOME}/.vibeguard/installed/runtime-provenance"
 SETUP
   chmod 0755 "${payload_root}/setup.sh"
 
@@ -176,19 +190,32 @@ if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
   shift
   repo=""
   destination=""
+  payload_requested=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --repo) repo="$2"; shift 2 ;;
       --repo=*) repo="${1#*=}"; shift ;;
       --dir) destination="$2"; shift 2 ;;
       --dir=*) destination="${1#*=}"; shift ;;
-      --pattern) shift 2 ;;
-      --pattern=*) shift ;;
+      --pattern)
+        [[ "$2" != "vibeguard-payload-1.2.3.tar.gz" ]] || payload_requested=1
+        shift 2 ;;
+      --pattern=*)
+        [[ "${1#*=}" != "vibeguard-payload-1.2.3.tar.gz" ]] || payload_requested=1
+        shift ;;
       *) exit 64 ;;
     esac
   done
   [[ "${repo}" == "${GH_REPO}" && "${tag}" == "${TAG_NAME}" && -n "${destination}" ]] || exit 1
   mkdir -p "${destination}"
+  if [[ "${payload_requested}" != "1" ]]; then
+    printf 'runtime=fixture-target\n' > "${destination}/vibeguard-runtime-fixture-target"
+    printf '%s  %s\n' \
+      "0000000000000000000000000000000000000000000000000000000000000000" \
+      "vibeguard-runtime-fixture-target" > "${destination}/SHA256SUMS"
+    printf 'runtime-download\n' >> "${GH_STUB_LOG}"
+    exit 0
+  fi
   download_count="$(grep -c '^download$' "${GH_STUB_LOG}" || true)"
   if [[ "${download_count}" -eq 0 ]]; then
     payload="${GH_STUB_PAYLOAD}"
@@ -272,6 +299,7 @@ run_fixture() {
     return 1
   fi
   [[ "$(grep -c '^download$' "${fixture_root}/gh.log" || true)" -eq 2 ]] || return 1
+  [[ "$(grep -c '^runtime-download$' "${fixture_root}/gh.log" || true)" -eq 1 ]] || return 1
   [[ "$(grep -c '^attest-exact$' "${fixture_root}/gh.log" || true)" -eq 1 ]] || return 1
   [[ "$(grep -c '^attest-loose$' "${fixture_root}/gh.log" || true)" -eq 1 ]] || return 1
 }
@@ -311,6 +339,16 @@ File.binwrite(ARGV.fetch(1), text)
 RUBY
 expect_failure "bootstrap cannot perform its second download from another repository" \
   run_fixture "${GOOD}" "${WRONG_REPO_SCRIPT}"
+
+UNBOUND_RUNTIME_SCRIPT="${TMP_ROOT}/unbound-runtime-repository.sh"
+ruby - "${JOB_SCRIPT}" "${UNBOUND_RUNTIME_SCRIPT}" <<'RUBY'
+text = File.binread(ARGV.fetch(0))
+pattern = /^[ \t]*VIBEGUARD_RUNTIME_RELEASE_REPO="\$\{GH_REPO\}" \\\n/
+raise "runtime repository binding missing" unless text.sub!(pattern, "")
+File.binwrite(ARGV.fetch(1), text)
+RUBY
+expect_failure "nested runtime download cannot fall back to the upstream repository" \
+  run_fixture "${GOOD}" "${UNBOUND_RUNTIME_SCRIPT}" 0 fork-owner/renamed-vibeguard
 
 UNSAFE="${TMP_ROOT}/unsafe"
 mkdir -p "${UNSAFE}"

--- a/tests/test_no_clone_release_smoke.sh
+++ b/tests/test_no_clone_release_smoke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Contract tests for the release-backed, no-checkout GH699 smoke job.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW="${REPO_DIR}/.github/workflows/release.yml"
+
+PASS=0
+FAIL=0
+
+check_contains() {
+  local description="$1" pattern="$2"
+  if grep -Fq -- "${pattern}" "${JOB_FILE}"; then
+    printf 'PASS: %s\n' "${description}"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL: %s\n' "${description}" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_absent() {
+  local description="$1" pattern="$2"
+  if grep -Fq -- "${pattern}" "${JOB_FILE}"; then
+    printf 'FAIL: %s\n' "${description}" >&2
+    FAIL=$((FAIL + 1))
+  else
+    printf 'PASS: %s\n' "${description}"
+    PASS=$((PASS + 1))
+  fi
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-no-clone-smoke.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+JOB_FILE="${TMP_ROOT}/job.yml"
+
+awk '
+  /^  no-clone-smoke:/ { capture = 1 }
+  capture { print }
+' "${WORKFLOW}" > "${JOB_FILE}"
+
+if [[ ! -s "${JOB_FILE}" ]]; then
+  printf 'FAIL: release workflow has no no-clone-smoke job\n' >&2
+  exit 1
+fi
+
+check_contains "smoke waits for immutable release publication" "needs: publish-release"
+check_contains "smoke runs on macOS" "os: macos-14"
+check_contains "smoke runs on Linux" "os: ubuntu-latest"
+check_contains "smoke receives only read access to release contents" "contents: read"
+check_contains "smoke downloads the exact pinned payload" 'vibeguard-payload-${VERSION}.tar.gz'
+check_contains "smoke downloads release assets with gh" 'gh release download "${TAG_NAME}"'
+check_contains "checksum manifest requires one exact asset row" "count == 1"
+check_contains "payload digest is computed before execution" 'actual="$(sha256_file "${DOWNLOAD_DIR}/${ASSET}")"'
+check_contains "checksum mismatch fails visibly" "payload checksum verification failed"
+check_contains "payload attestation is mandatory" 'gh attestation verify "${DOWNLOAD_DIR}/${ASSET}"'
+check_contains "attestation signer is pinned to release workflow" "--signer-workflow"
+check_contains "attestation source is pinned to exact tag" '--source-ref "refs/tags/${TAG_NAME}"'
+check_contains "bootstrap seed accepts regular archive members only" 'substr($1, 1, 1) == "-"'
+check_contains "bootstrap enforces payload provenance" '--version "${VERSION}" --require-provenance -- --yes --require-provenance'
+check_contains "installed release runs canonical verification" 'setup.sh" verify-install'
+check_absent "fresh-machine job never checks out the repository" "actions/checkout@"
+check_absent "fresh-machine job never pipes curl into a shell" "curl | bash"
+check_absent "fresh-machine job never pipes curl into sh" "curl | sh"
+check_absent "fresh-machine job never prints the GitHub token" 'echo ${GH_TOKEN}'
+
+printf '%s passed, %s failed\n' "${PASS}" "${FAIL}"
+test "${FAIL}" -eq 0


### PR DESCRIPTION
## 摘要

这是 GH-699 的 T4 implementation slice，不关闭 Issue。

- 发布完成后在 macOS 14 与 Ubuntu fresh runner 上运行真实 no-clone smoke。
- job 明确不 checkout 仓库，只从精确 tag 的 GitHub Release 下载 payload 与 SHA256SUMS。
- payload 在执行前必须通过唯一 checksum 条目校验与 GitHub artifact attestation；随后 canonical bootstrap 以 require-provenance 同时验证 payload 和 runtime。
- 安装使用隔离 HOME，最后执行现有 setup.sh verify-install，并确认 runtime binary 与 rules asset 均已落盘。
- 保持供应链边界：没有 curl pipe shell，没有秘密输出，job 仅 contents/attestations read 权限。

Refs #699

## Fresh verification

- bash tests/test_no_clone_release_smoke.sh — 19/19
- bash tests/test_release_workflow.sh — 81/81
- bash tests/test_payload.sh — 43/43
- bash scripts/ci/validate-workflow-contracts.sh — pass
- cargo check --manifest-path vibeguard-runtime/Cargo.toml — pass
- cargo test --manifest-path vibeguard-runtime/Cargo.toml — pass
- python YAML parse for release.yml and ci.yml — pass

全量 bash tests/test_workflow_contracts.sh 为 24/25；唯一失败 plan-mode exposes one activation heading 已在未修改的 origin/main@1c4c7b84 干净基线复现，非本 PR 引入。

## Merge gate

本 PR 需 current-head CI、独立供应链安全复核与 0 unresolved review threads 后才可合并。真实 tag/release smoke 通过前，GH-699 保持开放。