### PR TITLE
feat: add native Gemini CLI host adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 **The firewall between AI coding agents and your codebase.**
 
-Native rules + real-time hooks + static guards that stop **Claude Code** and
-**Codex CLI** from shipping hallucinated, duplicated, or unverified changes —
+Native rules + real-time hooks + static guards that stop **Claude Code**,
+**Codex CLI**, and **Gemini CLI** from shipping hallucinated, duplicated, or unverified changes —
 before they land.
 
 ![VibeGuard demo](docs/assets/demo.gif)
@@ -419,6 +419,7 @@ bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
 # Runtime / scheduler
 bash ~/vibeguard/setup.sh --build-from-source          # Force local Cargo build
 bash ~/vibeguard/setup.sh --with-scheduler             # Opt in to launchd/systemd scheduled GC
+bash ~/vibeguard/setup.sh --yes --host gemini          # Opt in to Gemini CLI BeforeTool protection
 bash ~/vibeguard/scripts/install-health-report-scheduler.sh --dry-run
 bash ~/vibeguard/scripts/install-health-report-scheduler.sh --install  # Opt in to weekly health reports
 
@@ -502,6 +503,23 @@ Codex hook command names are namespaced as `vibeguard-*.sh` to avoid collisions 
 Hook status is a separate human diagnostics surface. Use `vibeguard-runtime hook-status --mode focused` inside a git repository to inspect the matching project log, or add `--scope global` for `~/.vibeguard/events.jsonl`. `--log-file PATH` always wins for explicit fixtures or one-off diagnosis. The command reports recent `pass`, `skipped`, `slow`, `timeout`, and adapter-error states without adding successful hook summaries to the model context. Only actionable `warn` / `block` results should continue through `hookSpecificOutput.additionalContext`. See `docs/reference/codex-hook-status.md`.
 
 **MCP server status:** the legacy `mcp-server/` prototype is not installed by `setup.sh` and is not part of the supported runtime surface. Supported integrations are the Claude Code hooks, native Codex hooks, and the optional app-server wrapper below; any future MCP reintroduction must go through an explicit install path and hash/audit baseline.
+
+### Gemini CLI integration
+
+Gemini CLI support is an explicit opt-in because setup updates the high-context
+file `~/.gemini/settings.json`:
+
+```bash
+bash ~/vibeguard/setup.sh --yes --host gemini
+bash ~/vibeguard/setup.sh --check --host gemini
+```
+
+The adapter registers one managed synchronous `BeforeTool` hook for
+`run_shell_command`, `write_file`, and `replace`. It translates Gemini's native
+payload into the existing VibeGuard bash/write/edit guards and translates block
+results back to Gemini's native `decision: deny` response. Re-running setup is
+idempotent, preserves unrelated Gemini settings and hooks, and `--clean` removes
+only VibeGuard's managed hook and wrapper.
 
 **Optional app-server wrapper** (advanced orchestrators only):
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -6,7 +6,7 @@
 
 [English README](../README.md) | [规则索引](rule-reference.md) | [贡献指南](../CONTRIBUTING.md)
 
-无论你在用 Claude Code 还是 Codex，AI 都很容易出现同一类失误：编造不存在的 API、重复造轮子、硬编码假数据、顺手做一堆你没要求的“优化”。VibeGuard 通过 **规则注入 + 实时拦截 + 静态扫描** 三层防线，把能机械覆盖的高风险场景先告警或拦截；未被 hook/guard 覆盖的规则则通过审查、工作流和验证契约约束。
+无论你在用 Claude Code、Codex 还是 Gemini CLI，AI 都很容易出现同一类失误：编造不存在的 API、重复造轮子、硬编码假数据、顺手做一堆你没要求的“优化”。VibeGuard 通过 **规则注入 + 实时拦截 + 静态扫描** 三层防线，把能机械覆盖的高风险场景先告警或拦截；未被 hook/guard 覆盖的规则则通过审查、工作流和验证契约约束。
 
 > **VibeGuard vs Everything Claude Code：** ECC 更偏通用生产力工具箱；VibeGuard 更偏“防守系统”，重点是约束、拦截、验证和回放。两者不是互斥关系，反而适合一起使用。
 
@@ -275,6 +275,20 @@ Codex 中的 hook 命令名会使用 `vibeguard-*.sh` 命名空间，避免与�
 
 ## 安装选项
 
+### Gemini CLI（显式启用）
+
+Gemini CLI 适配器会修改高上下文文件 `~/.gemini/settings.json`，因此默认不启用：
+
+```bash
+bash ~/vibeguard/setup.sh --yes --host gemini
+bash ~/vibeguard/setup.sh --check --host gemini
+```
+
+它为 `run_shell_command`、`write_file`、`replace` 注册一个同步
+`BeforeTool` hook，复用现有 Bash/Write/Edit guards，并把拦截结果转换成
+Gemini 原生的 `decision: deny`。重复安装是幂等的，保留其他 Gemini 设置和
+hooks；`--clean` 只移除 VibeGuard 管理的 hook 与 wrapper。
+
 ### 运行时依赖
 
 默认安装会下载并校验与当前版本钉住的 `vibeguard-runtime` release binary。
@@ -307,6 +321,7 @@ bash ~/vibeguard/setup.sh --profile full --languages rust,typescript
 # 运行时 / 调度器
 bash ~/vibeguard/setup.sh --build-from-source          # 强制使用 Cargo 本地构建
 bash ~/vibeguard/setup.sh --with-scheduler             # opt in 安装 launchd/systemd 定时 GC
+bash ~/vibeguard/setup.sh --yes --host gemini          # opt in Gemini CLI BeforeTool 防护
 bash ~/vibeguard/scripts/install-health-report-scheduler.sh --dry-run
 bash ~/vibeguard/scripts/install-health-report-scheduler.sh --install  # opt in 安装每周健康报告
 

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,6 +1,6 @@
 # hooks/ directory
 
-AI coded agent hooks script, automatically triggered before and after the operation. Both Claude Code and Codex CLI are supported.
+AI coding-agent hook scripts, automatically triggered around tool operations. Claude Code, Codex CLI, and the opt-in Gemini CLI BeforeTool adapter are supported.
 
 ## File description
 
@@ -10,6 +10,7 @@ AI coded agent hooks script, automatically triggered before and after the operat
 | `log.sh` | Used by other hook sources | Log module, providing shared functions such as vg_log, JSON parsing, source code judgment, etc. | - |
 | `circuit-breaker.sh` | Checked by other hook sources | Circuit breaker library: CLOSED to OPEN to HALF-OPEN state machine, CI guard, stop_hook_active. | - |
 | `run-hook-codex.sh` | Codex wrapper | Codex output format adapter (decision:block to permissionDecision:deny). | - |
+| `run-hook-gemini.sh` | Gemini wrapper | Gemini BeforeTool routing and output adapter (decision:block to decision:deny). | - |
 | `pre-bash-guard.sh` | PreToolUse(Bash) | Intercept destructive local cleanup commands: dangerous rm -rf paths, git clean -f, and batch git checkout/restore .; force-push protection lives in the git pre-push hook. | native |
 | `pre-edit-guard.sh` | PreToolUse(Edit) | Block editing of non-existent files (anti-hallucination). | native |
 | `pre-write-guard.sh` | PreToolUse(Write) | Remind you to search for existing implementation before creating a new source code file. | native |
@@ -29,20 +30,21 @@ AI coded agent hooks script, automatically triggered before and after the operat
 
 Codex entries use namespaced hook script names (`vibeguard-*.sh`) and are resolved by `run-hook-codex.sh` to the actual local script files.
 
-## Dual platform deployment architecture
+## Host deployment architecture
 
 ```
-Claude Code                          Codex CLI
-~/.claude/settings.json              ~/.codex/hooks.json
-  ↓                                    ↓
-run-hook.sh (wrapper) run-hook-codex.sh (wrapper + format adaptation)
-  ↓                                    ↓
-~/.vibeguard/installed/hooks/* ~/.vibeguard/installed/hooks/* (shared)
+Claude Code                 Codex CLI                  Gemini CLI (opt-in)
+~/.claude/settings.json     ~/.codex/hooks.json        ~/.gemini/settings.json
+  ↓                           ↓                          ↓
+run-hook.sh                 run-hook-codex.sh          run-hook-gemini.sh
+  └───────────────────────────┴──────────────────────────┘
+                    ~/.vibeguard/installed/hooks/*
 ```
 
 - Claude Code: hooks are registered in `settings.json` and distributed through `run-hook.sh`
 - Codex CLI: hooks are registered in `hooks.json`, distributed through `run-hook-codex.sh`, normalized for apply_patch payloads, and adapted to the output format
-- Both share the same hook script snapshot (`~/.vibeguard/installed/hooks/`)
+- Gemini CLI: one managed synchronous BeforeTool group routes `run_shell_command`, `write_file`, and `replace` through `run-hook-gemini.sh`
+- All supported hosts share the same canonical hook script snapshot (`~/.vibeguard/installed/hooks/`)
 
 ## Decision type
 
@@ -53,7 +55,7 @@ Each event keeps the backward-compatible `cli` / `agent` fields and may include
 caller identity fields: `client`, `client_variant`, `wrapper`,
 `source_config`, `hook_protocol_version`, and `caller_evidence`. Unknown or
 manual callers must be recorded as `client: "unknown"` instead of being
-silently attributed to Claude or Codex.
+silently attributed to Claude, Codex, or Gemini.
 
 ## Development specifications
 
@@ -63,4 +65,4 @@ silently attributed to Claude or Codex.
   for structured parsing, policy, and adapter logic; Python helpers are allowed
   only for tests, CI, eval, install-support tooling, or deprecated compatibility
   artifacts that are not called by configured hooks.
