### PR TITLE
ci: shard setup regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,9 @@ env:
 
 jobs:
   validate-and-test:
-    name: CI (${{ matrix.os }})
+    name: Core CI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # The macOS runner reached 59m05s on main against the previous 60-minute
-    # limit, so any added regression cancelled the job instead of failing it.
-    timeout-minutes: 90
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -303,10 +301,6 @@ jobs:
         shell: bash
         run: bash tests/test_authorized_discard.sh
 
-      - name: Setup regression tests
-        shell: bash
-        run: bash tests/test_setup.sh
-
       - name: Setup hardening regression tests
         shell: bash
         run: bash tests/test_setup_hardening.sh
@@ -423,6 +417,93 @@ jobs:
           VG_PRECISION_CSV_FILE: precision-results.csv
         run: bash scripts/benchmark.sh --mode=fast
 
+  setup-runtime:
+    name: Setup runtime fixture (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Build setup runtime fixture
+        run: cargo build --manifest-path vibeguard-runtime/Cargo.toml
+
+      - name: Upload setup runtime fixture
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: setup-runtime-${{ matrix.os }}
+          path: vibeguard-runtime/target/debug/vibeguard-runtime
+          if-no-files-found: error
+          retention-days: 1
+
+  setup-regressions:
+    name: Setup regression (${{ matrix.os }}, ${{ matrix.shard }})
+    runs-on: ${{ matrix.os }}
+    needs: setup-runtime
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        shard: [bootstrap, install, protection, profile]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git identity (for tests that create commits)
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@vibeguard.test"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Download setup runtime fixture
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: setup-runtime-${{ matrix.os }}
+          path: vibeguard-runtime/target/debug
+
+      - name: Restore setup runtime executable bit
+        run: chmod +x vibeguard-runtime/target/debug/vibeguard-runtime
+
+      - name: Install bash 4+ (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install bash
+          echo "Bash: $(bash --version | head -1)"
+
+      - name: Run setup regression shard
+        env:
+          VIBEGUARD_TEST_PREBUILT_RUNTIME: "1"
+        run: bash tests/test_setup.sh --shard "${{ matrix.shard }}"
+
+  required-ci:
+    name: CI (${{ matrix.os }})
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [validate-and-test, setup-regressions]
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Enforce core and setup results
+        env:
+          CORE_RESULT: ${{ needs.validate-and-test.result }}
+          SETUP_RESULT: ${{ needs.setup-regressions.result }}
+        run: |
+          [[ "${CORE_RESULT}" == "success" ]]
+          [[ "${SETUP_RESULT}" == "success" ]]
+
   windows-smoke:
     # Keep this job name aligned with the protected required check while the
     # Windows job intentionally runs only cross-platform contract smoke tests.
@@ -518,7 +599,7 @@ jobs:
   benchmark-report:
     name: Benchmark Report
     runs-on: ubuntu-latest
-    needs: validate-and-test
+    needs: [validate-and-test, required-ci]
     # Isolated job so write tokens are not exposed to the shell-heavy CI steps above.
     permissions:
       contents: write

--- a/tests/setup/bootstrap_recovery_scheduler_tests.sh
+++ b/tests/setup/bootstrap_recovery_scheduler_tests.sh
@@ -799,3 +799,47 @@ assert_contains "${foreign_owner_out}" "lock ownership changed" \
   "cleanup reports foreign lock ownership instead of deleting it"
 assert_cmd "cleanup never deletes a foreign lock owner" \
   grep -qFx "nonce=foreign-owner" "${foreign_owner_lock}"
+
+bootstrap_deactivate_home="${TMP_HOME}/bootstrap-scheduler-deactivate-home"
+env "${bootstrap_base_env[@]}" HOME="${bootstrap_deactivate_home}" \
+  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes --with-scheduler \
+  >/dev/null
+bootstrap_deactivate_rc=0
+env "${bootstrap_base_env[@]}" HOME="${bootstrap_deactivate_home}" \
+  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_SYSTEMD_STOP_FAIL=1 \
+  VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --clean \
+  >/dev/null 2>&1 || bootstrap_deactivate_rc=$?
+assert_cmd "bootstrap clean propagates scheduler deactivation failure" \
+  test "${bootstrap_deactivate_rc}" -ne 0
+assert_cmd "bootstrap clean preserves payload, scheduler units, and cleaning receipt" bash -c \
+  'test -L "$1" && test -d "$2" && test -f "$3" && test -f "$4" && grep -qFx "phase=cleaning" "$5"' _ \
+  "${bootstrap_deactivate_home}/.vibeguard/dist/current" \
+  "${bootstrap_deactivate_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
+  "${bootstrap_deactivate_home}/.config/systemd/user/vibeguard-gc.service" \
+  "${bootstrap_deactivate_home}/.config/systemd/user/vibeguard-gc.timer" \
+  "${bootstrap_deactivate_home}/.vibeguard/scheduler-ownership"
+
+bootstrap_service_deactivate_home="${TMP_HOME}/bootstrap-service-deactivate-home"
+env "${bootstrap_base_env[@]}" HOME="${bootstrap_service_deactivate_home}" \
+  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes --with-scheduler \
+  >/dev/null
+touch "${bootstrap_service_deactivate_home}/.systemctl-vibeguard-gc-service-active"
+bootstrap_service_deactivate_rc=0
+env "${bootstrap_base_env[@]}" HOME="${bootstrap_service_deactivate_home}" \
+  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_SYSTEMD_SERVICE_STOP_FAIL=1 \
+  VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
+  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --clean \
+  >/dev/null 2>&1 || bootstrap_service_deactivate_rc=$?
+assert_cmd "bootstrap clean propagates active service deactivation failure" \
+  test "${bootstrap_service_deactivate_rc}" -ne 0
+assert_cmd "bootstrap service failure preserves payload, units, and receipt" bash -c \
+  'test -L "$1" && test -d "$2" && test -f "$3" && test -f "$4" && grep -qFx "phase=cleaning" "$5" && test -f "$6"' _ \
+  "${bootstrap_service_deactivate_home}/.vibeguard/dist/current" \
+  "${bootstrap_service_deactivate_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
+  "${bootstrap_service_deactivate_home}/.config/systemd/user/vibeguard-gc.service" \
+  "${bootstrap_service_deactivate_home}/.config/systemd/user/vibeguard-gc.timer" \
+  "${bootstrap_service_deactivate_home}/.vibeguard/scheduler-ownership" \
+  "${bootstrap_service_deactivate_home}/.systemctl-vibeguard-gc-service-active"

--- a/tests/setup/cleanup_failure_tests.sh
+++ b/tests/setup/cleanup_failure_tests.sh
@@ -1,27 +1,5 @@
-bootstrap_service_deactivate_home="${TMP_HOME}/bootstrap-service-deactivate-home"
-env "${bootstrap_base_env[@]}" HOME="${bootstrap_service_deactivate_home}" \
-  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
-  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes --with-scheduler \
-  >/dev/null
-touch "${bootstrap_service_deactivate_home}/.systemctl-vibeguard-gc-service-active"
-bootstrap_service_deactivate_rc=0
-env "${bootstrap_base_env[@]}" HOME="${bootstrap_service_deactivate_home}" \
-  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_SYSTEMD_SERVICE_STOP_FAIL=1 \
-  VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
-  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --clean \
-  >/dev/null 2>&1 || bootstrap_service_deactivate_rc=$?
-assert_cmd "bootstrap clean propagates active service deactivation failure" \
-  test "${bootstrap_service_deactivate_rc}" -ne 0
-assert_cmd "bootstrap service failure preserves payload, units, and receipt" bash -c \
-  'test -L "$1" && test -d "$2" && test -f "$3" && test -f "$4" && grep -qFx "phase=cleaning" "$5" && test -f "$6"' _ \
-  "${bootstrap_service_deactivate_home}/.vibeguard/dist/current" \
-  "${bootstrap_service_deactivate_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
-  "${bootstrap_service_deactivate_home}/.config/systemd/user/vibeguard-gc.service" \
-  "${bootstrap_service_deactivate_home}/.config/systemd/user/vibeguard-gc.timer" \
-  "${bootstrap_service_deactivate_home}/.vibeguard/scheduler-ownership" \
-  "${bootstrap_service_deactivate_home}/.systemctl-vibeguard-gc-service-active"
-
 cleanup_real_runtime="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+cleanup_fixture_version="$(tr -d '[:space:]' < "${REPO_DIR}/vibeguard-runtime/VERSION")"
 assert_cmd "cleanup failure fixtures have a real runtime delegate" \
   test -x "${cleanup_real_runtime}"
 
@@ -29,7 +7,7 @@ md_cleanup_failure_home="${TMP_HOME}/md-cleanup-failure-home"
 md_cleanup_failure_runtime="${TMP_HOME}/md-cleanup-failure-runtime"
 mkdir -p "${md_cleanup_failure_home}/.claude" \
   "${md_cleanup_failure_home}/.codex" \
-  "${md_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}"
+  "${md_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}"
 printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
   > "${md_cleanup_failure_home}/.claude/CLAUDE.md"
 printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
@@ -37,7 +15,7 @@ printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
 printf '#!/usr/bin/env bash\n' \
   > "${md_cleanup_failure_home}/.vibeguard/run-hook-codex.sh"
 printf 'verified payload\n' \
-  > "${md_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+  > "${md_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}/payload"
 cat > "${md_cleanup_failure_runtime}" <<SH
 #!/usr/bin/env bash
 if [[ "\${1:-}" == "setup-md-remove" \
@@ -59,12 +37,12 @@ assert_cmd "CLAUDE.md helper failure preserves high-context files and recovery p
   "${md_cleanup_failure_home}/.claude/CLAUDE.md" \
   "${md_cleanup_failure_home}/.codex/AGENTS.md" \
   "${md_cleanup_failure_home}/.vibeguard/run-hook-codex.sh" \
-  "${md_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+  "${md_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}/payload"
 
 hooks_cleanup_failure_home="${TMP_HOME}/hooks-cleanup-failure-home"
 hooks_cleanup_failure_runtime="${TMP_HOME}/hooks-cleanup-failure-runtime"
 mkdir -p "${hooks_cleanup_failure_home}/.codex" \
-  "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}"
+  "${hooks_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}"
 printf '<!-- vibeguard-start -->\nmanaged\n<!-- vibeguard-end -->\n' \
   > "${hooks_cleanup_failure_home}/.codex/AGENTS.md"
 printf '{"hooks":{"PreToolUse":[]}}\n' \
@@ -72,7 +50,7 @@ printf '{"hooks":{"PreToolUse":[]}}\n' \
 printf '#!/usr/bin/env bash\n' \
   > "${hooks_cleanup_failure_home}/.vibeguard/run-hook-codex.sh"
 printf 'verified payload\n' \
-  > "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+  > "${hooks_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}/payload"
 cat > "${hooks_cleanup_failure_runtime}" <<SH
 #!/usr/bin/env bash
 if [[ "\${1:-}" == "setup-codex-hooks-remove" \
@@ -93,7 +71,7 @@ assert_cmd "Codex hooks helper failure preserves hooks, wrapper, and recovery pa
   'test -f "$1" && test -f "$2" && test -f "$3"' _ \
   "${hooks_cleanup_failure_home}/.codex/hooks.json" \
   "${hooks_cleanup_failure_home}/.vibeguard/run-hook-codex.sh" \
-  "${hooks_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+  "${hooks_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}/payload"
 
 rm_cleanup_failure_home="${TMP_HOME}/rm-cleanup-failure-home"
 rm_cleanup_failure_bin="${TMP_HOME}/rm-cleanup-failure-bin"
@@ -101,7 +79,7 @@ rm_cleanup_failure_runtime="${TMP_HOME}/rm-cleanup-failure-runtime"
 rm_cleanup_failure_skill="${rm_cleanup_failure_home}/.codex/skills/vibeguard"
 rm_cleanup_real="$(command -v rm)"
 mkdir -p "${rm_cleanup_failure_home}/.vibeguard/_lib" \
-  "${rm_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
+  "${rm_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}" \
   "${rm_cleanup_failure_skill}" "${rm_cleanup_failure_bin}"
 printf 'managed skill\n' > "${rm_cleanup_failure_skill}/SKILL.md"
 python3 - "${rm_cleanup_failure_skill}" \
@@ -130,7 +108,7 @@ printf '#!/usr/bin/env bash\n' \
 printf '#!/usr/bin/env bash\n' \
   > "${rm_cleanup_failure_home}/.vibeguard/_lib/codex_diag.sh"
 printf 'verified payload\n' \
-  > "${rm_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+  > "${rm_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}/payload"
 cat > "${rm_cleanup_failure_runtime}" <<SH
 #!/usr/bin/env bash
 if [[ "\${1:-}" == "setup-codex-hooks-remove" ]]; then
@@ -160,4 +138,4 @@ assert_cmd "managed skill removal failure aborts clean" \
 assert_cmd "managed skill removal failure preserves skill and recovery payload" bash -c \
   'test -f "$1" && test -f "$2"' _ \
   "${rm_cleanup_failure_skill}/SKILL.md" \
-  "${rm_cleanup_failure_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}/payload"
+  "${rm_cleanup_failure_home}/.vibeguard/dist/${cleanup_fixture_version}/payload"

--- a/tests/setup/protection_clean_tests.sh
+++ b/tests/setup/protection_clean_tests.sh
@@ -199,27 +199,6 @@ assert_cmd "systemd clean removes runtime-enabled timer state and owned files" b
   "${runtime_clean_dir}/vibeguard-gc.timer" \
   "${runtime_clean_receipt}" "${runtime_clean_enabled}"
 
-bootstrap_deactivate_home="${TMP_HOME}/bootstrap-scheduler-deactivate-home"
-env "${bootstrap_base_env[@]}" HOME="${bootstrap_deactivate_home}" \
-  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
-  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --yes --with-scheduler \
-  >/dev/null
-bootstrap_deactivate_rc=0
-env "${bootstrap_base_env[@]}" HOME="${bootstrap_deactivate_home}" \
-  VIBEGUARD_TEST_UNAME=Linux VIBEGUARD_TEST_SYSTEMD_STOP_FAIL=1 \
-  VIBEGUARD_TEST_RELEASE_DIR="${scheduler_release}" \
-  bash "${BOOTSTRAP}" --version "${BOOTSTRAP_VERSION}" -- --clean \
-  >/dev/null 2>&1 || bootstrap_deactivate_rc=$?
-assert_cmd "bootstrap clean propagates scheduler deactivation failure" \
-  test "${bootstrap_deactivate_rc}" -ne 0
-assert_cmd "bootstrap clean preserves payload, scheduler units, and cleaning receipt" bash -c \
-  'test -L "$1" && test -d "$2" && test -f "$3" && test -f "$4" && grep -qFx "phase=cleaning" "$5"' _ \
-  "${bootstrap_deactivate_home}/.vibeguard/dist/current" \
-  "${bootstrap_deactivate_home}/.vibeguard/dist/${BOOTSTRAP_VERSION}" \
-  "${bootstrap_deactivate_home}/.config/systemd/user/vibeguard-gc.service" \
-  "${bootstrap_deactivate_home}/.config/systemd/user/vibeguard-gc.timer" \
-  "${bootstrap_deactivate_home}/.vibeguard/scheduler-ownership"
-
 for scheduler_clean_point in after-phase after-first before-receipt; do
   scheduler_clean_home="${TMP_HOME}/scheduler-clean-${scheduler_clean_point}-home"
   scheduler_clean_bin="${TMP_HOME}/scheduler-clean-${scheduler_clean_point}-bin"

--- a/tests/test_ci_workflow_contract.sh
+++ b/tests/test_ci_workflow_contract.sh
@@ -12,47 +12,94 @@ import sys
 
 
 workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
-job_match = re.search(
-    r"(?ms)^  validate-and-test:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
-    workflow,
-)
-if job_match is None:
-    raise SystemExit("missing validate-and-test job")
-job = job_match.group(0)
 
-required_job_lines = {
-    "stable check name": "    name: CI (${{ matrix.os }})",
+
+def job(name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise SystemExit(f"missing {name} job")
+    return match.group(0)
+
+
+def require_blocking_timeout(name: str, body: str) -> None:
+    timeouts = re.findall(r"(?m)^    timeout-minutes: ([1-9][0-9]*)$", body)
+    if len(timeouts) != 1:
+        raise SystemExit(f"{name} needs exactly one finite positive timeout")
+    if re.search(r"(?m)^    continue-on-error:", body):
+        raise SystemExit(f"{name} must remain blocking")
+
+
+core_job = job("validate-and-test")
+for description, line in {
+    "core check name": "    name: Core CI (${{ matrix.os }})",
     "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
-}
-for description, line in required_job_lines.items():
-    if line not in job.splitlines():
+}.items():
+    if line not in core_job.splitlines():
         raise SystemExit(f"validate-and-test missing {description}: {line}")
-
-timeouts = re.findall(r"(?m)^    timeout-minutes: ([1-9][0-9]*)$", job)
-if len(timeouts) != 1:
-    raise SystemExit("validate-and-test needs exactly one finite positive timeout")
-if re.search(r"(?m)^    continue-on-error:", job):
-    raise SystemExit("validate-and-test must remain blocking")
+require_blocking_timeout("validate-and-test", core_job)
+if "bash tests/test_setup.sh" in core_job:
+    raise SystemExit("validate-and-test must not serialize the full setup suite")
 
 required_steps = {
-    "Setup regression tests": "bash tests/test_setup.sh",
     "Hook performance static analysis": "bash scripts/ci/validate-hook-perf.sh",
     "Hook performance contract regression tests": "bash tests/test_hook_perf_contract.sh",
     "Hook latency benchmark": "bash tests/bench_hook_latency.sh --runs=3 --confirmation-runs=3 --fail-on-regression",
 }
 for name, command in required_steps.items():
     marker = f"      - name: {name}"
-    start = job.find(marker)
+    start = core_job.find(marker)
     if start < 0:
         raise SystemExit(f"missing required CI step: {name}")
-    next_step = job.find("\n      - name:", start + len(marker))
-    block = job[start:] if next_step < 0 else job[start:next_step]
+    next_step = core_job.find("\n      - name:", start + len(marker))
+    block = core_job[start:] if next_step < 0 else core_job[start:next_step]
     if command not in block:
         raise SystemExit(f"{name} does not run: {command}")
     if "continue-on-error" in block:
         raise SystemExit(f"{name} must remain blocking")
-    if name == "Setup regression tests" and re.search(r"(?m)^\s+if:", block):
-        raise SystemExit("setup regression tests must run on both matrix platforms")
+
+runtime_job = job("setup-runtime")
+for description, line in {
+    "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
+    "runtime build": "        run: cargo build --manifest-path vibeguard-runtime/Cargo.toml",
+    "per-OS artifact": "          name: setup-runtime-${{ matrix.os }}",
+}.items():
+    if line not in runtime_job.splitlines():
+        raise SystemExit(f"setup-runtime missing {description}: {line}")
+require_blocking_timeout("setup-runtime", runtime_job)
+
+setup_job = job("setup-regressions")
+for description, line in {
+    "runtime fixture dependency": "    needs: setup-runtime",
+    "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
+    "complete shard matrix": "        shard: [bootstrap, install, protection, profile]",
+    "per-OS artifact download": "          name: setup-runtime-${{ matrix.os }}",
+    "prebuilt fixture selection": '          VIBEGUARD_TEST_PREBUILT_RUNTIME: "1"',
+    "shard command": '        run: bash tests/test_setup.sh --shard "${{ matrix.shard }}"',
+}.items():
+    if line not in setup_job.splitlines():
+        raise SystemExit(f"setup-regressions missing {description}: {line}")
+require_blocking_timeout("setup-regressions", setup_job)
+
+required_job = job("required-ci")
+for description, line in {
+    "stable protected check name": "    name: CI (${{ matrix.os }})",
+    "Ubuntu/macOS matrix": "        os: [ubuntu-latest, macos-latest]",
+    "core and setup dependencies": "    needs: [validate-and-test, setup-regressions]",
+    "failure-safe execution": "    if: ${{ always() }}",
+}.items():
+    if line not in required_job.splitlines():
+        raise SystemExit(f"required-ci missing {description}: {line}")
+require_blocking_timeout("required-ci", required_job)
+for result in ("needs.validate-and-test.result", "needs.setup-regressions.result"):
+    if result not in required_job:
+        raise SystemExit(f"required-ci does not enforce {result}")
+
+benchmark_job = job("benchmark-report")
+if "    needs: [validate-and-test, required-ci]" not in benchmark_job.splitlines():
+    raise SystemExit("benchmark-report must wait for core and required CI")
 PY
 
 echo "CI workflow contract tests passed."

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # VibeGuard setup regression testing
 #
-# Usage: bash tests/test_setup.sh
+# Usage: bash tests/test_setup.sh [--shard full|bootstrap|install|protection|profile]
 
 set -euo pipefail
 
@@ -13,6 +13,36 @@ MANIFEST_HELPER="${REPO_DIR}/scripts/lib/vibeguard_manifest.py"
 PROJECT_CONFIG_HELPER="${REPO_DIR}/scripts/lib/project_config_validate.py"
 CHAT_CONTRACT_ANCHOR="Compact Chat Contract: progress updates, concise answers, plain formatting."
 CODEX_CONFIG_HELPER="${REPO_DIR}/scripts/lib/codex_config_toml.py"
+
+SETUP_SHARD="full"
+case "${1:-}" in
+  "") ;;
+  --shard)
+    [[ $# -eq 2 ]] || {
+      printf 'Usage: bash tests/test_setup.sh [--shard full|bootstrap|install|protection|profile]\n' >&2
+      exit 2
+    }
+    SETUP_SHARD="$2"
+    ;;
+  --shard=*)
+    [[ $# -eq 1 ]] || {
+      printf 'Usage: bash tests/test_setup.sh [--shard full|bootstrap|install|protection|profile]\n' >&2
+      exit 2
+    }
+    SETUP_SHARD="${1#--shard=}"
+    ;;
+  *)
+    printf 'Usage: bash tests/test_setup.sh [--shard full|bootstrap|install|protection|profile]\n' >&2
+    exit 2
+    ;;
+esac
+case "${SETUP_SHARD}" in
+  full|bootstrap|install|protection|profile) ;;
+  *)
+    printf 'Unknown setup test shard: %s\n' "${SETUP_SHARD}" >&2
+    exit 2
+    ;;
+esac
 
 PASS=0
 FAIL=0
@@ -597,7 +627,20 @@ export PATH="${TMP_HOME}/bin:${PATH}"
 
 TEST_RELEASE_DIR="${TMP_HOME}/release-assets"
 mkdir -p "${TEST_RELEASE_DIR}"
-cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
+runtime_fixture="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+if [[ "${VIBEGUARD_TEST_PREBUILT_RUNTIME:-0}" == "1" ]]; then
+  [[ -x "${runtime_fixture}" ]] || {
+    red "prebuilt runtime fixture is missing or not executable: ${runtime_fixture}"
+    exit 1
+  }
+  expected_runtime_version="$(tr -d '[:space:]' < "${REPO_DIR}/vibeguard-runtime/VERSION")"
+  [[ "$("${runtime_fixture}" version)" == "${expected_runtime_version}" ]] || {
+    red "prebuilt runtime fixture version does not match ${expected_runtime_version}"
+    exit 1
+  }
+else
+  cargo build --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml" >/dev/null
+fi
 : > "${TEST_RELEASE_DIR}/SHA256SUMS"
 for target in \
   aarch64-apple-darwin \
@@ -728,14 +771,67 @@ assert_cmd "quiet runtime download rejects manifest size mismatch" bash -c '
   test ! -e "${dest}"
 ' _ "${REPO_DIR}" "${TMP_HOME}"
 
+seed_installed_setup_fixture() {
+  case "${HOME}" in
+    "${TMP_HOME}"*) ;;
+    *) red "refusing to seed setup fixture outside TMP_HOME"; return 1 ;;
+  esac
 
-for setup_test in \
-  "${REPO_DIR}/tests/setup/syntax_manifest_tests.sh" \
-  "${REPO_DIR}/tests/setup/bootstrap_tests.sh" \
-  "${REPO_DIR}/tests/setup/runtime_install_tests.sh" \
-  "${REPO_DIR}/tests/setup/install_flow_tests.sh" \
-  "${REPO_DIR}/tests/setup/protection_clean_tests.sh" \
-  "${REPO_DIR}/tests/setup/profile_flow_tests.sh"; do
+  mkdir -p "${HOME}/.claude" "${HOME}/.codex"
+  PREEXISTING_CODEX_HOOK_SCRIPT="${HOME}/codex-third-party-hook.js"
+  printf 'process.exit(0)\n' > "${PREEXISTING_CODEX_HOOK_SCRIPT}"
+  printf '%s\n' '{"hooks": {}}' > "${HOME}/.claude/settings.json"
+  cat > "${HOME}/.codex/hooks.json" <<JSON
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${PREEXISTING_CODEX_HOOK_SCRIPT}"
+      }]
+    }]
+  }
+}
+JSON
+  printf '%s\n' '[features]' 'hooks = true' > "${HOME}/.codex/config.toml"
+  VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 bash "${REPO_DIR}/setup.sh" --yes >/dev/null
+}
+
+setup_tests=()
+case "${SETUP_SHARD}" in
+  full)
+    setup_tests=(
+      "${REPO_DIR}/tests/setup/syntax_manifest_tests.sh"
+      "${REPO_DIR}/tests/setup/bootstrap_tests.sh"
+      "${REPO_DIR}/tests/setup/runtime_install_tests.sh"
+      "${REPO_DIR}/tests/setup/install_flow_tests.sh"
+      "${REPO_DIR}/tests/setup/protection_clean_tests.sh"
+      "${REPO_DIR}/tests/setup/profile_flow_tests.sh"
+    )
+    ;;
+  bootstrap)
+    setup_tests=(
+      "${REPO_DIR}/tests/setup/syntax_manifest_tests.sh"
+      "${REPO_DIR}/tests/setup/bootstrap_tests.sh"
+      "${REPO_DIR}/tests/setup/runtime_install_tests.sh"
+    )
+    ;;
+  install)
+    setup_tests=("${REPO_DIR}/tests/setup/install_flow_tests.sh")
+    ;;
+  protection)
+    seed_installed_setup_fixture
+    setup_tests=("${REPO_DIR}/tests/setup/protection_clean_tests.sh")
+    ;;
+  profile)
+    seed_installed_setup_fixture
+    setup_tests=("${REPO_DIR}/tests/setup/profile_flow_tests.sh")
+    ;;
+esac
+
+printf 'Setup test shard: %s\n' "${SETUP_SHARD}"
+for setup_test in "${setup_tests[@]}"; do
   # shellcheck source=/dev/null
   source "${setup_test}"
 done

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -443,6 +443,14 @@ fi
 exec "${REAL_DATE}" "\$@"
 SH
 chmod +x "${TMP_HOME}/bin/date"
+cat > "${TMP_HOME}/bin/ast-grep" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'ast-grep test fixture\n'
+fi
+exit 0
+SH
+chmod +x "${TMP_HOME}/bin/ast-grep"
 cat > "${TMP_HOME}/bin/cargo" <<SH
 #!/usr/bin/env bash
 if [[ "\${VIBEGUARD_TEST_CARGO_UNAVAILABLE:-0}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- split the setup regression suite into bootstrap, install, protection, and profile shards on Ubuntu and macOS
- build the Rust runtime fixture once per OS and distribute it to shards
- preserve the protected `CI (ubuntu-latest)` and `CI (macos-latest)` checks as blocking aggregate gates
- keep `bash tests/test_setup.sh` backward-compatible as the full serial suite

## Verification
- bootstrap: 589/589
- install: 529/529
- protection: 127/127
- profile: 95/95
- prebuilt-runtime protection path: 127/127
- `bash tests/test_ci_workflow_contract.sh`
- `bash tests/test_workflow_contracts.sh`
- `bash scripts/ci/validate-workflow-contracts.sh`
- `bash scripts/local-contract-check.sh --quick`
- final review: PASS, Findings: 0