-- When adding a hook, synchronously check whether it can be deployed to Codex (see matcher support)
+- When adding a hook, synchronously check whether it can be deployed to Codex or Gemini (see each host's matcher support)

--- a/hooks/manifest.json
+++ b/hooks/manifest.json
@@ -34,6 +34,16 @@
       "codex": {"enabled": false, "support": "not-applicable", "reason": "wrapper"}
     },
     {
+      "name": "run-hook-gemini",
+      "script": "run-hook-gemini.sh",
+      "kind": "wrapper",
+      "trigger": "Gemini wrapper",
+      "responsibilities": "Gemini BeforeTool routing and output adapter (decision:block to decision:deny).",
+      "decision_types": [],
+      "claude": {"enabled": false, "support": "not-applicable", "reason": "wrapper"},
+      "codex": {"enabled": false, "support": "not-applicable", "reason": "wrapper"}
+    },
+    {
       "name": "pre-bash-guard",
       "script": "pre-bash-guard.sh",
       "kind": "hook",

--- a/hooks/run-hook-gemini.sh
+++ b/hooks/run-hook-gemini.sh
@@ -41,7 +41,7 @@ fallback_deny() {
 deny() {
   local reason="$1"
   if [[ -x "${runtime}" ]] \
-    && printf '%s' "${reason}" | vg_run_with_timeout 1 "${runtime}" gemini-deny 2>/dev/null; then
+    && printf '%s' "${reason}" | vg_run_with_timeout 2 "${runtime}" gemini-deny 2>/dev/null; then
     return 0
   fi
   fallback_deny
@@ -64,12 +64,12 @@ input="$(vg_run_with_timeout 2 cat)" || {
   exit 0
 }
 
-if ! hook_script="$(printf '%s' "${input}" | vg_run_with_timeout 1 "${runtime}" gemini-route-before-tool 2>/dev/null)"; then
+if ! hook_script="$(printf '%s' "${input}" | vg_run_with_timeout 2 "${runtime}" gemini-route-before-tool 2>/dev/null)"; then
   deny "VIBEGUARD Gemini adapter received a malformed or unsupported BeforeTool payload; the tool call was denied."
   exit 0
 fi
 
-session_id="$(printf '%s' "${input}" | vg_run_with_timeout 1 "${runtime}" json-field session_id 2>/dev/null || true)"
+session_id="$(printf '%s' "${input}" | vg_run_with_timeout 2 "${runtime}" json-field session_id 2>/dev/null || true)"
 if [[ -n "${session_id}" ]]; then
   export VIBEGUARD_SESSION_ID="${session_id}"
   export VIBEGUARD_SESSION_SOURCE="gemini-before-tool"
@@ -81,6 +81,6 @@ if ! guard_output="$(printf '%s' "${input}" | vg_run_with_timeout "${hook_timeou
   exit 0
 fi
 
-if ! printf '%s' "${guard_output}" | vg_run_with_timeout 1 "${runtime}" gemini-adapt-before-tool; then
+if ! printf '%s' "${guard_output}" | vg_run_with_timeout 2 "${runtime}" gemini-adapt-before-tool; then
   deny "VIBEGUARD Gemini adapter could not encode the policy result; the tool call was denied."
 fi

--- a/hooks/run-hook-gemini.sh
+++ b/hooks/run-hook-gemini.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# VibeGuard Gemini CLI BeforeTool adapter.
+set -euo pipefail
+
+wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+runtime="${wrapper_dir}/installed/bin/vibeguard-runtime"
+run_hook="${wrapper_dir}/run-hook.sh"
+timeout_helper="${wrapper_dir}/installed/hooks/_lib/timeout.sh"
+hook_timeout_seconds="5"
+if [[ $# -eq 6 && "$1" == "--test-only" ]]; then
+  runtime="$2"
+  run_hook="$3"
+  timeout_helper="$4"
+  export VIBEGUARD_EXECUTION_MODE="$5"
+  hook_timeout_seconds="$6"
+elif [[ $# -ne 0 ]]; then
+  printf '%s\n' '{"decision":"deny","reason":"VIBEGUARD Gemini adapter received invalid wrapper arguments; the tool call was denied."}'
+  exit 0
+else
+  export HOME="$(cd "${wrapper_dir}/.." && pwd -P)"
+  export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+  export VIBEGUARD_EXECUTION_MODE="installed-snapshot"
+  unset BASH_ENV ENV VIBEGUARD_RUNTIME VIBEGUARD_POLICY_RUNTIME
+  unset VG_POLICY_RUNTIME_PATH_CACHE VG_WRAPPER_ENV_RUNTIME_PATH_CACHE VIBEGUARD_HOOK_DIR
+  unset VIBEGUARD_CONFIG_FILE VIBEGUARD_USER_CONFIG_FILE VIBEGUARD_PROJECT_CONFIG
+  unset VIBEGUARD_POLICY_CWD VIBEGUARD_PROJECT_ROOT VIBEGUARD_PROJECT_CWD VIBEGUARD_LOG_DIR
+fi
+
+export VIBEGUARD_CLI="gemini"
+export VIBEGUARD_CLIENT="gemini"
+export VIBEGUARD_CLIENT_VARIANT="gemini-cli-hooks"
+export VIBEGUARD_WRAPPER="run-hook-gemini.sh"
+export VIBEGUARD_SOURCE_CONFIG="${GEMINI_CLI_HOME:-${HOME}}/.gemini/settings.json"
+export VIBEGUARD_HOOK_PROTOCOL_VERSION="gemini-cli-hooks-v1"
+export VIBEGUARD_CALLER_EVIDENCE="gemini-settings-before-tool"
+
+fallback_deny() {
+  printf '%s\n' '{"decision":"deny","reason":"VIBEGUARD Gemini adapter is unavailable; the tool call was denied. Re-run VibeGuard setup with --host gemini."}'
+}
+
+deny() {
+  local reason="$1"
+  if [[ -x "${runtime}" ]] \
+    && printf '%s' "${reason}" | vg_run_with_timeout 1 "${runtime}" gemini-deny 2>/dev/null; then
+    return 0
+  fi
+  fallback_deny
+}
+
+if [[ ! -f "${timeout_helper}" ]]; then
+  fallback_deny
+  exit 0
+fi
+# shellcheck source=hooks/_lib/timeout.sh
+source "${timeout_helper}"
+if ! declare -F vg_run_with_timeout >/dev/null 2>&1 \
+  || [[ ! -x "${runtime}" || ! -f "${run_hook}" ]]; then
+  fallback_deny
+  exit 0
+fi
+
+input="$(vg_run_with_timeout 2 cat)" || {
+  deny "VIBEGUARD Gemini adapter could not read the BeforeTool payload; the tool call was denied."
+  exit 0
+}
+
+if ! hook_script="$(printf '%s' "${input}" | vg_run_with_timeout 1 "${runtime}" gemini-route-before-tool 2>/dev/null)"; then
+  deny "VIBEGUARD Gemini adapter received a malformed or unsupported BeforeTool payload; the tool call was denied."
+  exit 0
+fi
+
+session_id="$(printf '%s' "${input}" | vg_run_with_timeout 1 "${runtime}" json-field session_id 2>/dev/null || true)"
+if [[ -n "${session_id}" ]]; then
+  export VIBEGUARD_SESSION_ID="${session_id}"
+  export VIBEGUARD_SESSION_SOURCE="gemini-before-tool"
+fi
+
+guard_output=""
+if ! guard_output="$(printf '%s' "${input}" | vg_run_with_timeout "${hook_timeout_seconds}" bash "${run_hook}" "${hook_script}")"; then
+  deny "VIBEGUARD Gemini adapter could not execute the policy hook; the tool call was denied."
+  exit 0
+fi
+
+if ! printf '%s' "${guard_output}" | vg_run_with_timeout 1 "${runtime}" gemini-adapt-before-tool; then
+  deny "VIBEGUARD Gemini adapter could not encode the policy result; the tool call was denied."
+fi

--- a/scripts/release/payload-manifest.txt
+++ b/scripts/release/payload-manifest.txt
@@ -64,6 +64,7 @@ scripts/setup/setup-lock.sh
 scripts/setup/workflow-skills.sh
 scripts/setup/targets/claude-home.sh
 scripts/setup/targets/codex-home.sh
+scripts/setup/targets/gemini-home.sh
 scripts/systemd/vibeguard-gc.service
 scripts/systemd/vibeguard-gc.timer
 scripts/release/payload-manifest.txt

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -37,6 +37,8 @@ source "${SCRIPT_DIR}/../lib/status_report.sh"
 source "${SCRIPT_DIR}/targets/claude-home.sh"
 # shellcheck source=targets/codex-home.sh
 source "${SCRIPT_DIR}/targets/codex-home.sh"
+# shellcheck source=targets/gemini-home.sh
+source "${SCRIPT_DIR}/targets/gemini-home.sh"
 # shellcheck source=runtime_config_health.sh
 source "${SCRIPT_DIR}/runtime_config_health.sh"
 
@@ -48,6 +50,7 @@ WITH_SUMMARY=1
 INSTALL=0
 PROJECT=0
 DEV_REPO=0
+VIBEGUARD_SETUP_GEMINI="${VIBEGUARD_SETUP_GEMINI:-0}"
 PROFILE="${VIBEGUARD_SETUP_PROFILE:-}"
 LANGUAGES="${VIBEGUARD_SETUP_LANGUAGES:-}"
 while [[ $# -gt 0 ]]; do
@@ -58,6 +61,12 @@ while [[ $# -gt 0 ]]; do
     --install)      INSTALL=1; shift ;;
     --project)      PROJECT=1; shift ;;
     --dev-repo)     DEV_REPO=1; shift ;;
+    --host)
+      [[ $# -lt 2 ]] && { red "ERROR: --host requires a value (gemini)"; exit 64; }
+      [[ "$2" == "gemini" ]] || { red "ERROR: unsupported host: $2 (expected gemini)"; exit 64; }
+      VIBEGUARD_SETUP_GEMINI=1; shift 2 ;;
+    --host=gemini) VIBEGUARD_SETUP_GEMINI=1; shift ;;
+    --host=*) red "ERROR: unsupported host: ${1#*=} (expected gemini)"; exit 64 ;;
     --no-summary)   WITH_SUMMARY=0; shift ;;
     --profile)
       [[ $# -lt 2 ]] && { red "ERROR: --profile requires a value (minimal|core|full|strict)"; exit 64; }
@@ -66,7 +75,7 @@ while [[ $# -gt 0 ]]; do
       PROFILE="${1#*=}"; shift ;;
     --help|-h)
       cat <<'USAGE'
-Usage: setup.sh --check [--quiet | --json | --strict | --install | --project | --no-summary] [--profile minimal|core|full|strict]
+Usage: setup.sh --check [--quiet | --json | --strict | --install | --project | --no-summary] [--host gemini] [--profile minimal|core|full|strict]
 
 Top-level commands:
   setup.sh doctor             Human-friendly report; exits 0 unless the checker cannot run.
@@ -85,6 +94,7 @@ Top-level commands:
                  state, but allow WARN/INFO rows for optional integrations.
   --project      Include current Git project's pre-commit/pre-push hook checks.
                  Used by setup.sh verify-project.
+  --host gemini  Verify the opt-in Gemini CLI BeforeTool adapter.
   --json         Emit a single-line JSON document (counts + events + verdict)
                  to stdout. Disables human-readable output. Implies --strict.
   --no-summary   Legacy mode: no rollup table, always exit 0.
@@ -642,6 +652,7 @@ run_legacy_checks() {
   if ! check_codex_home_installation; then
     red "[FAIL] Codex home installation check failed (invalid disabled_skills or manifest/runtime error)"
   fi
+  check_gemini_home_installation
 
   echo
   echo "Repository Git Hooks"
@@ -728,7 +739,11 @@ run_legacy_checks() {
       [[ "${line}" =~ ^(MISSING|DRIFT): ]] || continue
       _drift_path="${line#*: }"
       _drift_path="${_drift_path%% (*}"
-      if [[ "${line}" == DRIFT:* ]] && _semantic_msg="$(codex_semantic_drift_message "${_drift_path}" 2>/dev/null)"; then
+      if [[ "${line}" == DRIFT:* ]] \
+        && _semantic_msg="$(
+          codex_semantic_drift_message "${_drift_path}" 2>/dev/null \
+            || gemini_semantic_drift_message "${_drift_path}" 2>/dev/null
+        )"; then
         yellow "  INFO: ${_semantic_msg}"
         _semantic_drift=1
       else
@@ -739,7 +754,7 @@ run_legacy_checks() {
     if [[ "${_hard_drift}" -eq 1 ]]; then
       yellow "[WARN] Run 'bash setup.sh' to repair drifted files"
     elif [[ "${_semantic_drift}" -eq 1 ]]; then
-      yellow "[INFO] Install-state checksum drift is semantic-only for shared Codex files"
+      yellow "[INFO] Install-state checksum drift is semantic-only for shared host files"
     fi
   fi
 

--- a/scripts/setup/clean.sh
+++ b/scripts/setup/clean.sh
@@ -6,6 +6,7 @@ source "${SCRIPT_DIR}/lib.sh"
 source "${SCRIPT_DIR}/../lib/install-state.sh"
 source "${SCRIPT_DIR}/targets/claude-home.sh"
 source "${SCRIPT_DIR}/targets/codex-home.sh"
+source "${SCRIPT_DIR}/targets/gemini-home.sh"
 
 PURGE_DATA=0
 while [[ $# -gt 0 ]]; do
@@ -120,6 +121,8 @@ clean_vibeguard_home() {
     "${vibeguard_home}/execution-mode" \
     "${vibeguard_home}/run-hook.sh" \
     "${vibeguard_home}/run-hook-codex.sh" \
+    "${vibeguard_home}/run-hook-gemini.sh" \
+    "${vibeguard_home}/gemini-enabled" \
     "${vibeguard_home}/pre-commit" \
     "${vibeguard_home}/pre-push"
   rm -rf "${vibeguard_home}/installed" "${vibeguard_home}/_lib"
@@ -427,6 +430,7 @@ clean_repo_git_hooks
 clean_tracked_project_git_hooks
 clean_claude_home_installation
 clean_codex_home_installation
+clean_gemini_home_installation
 clean_vibeguard_home
 clean_scheduled_gc
 

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -2,20 +2,11 @@
 set -euo pipefail
 # VibeGuard Setup Script
 # One-click deployment of anti-hallucination specifications to ~/.claude/ and ~/.codex/
-#
-# How to use:
 # bash setup.sh # Install (default core)
 # bash setup.sh --profile full # Install full (including Stop signal/Build Check)
 # bash setup.sh --profile minimal # Minimal installation (pre-hooks only)
 # bash setup.sh --profile strict # Strict mode (full hooks + Claude Code U-32 SessionStart constraint budget)
-# bash setup.sh --languages rust,python # Only install rules and guards for the specified language
-# bash setup.sh --profile full --languages rust # Use in combination
-# bash setup.sh --dry-run # Show high-context diffs without writing
-# bash setup.sh --yes # Apply high-context diffs non-interactively
 # bash setup.sh --build-from-source # Build vibeguard-runtime with cargo instead of downloading a release binary
-# bash setup.sh --runtime-version v1.2.3 # Download a specific vibeguard-runtime release tag
-# bash setup.sh --require-provenance # Require GitHub artifact attestation verification for release binaries
-# bash setup.sh --with-scheduler # Opt in to launchd/systemd scheduled GC
 # bash setup.sh --host gemini # Opt in to Gemini CLI BeforeTool hooks
 # bash setup.sh --repair-stale-unmanaged-hooks # Opt in to prune missing-target Codex PreToolUse/PermissionRequest hooks
 # bash setup.sh --force-overwrite # Replace user-customized managed files/commands

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 # bash setup.sh --runtime-version v1.2.3 # Download a specific vibeguard-runtime release tag
 # bash setup.sh --require-provenance # Require GitHub artifact attestation verification for release binaries
 # bash setup.sh --with-scheduler # Opt in to launchd/systemd scheduled GC
+# bash setup.sh --host gemini # Opt in to Gemini CLI BeforeTool hooks
 # bash setup.sh --repair-stale-unmanaged-hooks # Opt in to prune missing-target Codex PreToolUse/PermissionRequest hooks
 # bash setup.sh --force-overwrite # Replace user-customized managed files/commands
 # bash setup.sh --dev-linked # Opt in to live-repo execution for local development
@@ -28,6 +29,7 @@ source "${SCRIPT_DIR}/../lib/install-state.sh"
 source "${SCRIPT_DIR}/../lib/project_config.sh"
 source "${SCRIPT_DIR}/targets/claude-home.sh"
 source "${SCRIPT_DIR}/targets/codex-home.sh"
+source "${SCRIPT_DIR}/targets/gemini-home.sh"
 source "${SCRIPT_DIR}/runtime-install.sh"
 # --- Mode dispatch ---
 case "${1:-}" in
@@ -46,6 +48,7 @@ REPAIR_STALE_UNMANAGED_HOOKS="${VIBEGUARD_SETUP_REPAIR_STALE_UNMANAGED_HOOKS:-0}
 BUILD_FROM_SOURCE="${VIBEGUARD_SETUP_BUILD_FROM_SOURCE:-0}"
 REQUIRE_PROVENANCE="${VIBEGUARD_SETUP_REQUIRE_PROVENANCE:-0}"
 DEV_LINKED="${VIBEGUARD_SETUP_DEV_LINKED:-0}"
+VIBEGUARD_SETUP_GEMINI="${VIBEGUARD_SETUP_GEMINI:-0}"
 VIBEGUARD_HOME="${HOME}/.vibeguard"
 _INSTALL_TMP=""
 _INSTALL_FINAL_TMP=""
@@ -84,6 +87,14 @@ while [[ $# -gt 0 ]]; do
       VIBEGUARD_SETUP_FORCE_OVERWRITE=1; shift ;;
     --dev-linked)
       DEV_LINKED=1; shift ;;
+    --host)
+      [[ $# -lt 2 ]] && { red "ERROR: --host requires a value (gemini)"; exit 1; }
+      [[ "$2" == "gemini" ]] || { red "ERROR: unsupported host: $2 (expected gemini)"; exit 1; }
+      VIBEGUARD_SETUP_GEMINI=1; shift 2 ;;
+    --host=gemini)
+      VIBEGUARD_SETUP_GEMINI=1; shift ;;
+    --host=*)
+      red "ERROR: unsupported host: ${1#*=} (expected gemini)"; exit 1 ;;
     --profile)
       [[ $# -lt 2 ]] && { red "ERROR: --profile requires a value (minimal|core|full|strict)"; exit 1; }
       PROFILE="$2"; shift 2 ;;
@@ -96,11 +107,11 @@ while [[ $# -gt 0 ]]; do
       LANGUAGES="${1#*=}"; shift ;;
     *)
       red "ERROR: unknown argument: $1"
-      red "Usage: bash setup.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--require-provenance] [--with-scheduler] [--repair-stale-unmanaged-hooks] [--force-overwrite] [--dev-linked] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean [--purge-data]"
+      red "Usage: bash setup.sh [--yes] [--dry-run] [--build-from-source] [--runtime-version vX.Y.Z] [--require-provenance] [--with-scheduler] [--host gemini] [--repair-stale-unmanaged-hooks] [--force-overwrite] [--dev-linked] [--profile minimal|core|full|strict] [--languages lang1,lang2] | --check | --clean [--purge-data]"
       exit 1 ;;
   esac
 done
-export VIBEGUARD_SETUP_DRY_RUN VIBEGUARD_SETUP_AUTO VIBEGUARD_SETUP_FORCE_OVERWRITE
+export VIBEGUARD_SETUP_DRY_RUN VIBEGUARD_SETUP_AUTO VIBEGUARD_SETUP_FORCE_OVERWRITE VIBEGUARD_SETUP_GEMINI
 export VIBEGUARD_SETUP_REPAIR_STALE_UNMANAGED_HOOKS="${REPAIR_STALE_UNMANAGED_HOOKS}"
 export VIBEGUARD_SETUP_REQUIRE_PROVENANCE="${REQUIRE_PROVENANCE}"
 export VIBEGUARD_SETUP_DEV_LINKED="${DEV_LINKED}"
@@ -467,6 +478,9 @@ if [[ "${DEV_LINKED}" == "1" ]]; then
 else
   echo "Mode: installed snapshot (execution uses ~/.vibeguard/installed)"
 fi
+if [[ "${VIBEGUARD_SETUP_GEMINI}" == "1" ]]; then
+  echo "Host adapter: Gemini CLI (explicit opt-in)"
+fi
 echo "=============================="
 echo
 project_config_file="$(vg_project_config_file)"
@@ -477,6 +491,7 @@ fi
 if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
   stage_install_snapshot
   configure_claude_home_runtime
+  configure_gemini_home_runtime
   inject_claude_home_rules
   inject_codex_home_rules
   yellow "Dry run complete. No files were written by setup.sh --dry-run."
@@ -579,6 +594,8 @@ echo
 install_claude_home_assets
 
 install_codex_home_assets
+
+configure_gemini_home_runtime
 
 configure_claude_home_runtime
 

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -93,6 +93,9 @@ setup_runtime_supports() {
     setup-codex-hooks-check-stale \
     setup-codex-hooks-prune-stale-unmanaged \
     setup-codex-hooks-check-timeouts \
+    setup-gemini-hooks-upsert \
+    setup-gemini-hooks-check \
+    setup-gemini-hooks-remove \
     setup-state-init \
     setup-state-list-tracked-under \
     setup-state-verify-managed-tree \

--- a/scripts/setup/targets/gemini-home.sh
+++ b/scripts/setup/targets/gemini-home.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+GEMINI_DIR="${GEMINI_CLI_HOME:-${HOME}}/.gemini"
+GEMINI_SETTINGS_FILE="${GEMINI_DIR}/settings.json"
+GEMINI_WRAPPER="${HOME}/.vibeguard/run-hook-gemini.sh"
+GEMINI_ENABLED_MARKER="${HOME}/.vibeguard/gemini-enabled"
+
+gemini_install_expected() {
+  [[ "${VIBEGUARD_SETUP_GEMINI:-0}" == "1" || -f "${GEMINI_ENABLED_MARKER}" ]]
+}
+
+configure_gemini_home_runtime() {
+  gemini_install_expected || return 0
+  echo "Step 6.7: Configure Gemini CLI hooks"
+
+  local settings_diff result
+  if ! settings_diff="$(
+    setup_runtime setup-gemini-hooks-upsert \
+      "${GEMINI_SETTINGS_FILE}" "${GEMINI_WRAPPER}" --dry-run 2>&1
+  )"; then
+    red "  Failed to compute ~/.gemini/settings.json diff"
+    return 1
+  fi
+  if ! confirm_high_context_write "~/.gemini/settings.json" "${settings_diff}"; then
+    if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
+      echo
+      return 0
+    fi
+    return 1
+  fi
+
+  mkdir -p "${GEMINI_DIR}" "${HOME}/.vibeguard"
+  cp "${REPO_DIR}/hooks/run-hook-gemini.sh" "${GEMINI_WRAPPER}"
+  chmod +x "${GEMINI_WRAPPER}"
+  if ! result="$(
+    setup_runtime setup-gemini-hooks-upsert \
+      "${GEMINI_SETTINGS_FILE}" "${GEMINI_WRAPPER}" 2>&1
+  )"; then
+    red "  Failed to update ~/.gemini/settings.json"
+    return 1
+  fi
+  printf 'gemini-cli-hooks-v1\n' > "${GEMINI_ENABLED_MARKER}"
+  state_record_file "${GEMINI_WRAPPER}" "hooks/run-hook-gemini.sh" "copy"
+  state_record_file "${GEMINI_SETTINGS_FILE}" "generated/gemini-settings.json" "copy"
+  state_record_file "${GEMINI_ENABLED_MARKER}" "generated/gemini-enabled" "copy"
+  green "  Gemini CLI adapter configured (${result})"
+  echo
+}
+
+check_gemini_home_installation() {
+  if ! gemini_install_expected; then
+    yellow "[INFO] Gemini CLI adapter not enabled (opt in: bash setup.sh --yes --host gemini)"
+    return 0
+  fi
+  if [[ ! -x "${GEMINI_WRAPPER}" ]]; then
+    red "[BROKEN] Gemini CLI adapter wrapper missing: ${GEMINI_WRAPPER}"
+    return 0
+  fi
+  if setup_runtime setup-gemini-hooks-check \
+    "${GEMINI_SETTINGS_FILE}" "${GEMINI_WRAPPER}" >/dev/null 2>&1; then
+    if ! command -v gemini >/dev/null 2>&1; then
+      yellow "[WARN] Gemini CLI adapter configured, but the gemini executable is not available"
+    elif ! gemini hooks --help >/dev/null 2>&1; then
+      red "[BROKEN] Gemini CLI does not expose hook support; upgrade Gemini CLI"
+    else
+      green "[OK] Gemini CLI BeforeTool adapter active"
+    fi
+  else
+    red "[BROKEN] Gemini CLI adapter is not canonical in ~/.gemini/settings.json"
+  fi
+}
+
+gemini_semantic_drift_message() {
+  local path="$1"
+  [[ "${path}" == "${GEMINI_SETTINGS_FILE}" ]] || return 1
+  if [[ -f "${GEMINI_SETTINGS_FILE}" ]] \
+    && setup_runtime setup-gemini-hooks-check \
+      "${GEMINI_SETTINGS_FILE}" "${GEMINI_WRAPPER}" >/dev/null 2>&1; then
+    printf '%s\n' "${path} (checksum drift; VibeGuard Gemini hook semantics OK)"
+    return 0
+  fi
+  return 1
+}
+
+clean_gemini_home_installation() {
+  local result
+  if [[ ! -f "${GEMINI_ENABLED_MARKER}" && ! -e "${GEMINI_WRAPPER}" ]]; then
+    return 0
+  fi
+  if ! result="$(
+    setup_runtime setup-gemini-hooks-remove "${GEMINI_SETTINGS_FILE}" 2>&1
+  )"; then
+    red "Failed to clean VibeGuard entries in ~/.gemini/settings.json"
+    return 1
+  fi
+  case "${result}" in
+    CHANGED) yellow "Removed VibeGuard hook entry from ~/.gemini/settings.json" ;;
+    SKIP) yellow "No VibeGuard hook entry found in ~/.gemini/settings.json" ;;
+    *) red "Unexpected Gemini clean result: ${result}"; return 1 ;;
+  esac
+  rm -f "${GEMINI_WRAPPER}" "${GEMINI_ENABLED_MARKER}"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -47,6 +47,7 @@ Install options:
   --with-scheduler
   --repair-stale-unmanaged-hooks
   --force-overwrite
+  --host gemini
   --profile minimal|core|full|strict
   --languages lang1,lang2
 
@@ -68,6 +69,7 @@ Examples:
   bash setup.sh verify-project --json
   bash setup.sh --check --profile strict
   bash setup.sh --profile strict --languages rust,python
+  bash setup.sh --yes --host gemini
 
 Migration:
   bash setup.sh --check --strict   -> bash setup.sh verify-project

--- a/tests/setup/gemini_host_tests.sh
+++ b/tests/setup/gemini_host_tests.sh
@@ -1,0 +1,124 @@
+header "Gemini CLI host adapter"
+
+gemini_runtime="${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime"
+gemini_home="${TMP_HOME}/gemini-host-home"
+gemini_dry_home="${TMP_HOME}/gemini-host-dry-home"
+gemini_unmanaged_home="${TMP_HOME}/gemini-host-unmanaged-home"
+gemini_bin_dir="${TMP_HOME}/gemini-host-bin"
+mkdir -p "${gemini_home}/.gemini" "${gemini_dry_home}" "${gemini_bin_dir}"
+printf '%s\n' '#!/usr/bin/env bash' '[[ "$1" == "hooks" && "$2" == "--help" ]]' \
+  > "${gemini_bin_dir}/gemini"
+chmod +x "${gemini_bin_dir}/gemini"
+printf '%s\n' '{"theme":"custom","hooks":{"BeforeTool":[{"matcher":"read_file","hooks":[{"name":"custom","type":"command","command":"custom-hook"}]}]}}' \
+  > "${gemini_home}/.gemini/settings.json"
+
+gemini_target_script='set -euo pipefail
+source "$1/scripts/setup/lib.sh"
+source "$1/scripts/lib/install-state.sh"
+source "$1/scripts/setup/targets/gemini-home.sh"
+state_record_file() { :; }
+configure_gemini_home_runtime'
+
+gemini_install_out="$(
+  HOME="${gemini_home}" \
+  PATH="${gemini_bin_dir}:${PATH}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  VIBEGUARD_SETUP_GEMINI=1 \
+  VIBEGUARD_SETUP_AUTO=1 \
+  bash -c "${gemini_target_script}" _ "${REPO_DIR}" 2>&1
+)"
+assert_contains "${gemini_install_out}" "Gemini CLI adapter configured (CHANGED)" "Gemini target installs the adapter"
+assert_cmd "Gemini wrapper is executable" test -x "${gemini_home}/.vibeguard/run-hook-gemini.sh"
+assert_cmd "Gemini ownership marker is written" test -f "${gemini_home}/.vibeguard/gemini-enabled"
+assert_cmd "Gemini settings preserve custom hooks and add one managed hook" python3 - \
+  "${gemini_home}/.gemini/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+entries = data["hooks"]["BeforeTool"]
+hooks = [hook for entry in entries for hook in entry.get("hooks", [])]
+names = [hook.get("name") for hook in hooks]
+assert data["theme"] == "custom"
+assert names.count("custom") == 1
+assert names.count("vibeguard-before-tool") == 1
+PY
+
+gemini_reinstall_out="$(
+  HOME="${gemini_home}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  VIBEGUARD_SETUP_GEMINI=1 \
+  VIBEGUARD_SETUP_AUTO=1 \
+  bash -c "${gemini_target_script}" _ "${REPO_DIR}" 2>&1
+)"
+assert_contains "${gemini_reinstall_out}" "Gemini CLI adapter configured (SKIP)" "Gemini target reinstall is idempotent"
+
+gemini_check_out="$(
+  HOME="${gemini_home}" \
+  PATH="${gemini_bin_dir}:${PATH}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  bash -c 'source "$1/scripts/setup/lib.sh"; source "$1/scripts/setup/targets/gemini-home.sh"; check_gemini_home_installation' \
+    _ "${REPO_DIR}" 2>&1
+)"
+assert_contains "${gemini_check_out}" "[OK] Gemini CLI BeforeTool adapter active" "Gemini target health check proves active configuration"
+
+gemini_dry_out="$(
+  HOME="${gemini_dry_home}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  VIBEGUARD_SETUP_GEMINI=1 \
+  VIBEGUARD_SETUP_DRY_RUN=1 \
+  bash -c "${gemini_target_script}" _ "${REPO_DIR}" 2>&1
+)"
+assert_contains "${gemini_dry_out}" '"matcher": "^(run_shell_command|write_file|replace)$"' "Gemini dry-run shows the exact matcher diff"
+assert_cmd "Gemini dry-run does not write settings" test ! -e "${gemini_dry_home}/.gemini/settings.json"
+
+gemini_cli_home_out="$(
+  HOME="${gemini_home}" \
+  GEMINI_CLI_HOME="${gemini_dry_home}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  VIBEGUARD_SETUP_GEMINI=1 \
+  VIBEGUARD_SETUP_AUTO=1 \
+  bash -c "${gemini_target_script}" _ "${REPO_DIR}" 2>&1
+)"
+assert_contains "${gemini_cli_home_out}" "Gemini CLI adapter configured (CHANGED)" "Gemini target honors GEMINI_CLI_HOME root semantics"
+assert_cmd "GEMINI_CLI_HOME stores settings beneath its .gemini directory" \
+  test -f "${gemini_dry_home}/.gemini/settings.json"
+
+gemini_clean_out="$(
+  HOME="${gemini_home}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  bash -c 'source "$1/scripts/setup/lib.sh"; source "$1/scripts/setup/targets/gemini-home.sh"; clean_gemini_home_installation' \
+    _ "${REPO_DIR}" 2>&1
+)"
+assert_contains "${gemini_clean_out}" "Removed VibeGuard hook entry" "Gemini clean removes the managed entry"
+assert_cmd "Gemini clean preserves custom settings and removes only VibeGuard" python3 - \
+  "${gemini_home}/.gemini/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+text = json.dumps(data)
+assert data["theme"] == "custom"
+assert "custom-hook" in text
+assert "vibeguard-before-tool" not in text
+PY
+assert_cmd "Gemini clean removes wrapper" test ! -e "${gemini_home}/.vibeguard/run-hook-gemini.sh"
+
+mkdir -p "${gemini_unmanaged_home}/.gemini"
+printf '%s\n' 'not-json' > "${gemini_unmanaged_home}/.gemini/settings.json"
+assert_cmd "Gemini clean ignores unmanaged settings without ownership evidence" env \
+  HOME="${gemini_unmanaged_home}" \
+  VIBEGUARD_REPO_DIR="${REPO_DIR}" \
+  VIBEGUARD_SETUP_RUNTIME="${gemini_runtime}" \
+  bash -c 'source "$1/scripts/setup/lib.sh"; source "$1/scripts/setup/targets/gemini-home.sh"; clean_gemini_home_installation' \
+    _ "${REPO_DIR}"
+assert_cmd "Gemini clean preserves unmanaged malformed settings byte-for-byte" \
+  grep -qFx 'not-json' "${gemini_unmanaged_home}/.gemini/settings.json"

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -814,6 +814,7 @@ case "${SETUP_SHARD}" in
       "${REPO_DIR}/tests/setup/bootstrap_tests.sh"
       "${REPO_DIR}/tests/setup/runtime_install_tests.sh"
       "${REPO_DIR}/tests/setup/install_flow_tests.sh"
+      "${REPO_DIR}/tests/setup/gemini_host_tests.sh"
       "${REPO_DIR}/tests/setup/protection_clean_tests.sh"
       "${REPO_DIR}/tests/setup/profile_flow_tests.sh"
     )
@@ -826,7 +827,10 @@ case "${SETUP_SHARD}" in
     )
     ;;
   install)
-    setup_tests=("${REPO_DIR}/tests/setup/install_flow_tests.sh")
+    setup_tests=(
+      "${REPO_DIR}/tests/setup/install_flow_tests.sh"
+      "${REPO_DIR}/tests/setup/gemini_host_tests.sh"
+    )
     ;;
   protection)
     seed_installed_setup_fixture

--- a/vibeguard-runtime/src/gemini_hooks.rs
+++ b/vibeguard-runtime/src/gemini_hooks.rs
@@ -1,0 +1,131 @@
+use crate::codex_hooks::ensure_no_args;
+use crate::hook_checks_common::read_stdin;
+use serde_json::{Value, json};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+const INVALID_OUTPUT_REASON: &str =
+    "VIBEGUARD Gemini adapter failed to parse the guard result; the tool call was denied.";
+
+pub(crate) fn route_before_tool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime gemini-route-before-tool")?;
+    let input = read_stdin()?;
+    let payload: Value = serde_json::from_str(&input)?;
+    let object = payload
+        .as_object()
+        .ok_or("Gemini BeforeTool payload must be a JSON object")?;
+    if object.get("hook_event_name").and_then(Value::as_str) != Some("BeforeTool") {
+        return Err("Gemini adapter only accepts BeforeTool events".into());
+    }
+    if !object.get("tool_input").is_some_and(Value::is_object) {
+        return Err("Gemini BeforeTool payload requires an object tool_input".into());
+    }
+    let route = match object.get("tool_name").and_then(Value::as_str) {
+        Some("run_shell_command") => "pre-bash-guard.sh",
+        Some("write_file") => "pre-write-guard.sh",
+        Some("replace") => "pre-edit-guard.sh",
+        Some(_) => return Err("Gemini BeforeTool tool is not supported by VibeGuard".into()),
+        None => return Err("Gemini BeforeTool payload requires a string tool_name".into()),
+    };
+    println!("{route}");
+    Ok(())
+}
+
+pub(crate) fn adapt_before_tool(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime gemini-adapt-before-tool")?;
+    let input = read_stdin()?;
+    let output = adapt_guard_output(&input);
+    println!("{}", serde_json::to_string(&output)?);
+    Ok(())
+}
+
+pub(crate) fn deny(args: &[String]) -> Result {
+    ensure_no_args(args, "Usage: vibeguard-runtime gemini-deny")?;
+    let reason = read_stdin()?;
+    let reason = if reason.trim().is_empty() {
+        INVALID_OUTPUT_REASON
+    } else {
+        reason.trim()
+    };
+    print_deny(reason)?;
+    Ok(())
+}
+
+fn adapt_guard_output(input: &str) -> Value {
+    if input.trim().is_empty() {
+        return json!({});
+    }
+    let Ok(Value::Object(object)) = serde_json::from_str::<Value>(input) else {
+        return deny_payload(INVALID_OUTPUT_REASON);
+    };
+    if let Some(updated_input) = object.get("updatedInput").filter(|value| value.is_object()) {
+        return json!({
+            "decision": "allow",
+            "hookSpecificOutput": { "tool_input": updated_input }
+        });
+    }
+    if let Some(context) = object
+        .get("hookSpecificOutput")
+        .and_then(|value| value.get("additionalContext"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        return json!({ "systemMessage": context });
+    }
+    let reason = object
+        .get("reason")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(INVALID_OUTPUT_REASON);
+    match object.get("decision").and_then(Value::as_str) {
+        Some("block" | "deny" | "gate" | "escalate") => deny_payload(reason),
+        Some("warn" | "correction") => json!({ "systemMessage": reason }),
+        Some("allow" | "pass" | "complete") => json!({}),
+        _ => deny_payload(INVALID_OUTPUT_REASON),
+    }
+}
+
+fn deny_payload(reason: &str) -> Value {
+    json!({ "decision": "deny", "reason": reason })
+}
+
+fn print_deny(reason: &str) -> Result {
+    println!("{}", serde_json::to_string(&deny_payload(reason))?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_output_maps_to_gemini_before_tool_contract() {
+        assert_eq!(adapt_guard_output(""), json!({}));
+        assert_eq!(
+            adapt_guard_output(r#"{"decision":"block","reason":"unsafe"}"#),
+            json!({"decision":"deny","reason":"unsafe"})
+        );
+        assert_eq!(
+            adapt_guard_output(r#"{"decision":"warn","reason":"review"}"#),
+            json!({"systemMessage":"review"})
+        );
+        assert_eq!(adapt_guard_output(r#"{"decision":"pass"}"#), json!({}));
+        assert_eq!(
+            adapt_guard_output("not-json"),
+            deny_payload(INVALID_OUTPUT_REASON)
+        );
+        assert_eq!(
+            adapt_guard_output(
+                r#"{"decision":"allow","updatedInput":{"command":"pnpm add serde"}}"#
+            ),
+            json!({
+                "decision": "allow",
+                "hookSpecificOutput": {"tool_input": {"command": "pnpm add serde"}}
+            })
+        );
+        assert_eq!(
+            adapt_guard_output(r#"{"hookSpecificOutput":{"additionalContext":"search first"}}"#),
+            json!({"systemMessage":"search first"})
+        );
+    }
+}

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -12,6 +12,7 @@ mod codex_hooks;
 mod codex_hooks_adapter;
 mod codex_hooks_diag;
 mod event_schema;
+mod gemini_hooks;
 mod git_root;
 mod hook_checks;
 mod hook_checks_bash;
@@ -48,6 +49,7 @@ mod session_metrics;
 mod setup_codex_config;
 mod setup_codex_hooks;
 mod setup_codex_hooks_health;
+mod setup_gemini_hooks;
 mod setup_install_state;
 mod setup_lock_lifecycle;
 mod setup_managed_tree_remove;
@@ -86,6 +88,21 @@ static COMMANDS: &[Command] = &[
         name: "json-field",
         usage: "<field_path>  — extract one field from stdin JSON",
         handler: json_field::run_field,
+    },
+    Command {
+        name: "gemini-route-before-tool",
+        usage: "  — validate and route a Gemini CLI BeforeTool payload",
+        handler: gemini_hooks::route_before_tool,
+    },
+    Command {
+        name: "gemini-adapt-before-tool",
+        usage: "  — adapt a canonical guard decision to Gemini CLI BeforeTool output",
+        handler: gemini_hooks::adapt_before_tool,
+    },
+    Command {
+        name: "gemini-deny",
+        usage: "  — emit a Gemini CLI BeforeTool deny response from stdin reason",
+        handler: gemini_hooks::deny,
     },
     Command {
         name: "json-bool-field",
@@ -586,6 +603,21 @@ static COMMANDS: &[Command] = &[
         name: "setup-codex-hooks-check-timeouts",
         usage: "<repo-dir> <hooks-file>  — detect Codex hooks without timeout",
         handler: setup_codex_hooks::codex_hooks_check_timeouts,
+    },
+    Command {
+        name: "setup-gemini-hooks-upsert",
+        usage: "<settings-file> <wrapper> [--dry-run]  — upsert the Gemini CLI adapter",
+        handler: setup_gemini_hooks::upsert,
+    },
+    Command {
+        name: "setup-gemini-hooks-remove",
+        usage: "<settings-file>  — remove the VibeGuard Gemini CLI adapter",
+        handler: setup_gemini_hooks::remove,
+    },
+    Command {
+        name: "setup-gemini-hooks-check",
+        usage: "<settings-file> <wrapper>  — check the Gemini CLI adapter",
+        handler: setup_gemini_hooks::check,
     },
 ];
 

--- a/vibeguard-runtime/src/setup_gemini_hooks.rs
+++ b/vibeguard-runtime/src/setup_gemini_hooks.rs
@@ -1,0 +1,206 @@
+use crate::setup_support::{
+    SetupResult, read_json_object, shell_quote, simple_unified_diff, write_json_atomic_private,
+};
+use serde_json::{Value, json};
+use std::path::Path;
+
+const EVENT: &str = "BeforeTool";
+const MANAGED_NAME: &str = "vibeguard-before-tool";
+const MATCHER: &str = "^(run_shell_command|write_file|replace)$";
+const TIMEOUT_MS: u64 = 20_000;
+
+pub(crate) fn upsert(args: &[String]) -> SetupResult<()> {
+    if !(args.len() == 2 || (args.len() == 3 && args[2] == "--dry-run")) {
+        return Err(
+            "Usage: vibeguard-runtime setup-gemini-hooks-upsert <settings-file> <wrapper> [--dry-run]"
+                .into(),
+        );
+    }
+    let path = Path::new(&args[0]);
+    let wrapper = &args[1];
+    let dry_run = args.get(2).is_some_and(|arg| arg == "--dry-run");
+    let before_text = std::fs::read_to_string(path).unwrap_or_default();
+    let mut data = Value::Object(read_json_object(path, true)?);
+    remove_managed(&mut data)?;
+    before_tool_entries(&mut data)?.push(managed_entry(wrapper));
+    let after_text = serde_json::to_string_pretty(&data)? + "\n";
+    if after_text == before_text {
+        println!("SKIP");
+    } else if dry_run {
+        print!("{}", simple_unified_diff(path, &before_text, &after_text));
+        println!("CHANGED");
+    } else {
+        write_json_atomic_private(path, &data)?;
+        println!("CHANGED");
+    }
+    Ok(())
+}
+
+pub(crate) fn remove(args: &[String]) -> SetupResult<()> {
+    if args.len() != 1 {
+        return Err("Usage: vibeguard-runtime setup-gemini-hooks-remove <settings-file>".into());
+    }
+    let path = Path::new(&args[0]);
+    if !path.exists() {
+        println!("SKIP");
+        return Ok(());
+    }
+    let mut data = Value::Object(read_json_object(path, false)?);
+    let before = serde_json::to_string(&data)?;
+    remove_managed(&mut data)?;
+    if serde_json::to_string(&data)? == before {
+        println!("SKIP");
+    } else {
+        write_json_atomic_private(path, &data)?;
+        println!("CHANGED");
+    }
+    Ok(())
+}
+
+pub(crate) fn check(args: &[String]) -> SetupResult<()> {
+    if args.len() != 2 {
+        return Err(
+            "Usage: vibeguard-runtime setup-gemini-hooks-check <settings-file> <wrapper>".into(),
+        );
+    }
+    let data = Value::Object(read_json_object(Path::new(&args[0]), false)?);
+    let enabled = match data.pointer("/hooksConfig/enabled") {
+        None | Some(Value::Bool(true)) => true,
+        Some(Value::Bool(false)) | Some(_) => false,
+    };
+    let disabled_names_valid = match data.pointer("/hooksConfig/disabled") {
+        None => true,
+        Some(Value::Array(names)) => {
+            names.iter().all(Value::is_string)
+                && !names.iter().any(|name| name.as_str() == Some(MANAGED_NAME))
+        }
+        Some(_) => false,
+    };
+    if !enabled || !disabled_names_valid {
+        std::process::exit(1);
+    }
+    let expected = managed_entry(&args[1]);
+    let count = data
+        .pointer("/hooks/BeforeTool")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|entry| contains_managed_hook(entry))
+        .count();
+    if count != 1
+        || !data
+            .pointer("/hooks/BeforeTool")
+            .and_then(Value::as_array)
+            .is_some_and(|entries| entries.contains(&expected))
+    {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn before_tool_entries(data: &mut Value) -> SetupResult<&mut Vec<Value>> {
+    let root = data
+        .as_object_mut()
+        .ok_or("Gemini settings root must be an object")?;
+    let hooks = root
+        .entry("hooks")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or("Gemini settings hooks must be an object")?;
+    hooks
+        .entry(EVENT)
+        .or_insert_with(|| json!([]))
+        .as_array_mut()
+        .ok_or_else(|| "Gemini settings hooks.BeforeTool must be an array".into())
+}
+
+fn managed_entry(wrapper: &str) -> Value {
+    json!({
+        "matcher": MATCHER,
+        "sequential": true,
+        "hooks": [{
+            "name": MANAGED_NAME,
+            "type": "command",
+            "command": format!(
+                "/usr/bin/env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin /bin/bash {}",
+                shell_quote(wrapper)
+            ),
+            "timeout": TIMEOUT_MS,
+            "description": "VibeGuard policy checks for Gemini CLI tool calls"
+        }]
+    })
+}
+
+fn contains_managed_hook(entry: &Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hooks| hooks.iter().any(is_managed_hook))
+}
+
+fn is_managed_hook(hook: &Value) -> bool {
+    hook.get("name").and_then(Value::as_str) == Some(MANAGED_NAME)
+}
+
+fn remove_managed(data: &mut Value) -> SetupResult<()> {
+    let Some(root) = data.as_object_mut() else {
+        return Err("Gemini settings root must be an object".into());
+    };
+    let Some(hooks_value) = root.get_mut("hooks") else {
+        return Ok(());
+    };
+    let hooks = hooks_value
+        .as_object_mut()
+        .ok_or("Gemini settings hooks must be an object")?;
+    let Some(entries_value) = hooks.get_mut(EVENT) else {
+        return Ok(());
+    };
+    let entries = entries_value
+        .as_array_mut()
+        .ok_or("Gemini settings hooks.BeforeTool must be an array")?;
+    let mut retained = Vec::new();
+    for entry in std::mem::take(entries) {
+        retained.extend(remove_managed_from_entry(entry));
+    }
+    *entries = retained;
+    if entries.is_empty() {
+        hooks.remove(EVENT);
+    }
+    if hooks.is_empty() {
+        root.remove("hooks");
+    }
+    Ok(())
+}
+
+fn remove_managed_from_entry(mut entry: Value) -> Option<Value> {
+    let Some(object) = entry.as_object_mut() else {
+        return Some(entry);
+    };
+    let Some(hooks) = object.get_mut("hooks").and_then(Value::as_array_mut) else {
+        return Some(entry);
+    };
+    hooks.retain(|hook| !is_managed_hook(hook));
+    (!hooks.is_empty()).then_some(entry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removal_preserves_unrelated_hooks_in_the_same_group() {
+        let mut data = json!({"hooks": {"BeforeTool": [{
+            "matcher": ".*",
+            "hooks": [
+                {"name": MANAGED_NAME, "type": "command", "command": "old"},
+                {"name": "custom", "type": "command", "command": "custom"}
+            ]
+        }]}});
+        remove_managed(&mut data).unwrap();
+        assert_eq!(
+            data.pointer("/hooks/BeforeTool/0/hooks/0/name")
+                .and_then(Value::as_str),
+            Some("custom")
+        );
+    }
+}

--- a/vibeguard-runtime/src/setup_support.rs
+++ b/vibeguard-runtime/src/setup_support.rs
@@ -58,6 +58,52 @@ pub fn write_json_atomic(path: &Path, value: &Value) -> SetupResult<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+pub fn write_json_atomic_private(path: &Path, value: &Value) -> SetupResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let original_mode = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(format!("{} must be a regular file", path.display()).into());
+        }
+        Ok(metadata) => Some(metadata.permissions().mode() & 0o777),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    let text = serde_json::to_string_pretty(value)? + "\n";
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = temp_path_for(path);
+    let write_result = (|| {
+        let mut file = File::create(&tmp)?;
+        fs::set_permissions(
+            &tmp,
+            fs::Permissions::from_mode(original_mode.unwrap_or(0o600)),
+        )?;
+        file.write_all(text.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&tmp, path)?;
+        Ok::<(), io::Error>(())
+    })();
+    if let Err(error) = write_result {
+        if let Err(cleanup_error) = fs::remove_file(&tmp)
+            && cleanup_error.kind() != io::ErrorKind::NotFound
+        {
+            return Err(io::Error::new(
+                error.kind(),
+                format!("{error}; temporary-file cleanup failed: {cleanup_error}"),
+            )
+            .into());
+        }
+        return Err(error.into());
+    }
+    if let Some(parent) = path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
 pub fn sha256_file(path: &Path) -> SetupResult<String> {
     let mut file = File::open(path)?;
     let mut data = Vec::new();

--- a/vibeguard-runtime/tests/cli.rs
+++ b/vibeguard-runtime/tests/cli.rs
@@ -49,6 +49,9 @@ fn help_lists_all_commands() {
         "json-field",
         "json-bool-field",
         "json-two-fields",
+        "gemini-route-before-tool",
+        "gemini-adapt-before-tool",
+        "gemini-deny",
         "churn-count",
         "warn-count",
         "reason-count",
@@ -96,6 +99,9 @@ fn help_lists_all_commands() {
         "post-write-fast-check",
         "post-write-check",
         "codex-app-server-wrapper",
+        "setup-gemini-hooks-upsert",
+        "setup-gemini-hooks-remove",
+        "setup-gemini-hooks-check",
     ] {
         assert!(
             stderr.contains(name),

--- a/vibeguard-runtime/tests/cli_gemini.rs
+++ b/vibeguard-runtime/tests/cli_gemini.rs
@@ -85,6 +85,9 @@ fn run_wrapper(project: &Path, home: &Path, log_root: &Path, input: &str) -> Out
         .env("HOME", home)
         .env("PATH", path)
         .env("VIBEGUARD_LOG_DIR", log_root);
+    if let Some(profile_file) = env::var_os("LLVM_PROFILE_FILE") {
+        command.env("LLVM_PROFILE_FILE", profile_file);
+    }
     run_with_stdin(&mut command, input)
 }
 
@@ -115,12 +118,21 @@ fn gemini_wrapper_blocks_dangerous_shell_and_allows_safe_shell() {
     );
     assert!(blocked.status.success(), "{:?}", blocked.status);
     let blocked_json: Value = serde_json::from_slice(&blocked.stdout).unwrap();
-    assert_eq!(blocked_json["decision"], "deny");
+    assert_eq!(
+        blocked_json["decision"],
+        "deny",
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&blocked.stdout),
+        String::from_utf8_lossy(&blocked.stderr)
+    );
     assert!(
         blocked_json["reason"]
             .as_str()
             .unwrap()
-            .contains("VIBEGUARD")
+            .contains("VIBEGUARD"),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&blocked.stdout),
+        String::from_utf8_lossy(&blocked.stderr)
     );
 
     let event = first_project_event(&log_root);
@@ -161,7 +173,13 @@ fn gemini_wrapper_preserves_advisories_corrections_and_denies_timeouts() {
         ),
     );
     let correction_json: Value = serde_json::from_slice(&correction.stdout).unwrap();
-    assert_eq!(correction_json["decision"], "allow");
+    assert_eq!(
+        correction_json["decision"],
+        "allow",
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&correction.stdout),
+        String::from_utf8_lossy(&correction.stderr)
+    );
     assert_eq!(
         correction_json["hookSpecificOutput"]["tool_input"]["command"],
         "pnpm add lodash"

--- a/vibeguard-runtime/tests/cli_gemini.rs
+++ b/vibeguard-runtime/tests/cli_gemini.rs
@@ -1,0 +1,517 @@
+mod common;
+
+use common::{bin, unique_temp_dir};
+use serde_json::{Value, json};
+use std::fs;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn run_with_stdin(command: &mut Command, input: &str) -> Output {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn gemini_payload(tool_name: &str, tool_input: Value) -> String {
+    json!({
+        "session_id": "gemini-session-test",
+        "cwd": "/repo",
+        "hook_event_name": "BeforeTool",
+        "tool_name": tool_name,
+        "tool_input": tool_input
+    })
+    .to_string()
+}
+
+fn run_wrapper(project: &Path, home: &Path, log_root: &Path, input: &str) -> Output {
+    let source_root = repo_root();
+    fs::create_dir_all(home.join(".vibeguard")).unwrap();
+    let wrapper = home.join(".vibeguard/run-hook-gemini.sh");
+    fs::copy(source_root.join("hooks/run-hook-gemini.sh"), &wrapper).unwrap();
+    fs::write(
+        home.join(".vibeguard/repo-path"),
+        source_root.to_string_lossy().as_bytes(),
+    )
+    .unwrap();
+    let runtime = bin().get_program().to_owned();
+    let mut command = Command::new("bash");
+    command
+        .arg(wrapper)
+        .args([
+            "--test-only",
+            runtime.to_str().unwrap(),
+            source_root.join("hooks/run-hook.sh").to_str().unwrap(),
+            source_root.join("hooks/_lib/timeout.sh").to_str().unwrap(),
+            "dev-linked-repo",
+            "8",
+        ])
+        .current_dir(project)
+        .env("HOME", home)
+        .env("VIBEGUARD_LOG_DIR", log_root);
+    for name in [
+        "CI",
+        "GITHUB_ACTIONS",
+        "TRAVIS",
+        "CIRCLECI",
+        "JENKINS_URL",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ] {
+        command.env_remove(name);
+    }
+    run_with_stdin(&mut command, input)
+}
+
+fn first_project_event(log_root: &Path) -> Value {
+    let project_dir = fs::read_dir(log_root.join("projects"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let text = fs::read_to_string(project_dir.join("events.jsonl")).unwrap();
+    serde_json::from_str(text.lines().next().unwrap()).unwrap()
+}
+
+#[test]
+fn gemini_wrapper_blocks_dangerous_shell_and_allows_safe_shell() {
+    let root = unique_temp_dir("gemini-wrapper-shell");
+    let project = root.join("project");
+    let home = root.join("home");
+    let log_root = root.join("logs");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let blocked = run_wrapper(
+        &project,
+        &home,
+        &log_root,
+        &gemini_payload("run_shell_command", json!({"command": "git restore ."})),
+    );
+    assert!(blocked.status.success(), "{:?}", blocked.status);
+    let blocked_json: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+    assert_eq!(blocked_json["decision"], "deny");
+    assert!(
+        blocked_json["reason"]
+            .as_str()
+            .unwrap()
+            .contains("VIBEGUARD")
+    );
+
+    let event = first_project_event(&log_root);
+    assert_eq!(event["hook"], "pre-bash-guard");
+    assert_eq!(event["decision"], "block");
+    assert_eq!(event["cli"], "gemini");
+    assert_eq!(event["client"], "gemini");
+    assert_eq!(event["client_variant"], "gemini-cli-hooks");
+    assert_eq!(event["session"], "gemini-session-test");
+
+    let safe = run_wrapper(
+        &project,
+        &home,
+        &log_root,
+        &gemini_payload("run_shell_command", json!({"command": "git status"})),
+    );
+    assert!(safe.status.success(), "{:?}", safe.status);
+    assert_eq!(safe.stdout, b"{}\n");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn gemini_wrapper_preserves_advisories_corrections_and_denies_timeouts() {
+    let root = unique_temp_dir("gemini-wrapper-output");
+    let project = root.join("project");
+    let home = root.join("home");
+    let log_root = root.join("logs");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let correction = run_wrapper(
+        &project,
+        &home,
+        &log_root,
+        &gemini_payload(
+            "run_shell_command",
+            json!({"command": "npm install lodash"}),
+        ),
+    );
+    let correction_json: Value = serde_json::from_slice(&correction.stdout).unwrap();
+    assert_eq!(correction_json["decision"], "allow");
+    assert_eq!(
+        correction_json["hookSpecificOutput"]["tool_input"]["command"],
+        "pnpm add lodash"
+    );
+
+    let advisory = run_wrapper(
+        &project,
+        &home,
+        &log_root,
+        &gemini_payload(
+            "write_file",
+            json!({"file_path": project.join("new_module.rs"), "content": "fn main() {}"}),
+        ),
+    );
+    let advisory_json: Value = serde_json::from_slice(&advisory.stdout).unwrap();
+    assert!(
+        advisory_json["systemMessage"]
+            .as_str()
+            .unwrap()
+            .contains("search for similar implementation")
+    );
+
+    let source_root = repo_root();
+    let timeout_home = root.join("timeout-home");
+    let timeout_wrapper = timeout_home.join(".vibeguard/run-hook-gemini.sh");
+    let slow_hook = root.join("slow-run-hook.sh");
+    fs::create_dir_all(timeout_wrapper.parent().unwrap()).unwrap();
+    fs::copy(
+        source_root.join("hooks/run-hook-gemini.sh"),
+        &timeout_wrapper,
+    )
+    .unwrap();
+    fs::write(&slow_hook, "sleep 2\nprintf '{}\\n'\n").unwrap();
+    let mut timeout_command = Command::new("bash");
+    timeout_command
+        .arg(timeout_wrapper)
+        .args([
+            "--test-only",
+            bin().get_program().to_str().unwrap(),
+            slow_hook.to_str().unwrap(),
+            source_root.join("hooks/_lib/timeout.sh").to_str().unwrap(),
+            "installed-snapshot",
+            "0.1",
+        ])
+        .env("HOME", &timeout_home);
+    let started = Instant::now();
+    let timed_out = run_with_stdin(
+        &mut timeout_command,
+        &gemini_payload("run_shell_command", json!({"command": "git status"})),
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+    let timeout_json: Value = serde_json::from_slice(&timed_out.stdout).unwrap();
+    assert_eq!(timeout_json["decision"], "deny");
+    assert!(
+        timeout_json["reason"]
+            .as_str()
+            .unwrap()
+            .contains("could not execute the policy hook")
+    );
+
+    let stalled_home = root.join("stalled-home");
+    let stalled_wrapper = stalled_home.join(".vibeguard/run-hook-gemini.sh");
+    fs::create_dir_all(stalled_wrapper.parent().unwrap()).unwrap();
+    fs::copy(
+        source_root.join("hooks/run-hook-gemini.sh"),
+        &stalled_wrapper,
+    )
+    .unwrap();
+    let mut stalled_command = Command::new("bash");
+    stalled_command
+        .arg(stalled_wrapper)
+        .args([
+            "--test-only",
+            bin().get_program().to_str().unwrap(),
+            slow_hook.to_str().unwrap(),
+            source_root.join("hooks/_lib/timeout.sh").to_str().unwrap(),
+            "installed-snapshot",
+            "0.1",
+        ])
+        .env("HOME", &stalled_home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut stalled_child = stalled_command.spawn().unwrap();
+    let mut held_stdin = stalled_child.stdin.take().unwrap();
+    held_stdin.write_all(b"{").unwrap();
+    let stalled_started = Instant::now();
+    let stalled = stalled_child.wait_with_output().unwrap();
+    drop(held_stdin);
+    assert!(stalled_started.elapsed() < Duration::from_secs(4));
+    let stalled_json: Value = serde_json::from_slice(&stalled.stdout).unwrap();
+    assert_eq!(stalled_json["decision"], "deny");
+    assert!(
+        stalled_json["reason"]
+            .as_str()
+            .unwrap()
+            .contains("could not read the BeforeTool payload")
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn gemini_wrapper_blocks_missing_replace_target_and_unknown_tools() {
+    let root = unique_temp_dir("gemini-wrapper-edit");
+    let project = root.join("project");
+    let home = root.join("home");
+    let log_root = root.join("logs");
+    fs::create_dir_all(project.join(".git")).unwrap();
+    fs::create_dir_all(project.join("src")).unwrap();
+    let missing = project.join("src/missing.rs");
+
+    let edit = run_wrapper(
+        &project,
+        &home,
+        &log_root,
+        &gemini_payload(
+            "replace",
+            json!({
+                "file_path": missing,
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        ),
+    );
+    let edit_json: Value = serde_json::from_slice(&edit.stdout).unwrap();
+    assert_eq!(edit_json["decision"], "deny");
+
+    let unknown = run_wrapper(
+        &project,
+        &home,
+        &log_root,
+        &gemini_payload("read_file", json!({"file_path": "README.md"})),
+    );
+    let unknown_json: Value = serde_json::from_slice(&unknown.stdout).unwrap();
+    assert_eq!(unknown_json["decision"], "deny");
+    assert!(
+        unknown_json["reason"]
+            .as_str()
+            .unwrap()
+            .contains("malformed or unsupported")
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn gemini_settings_lifecycle_is_idempotent_and_preserves_custom_hooks() {
+    let root = unique_temp_dir("gemini-settings");
+    let settings = root.join("settings.json");
+    let wrapper = root.join("wrapper with spaces.sh");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        &settings,
+        serde_json::to_vec_pretty(&json!({
+            "theme": "custom",
+            "hooks": {
+                "BeforeTool": [{
+                    "matcher": "read_file",
+                    "hooks": [{"name": "custom", "type": "command", "command": "custom-hook"}]
+                }],
+                "AfterTool": []
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    fs::set_permissions(&settings, fs::Permissions::from_mode(0o600)).unwrap();
+
+    let first = bin()
+        .args([
+            "setup-gemini-hooks-upsert",
+            settings.to_str().unwrap(),
+            wrapper.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_eq!(first.stdout, b"CHANGED\n");
+    let data: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(data["theme"], "custom");
+    assert_eq!(data["hooks"]["BeforeTool"].as_array().unwrap().len(), 2);
+    assert!(data.to_string().contains("custom-hook"));
+    assert!(data.to_string().contains("vibeguard-before-tool"));
+    assert_eq!(
+        data["hooks"]["BeforeTool"][1]["matcher"],
+        "^(run_shell_command|write_file|replace)$"
+    );
+    assert_eq!(
+        data["hooks"]["BeforeTool"][1]["hooks"][0]["timeout"],
+        20_000
+    );
+    assert!(
+        data["hooks"]["BeforeTool"][1]["hooks"][0]["command"]
+            .as_str()
+            .unwrap()
+            .starts_with("/usr/bin/env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin /bin/bash ")
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        fs::metadata(&settings).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+
+    let second = bin()
+        .args([
+            "setup-gemini-hooks-upsert",
+            settings.to_str().unwrap(),
+            wrapper.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(second.stdout, b"SKIP\n");
+    assert!(
+        bin()
+            .args([
+                "setup-gemini-hooks-check",
+                settings.to_str().unwrap(),
+                wrapper.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    let mut disabled = data.clone();
+    disabled["hooksConfig"] = json!({"enabled": false});
+    fs::write(&settings, serde_json::to_vec_pretty(&disabled).unwrap()).unwrap();
+    assert!(
+        !bin()
+            .args([
+                "setup-gemini-hooks-check",
+                settings.to_str().unwrap(),
+                wrapper.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    let removed = bin()
+        .args(["setup-gemini-hooks-remove", settings.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert_eq!(removed.stdout, b"CHANGED\n");
+    let data: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(data["theme"], "custom");
+    assert!(data.to_string().contains("custom-hook"));
+    assert!(!data.to_string().contains("vibeguard-before-tool"));
+    assert_eq!(data["hooks"]["AfterTool"], json!([]));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn gemini_settings_new_files_are_private_and_symlinks_fail_closed() {
+    use std::os::unix::fs::symlink;
+
+    let root = unique_temp_dir("gemini-settings-permissions");
+    let fresh = root.join("fresh/settings.json");
+    let wrapper = root.join("wrapper.sh");
+    let created = bin()
+        .args([
+            "setup-gemini-hooks-upsert",
+            fresh.to_str().unwrap(),
+            wrapper.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(created.status.success());
+    assert_eq!(
+        fs::metadata(&fresh).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+
+    let external = root.join("external.json");
+    let linked = root.join("linked.json");
+    fs::write(&external, "{}\n").unwrap();
+    symlink(&external, &linked).unwrap();
+    let rejected = bin()
+        .args([
+            "setup-gemini-hooks-upsert",
+            linked.to_str().unwrap(),
+            wrapper.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!rejected.status.success());
+    assert_eq!(fs::read_to_string(&external).unwrap(), "{}\n");
+    assert!(linked.is_symlink());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn gemini_installed_wrapper_ignores_hostile_runtime_environment() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let root = unique_temp_dir("gemini-hostile-environment");
+    let home = root.join("home");
+    let project = root.join("project");
+    let vibeguard_home = home.join(".vibeguard");
+    let installed = vibeguard_home.join("installed");
+    let source_root = repo_root();
+    fs::create_dir_all(installed.join("bin")).unwrap();
+    fs::create_dir_all(&project).unwrap();
+    fs::copy(
+        source_root.join("hooks/run-hook-gemini.sh"),
+        vibeguard_home.join("run-hook-gemini.sh"),
+    )
+    .unwrap();
+    fs::copy(
+        source_root.join("hooks/run-hook.sh"),
+        vibeguard_home.join("run-hook.sh"),
+    )
+    .unwrap();
+    symlink(source_root.join("hooks"), installed.join("hooks")).unwrap();
+    symlink(bin().get_program(), installed.join("bin/vibeguard-runtime")).unwrap();
+
+    let marker = root.join("hostile-runtime-used");
+    let hostile_runtime = root.join("hostile-runtime.sh");
+    fs::write(
+        &hostile_runtime,
+        format!(
+            "#!/bin/bash\nprintf used > '{}'\nprintf '{{}}\\n'\n",
+            marker.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&hostile_runtime, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let mut command = Command::new("/bin/bash");
+    command
+        .arg(vibeguard_home.join("run-hook-gemini.sh"))
+        .current_dir(&project)
+        .env("HOME", root.join("attacker-home"))
+        .env("VIBEGUARD_RUNTIME", &hostile_runtime)
+        .env("VIBEGUARD_POLICY_RUNTIME", &hostile_runtime)
+        .env("VIBEGUARD_EXECUTION_MODE", "dev-linked-repo")
+        .env("VIBEGUARD_LOG_DIR", root.join("attacker-config"));
+    let output = run_with_stdin(
+        &mut command,
+        &gemini_payload("run_shell_command", json!({"command": "git restore ."})),
+    );
+    assert!(output.status.success());
+    let decision: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(decision["decision"], "deny");
+    assert!(!marker.exists());
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/vibeguard-runtime/tests/cli_gemini.rs
+++ b/vibeguard-runtime/tests/cli_gemini.rs
@@ -84,6 +84,7 @@ fn run_wrapper(project: &Path, home: &Path, log_root: &Path, input: &str) -> Out
         .env_clear()
         .env("HOME", home)
         .env("PATH", path)
+        .env("VIBEGUARD_RUNTIME", &runtime)
         .env("VIBEGUARD_LOG_DIR", log_root);
     if let Some(profile_file) = env::var_os("LLVM_PROFILE_FILE") {
         command.env("LLVM_PROFILE_FILE", profile_file);

--- a/vibeguard-runtime/tests/cli_gemini.rs
+++ b/vibeguard-runtime/tests/cli_gemini.rs
@@ -2,13 +2,13 @@ mod common;
 
 use common::{bin, unique_temp_dir};
 use serde_json::{Value, json};
-use std::fs;
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
+use std::{env, fs};
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -46,7 +46,13 @@ fn gemini_payload(tool_name: &str, tool_input: Value) -> String {
 
 fn run_wrapper(project: &Path, home: &Path, log_root: &Path, input: &str) -> Output {
     let source_root = repo_root();
+    let test_bin = home.join("test-bin");
     fs::create_dir_all(home.join(".vibeguard")).unwrap();
+    fs::create_dir_all(&test_bin).unwrap();
+    let pnpm = test_bin.join("pnpm");
+    fs::write(&pnpm, "#!/bin/sh\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    fs::set_permissions(&pnpm, fs::Permissions::from_mode(0o700)).unwrap();
     let wrapper = home.join(".vibeguard/run-hook-gemini.sh");
     fs::copy(source_root.join("hooks/run-hook-gemini.sh"), &wrapper).unwrap();
     fs::write(
@@ -55,6 +61,14 @@ fn run_wrapper(project: &Path, home: &Path, log_root: &Path, input: &str) -> Out
     )
     .unwrap();
     let runtime = bin().get_program().to_owned();
+    let path = env::join_paths(
+        std::iter::once(test_bin).chain(
+            env::var_os("PATH")
+                .into_iter()
+                .flat_map(|value| env::split_paths(&value).collect::<Vec<_>>()),
+        ),
+    )
+    .unwrap();
     let mut command = Command::new("bash");
     command
         .arg(wrapper)
@@ -67,19 +81,10 @@ fn run_wrapper(project: &Path, home: &Path, log_root: &Path, input: &str) -> Out
             "8",
         ])
         .current_dir(project)
+        .env_clear()
         .env("HOME", home)
+        .env("PATH", path)
         .env("VIBEGUARD_LOG_DIR", log_root);
-    for name in [
-        "CI",
-        "GITHUB_ACTIONS",
-        "TRAVIS",
-        "CIRCLECI",
-        "JENKINS_URL",
-        "GITLAB_CI",
-        "TF_BUILD",
-    ] {
-        command.env_remove(name);
-    }
     run_with_stdin(&mut command, input)
 }
 


### PR DESCRIPTION
## Summary

- add a native Gemini CLI BeforeTool adapter that reuses canonical shell, write, and edit guards
- add opt-in install, health-check, idempotent update, and exact owned cleanup for Gemini settings
- fail closed on malformed input, unsupported tools, stalled input, and hostile runtime overrides

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Tests

## Checklist

- [x] I have tested my changes locally
- [x] I have added tests that prove the fix or feature works
- [x] New and existing unit tests pass locally
- [x] Rust formatting and clippy checks pass
- [x] Documentation and payload manifests are updated

## Verification

- cargo fmt --manifest-path vibeguard-runtime/Cargo.toml --check
- cargo check --manifest-path vibeguard-runtime/Cargo.toml
- cargo clippy --manifest-path vibeguard-runtime/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path vibeguard-runtime/Cargo.toml
- bash tests/setup/gemini_host_tests.sh
- bash tests/test_payload.sh (45/45)
- bash scripts/local-contract-check.sh --quick
- generated settings accepted by Gemini CLI 0.54.4

Closes #745