### PR TITLE
feat(setup): split global guidance by host

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Inspired by [OpenAI Harness Engineering](https://openai.com/index/harness-engine
 
 ### Rule Injection (active from session start)
 
-The native rule set in `rules/claude-rules/` is installed to Claude Code's native rules system (`~/.claude/rules/vibeguard/`). Global instruction files receive a smaller shared core for scope, factuality, error visibility, safety, preservation, and verification. The installer then adds a host-specific section: Claude Code receives native-rule and slash-command guidance, while Codex receives `AGENTS.md`, managed-skill, and native-hook capability guidance. Project facts and exact test commands stay in the nearest repository instructions.
+Claude Code's `full` and `strict` profiles expose the native rule set from `rules/claude-rules/` through `~/.claude/rules/vibeguard/`; `core` (the default) and `minimal` do not front-inject that tree. Every profile receives a smaller shared global core for scope, factuality, error visibility, safety, preservation, and verification. The installer then adds a host-specific section: Claude Code receives profile-aware native-rule and slash-command guidance, while Codex receives `AGENTS.md`, managed-skill, and native-hook capability guidance. Project facts and exact test commands stay in the nearest repository instructions.
 
 Canonical references for this contract:
 - Install/runtime contract: `schemas/install-modules.json`

--- a/README.md
+++ b/README.md
@@ -153,19 +153,7 @@ Inspired by [OpenAI Harness Engineering](https://openai.com/index/harness-engine
 
 ### Rule Injection (active from session start)
 
-The native rule set in `rules/claude-rules/` is installed to Claude Code's native rules system (`~/.claude/rules/vibeguard/`), directly influencing AI reasoning. Plus a 7-layer constraint index injected into `~/.claude/CLAUDE.md`:
-
-| Layer | Constraint | Effect |
-|-------|-----------|--------|
-| L1 | Search before create | Must search for existing implementations before creating new files |
-| L2 | Naming conventions | `snake_case` internally, `camelCase` at API boundaries, no aliases |
-| L3 | Quality baseline | No silent exception swallowing, no `Any` types in public methods |
-| L4 | Data integrity | No data = show blank, no hardcoding, no inventing APIs |
-| L5 | Minimal changes | Only do what was asked, no unsolicited "improvements" |
-| L6 | Process gates | Large changes require preflight, structured planning, and verification |
-| L7 | Commit discipline | No AI markers, no force push, no secrets |
-
-Rules use **negative constraints** ("X does not exist") to implicitly guide AI, which is often more effective than positive descriptions.
+The native rule set in `rules/claude-rules/` is installed to Claude Code's native rules system (`~/.claude/rules/vibeguard/`). Global instruction files receive a smaller shared core for scope, factuality, error visibility, safety, preservation, and verification. The installer then adds a host-specific section: Claude Code receives native-rule and slash-command guidance, while Codex receives `AGENTS.md`, managed-skill, and native-hook capability guidance. Project facts and exact test commands stay in the nearest repository instructions.
 
 Canonical references for this contract:
 - Install/runtime contract: `schemas/install-modules.json`
@@ -576,7 +564,7 @@ Add your own rules to `~/.vibeguard/user-rules/`. Any `.md` files placed there a
 |-----------|------|----------------|
 | Automation over documentation | Harness #3 | Mechanized checks complement rules, workflows, and review |
 | Error messages = fix instructions | Harness #3 | Every interception tells AI how to fix, not just what's wrong |
-| Maps not manuals | Harness #5 | 7-layer index + negative constraints + lazy loading |
+| Maps not manuals | Harness #5 | Shared core + host guidance + lazy-loaded detailed rules |
 | Failure → capability | Harness #2 | Mistake → learn → new guard → never again |
 | If agent can't see it, it doesn't exist | Harness #1 | All decisions written to repo (`CLAUDE.md` / ExecPlan / logs) |
 | Give agent eyes | Harness #4 | Observability stack (logs + metrics + alerts) |

--- a/claude-md/CLAUDE.md
+++ b/claude-md/CLAUDE.md
@@ -1,16 +1,24 @@
 # claude-md/ directory
 
-VibeGuard rule injection mechanism. This directory contains template files that inject VibeGuard rules into users `~/.claude/CLAUDE.md`.
+VibeGuard rule injection mechanism. This directory contains the shared global
+contract and the host-specific additions injected into Claude Code and Codex.
 
 ## How to work
 
-1. `vibeguard-rules.md` contains the rule content injected into CLAUDE.md
-2. `setup.sh` manages the injection area through `<!-- vibeguard-start -->` / `<!-- vibeguard-end -->` tags
-3. Rerunning `setup.sh` will update the content in the existing marked area and will not affect user-defined content.
+1. `vibeguard-rules.md` contains the cross-host shared core and managed markers.
+2. `vibeguard-claude.md` contains Claude Code-only guidance.
+3. `vibeguard-codex.md` contains Codex-only guidance.
+4. `python3 scripts/generate_rule_docs.py` composes the shared core with each
+   host addition into `vibeguard-claude-rules.md` and
+   `vibeguard-codex-rules.md`.
+5. `setup.sh` injects the matching generated block inside
+   `<!-- vibeguard-start -->` / `<!-- vibeguard-end -->`.
+6. Rerunning `setup.sh` updates only the marked area and preserves user content.
 
 ## Modify rules
 
 1. Edit the canonical rule under `rules/claude-rules/**`, including its `**Compact guidance:**` field when the rule is selected for compact injection
 2. Run `python3 scripts/generate_rule_docs.py` from the repository root
 3. Run `bash setup.sh` to re-inject
-4. Valid in new Claude Code session
+4. Validate both Claude and Codex rendered blocks.
+5. The change becomes active in a new host session after setup is rerun.

--- a/claude-md/vibeguard-claude-rules.md
+++ b/claude-md/vibeguard-claude-rules.md
@@ -1,7 +1,7 @@
 <!-- vibeguard-start -->
 # VibeGuard shared core
 
-> __VIBEGUARD_RULE_COUNT__ rules total are available. This managed block keeps only cross-project defaults in global context. The user's request and the nearest repository-level `AGENTS.md` or `CLAUDE.md` define project facts, conventions, and verification commands. Load deeper rules on demand from `~/.vibeguard/installed/rules/claude-rules/`.
+> __VIBEGUARD_RULE_COUNT__ rules total are available. This managed block keeps only cross-project defaults in global context. The user's request and the nearest applicable repository instructions define project facts, conventions, and verification commands. Load deeper rules on demand from `~/.vibeguard/installed/rules/claude-rules/`.
 
 ## Scope and precedence
 

--- a/claude-md/vibeguard-claude-rules.md
+++ b/claude-md/vibeguard-claude-rules.md
@@ -49,4 +49,11 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 | SEC-11 | Strict | AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`. |
 | SEC-13 | Strict | High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators. |
 <!-- vibeguard-generated-compact-rules:end -->
+
+## Claude Code host guidance
+
+- The compact shared core is always present. `full` and `strict` profiles may also expose matching native rule files through `~/.claude/rules/vibeguard/`.
+- Claude Code hooks can cover read/search loops as well as Bash and file changes; treat hook output as guard feedback, not proof that the task is complete.
+- VibeGuard commands are available under `/vibeguard:*` with `/vg:*` shortcuts when the command bundle is installed.
+- Use the current project's own verification commands instead of assuming a language-wide default.
 <!-- vibeguard-end -->

--- a/claude-md/vibeguard-claude.md
+++ b/claude-md/vibeguard-claude.md
@@ -1,0 +1,6 @@
+## Claude Code host guidance
+
+- The compact shared core is always present. `full` and `strict` profiles may also expose matching native rule files through `~/.claude/rules/vibeguard/`.
+- Claude Code hooks can cover read/search loops as well as Bash and file changes; treat hook output as guard feedback, not proof that the task is complete.
+- VibeGuard commands are available under `/vibeguard:*` with `/vg:*` shortcuts when the command bundle is installed.
+- Use the current project's own verification commands instead of assuming a language-wide default.

--- a/claude-md/vibeguard-codex-rules.md
+++ b/claude-md/vibeguard-codex-rules.md
@@ -1,7 +1,7 @@
 <!-- vibeguard-start -->
 # VibeGuard shared core
 
-> __VIBEGUARD_RULE_COUNT__ rules total are available. This managed block keeps only cross-project defaults in global context. The user's request and the nearest repository-level `AGENTS.md` or `CLAUDE.md` define project facts, conventions, and verification commands. Load deeper rules on demand from `~/.vibeguard/installed/rules/claude-rules/`.
+> __VIBEGUARD_RULE_COUNT__ rules total are available. This managed block keeps only cross-project defaults in global context. The user's request and the nearest applicable repository instructions define project facts, conventions, and verification commands. Load deeper rules on demand from `~/.vibeguard/installed/rules/claude-rules/`.
 
 ## Scope and precedence
 

--- a/claude-md/vibeguard-codex-rules.md
+++ b/claude-md/vibeguard-codex-rules.md
@@ -54,6 +54,6 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
 - When managed VibeGuard skills are installed, they live under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
-- Every Codex setup profile covers native Bash and `apply_patch` gates. Only the `full` and `strict` profile contracts add `Stop` hooks, including `stop-guard`; `minimal` and `core` do not promise Stop coverage. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
+- Every Codex setup profile covers native Bash and `apply_patch` gates plus `Stop` hooks, including `stop-guard`; unlike Claude Code, Codex hook installation is not profile-filtered. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.
 <!-- vibeguard-end -->

--- a/claude-md/vibeguard-codex-rules.md
+++ b/claude-md/vibeguard-codex-rules.md
@@ -54,6 +54,6 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
 - When managed VibeGuard skills are installed, they live under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
-- Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
+- Every Codex setup profile covers native Bash and `apply_patch` gates. Only the `full` and `strict` profile contracts add `Stop` hooks, including `stop-guard`; `minimal` and `core` do not promise Stop coverage. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.
 <!-- vibeguard-end -->

--- a/claude-md/vibeguard-codex-rules.md
+++ b/claude-md/vibeguard-codex-rules.md
@@ -53,7 +53,7 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 ## Codex host guidance
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
-- Managed VibeGuard skills are installed under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
+- When managed VibeGuard skills are installed, they live under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
 - Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.
 <!-- vibeguard-end -->

--- a/claude-md/vibeguard-codex-rules.md
+++ b/claude-md/vibeguard-codex-rules.md
@@ -53,7 +53,7 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 ## Codex host guidance
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
-- Managed VibeGuard skills are installed under `~/.codex/skills/`; use a skill only when its activation conditions match the task.
+- Managed VibeGuard skills are installed under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
 - Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.
 <!-- vibeguard-end -->

--- a/claude-md/vibeguard-codex-rules.md
+++ b/claude-md/vibeguard-codex-rules.md
@@ -49,4 +49,11 @@ Compact Chat Contract: progress updates, concise answers, plain formatting.
 | SEC-11 | Strict | AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`. |
 | SEC-13 | Strict | High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators. |
 <!-- vibeguard-generated-compact-rules:end -->
+
+## Codex host guidance
+
+- Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
+- Managed VibeGuard skills are installed under `~/.codex/skills/`; use a skill only when its activation conditions match the task.
+- Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
+- Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.
 <!-- vibeguard-end -->

--- a/claude-md/vibeguard-codex.md
+++ b/claude-md/vibeguard-codex.md
@@ -2,5 +2,5 @@
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
 - When managed VibeGuard skills are installed, they live under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
-- Every Codex setup profile covers native Bash and `apply_patch` gates. Only the `full` and `strict` profile contracts add `Stop` hooks, including `stop-guard`; `minimal` and `core` do not promise Stop coverage. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
+- Every Codex setup profile covers native Bash and `apply_patch` gates plus `Stop` hooks, including `stop-guard`; unlike Claude Code, Codex hook installation is not profile-filtered. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.

--- a/claude-md/vibeguard-codex.md
+++ b/claude-md/vibeguard-codex.md
@@ -2,5 +2,5 @@
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
 - When managed VibeGuard skills are installed, they live under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
-- Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
+- Every Codex setup profile covers native Bash and `apply_patch` gates. Only the `full` and `strict` profile contracts add `Stop` hooks, including `stop-guard`; `minimal` and `core` do not promise Stop coverage. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.

--- a/claude-md/vibeguard-codex.md
+++ b/claude-md/vibeguard-codex.md
@@ -1,6 +1,6 @@
 ## Codex host guidance
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
-- Managed VibeGuard skills are installed under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
+- When managed VibeGuard skills are installed, they live under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
 - Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.

--- a/claude-md/vibeguard-codex.md
+++ b/claude-md/vibeguard-codex.md
@@ -1,0 +1,6 @@
+## Codex host guidance
+
+- Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
+- Managed VibeGuard skills are installed under `~/.codex/skills/`; use a skill only when its activation conditions match the task.
+- Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
+- Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.

--- a/claude-md/vibeguard-codex.md
+++ b/claude-md/vibeguard-codex.md
@@ -1,6 +1,6 @@
 ## Codex host guidance
 
 - Repository-level and nested `AGENTS.md` files provide project-specific facts and take precedence over these global defaults.
-- Managed VibeGuard skills are installed under `~/.codex/skills/`; use a skill only when its activation conditions match the task.
+- Managed VibeGuard skills are installed under `$CODEX_HOME/skills/`, defaulting to `~/.codex/skills/`; use a skill only when its activation conditions match the task.
 - Native Codex hooks cover Bash and `apply_patch` gates plus Stop events. Read, Glob, and Grep hook surfaces are unavailable, so do not claim those loops were mechanically intercepted.
 - Claude-only slash commands, `/clear`, native rule paths, and compaction behavior are not part of this Codex contract.

--- a/claude-md/vibeguard-rules.md
+++ b/claude-md/vibeguard-rules.md
@@ -1,7 +1,7 @@
 <!-- vibeguard-start -->
 # VibeGuard shared core
 
-> __VIBEGUARD_RULE_COUNT__ rules total are available. This managed block keeps only cross-project defaults in global context. The user's request and the nearest repository-level `AGENTS.md` or `CLAUDE.md` define project facts, conventions, and verification commands. Load deeper rules on demand from `~/.vibeguard/installed/rules/claude-rules/`.
+> __VIBEGUARD_RULE_COUNT__ rules total are available. This managed block keeps only cross-project defaults in global context. The user's request and the nearest applicable repository instructions define project facts, conventions, and verification commands. Load deeper rules on demand from `~/.vibeguard/installed/rules/claude-rules/`.
 
 ## Scope and precedence
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -70,19 +70,7 @@ VibeGuard 现在明确分成两层：
 
 ### 1. 规则注入
 
-`rules/claude-rules/` 中的原生规则会被安装到 `~/.claude/rules/vibeguard/`，直接影响 Claude Code 的推理层。同时，VibeGuard 还会把 7 层约束索引注入到 `~/.claude/CLAUDE.md`。
-
-| 层级 | 约束 | 作用 |
-|------|------|------|
-| L1 | 先搜索再创建 | 新建文件/类/函数前先确认仓库里是否已有实现 |
-| L2 | 命名规范 | 内部优先 `snake_case`，API 边界再用 `camelCase`，禁止别名 |
-| L3 | 质量基线 | 禁止吞异常、公共接口滥用 `Any` |
-| L4 | 数据真实性 | 没数据就显示空，不允许硬编码和虚构 API |
-| L5 | 最小改动 | 只做被要求的事，不顺手加“升级” |
-| L6 | 过程闸门 | 大改动先预检和规划，结束前必须验证 |
-| L7 | 提交纪律 | 禁止 AI 标记、禁止 force push、禁止秘钥入库 |
-
-这里大量使用了“负约束”表达，例如“X 不存在”“不要假设 Y 已经有”，通常比纯正向描述更能稳定影响 agent 行为。
+`rules/claude-rules/` 中的原生规则会安装到 `~/.claude/rules/vibeguard/`。全局高上下文文件只接收一份较小的共享核心，覆盖范围、事实真实性、错误可见性、安全、内容保留和验证；安装器再按宿主追加专属说明：Claude Code 获得原生规则与 slash command 指引，Codex 获得 `AGENTS.md`、托管 Skill 和原生 hook 能力边界。项目事实与准确测试命令仍由最近的仓库级说明提供。
 
 当前 canonical 参考入口：
 - 安装/运行时契约：`schemas/install-modules.json`

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -70,7 +70,7 @@ VibeGuard 现在明确分成两层：
 
 ### 1. 规则注入
 
-`rules/claude-rules/` 中的原生规则会安装到 `~/.claude/rules/vibeguard/`。全局高上下文文件只接收一份较小的共享核心，覆盖范围、事实真实性、错误可见性、安全、内容保留和验证；安装器再按宿主追加专属说明：Claude Code 获得原生规则与 slash command 指引，Codex 获得 `AGENTS.md`、托管 Skill 和原生 hook 能力边界。项目事实与准确测试命令仍由最近的仓库级说明提供。
+Claude Code 的 `full` 和 `strict` profile 会把 `rules/claude-rules/` 中的原生规则暴露到 `~/.claude/rules/vibeguard/`；默认的 `core` profile 和 `minimal` profile 不会前置注入这棵规则树。所有 profile 的全局高上下文文件都会接收一份较小的共享核心，覆盖范围、事实真实性、错误可见性、安全、内容保留和验证；安装器再按宿主追加专属说明：Claude Code 获得与 profile 一致的原生规则和 slash command 指引，Codex 获得 `AGENTS.md`、托管 Skill 和原生 hook 能力边界。项目事实与准确测试命令仍由最近的仓库级说明提供。
 
 当前 canonical 参考入口：
 - 安装/运行时契约：`schemas/install-modules.json`

--- a/eval/paired_runner.py
+++ b/eval/paired_runner.py
@@ -78,8 +78,6 @@ SHARED_CORE_RULE_EQUIVALENTS = {
     "SEC-02": "Key detailed rules (SEC-02)",
     "U-04": "Core contract (Scope)",
     "U-17": "Key detailed rules (U-17)",
-    "U-23": "Core contract (Errors)",
-    "U-24": "Core contract (Facts)",
     "U-29": "Key detailed rules (U-29)",
 }
 APPROVED_PLACEBO_PAIRS = {

--- a/eval/paired_runner.py
+++ b/eval/paired_runner.py
@@ -76,7 +76,6 @@ THRESHOLD_KEYS = {
 }
 SHARED_CORE_RULE_EQUIVALENTS = {
     "SEC-02": "Core contract (Safety)",
-    "SEC-13": "Core contract (Preservation)",
     "U-04": "Core contract (Scope)",
     "U-08": "Core contract (Verification)",
     "U-17": "Core contract (Errors)",

--- a/eval/paired_runner.py
+++ b/eval/paired_runner.py
@@ -74,13 +74,13 @@ THRESHOLD_KEYS = {
     "max_placebo_length_ratio",
     "calibrated",
 }
-ANONYMOUS_COMPACT_RULE_EQUIVALENTS = {
-    "SEC-02": "L7",
-    "U-04": "L5",
-    "U-17": "L3",
-    "U-23": "L3",
-    "U-24": "L2",
-    "U-29": "L3",
+SHARED_CORE_RULE_EQUIVALENTS = {
+    "SEC-02": "Key detailed rules (SEC-02)",
+    "U-04": "Core contract (Scope)",
+    "U-17": "Key detailed rules (U-17)",
+    "U-23": "Core contract (Errors)",
+    "U-24": "Core contract (Facts)",
+    "U-29": "Key detailed rules (U-29)",
 }
 APPROVED_PLACEBO_PAIRS = {
     frozenset(("SEC-12", "U-32")): (
@@ -525,11 +525,11 @@ def validate_placebo_candidate(
 
 
 def validate_candidate_supported(candidate: str) -> None:
-    compact_layer = ANONYMOUS_COMPACT_RULE_EQUIVALENTS.get(candidate.upper())
-    if compact_layer:
+    compact_location = SHARED_CORE_RULE_EQUIVALENTS.get(candidate.upper())
+    if compact_location:
         raise PairedEvalError(
-            f"candidate {candidate.upper()} is unsupported because anonymous compact "
-            f"{compact_layer} retains equivalent semantics in the without prompt"
+            f"candidate {candidate.upper()} is unsupported because the shared compact "
+            f"core retains equivalent semantics in {compact_location}"
         )
 
 

--- a/eval/paired_runner.py
+++ b/eval/paired_runner.py
@@ -75,10 +75,15 @@ THRESHOLD_KEYS = {
     "calibrated",
 }
 SHARED_CORE_RULE_EQUIVALENTS = {
-    "SEC-02": "Key detailed rules (SEC-02)",
+    "SEC-02": "Core contract (Safety)",
+    "SEC-13": "Core contract (Preservation)",
     "U-04": "Core contract (Scope)",
-    "U-17": "Key detailed rules (U-17)",
-    "U-29": "Key detailed rules (U-29)",
+    "U-08": "Core contract (Verification)",
+    "U-17": "Core contract (Errors)",
+    "U-29": "Core contract (Errors)",
+    "W-03": "Core contract (Verification)",
+    "W-12": "Core contract (Safety)",
+    "W-16": "Core contract (Verification)",
 }
 APPROVED_PLACEBO_PAIRS = {
     frozenset(("SEC-12", "U-32")): (

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -32,7 +32,7 @@ from scoring import CONFIDENCE_SCORES, ScorerParseError, parse_confidence, parse
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RULES_DIR = REPO_ROOT / "rules" / "claude-rules"
-DEFAULT_CORE_RULES_FILE = REPO_ROOT / "claude-md" / "vibeguard-rules.md"
+DEFAULT_CORE_RULES_FILE = REPO_ROOT / "claude-md" / "vibeguard-claude-rules.md"
 
 
 def load_rules(rules_dir: Path, core_rules_file: Path | None) -> str:

--- a/eval/test_paired_dataset.py
+++ b/eval/test_paired_dataset.py
@@ -105,10 +105,10 @@ class DatasetAndIdentityTest(unittest.TestCase):
             paired.validate_placebo_candidate("U-21", "U-16", 240, 406, 0.25)
         paired.validate_placebo_candidate("U-32", "SEC-12", 4000, 4100, 0.25)
 
-    def test_candidates_duplicated_by_anonymous_compact_rules_are_rejected(self) -> None:
+    def test_candidates_duplicated_by_shared_compact_core_are_rejected(self) -> None:
         for candidate in ("U-04", "U-17", "U-23", "U-24", "U-29", "SEC-02"):
             with self.subTest(candidate=candidate), self.assertRaisesRegex(
-                paired.PairedEvalError, "anonymous compact"
+                paired.PairedEvalError, "shared compact core"
             ):
                 paired.validate_candidate_supported(candidate)
         paired.validate_candidate_supported("U-32")

--- a/eval/test_paired_dataset.py
+++ b/eval/test_paired_dataset.py
@@ -109,7 +109,6 @@ class DatasetAndIdentityTest(unittest.TestCase):
     def test_candidates_duplicated_by_shared_compact_core_are_rejected(self) -> None:
         expected_locations = {
             "SEC-02": "Core contract (Safety)",
-            "SEC-13": "Core contract (Preservation)",
             "U-04": "Core contract (Scope)",
             "U-08": "Core contract (Verification)",
             "U-17": "Core contract (Errors)",
@@ -124,9 +123,8 @@ class DatasetAndIdentityTest(unittest.TestCase):
                 rf"shared compact core retains equivalent semantics in {re.escape(location)}",
             ):
                 paired.validate_candidate_supported(candidate)
-        paired.validate_candidate_supported("U-23")
-        paired.validate_candidate_supported("U-24")
-        paired.validate_candidate_supported("U-32")
+        for candidate in ("SEC-13", "U-23", "U-24", "U-32"):
+            paired.validate_candidate_supported(candidate)
 
 if __name__ == "__main__":
     unittest.main()

--- a/eval/test_paired_dataset.py
+++ b/eval/test_paired_dataset.py
@@ -106,11 +106,13 @@ class DatasetAndIdentityTest(unittest.TestCase):
         paired.validate_placebo_candidate("U-32", "SEC-12", 4000, 4100, 0.25)
 
     def test_candidates_duplicated_by_shared_compact_core_are_rejected(self) -> None:
-        for candidate in ("U-04", "U-17", "U-23", "U-24", "U-29", "SEC-02"):
+        for candidate in ("U-04", "U-17", "U-29", "SEC-02"):
             with self.subTest(candidate=candidate), self.assertRaisesRegex(
                 paired.PairedEvalError, "shared compact core"
             ):
                 paired.validate_candidate_supported(candidate)
+        paired.validate_candidate_supported("U-23")
+        paired.validate_candidate_supported("U-24")
         paired.validate_candidate_supported("U-32")
 
 if __name__ == "__main__":

--- a/eval/test_paired_dataset.py
+++ b/eval/test_paired_dataset.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 import tempfile
 import unittest
@@ -106,9 +107,21 @@ class DatasetAndIdentityTest(unittest.TestCase):
         paired.validate_placebo_candidate("U-32", "SEC-12", 4000, 4100, 0.25)
 
     def test_candidates_duplicated_by_shared_compact_core_are_rejected(self) -> None:
-        for candidate in ("U-04", "U-17", "U-29", "SEC-02"):
+        expected_locations = {
+            "SEC-02": "Core contract (Safety)",
+            "SEC-13": "Core contract (Preservation)",
+            "U-04": "Core contract (Scope)",
+            "U-08": "Core contract (Verification)",
+            "U-17": "Core contract (Errors)",
+            "U-29": "Core contract (Errors)",
+            "W-03": "Core contract (Verification)",
+            "W-12": "Core contract (Safety)",
+            "W-16": "Core contract (Verification)",
+        }
+        for candidate, location in expected_locations.items():
             with self.subTest(candidate=candidate), self.assertRaisesRegex(
-                paired.PairedEvalError, "shared compact core"
+                paired.PairedEvalError,
+                rf"shared compact core retains equivalent semantics in {re.escape(location)}",
             ):
                 paired.validate_candidate_supported(candidate)
         paired.validate_candidate_supported("U-23")

--- a/hooks/count_active_constraints.sh
+++ b/hooks/count_active_constraints.sh
@@ -26,7 +26,7 @@ fi
 HOOK_EVENT=$(printf '%s' "${INPUT}" | vg_json_field "hook_event_name" 2>/dev/null || true)
 HOOK_EVENT="${HOOK_EVENT:-SessionStart}"
 
-COUNTER_ARGS=(--root "${PROJECT_ROOT}" --home "${HOME}" --hook-fields)
+COUNTER_ARGS=(--root "${PROJECT_ROOT}" --home "${HOME}" --host claude --hook-fields)
 
 if [[ -n "${VIBEGUARD_TASK_PATHS:-}" ]]; then
   IFS=',' read -r -a _vg_task_paths <<< "${VIBEGUARD_TASK_PATHS}"

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -28,10 +28,12 @@ require_present() {
   fi
 }
 
-require_absent "claude-md/vibeguard-rules.md" 'L1-L7 are enforced by Hooks' \
-  "managed VibeGuard rule block must not claim all L1-L7 layers are hook-enforced"
-require_present "claude-md/vibeguard-rules.md" '## Constraints (L1-L7 use rules, hooks, guards, and workflows)' \
-  "managed VibeGuard rule block must describe mixed layer coverage"
+require_absent "claude-md/vibeguard-rules.md" 'are enforced by Hooks' \
+  "managed VibeGuard shared core must not claim all rules are hook-enforced"
+require_present "claude-md/vibeguard-rules.md" '## Scope and precedence' \
+  "managed VibeGuard shared core must declare instruction precedence"
+require_present "claude-md/vibeguard-codex.md" 'Read, Glob, and Grep hook surfaces are unavailable' \
+  "Codex host guidance must preserve the native hook capability boundary"
 
 require_absent "README.md" '| AI tries to finish with unverified changes | `stop-guard` | **Gate**' \
   "README.md must not describe stop-guard as a blocking Gate"

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -88,55 +88,32 @@ def _normalize_constraint(value: str) -> str:
     return value[:240]
 
 
-# Keep this semantic map aligned with SHARED_CORE_RULE_EQUIVALENTS in
-# eval/paired_runner.py and with the Rust production mirror below.
-RULE_EQUIVALENT_KEYS = {
-    "SEC-02": "shared-core:safety",
-    "SEC-13": "shared-core:preservation",
-    "U-04": "shared-core:scope",
-    "U-08": "shared-core:verification",
-    "U-17": "shared-core:errors",
-    "U-29": "shared-core:errors",
-    "W-03": "shared-core:verification",
-    "W-12": "shared-core:safety",
-    "W-16": "shared-core:verification",
-}
+# Core rows may summarize one detailed rule, but detailed rule IDs remain
+# independent constraints even when they share a broad topic.
 CORE_EQUIVALENT_KEYS = {
     (
         _normalize_constraint("Errors"),
         _normalize_constraint(
             "User-visible missing data, malformed input, or wrong output must fail clearly."
         ),
-    ): "shared-core:errors",
+    ): "rule:U-29",
     (
         _normalize_constraint("Scope"),
         _normalize_constraint(
             "Make the smallest requested change; do not add adjacent improvements."
         ),
-    ): "shared-core:scope",
-    (
-        _normalize_constraint("Safety"),
-        _normalize_constraint(
-            "Never expose secrets, add hidden AI attribution, force-push, or weaken tests."
-        ),
-    ): "shared-core:safety",
-    (
-        _normalize_constraint("Preservation"),
-        _normalize_constraint(
-            "Preserve unmanaged content in high-context files, settings, and hooks."
-        ),
-    ): "shared-core:preservation",
+    ): "rule:U-04",
     (
         _normalize_constraint("Verification"),
         _normalize_constraint(
             "Run a fresh, focused project command before claiming completion."
         ),
-    ): "shared-core:verification",
+    ): "rule:W-03",
 }
 
 
 def _rule_constraint_key(rule_id: str) -> str:
-    return RULE_EQUIVALENT_KEYS.get(rule_id, f"rule:{rule_id}")
+    return f"rule:{rule_id}"
 
 
 def _core_constraint_key(area: str, requirement: str) -> str:
@@ -314,6 +291,8 @@ def discover_sources(
             _add_source(sources, path, "global-rule", root=root, task_paths=task_paths)
 
     project_files = [root / "AGENTS.md"]
+    if _host_includes_codex(host):
+        project_files.extend(_codex_project_instruction_files(root, task_paths))
     if _host_includes_claude(host):
         project_files.extend([root / "CLAUDE.md", root / ".claude" / "CLAUDE.md"])
     for path in project_files:
@@ -340,6 +319,28 @@ def discover_sources(
             _add_source(sources, base / skill / "SKILL.md", "skill", root=root, task_paths=task_paths)
 
     return sources
+
+
+def _codex_project_instruction_files(root: Path, task_paths: list[str]) -> list[Path]:
+    resolved_root = root.resolve()
+    instruction_files: set[Path] = set()
+    for task_path in task_paths:
+        candidate = Path(task_path)
+        if not candidate.is_absolute():
+            candidate = resolved_root / candidate
+        candidate = candidate.resolve()
+        try:
+            candidate.relative_to(resolved_root)
+        except ValueError:
+            continue
+        directory = candidate if candidate.is_dir() else candidate.parent
+        while directory != resolved_root:
+            instruction_files.add(directory / "AGENTS.md")
+            parent = directory.parent
+            if parent == directory:
+                break
+            directory = parent
+    return sorted(instruction_files)
 
 
 def count_constraints(sources: dict[Path, str]) -> tuple[list[SourceReport], list[Constraint]]:

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -208,6 +208,7 @@ def _host_includes_codex(host: str) -> bool:
 def discover_sources(
     root: Path,
     home: Path,
+    codex_home: Path,
     task_paths: list[str],
     skills: list[str],
     explicit_sources: list[Path],
@@ -228,7 +229,7 @@ def discover_sources(
             ]
         )
     if _host_includes_codex(host):
-        global_files.append(home / ".codex" / "AGENTS.md")
+        global_files.append(codex_home / "AGENTS.md")
     for path in global_files:
         _add_source(sources, path, "global", root=root, task_paths=task_paths)
 
@@ -236,21 +237,20 @@ def discover_sources(
     if _host_includes_claude(host):
         global_rule_roots.append(home / ".claude" / "rules")
     if _host_includes_codex(host):
-        global_rule_roots.append(home / ".codex" / "rules")
+        global_rule_roots.append(codex_home / "rules")
     for base in global_rule_roots:
         for path in _iter_files(base, "**/*.md"):
             _add_source(sources, path, "global-rule", root=root, task_paths=task_paths)
 
-    project_files = [
-        root / "AGENTS.md",
-        root / "CLAUDE.md",
-        root / ".claude" / "CLAUDE.md",
-    ]
+    project_files = [root / "AGENTS.md"]
+    if _host_includes_claude(host):
+        project_files.extend([root / "CLAUDE.md", root / ".claude" / "CLAUDE.md"])
     for path in project_files:
         _add_source(sources, path, "project", root=root, task_paths=task_paths)
 
-    for path in _iter_files(root / ".claude" / "rules", "**/*.md"):
-        _add_source(sources, path, "path-rule", root=root, task_paths=task_paths)
+    if _host_includes_claude(host):
+        for path in _iter_files(root / ".claude" / "rules", "**/*.md"):
+            _add_source(sources, path, "path-rule", root=root, task_paths=task_paths)
 
     if include_canonical_rules:
         for path in _iter_files(root / "rules" / "claude-rules", "**/*.md"):
@@ -263,7 +263,7 @@ def discover_sources(
     if _host_includes_claude(host):
         skill_roots.append(home / ".claude" / "skills")
     if _host_includes_codex(host):
-        skill_roots.append(home / ".codex" / "skills")
+        skill_roots.append(codex_home / "skills")
     for skill in skills:
         for base in skill_roots:
             _add_source(sources, base / skill / "SKILL.md", "skill", root=root, task_paths=task_paths)
@@ -338,12 +338,18 @@ def status_for(total: int, warn_threshold: int, block_threshold: int) -> str:
 def build_report(args: argparse.Namespace) -> dict[str, Any]:
     root = _safe_resolve(Path(args.root))
     home = _safe_resolve(Path(args.home).expanduser())
+    codex_home = _safe_resolve(
+        Path(args.codex_home).expanduser()
+        if args.codex_home
+        else Path(os.environ.get("CODEX_HOME", home / ".codex")).expanduser()
+    )
     task_paths = args.task_path or []
     skills = args.skill or []
     explicit_sources = [Path(item) for item in (args.source or [])]
     sources = discover_sources(
         root,
         home,
+        codex_home,
         task_paths,
         skills,
         explicit_sources,
@@ -428,6 +434,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Count effective VibeGuard constraints")
     parser.add_argument("--root", default=".", help="Project root to scan")
     parser.add_argument("--home", default=str(Path.home()), help="Home directory for global agent surfaces")
+    parser.add_argument(
+        "--codex-home",
+        help="Codex home directory (default: $CODEX_HOME or <home>/.codex)",
+    )
     parser.add_argument(
         "--host",
         choices=("all", "claude", "codex"),

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -23,6 +23,8 @@ WARN_THRESHOLD = 15
 BLOCK_THRESHOLD = 30
 RULE_ID_RE = re.compile(r"^##\s+((?:U|W|SEC|RS|PY|TS|GO|TASTE)-\d+):", re.M)
 TABLE_RULE_ID_RE = re.compile(r"(?:U|W|SEC|RS|PY|TS|GO|TASTE)-\d+")
+COMPACT_RULES_START = "<!-- vibeguard-generated-compact-rules:start -->"
+COMPACT_RULES_END = "<!-- vibeguard-generated-compact-rules:end -->"
 BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(.+)")
 NORMATIVE_RE = re.compile(
     r"\b(must|must not|should|should not|never|always|require|requires|required|"
@@ -86,6 +88,70 @@ def _normalize_constraint(value: str) -> str:
     return value[:240]
 
 
+# Keep this semantic map aligned with SHARED_CORE_RULE_EQUIVALENTS in
+# eval/paired_runner.py and with the Rust production mirror below.
+RULE_EQUIVALENT_KEYS = {
+    "SEC-02": "shared-core:safety",
+    "SEC-13": "shared-core:preservation",
+    "U-04": "shared-core:scope",
+    "U-08": "shared-core:verification",
+    "U-17": "shared-core:errors",
+    "U-29": "shared-core:errors",
+    "W-03": "shared-core:verification",
+    "W-12": "shared-core:safety",
+    "W-16": "shared-core:verification",
+}
+CORE_EQUIVALENT_KEYS = {
+    (
+        _normalize_constraint("Errors"),
+        _normalize_constraint(
+            "User-visible missing data, malformed input, or wrong output must fail clearly."
+        ),
+    ): "shared-core:errors",
+    (
+        _normalize_constraint("Scope"),
+        _normalize_constraint(
+            "Make the smallest requested change; do not add adjacent improvements."
+        ),
+    ): "shared-core:scope",
+    (
+        _normalize_constraint("Safety"),
+        _normalize_constraint(
+            "Never expose secrets, add hidden AI attribution, force-push, or weaken tests."
+        ),
+    ): "shared-core:safety",
+    (
+        _normalize_constraint("Preservation"),
+        _normalize_constraint(
+            "Preserve unmanaged content in high-context files, settings, and hooks."
+        ),
+    ): "shared-core:preservation",
+    (
+        _normalize_constraint("Verification"),
+        _normalize_constraint(
+            "Run a fresh, focused project command before claiming completion."
+        ),
+    ): "shared-core:verification",
+}
+
+
+def _rule_constraint_key(rule_id: str) -> str:
+    return RULE_EQUIVALENT_KEYS.get(rule_id, f"rule:{rule_id}")
+
+
+def _core_constraint_key(area: str, requirement: str) -> str:
+    normalized_area = _normalize_constraint(area)
+    normalized_requirement = _normalize_constraint(requirement)
+    return CORE_EQUIVALENT_KEYS.get(
+        (normalized_area, normalized_requirement),
+        f"core:{normalized_area}:{normalized_requirement}",
+    )
+
+
+def _is_rule_constraint(constraint: Constraint) -> bool:
+    return TABLE_RULE_ID_RE.fullmatch(constraint.label) is not None
+
+
 def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
     _fields, body = _strip_frontmatter(text)
     frontmatter_offset = len(text) - len(body)
@@ -93,7 +159,7 @@ def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
     for match in RULE_ID_RE.finditer(body):
         rule_id = match.group(1)
         yield Constraint(
-            key=f"rule:{rule_id}",
+            key=_rule_constraint_key(rule_id),
             label=rule_id,
             source=path,
             line=_line_number(text, frontmatter_offset + match.start()),
@@ -101,6 +167,7 @@ def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
 
     in_fence = False
     in_core_contract = False
+    in_compact_rules = False
     body_lines = body.splitlines()
     for index, line in enumerate(body_lines, start=_line_number(text, frontmatter_offset)):
         stripped = line.strip()
@@ -109,14 +176,20 @@ def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
             continue
         if in_fence or not stripped:
             continue
+        if stripped == COMPACT_RULES_START:
+            in_compact_rules = True
+            continue
+        if stripped == COMPACT_RULES_END:
+            in_compact_rules = False
+            continue
         if stripped.startswith("## "):
             in_core_contract = stripped == "## Core contract"
         if stripped.startswith("|"):
             cells = [cell.strip() for cell in stripped.strip("|").split("|")]
             first_cell = cells[0] if cells else ""
-            if TABLE_RULE_ID_RE.fullmatch(first_cell):
+            if in_compact_rules and TABLE_RULE_ID_RE.fullmatch(first_cell):
                 yield Constraint(
-                    key=f"rule:{first_cell}",
+                    key=_rule_constraint_key(first_cell),
                     label=first_cell,
                     source=path,
                     line=index,
@@ -128,12 +201,7 @@ def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
                 and not set(first_cell) <= {"-", ":"}
             ):
                 yield Constraint(
-                    key=(
-                        "core:"
-                        + _normalize_constraint(first_cell)
-                        + ":"
-                        + _normalize_constraint(cells[1])
-                    ),
+                    key=_core_constraint_key(first_cell, cells[1]),
                     label=f"Core contract: {first_cell}",
                     source=path,
                     line=index,
@@ -276,18 +344,29 @@ def discover_sources(
 
 def count_constraints(sources: dict[Path, str]) -> tuple[list[SourceReport], list[Constraint]]:
     seen: set[str] = set()
-    reports: list[SourceReport] = []
+    parsed_sources: list[tuple[SourceReport, list[Constraint]]] = []
     all_constraints: list[Constraint] = []
 
     for path, kind in sorted(sources.items(), key=lambda item: str(item[0])):
         text = _read_text(path)
         report = SourceReport(path=path, kind=kind)
-        for constraint in _iter_constraints(path, text):
-            if constraint.key in seen:
-                continue
-            seen.add(constraint.key)
-            report.constraints.append(constraint)
-            all_constraints.append(constraint)
+        parsed_sources.append((report, list(_iter_constraints(path, text))))
+
+    # Rule IDs win over equivalent shared-core rows so reports retain a useful
+    # canonical ID while still counting the semantic requirement only once.
+    for rule_pass in (True, False):
+        for report, constraints in parsed_sources:
+            for constraint in constraints:
+                if _is_rule_constraint(constraint) != rule_pass:
+                    continue
+                if constraint.key in seen:
+                    continue
+                seen.add(constraint.key)
+                report.constraints.append(constraint)
+                all_constraints.append(constraint)
+
+    reports: list[SourceReport] = []
+    for report, _constraints in parsed_sources:
         report.count = len(report.constraints)
         if report.count:
             reports.append(report)
@@ -311,7 +390,7 @@ def load_recent_event_text(log_paths: list[Path], max_lines: int) -> str:
 def low_frequency_candidates(constraints: list[Constraint], event_text: str, limit: int) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
     for constraint in constraints:
-        if not constraint.key.startswith("rule:"):
+        if not _is_rule_constraint(constraint):
             continue
         rule_id = constraint.label
         if rule_id in event_text:
@@ -383,7 +462,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         ],
         "constraints": [
             {
-                "id": constraint.label if constraint.key.startswith("rule:") else "",
+                "id": constraint.label if _is_rule_constraint(constraint) else "",
                 "label": constraint.label,
                 "source": str(constraint.source),
                 "line": constraint.line,

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -22,6 +22,7 @@ from typing import Any, Iterable
 WARN_THRESHOLD = 15
 BLOCK_THRESHOLD = 30
 RULE_ID_RE = re.compile(r"^##\s+((?:U|W|SEC|RS|PY|TS|GO|TASTE)-\d+):", re.M)
+TABLE_RULE_ID_RE = re.compile(r"(?:U|W|SEC|RS|PY|TS|GO|TASTE)-\d+")
 BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(.+)")
 NORMATIVE_RE = re.compile(
     r"\b(must|must not|should|should not|never|always|require|requires|required|"
@@ -99,13 +100,39 @@ def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
         )
 
     in_fence = False
+    in_core_contract = False
     body_lines = body.splitlines()
     for index, line in enumerate(body_lines, start=_line_number(text, frontmatter_offset)):
         stripped = line.strip()
         if stripped.startswith("```"):
             in_fence = not in_fence
             continue
-        if in_fence or not stripped or stripped.startswith("|"):
+        if in_fence or not stripped:
+            continue
+        if stripped.startswith("## "):
+            in_core_contract = stripped == "## Core contract"
+        if stripped.startswith("|"):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            first_cell = cells[0] if cells else ""
+            if TABLE_RULE_ID_RE.fullmatch(first_cell):
+                yield Constraint(
+                    key=f"rule:{first_cell}",
+                    label=first_cell,
+                    source=path,
+                    line=index,
+                )
+            elif (
+                in_core_contract
+                and len(cells) >= 2
+                and first_cell not in {"Area", ""}
+                and not set(first_cell) <= {"-", ":"}
+            ):
+                yield Constraint(
+                    key="core:" + _normalize_constraint(first_cell),
+                    label=f"Core contract: {first_cell}",
+                    source=path,
+                    line=index,
+                )
             continue
         bullet = BULLET_RE.match(line)
         if not bullet:

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -170,6 +170,14 @@ def _add_source(
     sources[resolved] = kind
 
 
+def _host_includes_claude(host: str) -> bool:
+    return host in {"all", "claude"}
+
+
+def _host_includes_codex(host: str) -> bool:
+    return host in {"all", "codex"}
+
+
 def discover_sources(
     root: Path,
     home: Path,
@@ -177,21 +185,32 @@ def discover_sources(
     skills: list[str],
     explicit_sources: list[Path],
     include_canonical_rules: bool,
+    host: str,
 ) -> dict[Path, str]:
     sources: dict[Path, str] = {}
 
     for path in explicit_sources:
         _add_source(sources, path, "explicit", root=root, task_paths=task_paths)
 
-    global_files = [
-        home / ".claude" / "CLAUDE.md",
-        home / ".claude" / "AGENTS.md",
-        home / ".codex" / "AGENTS.md",
-    ]
+    global_files = []
+    if _host_includes_claude(host):
+        global_files.extend(
+            [
+                home / ".claude" / "CLAUDE.md",
+                home / ".claude" / "AGENTS.md",
+            ]
+        )
+    if _host_includes_codex(host):
+        global_files.append(home / ".codex" / "AGENTS.md")
     for path in global_files:
         _add_source(sources, path, "global", root=root, task_paths=task_paths)
 
-    for base in (home / ".claude" / "rules", home / ".codex" / "rules"):
+    global_rule_roots = []
+    if _host_includes_claude(host):
+        global_rule_roots.append(home / ".claude" / "rules")
+    if _host_includes_codex(host):
+        global_rule_roots.append(home / ".codex" / "rules")
+    for base in global_rule_roots:
         for path in _iter_files(base, "**/*.md"):
             _add_source(sources, path, "global-rule", root=root, task_paths=task_paths)
 
@@ -213,9 +232,11 @@ def discover_sources(
     skill_roots = [
         root / "skills",
         root / "workflows",
-        home / ".claude" / "skills",
-        home / ".codex" / "skills",
     ]
+    if _host_includes_claude(host):
+        skill_roots.append(home / ".claude" / "skills")
+    if _host_includes_codex(host):
+        skill_roots.append(home / ".codex" / "skills")
     for skill in skills:
         for base in skill_roots:
             _add_source(sources, base / skill / "SKILL.md", "skill", root=root, task_paths=task_paths)
@@ -300,6 +321,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         skills,
         explicit_sources,
         args.include_canonical_rules,
+        args.host,
     )
     reports, constraints = count_constraints(sources)
     total = len(constraints)
@@ -379,6 +401,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Count effective VibeGuard constraints")
     parser.add_argument("--root", default=".", help="Project root to scan")
     parser.add_argument("--home", default=str(Path.home()), help="Home directory for global agent surfaces")
+    parser.add_argument(
+        "--host",
+        choices=("all", "claude", "codex"),
+        default="all",
+        help="Agent host whose global surfaces are active",
+    )
     parser.add_argument("--task-path", action="append", help="Task path used to activate path-scoped rules")
     parser.add_argument("--skill", action="append", help="Active skill name whose SKILL.md is loaded")
     parser.add_argument("--source", action="append", help="Explicit markdown source to include")

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -290,11 +290,13 @@ def discover_sources(
         for path in _iter_files(base, "**/*.md"):
             _add_source(sources, path, "global-rule", root=root, task_paths=task_paths)
 
-    project_files = [root / "AGENTS.md"]
+    project_files = []
     if _host_includes_codex(host):
         project_files.extend(_codex_project_instruction_files(root, task_paths))
     if _host_includes_claude(host):
-        project_files.extend([root / "CLAUDE.md", root / ".claude" / "CLAUDE.md"])
+        project_files.extend(
+            [root / "AGENTS.md", root / "CLAUDE.md", root / ".claude" / "CLAUDE.md"]
+        )
     for path in project_files:
         _add_source(sources, path, "project", root=root, task_paths=task_paths)
 
@@ -323,7 +325,7 @@ def discover_sources(
 
 def _codex_project_instruction_files(root: Path, task_paths: list[str]) -> list[Path]:
     resolved_root = root.resolve()
-    instruction_files: set[Path] = set()
+    instruction_files = {_codex_instruction_file(resolved_root)}
     for task_path in task_paths:
         candidate = Path(task_path)
         if not candidate.is_absolute():
@@ -335,12 +337,17 @@ def _codex_project_instruction_files(root: Path, task_paths: list[str]) -> list[
             continue
         directory = candidate if candidate.is_dir() else candidate.parent
         while directory != resolved_root:
-            instruction_files.add(directory / "AGENTS.md")
+            instruction_files.add(_codex_instruction_file(directory))
             parent = directory.parent
             if parent == directory:
                 break
             directory = parent
     return sorted(instruction_files)
+
+
+def _codex_instruction_file(directory: Path) -> Path:
+    override_path = directory / "AGENTS.override.md"
+    return override_path if override_path.is_file() else directory / "AGENTS.md"
 
 
 def count_constraints(sources: dict[Path, str]) -> tuple[list[SourceReport], list[Constraint]]:

--- a/scripts/constraints/count_active_constraints.py
+++ b/scripts/constraints/count_active_constraints.py
@@ -128,7 +128,12 @@ def _iter_constraints(path: Path, text: str) -> Iterable[Constraint]:
                 and not set(first_cell) <= {"-", ":"}
             ):
                 yield Constraint(
-                    key="core:" + _normalize_constraint(first_cell),
+                    key=(
+                        "core:"
+                        + _normalize_constraint(first_cell)
+                        + ":"
+                        + _normalize_constraint(cells[1])
+                    ),
                     label=f"Core contract: {first_cell}",
                     source=path,
                     line=index,
@@ -236,8 +241,6 @@ def discover_sources(
     global_rule_roots = []
     if _host_includes_claude(host):
         global_rule_roots.append(home / ".claude" / "rules")
-    if _host_includes_codex(host):
-        global_rule_roots.append(codex_home / "rules")
     for base in global_rule_roots:
         for path in _iter_files(base, "**/*.md"):
             _add_source(sources, path, "global-rule", root=root, task_paths=task_paths)

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -217,19 +217,44 @@ def replace_compact_region(document: str, table: str) -> str:
 
 
 def compose_host_rules(shared: str, host: str) -> str:
-    if shared.count(VIBEGUARD_START_MARKER) != 1 or shared.count(VIBEGUARD_END_MARKER) != 1:
-        raise ValueError("shared VibeGuard markers must appear exactly once")
+    managed_shared = extract_vibeguard_managed_block(shared)
     if VIBEGUARD_START_MARKER in host or VIBEGUARD_END_MARKER in host:
         raise ValueError("host guidance must not contain VibeGuard managed markers")
 
-    start_index = shared.find(VIBEGUARD_START_MARKER)
-    end_index = shared.find(VIBEGUARD_END_MARKER)
-    if start_index >= end_index:
-        raise ValueError("shared VibeGuard markers must be in order")
     host = host.strip()
     if not host:
         raise ValueError("host guidance must not be empty")
-    return shared[:end_index].rstrip() + "\n\n" + host + "\n" + shared[end_index:]
+    end_index = managed_shared.find(VIBEGUARD_END_MARKER)
+    return (
+        managed_shared[:end_index].rstrip()
+        + "\n\n"
+        + host
+        + "\n"
+        + managed_shared[end_index:]
+        + "\n"
+    )
+
+
+def extract_vibeguard_managed_block(shared: str) -> str:
+    if shared.count(VIBEGUARD_START_MARKER) != 1 or shared.count(VIBEGUARD_END_MARKER) != 1:
+        raise ValueError("shared VibeGuard markers must appear exactly once")
+
+    start_token = VIBEGUARD_START_MARKER + "\n"
+    start_index = shared.find(start_token)
+    end_index = shared.find(VIBEGUARD_END_MARKER)
+    if start_index < 0 or end_index < start_index + len(start_token):
+        raise ValueError("shared VibeGuard markers must be on their own lines and in order")
+    if start_index > 0 and shared[start_index - 1] != "\n":
+        raise ValueError("shared VibeGuard marker must be on its own line")
+    if end_index > 0 and shared[end_index - 1] != "\n":
+        raise ValueError("shared VibeGuard marker must be on its own line")
+
+    after_end = end_index + len(VIBEGUARD_END_MARKER)
+    if after_end < len(shared) and shared[after_end] != "\n":
+        raise ValueError("shared VibeGuard marker must be on its own line")
+    if shared[:start_index].strip() or shared[after_end:].strip():
+        raise ValueError("shared VibeGuard block must not contain content outside managed markers")
+    return shared[start_index:after_end]
 
 
 def make_table(headers: list[str], rows: list[list[str]]) -> str:
@@ -652,18 +677,26 @@ def render_all(rules: list[Rule]) -> dict[Path, str]:
             compact_document,
             render_compact_table(rules),
         )
-        outputs[COMPACT_RULES_PATH] = rendered_core
-        outputs[CLAUDE_RENDERED_RULES_PATH] = compose_host_rules(
-            rendered_core,
-            CLAUDE_HOST_RULES_PATH.read_text(encoding="utf-8"),
-        )
-        outputs[CODEX_RENDERED_RULES_PATH] = compose_host_rules(
-            rendered_core,
-            CODEX_HOST_RULES_PATH.read_text(encoding="utf-8"),
-        )
+        extract_vibeguard_managed_block(rendered_core)
     except ValueError as error:
         relative_path = COMPACT_RULES_PATH.relative_to(ROOT)
         raise ValueError(f"{relative_path}: {error}") from error
+
+    outputs[COMPACT_RULES_PATH] = rendered_core
+    for rendered_path, host_path in (
+        (CLAUDE_RENDERED_RULES_PATH, CLAUDE_HOST_RULES_PATH),
+        (CODEX_RENDERED_RULES_PATH, CODEX_HOST_RULES_PATH),
+    ):
+        try:
+            outputs[rendered_path] = compose_host_rules(
+                rendered_core,
+                host_path.read_text(encoding="utf-8"),
+            )
+        except ValueError as error:
+            relative_path = (
+                host_path.relative_to(ROOT) if host_path.is_relative_to(ROOT) else host_path
+            )
+            raise ValueError(f"{relative_path}: {error}") from error
     return outputs
 
 

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -15,20 +15,21 @@ from typing import Callable, Iterable
 ROOT = Path(__file__).resolve().parents[1]
 CANONICAL_RULES_DIR = ROOT / "rules" / "claude-rules"
 COMPACT_RULES_PATH = ROOT / "claude-md" / "vibeguard-rules.md"
+CLAUDE_HOST_RULES_PATH = ROOT / "claude-md" / "vibeguard-claude.md"
+CODEX_HOST_RULES_PATH = ROOT / "claude-md" / "vibeguard-codex.md"
+CLAUDE_RENDERED_RULES_PATH = ROOT / "claude-md" / "vibeguard-claude-rules.md"
+CODEX_RENDERED_RULES_PATH = ROOT / "claude-md" / "vibeguard-codex-rules.md"
 COMPACT_START_MARKER = "<!-- vibeguard-generated-compact-rules:start -->"
 COMPACT_END_MARKER = "<!-- vibeguard-generated-compact-rules:end -->"
+VIBEGUARD_START_MARKER = "<!-- vibeguard-start -->"
+VIBEGUARD_END_MARKER = "<!-- vibeguard-end -->"
 COMPACT_RULE_IDS = (
-    "U-16",
     "U-17",
-    "U-22",
-    "U-25",
     "U-26",
     "U-29",
-    "W-01",
     "W-02",
     "W-03",
     "W-12",
-    "W-14",
     "W-16",
     "SEC-01",
     "SEC-02",
@@ -213,6 +214,22 @@ def replace_compact_region(document: str, table: str) -> str:
 
     content_start = start_index + len(start_token)
     return document[:content_start] + table.rstrip("\n") + "\n" + document[end_index:]
+
+
+def compose_host_rules(shared: str, host: str) -> str:
+    if shared.count(VIBEGUARD_START_MARKER) != 1 or shared.count(VIBEGUARD_END_MARKER) != 1:
+        raise ValueError("shared VibeGuard markers must appear exactly once")
+    if VIBEGUARD_START_MARKER in host or VIBEGUARD_END_MARKER in host:
+        raise ValueError("host guidance must not contain VibeGuard managed markers")
+
+    start_index = shared.find(VIBEGUARD_START_MARKER)
+    end_index = shared.find(VIBEGUARD_END_MARKER)
+    if start_index >= end_index:
+        raise ValueError("shared VibeGuard markers must be in order")
+    host = host.strip()
+    if not host:
+        raise ValueError("host guidance must not be empty")
+    return shared[:end_index].rstrip() + "\n\n" + host + "\n" + shared[end_index:]
 
 
 def make_table(headers: list[str], rows: list[list[str]]) -> str:
@@ -631,9 +648,18 @@ def render_all(rules: list[Rule]) -> dict[Path, str]:
     outputs = {path: generator(rules).rstrip() + "\n" for path, generator in GENERATORS.items()}
     compact_document = COMPACT_RULES_PATH.read_text(encoding="utf-8")
     try:
-        outputs[COMPACT_RULES_PATH] = replace_compact_region(
+        rendered_core = replace_compact_region(
             compact_document,
             render_compact_table(rules),
+        )
+        outputs[COMPACT_RULES_PATH] = rendered_core
+        outputs[CLAUDE_RENDERED_RULES_PATH] = compose_host_rules(
+            rendered_core,
+            CLAUDE_HOST_RULES_PATH.read_text(encoding="utf-8"),
+        )
+        outputs[CODEX_RENDERED_RULES_PATH] = compose_host_rules(
+            rendered_core,
+            CODEX_HOST_RULES_PATH.read_text(encoding="utf-8"),
         )
     except ValueError as error:
         relative_path = COMPACT_RULES_PATH.relative_to(ROOT)

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -627,8 +627,7 @@ vibeguard_managed_rule_banner_count() {
 }
 
 vibeguard_managed_rules_block_matches_source() {
-  local target_file="$1" rule_count="$2"
-  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
+  local target_file="$1" rule_count="$2" rules_file="$3"
   local diff_output
   [[ -f "${target_file}" ]] || return 2
   if ! diff_output=$(setup_runtime setup-md-diff-inject "${target_file}" "${rules_file}" "${REPO_DIR}" "${rule_count}" 2>/dev/null); then
@@ -638,8 +637,7 @@ vibeguard_managed_rules_block_matches_source() {
 }
 
 inject_vibeguard_rules() {
-  local target_file="$1" display_label="$2" state_source="$3"
-  local rules_file="${REPO_DIR}/claude-md/vibeguard-rules.md"
+  local target_file="$1" display_label="$2" state_source="$3" rules_file="$4"
   local rules_diff rule_count result
 
   rule_count=$(claude_rule_count_for_banner)

--- a/scripts/setup/targets/claude-home.sh
+++ b/scripts/setup/targets/claude-home.sh
@@ -187,7 +187,7 @@ _rule_label_is_selected() {
 
 # GH-541: the full native rule text (~126 constraints across rules/claude-rules/**)
 # is only front-injected under the full/strict profiles. The default (core) and
-# minimal profiles rely on the compact L1-L7 + Key Detailed Rules table already
+# minimal profiles rely on the shared compact core plus Claude host guidance
 # synced into ~/.claude/CLAUDE.md, keeping the live payload within the U-32
 # budget. The full-text tree stays installed under ~/.vibeguard and is opt-in.
 _claude_profile_injects_full_rule_tree() {
@@ -335,8 +335,8 @@ install_claude_home_assets() {
   else
     # GH-541: compact core default — remove any previously front-injected full
     # rule tree so switching down from full/strict shrinks the live payload.
-    # The compact L1-L7 + Key Detailed Rules table in ~/.claude/CLAUDE.md is the
-    # always-on surface; custom/ user rules below are preserved.
+    # The shared compact core plus Claude host guidance in ~/.claude/CLAUDE.md
+    # is the always-on surface; custom/ user rules below are preserved.
     all_labels="$(manifest_rule_labels_checked "")" || return 1
     while IFS= read -r label; do
       [[ -n "${label}" ]] || continue
@@ -344,7 +344,7 @@ install_claude_home_assets() {
         _remove_rule_subtree_if_safe "$(_claude_source_path "rules/claude-rules/${label}")" "${rules_dest}/${label}" "${label}" || return 1
       fi
     done <<< "${all_labels}"
-    green "  compact core (${PROFILE} profile): L1-L7 + Key Detailed Rules table via ~/.claude/CLAUDE.md; full rule text opt-in with --profile full|strict"
+    green "  compact core (${PROFILE} profile): shared core + Claude host guidance via ~/.claude/CLAUDE.md; full rule text opt-in with --profile full|strict"
   fi
 
   if [[ -d "${rules_dest}" ]]; then
@@ -418,7 +418,11 @@ configure_claude_home_runtime() {
 
 inject_claude_home_rules() {
   echo "Step 10: Update VibeGuard rules in CLAUDE.md"
-  inject_vibeguard_rules "${CLAUDE_DIR}/CLAUDE.md" "~/.claude/CLAUDE.md" "generated/CLAUDE.md"
+  inject_vibeguard_rules \
+    "${CLAUDE_DIR}/CLAUDE.md" \
+    "~/.claude/CLAUDE.md" \
+    "generated/CLAUDE.md" \
+    "${REPO_DIR}/claude-md/vibeguard-claude-rules.md"
 }
 
 check_claude_home_installation() {
@@ -532,7 +536,10 @@ check_claude_home_installation() {
         yellow "[INFO] Re-run 'bash setup.sh' to repair the rule count banner in ~/.claude/CLAUDE.md"
       fi
       local block_check_rc=0
-      if vibeguard_managed_rules_block_matches_source "${claude_md}" "${actual_rule_count}"; then
+      if vibeguard_managed_rules_block_matches_source \
+        "${claude_md}" \
+        "${actual_rule_count}" \
+        "${REPO_DIR}/claude-md/vibeguard-claude-rules.md"; then
         green "[OK] CLAUDE.md managed VibeGuard block matches current rules"
       else
         block_check_rc=$?

--- a/scripts/setup/targets/codex-home.sh
+++ b/scripts/setup/targets/codex-home.sh
@@ -151,7 +151,11 @@ codex_native_capability_summary() {
 inject_codex_home_rules() {
   echo "Step 10.1: Update VibeGuard rules in ~/.codex/AGENTS.md"
   local agents_md="${CODEX_DIR}/AGENTS.md"
-  inject_vibeguard_rules "${agents_md}" "~/.codex/AGENTS.md" "generated/AGENTS.md"
+  inject_vibeguard_rules \
+    "${agents_md}" \
+    "~/.codex/AGENTS.md" \
+    "generated/AGENTS.md" \
+    "${REPO_DIR}/claude-md/vibeguard-codex-rules.md"
 }
 
 check_codex_home_installation() {
@@ -439,11 +443,11 @@ check_codex_agents_hygiene() {
   local -a missing_anchors=()
   managed_block=$(sed -n "${start_line},${end_line}p" "${agents_md}")
   for anchor in \
-    "#VibeGuard" \
-    "## Constraints" \
+    "# VibeGuard shared core" \
+    "## Core contract" \
     "## Chat Contract" \
-    "## Key Detailed Rules" \
-    "| L1 |" \
+    "## Key detailed rules" \
+    "## Codex host guidance" \
     "| W-03 |" \
     "| SEC-13 |"; do
     if ! grep -qF "${anchor}" <<< "${managed_block}"; then
@@ -471,7 +475,10 @@ check_codex_agents_hygiene() {
       yellow "[INFO] Re-run 'bash setup.sh' to repair the rule count banner in ~/.codex/AGENTS.md"
     fi
     local block_check_rc=0
-    if vibeguard_managed_rules_block_matches_source "${agents_md}" "${actual_rule_count}"; then
+    if vibeguard_managed_rules_block_matches_source \
+      "${agents_md}" \
+      "${actual_rule_count}" \
+      "${REPO_DIR}/claude-md/vibeguard-codex-rules.md"; then
       green "[OK] ~/.codex/AGENTS.md managed VibeGuard block matches current rules"
     else
       block_check_rc=$?

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -123,6 +123,34 @@ assert_not_contains "${host_claude_json}" "Codex global guidance" "Claude host s
 host_all_json="$(python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --json)"
 assert_contains "${host_all_json}" '"total": 2' "default host scope preserves all global guidance"
 
+CUSTOM_CODEX_HOME="${TMP_ROOT}/custom-codex-home"
+mkdir -p "${CUSTOM_CODEX_HOME}" "${HOST_REPO}/.claude/rules"
+cat > "${CUSTOM_CODEX_HOME}/AGENTS.md" <<'MD'
+# Custom Codex Global
+
+- Must count configured Codex guidance.
+MD
+cat > "${HOST_REPO}/AGENTS.md" <<'MD'
+# Shared Project
+
+- Must count project AGENTS guidance.
+MD
+cat > "${HOST_REPO}/CLAUDE.md" <<'MD'
+# Claude Project
+
+- Must not count Claude project guidance.
+MD
+cat > "${HOST_REPO}/.claude/rules/claude.md" <<'MD'
+# Claude Project Rule
+
+- Must not count Claude project rules.
+MD
+custom_codex_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --json)"
+assert_contains "${custom_codex_json}" '"total": 2' "Codex scope counts configured CODEX_HOME plus project AGENTS only"
+assert_contains "${custom_codex_json}" "configured Codex guidance" "Codex scope honors CODEX_HOME"
+assert_not_contains "${custom_codex_json}" "Claude project" "Codex scope excludes Claude-only project instructions and rules"
+assert_not_contains "${custom_codex_json}" "Codex global guidance" "configured CODEX_HOME replaces the fallback ~/.codex source"
+
 canonical_ids_for_task_path() {
   local task_path="$1"
   python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path "${task_path}" --json \

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -98,6 +98,27 @@ assert_contains "${path_json}" '"id": "PY-01"' "path-scoped rule activates for m
 no_path_json="$(python3 "${COUNTER}" --root "${PATH_REPO}" --home "${PATH_HOME}" --task-path README.md --json)"
 assert_not_contains "${no_path_json}" '"id": "PY-01"' "path-scoped rule stays unloaded for non-matching task path"
 
+HOST_HOME="${TMP_ROOT}/home-host"
+HOST_REPO="${TMP_ROOT}/repo-host"
+make_home "${HOST_HOME}"
+make_repo "${HOST_REPO}"
+mkdir -p "${HOST_HOME}/.codex"
+cat > "${HOST_HOME}/.claude/CLAUDE.md" <<'MD'
+# Claude Global
+
+- Must keep Claude global guidance.
+MD
+cat > "${HOST_HOME}/.codex/AGENTS.md" <<'MD'
+# Codex Global
+
+- Must not count Codex global guidance.
+MD
+host_claude_json="$(python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --host claude --json)"
+assert_contains "${host_claude_json}" '"total": 1' "Claude host scope counts only Claude global guidance"
+assert_not_contains "${host_claude_json}" "Codex global guidance" "Claude host scope excludes Codex global guidance"
+host_all_json="$(python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --json)"
+assert_contains "${host_all_json}" '"total": 2' "default host scope preserves all global guidance"
+
 canonical_ids_for_task_path() {
   local task_path="$1"
   python3 "${COUNTER}" --root "${REPO_DIR}" --home "${PATH_HOME}" --include-canonical-rules --task-path "${task_path}" --json \

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -158,6 +158,24 @@ assert_not_contains "${custom_codex_json}" "Claude project" "Codex scope exclude
 assert_not_contains "${custom_codex_json}" "Codex global guidance" "configured CODEX_HOME replaces the fallback ~/.codex source"
 assert_not_contains "${custom_codex_json}" "unsupported Codex native rules" "Codex scope excludes unsupported native rule paths"
 
+mkdir -p "${HOST_REPO}/packages/api/src" "${HOST_REPO}/packages/web"
+cat > "${HOST_REPO}/packages/AGENTS.md" <<'MD'
+- Must count parent package guidance.
+MD
+cat > "${HOST_REPO}/packages/api/AGENTS.md" <<'MD'
+- Must count nested API guidance.
+MD
+cat > "${HOST_REPO}/packages/web/AGENTS.md" <<'MD'
+- Must not count sibling guidance.
+MD
+nested_codex_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path packages/api/src/lib.rs --json)"
+assert_contains "${nested_codex_json}" '"total": 4' "Codex scope counts root and applicable nested AGENTS files"
+assert_contains "${nested_codex_json}" "parent package guidance" "Codex scope counts parent AGENTS guidance"
+assert_contains "${nested_codex_json}" "nested API guidance" "Codex scope counts nearest nested AGENTS guidance"
+assert_not_contains "${nested_codex_json}" "sibling guidance" "Codex scope excludes sibling AGENTS guidance"
+nested_codex_runtime_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" "${RUNTIME_BIN}" active-constraints --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path packages/api/src/lib.rs --json)"
+assert_contains "${nested_codex_runtime_json}" '"total": 4' "production counter matches nested Codex instruction discovery"
+
 CORE_ROW_REPO="${TMP_ROOT}/repo-core-row-dedupe"
 CORE_ROW_HOME="${TMP_ROOT}/home-core-row-dedupe"
 make_home "${CORE_ROW_HOME}"
@@ -218,9 +236,11 @@ cat > "${EQUIVALENT_REPO}/AGENTS.md" <<'MD'
 <!-- vibeguard-generated-compact-rules:end -->
 MD
 equivalent_json="$(python3 "${COUNTER}" --root "${EQUIVALENT_REPO}" --home "${EQUIVALENT_HOME}" --host claude --json)"
-assert_contains "${equivalent_json}" '"total": 5' "Python counter deduplicates all shared-core rule equivalents"
+assert_contains "${equivalent_json}" '"total": 11' "Python counter keeps distinct detailed rules while deduplicating exact core equivalents"
+equivalent_ids="$(printf '%s' "${equivalent_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
+assert_exit_zero "Python counter retains every detailed constraint ID" test "${equivalent_ids}" = "SEC-02,SEC-13,U-04,U-08,U-17,U-29,W-03,W-12,W-16"
 equivalent_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${EQUIVALENT_REPO}" --home "${EQUIVALENT_HOME}" --host claude --json)"
-assert_contains "${equivalent_runtime_json}" '"total": 5' "production counter matches shared-core rule equivalence"
+assert_contains "${equivalent_runtime_json}" '"total": 11' "production counter matches exact shared-core equivalence"
 
 canonical_ids_for_task_path() {
   local task_path="$1"
@@ -330,12 +350,12 @@ if [[ -f "${CLAUDE_COMPACT_SRC}" && -f "${CODEX_COMPACT_SRC}" ]]; then
   make_repo "${CLAUDE_CORE_REPO}"
   cp "${CLAUDE_COMPACT_SRC}" "${CLAUDE_CORE_HOME}/.claude/CLAUDE.md"
   claude_core_json="$(python3 "${COUNTER}" --root "${CLAUDE_CORE_REPO}" --home "${CLAUDE_CORE_HOME}" --host claude --json)"
-  assert_contains "${claude_core_json}" '"total": 15' "Python counter deduplicates equivalent core rows in Claude payload"
-  assert_contains "${claude_core_json}" '"status": "ok"' "Claude payload stays below the advisory threshold after semantic deduplication"
+  assert_contains "${claude_core_json}" '"total": 20' "Python counter reports the exact Claude payload budget"
+  assert_contains "${claude_core_json}" '"status": "warn"' "Claude payload truthfully reports its advisory budget status"
   claude_compact_ids="$(printf '%s' "${claude_core_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
-  assert_contains "${claude_compact_ids}" "U-17,U-26,W-02,W-03,W-12,SEC-01,SEC-11,SEC-13" "Claude payload retains canonical IDs for distinct compact constraints"
+  assert_exit_zero "Claude payload retains every compact constraint ID" test "${claude_compact_ids}" = "U-17,U-26,U-29,W-02,W-03,W-12,W-16,SEC-01,SEC-02,SEC-11,SEC-13"
   claude_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${CLAUDE_CORE_REPO}" --home "${CLAUDE_CORE_HOME}" --host claude --json)"
-  assert_contains "${claude_runtime_json}" '"total": 15' "production counter matches the deduplicated Claude payload count"
+  assert_contains "${claude_runtime_json}" '"total": 20' "production counter matches the exact Claude payload count"
 
   CODEX_CORE_HOME="${TMP_ROOT}/home-gh541-codex-core"
   CODEX_CORE_REPO="${TMP_ROOT}/repo-gh541-codex-core"
@@ -344,12 +364,12 @@ if [[ -f "${CLAUDE_COMPACT_SRC}" && -f "${CODEX_COMPACT_SRC}" ]]; then
   mkdir -p "${CODEX_CORE_HOME}/.codex"
   cp "${CODEX_COMPACT_SRC}" "${CODEX_CORE_HOME}/.codex/AGENTS.md"
   codex_core_json="$(python3 "${COUNTER}" --root "${CODEX_CORE_REPO}" --home "${CODEX_CORE_HOME}" --host codex --json)"
-  assert_contains "${codex_core_json}" '"total": 15' "Python counter deduplicates equivalent core rows in Codex payload"
-  assert_contains "${codex_core_json}" '"status": "ok"' "Codex payload stays below the advisory threshold after semantic deduplication"
+  assert_contains "${codex_core_json}" '"total": 20' "Python counter reports the exact Codex payload budget"
+  assert_contains "${codex_core_json}" '"status": "warn"' "Codex payload truthfully reports its advisory budget status"
   codex_compact_ids="$(printf '%s' "${codex_core_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
-  assert_contains "${codex_compact_ids}" "U-17,U-26,W-02,W-03,W-12,SEC-01,SEC-11,SEC-13" "Codex payload retains canonical IDs for distinct compact constraints"
+  assert_exit_zero "Codex payload retains every compact constraint ID" test "${codex_compact_ids}" = "U-17,U-26,U-29,W-02,W-03,W-12,W-16,SEC-01,SEC-02,SEC-11,SEC-13"
   codex_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${CODEX_CORE_REPO}" --home "${CODEX_CORE_HOME}" --host codex --json)"
-  assert_contains "${codex_runtime_json}" '"total": 15' "production counter matches the deduplicated Codex payload count"
+  assert_contains "${codex_runtime_json}" '"total": 20' "production counter matches the exact Codex payload count"
 
   FULL_HOME="${TMP_ROOT}/home-gh541-full"
   FULL_REPO="${TMP_ROOT}/repo-gh541-full"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -179,7 +179,6 @@ assert_not_contains "${nested_codex_json}" "overridden API fallback guidance" "C
 assert_not_contains "${nested_codex_json}" "sibling guidance" "Codex scope excludes sibling AGENTS guidance"
 nested_codex_runtime_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" "${RUNTIME_BIN}" active-constraints --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path packages/api/src/lib.rs --json)"
 assert_contains "${nested_codex_runtime_json}" '"total": 4' "production counter matches nested Codex instruction discovery"
-
 mkdir -p "${TMP_ROOT}/outside"
 cat > "${TMP_ROOT}/outside/AGENTS.md" <<'MD'
 - Must not count an instruction outside the repository.
@@ -190,7 +189,6 @@ assert_not_contains "${outside_codex_json}" "outside the repository" "Codex scop
 outside_codex_runtime_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" "${RUNTIME_BIN}" active-constraints --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path ../outside/new.rs --json)"
 assert_contains "${outside_codex_runtime_json}" '"total": 2' "production counter rejects unresolved external task paths"
 assert_not_contains "${outside_codex_runtime_json}" "outside the repository" "production counter excludes external AGENTS guidance"
-
 CORE_ROW_REPO="${TMP_ROOT}/repo-core-row-dedupe"
 CORE_ROW_HOME="${TMP_ROOT}/home-core-row-dedupe"
 make_home "${CORE_ROW_HOME}"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -12,6 +12,10 @@ trap cleanup_count_active_constraints EXIT
 
 COUNTER="${REPO_DIR}/scripts/constraints/count_active_constraints.py"
 HOOK="${REPO_DIR}/hooks/count_active_constraints.sh"
+RUNTIME_BIN="${VIBEGUARD_RUNTIME:-${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime}"
+if [[ ! -x "${RUNTIME_BIN}" ]]; then
+  cargo build --quiet --manifest-path "${REPO_DIR}/vibeguard-runtime/Cargo.toml"
+fi
 
 hook_no_ci_env=(
   CI=false
@@ -209,23 +213,44 @@ header "GH-541 rule-delivery budget (compact core default vs full-tree opt-in)"
 # The default (core/minimal) Claude profile injects only the shared compact core
 # plus Claude host guidance into ~/.claude/CLAUDE.md; the full rules/claude-rules
 # tree is opt-in under full/strict. This asserts the actual production content:
-# the compact core stays within the U-32 budget, while the full common/ tree —
-# the payload the default profile must NOT front-inject — blows past the block
-# threshold. See scripts/setup/targets/claude-home.sh Step 5.5.
+# the compact core stays below U-32's block threshold while retaining the
+# truthful >15 advisory, whereas the full common/ tree — the payload the
+# default profile must NOT front-inject — blows past the block threshold.
+# See scripts/setup/targets/claude-home.sh Step 5.5.
 
-COMPACT_SRC="${REPO_DIR}/claude-md/vibeguard-rules.md"
+CLAUDE_COMPACT_SRC="${REPO_DIR}/claude-md/vibeguard-claude-rules.md"
+CODEX_COMPACT_SRC="${REPO_DIR}/claude-md/vibeguard-codex-rules.md"
 TOTAL=$((TOTAL + 1))
-if [[ -f "${COMPACT_SRC}" ]]; then
-  green "compact core source present: claude-md/vibeguard-rules.md"
+if [[ -f "${CLAUDE_COMPACT_SRC}" && -f "${CODEX_COMPACT_SRC}" ]]; then
+  green "rendered host payloads are present"
   PASS=$((PASS + 1))
 
-  CORE_HOME="${TMP_ROOT}/home-gh541-core"
-  CORE_REPO="${TMP_ROOT}/repo-gh541-core"
-  make_home "${CORE_HOME}"
-  make_repo "${CORE_REPO}"
-  cp "${COMPACT_SRC}" "${CORE_HOME}/.claude/CLAUDE.md"
-  core_json="$(python3 "${COUNTER}" --root "${CORE_REPO}" --home "${CORE_HOME}" --json)"
-  assert_contains "${core_json}" '"status": "ok"' "compact core default payload stays within U-32 budget"
+  CLAUDE_CORE_HOME="${TMP_ROOT}/home-gh541-claude-core"
+  CLAUDE_CORE_REPO="${TMP_ROOT}/repo-gh541-claude-core"
+  make_home "${CLAUDE_CORE_HOME}"
+  make_repo "${CLAUDE_CORE_REPO}"
+  cp "${CLAUDE_COMPACT_SRC}" "${CLAUDE_CORE_HOME}/.claude/CLAUDE.md"
+  claude_core_json="$(python3 "${COUNTER}" --root "${CLAUDE_CORE_REPO}" --home "${CLAUDE_CORE_HOME}" --host claude --json)"
+  assert_contains "${claude_core_json}" '"total": 22' "Python counter sees all 11 compact rules, 7 core defaults, and 4 normative bullets in Claude payload"
+  assert_contains "${claude_core_json}" '"status": "warn"' "Claude payload truthfully crosses the advisory threshold without blocking"
+  claude_compact_ids="$(printf '%s' "${claude_core_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
+  assert_contains "${claude_compact_ids}" "U-17,U-26,U-29,W-02,W-03,W-12,W-16,SEC-01,SEC-02,SEC-11,SEC-13" "Claude payload exposes the exact compact rule IDs to the counter"
+  claude_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${CLAUDE_CORE_REPO}" --home "${CLAUDE_CORE_HOME}" --host claude --json)"
+  assert_contains "${claude_runtime_json}" '"total": 22' "production counter matches the exact Claude payload count"
+
+  CODEX_CORE_HOME="${TMP_ROOT}/home-gh541-codex-core"
+  CODEX_CORE_REPO="${TMP_ROOT}/repo-gh541-codex-core"
+  make_home "${CODEX_CORE_HOME}"
+  make_repo "${CODEX_CORE_REPO}"
+  mkdir -p "${CODEX_CORE_HOME}/.codex"
+  cp "${CODEX_COMPACT_SRC}" "${CODEX_CORE_HOME}/.codex/AGENTS.md"
+  codex_core_json="$(python3 "${COUNTER}" --root "${CODEX_CORE_REPO}" --home "${CODEX_CORE_HOME}" --host codex --json)"
+  assert_contains "${codex_core_json}" '"total": 22' "Python counter sees all 11 compact rules, 7 core defaults, and 4 normative bullets in Codex payload"
+  assert_contains "${codex_core_json}" '"status": "warn"' "Codex payload truthfully crosses the advisory threshold without blocking"
+  codex_compact_ids="$(printf '%s' "${codex_core_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
+  assert_contains "${codex_compact_ids}" "U-17,U-26,U-29,W-02,W-03,W-12,W-16,SEC-01,SEC-02,SEC-11,SEC-13" "Codex payload exposes the exact compact rule IDs to the counter"
+  codex_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${CODEX_CORE_REPO}" --home "${CODEX_CORE_HOME}" --host codex --json)"
+  assert_contains "${codex_runtime_json}" '"total": 22' "production counter matches the exact Codex payload count"
 
   FULL_HOME="${TMP_ROOT}/home-gh541-full"
   FULL_REPO="${TMP_ROOT}/repo-gh541-full"
@@ -236,7 +261,7 @@ if [[ -f "${COMPACT_SRC}" ]]; then
   assert_exit_nonzero "full common/ tree exceeds the block budget (must stay opt-in, not default)" \
     python3 "${COUNTER}" --root "${FULL_REPO}" --home "${FULL_HOME}" --fail-on-block
 else
-  red "compact core source present: claude-md/vibeguard-rules.md"
+  red "rendered host payloads are present"
   FAIL=$((FAIL + 1))
 fi
 

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -163,7 +163,10 @@ cat > "${HOST_REPO}/packages/AGENTS.md" <<'MD'
 - Must count parent package guidance.
 MD
 cat > "${HOST_REPO}/packages/api/AGENTS.md" <<'MD'
-- Must count nested API guidance.
+- Must not count overridden API fallback guidance.
+MD
+cat > "${HOST_REPO}/packages/api/AGENTS.override.md" <<'MD'
+- Must count nested API override guidance.
 MD
 cat > "${HOST_REPO}/packages/web/AGENTS.md" <<'MD'
 - Must not count sibling guidance.
@@ -171,10 +174,22 @@ MD
 nested_codex_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path packages/api/src/lib.rs --json)"
 assert_contains "${nested_codex_json}" '"total": 4' "Codex scope counts root and applicable nested AGENTS files"
 assert_contains "${nested_codex_json}" "parent package guidance" "Codex scope counts parent AGENTS guidance"
-assert_contains "${nested_codex_json}" "nested API guidance" "Codex scope counts nearest nested AGENTS guidance"
+assert_contains "${nested_codex_json}" "nested API override guidance" "Codex scope prefers nearest AGENTS override guidance"
+assert_not_contains "${nested_codex_json}" "overridden API fallback guidance" "Codex scope excludes overridden fallback AGENTS guidance"
 assert_not_contains "${nested_codex_json}" "sibling guidance" "Codex scope excludes sibling AGENTS guidance"
 nested_codex_runtime_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" "${RUNTIME_BIN}" active-constraints --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path packages/api/src/lib.rs --json)"
 assert_contains "${nested_codex_runtime_json}" '"total": 4' "production counter matches nested Codex instruction discovery"
+
+mkdir -p "${TMP_ROOT}/outside"
+cat > "${TMP_ROOT}/outside/AGENTS.md" <<'MD'
+- Must not count an instruction outside the repository.
+MD
+outside_codex_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path ../outside/new.rs --json)"
+assert_contains "${outside_codex_json}" '"total": 2' "Codex scope rejects unresolved task paths outside the repository"
+assert_not_contains "${outside_codex_json}" "outside the repository" "Codex scope excludes external AGENTS guidance"
+outside_codex_runtime_json="$(env CODEX_HOME="${CUSTOM_CODEX_HOME}" "${RUNTIME_BIN}" active-constraints --root "${HOST_REPO}" --home "${HOST_HOME}" --host codex --task-path ../outside/new.rs --json)"
+assert_contains "${outside_codex_runtime_json}" '"total": 2' "production counter rejects unresolved external task paths"
+assert_not_contains "${outside_codex_runtime_json}" "outside the repository" "production counter excludes external AGENTS guidance"
 
 CORE_ROW_REPO="${TMP_ROOT}/repo-core-row-dedupe"
 CORE_ROW_HOME="${TMP_ROOT}/home-core-row-dedupe"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -185,8 +185,8 @@ JSON
 assert_contains "${hook_override_out}" "hookSpecificOutput" "VIBEGUARD_U32_STRICT=0 downgrades strict block to context"
 
 header "GH-541 rule-delivery budget (compact core default vs full-tree opt-in)"
-# The default (core/minimal) Claude profile injects only the compact L1-L7 +
-# Key Detailed Rules table into ~/.claude/CLAUDE.md; the full rules/claude-rules
+# The default (core/minimal) Claude profile injects only the shared compact core
+# plus Claude host guidance into ~/.claude/CLAUDE.md; the full rules/claude-rules
 # tree is opt-in under full/strict. This asserts the actual production content:
 # the compact core stays within the U-32 budget, while the full common/ tree —
 # the payload the default profile must NOT front-inject — blows past the block

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -124,11 +124,16 @@ host_all_json="$(python3 "${COUNTER}" --root "${HOST_REPO}" --home "${HOST_HOME}
 assert_contains "${host_all_json}" '"total": 2' "default host scope preserves all global guidance"
 
 CUSTOM_CODEX_HOME="${TMP_ROOT}/custom-codex-home"
-mkdir -p "${CUSTOM_CODEX_HOME}" "${HOST_REPO}/.claude/rules"
+mkdir -p "${CUSTOM_CODEX_HOME}/rules" "${HOST_REPO}/.claude/rules"
 cat > "${CUSTOM_CODEX_HOME}/AGENTS.md" <<'MD'
 # Custom Codex Global
 
 - Must count configured Codex guidance.
+MD
+cat > "${CUSTOM_CODEX_HOME}/rules/decoy.md" <<'MD'
+# Unsupported Codex Native Rule
+
+- Must not count unsupported Codex native rules.
 MD
 cat > "${HOST_REPO}/AGENTS.md" <<'MD'
 # Shared Project
@@ -150,6 +155,28 @@ assert_contains "${custom_codex_json}" '"total": 2' "Codex scope counts configur
 assert_contains "${custom_codex_json}" "configured Codex guidance" "Codex scope honors CODEX_HOME"
 assert_not_contains "${custom_codex_json}" "Claude project" "Codex scope excludes Claude-only project instructions and rules"
 assert_not_contains "${custom_codex_json}" "Codex global guidance" "configured CODEX_HOME replaces the fallback ~/.codex source"
+assert_not_contains "${custom_codex_json}" "unsupported Codex native rules" "Codex scope excludes unsupported native rule paths"
+
+CORE_ROW_REPO="${TMP_ROOT}/repo-core-row-dedupe"
+CORE_ROW_HOME="${TMP_ROOT}/home-core-row-dedupe"
+make_home "${CORE_ROW_HOME}"
+make_repo "${CORE_ROW_REPO}"
+cat > "${CORE_ROW_HOME}/.claude/CLAUDE.md" <<'MD'
+## Core contract
+
+| Area | Default |
+|---|---|
+| Scope | Keep changes focused. |
+MD
+cat > "${CORE_ROW_REPO}/AGENTS.md" <<'MD'
+## Core contract
+
+| Area | Default |
+|---|---|
+| Scope | Do not edit generated files. |
+MD
+core_row_json="$(python3 "${COUNTER}" --root "${CORE_ROW_REPO}" --home "${CORE_ROW_HOME}" --host claude --json)"
+assert_contains "${core_row_json}" '"total": 2' "same-area core rows with different requirements remain distinct"
 
 canonical_ids_for_task_path() {
   local task_path="$1"

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -76,7 +76,8 @@ make_repo "${BLOCK_REPO}"
 {
   echo "# Block"
   for i in $(seq 1 31); do
-    printf '## U-%02d: Rule %02d\n\nText.\n\n' "${i}" "${i}"
+    rule_id=$((i + 100))
+    printf '## U-%d: Rule %d\n\nText.\n\n' "${rule_id}" "${rule_id}"
   done
 } > "${BLOCK_REPO}/.claude/rules/common.md"
 
@@ -174,9 +175,52 @@ cat > "${CORE_ROW_REPO}/AGENTS.md" <<'MD'
 | Area | Default |
 |---|---|
 | Scope | Do not edit generated files. |
+
+## Rule inventory
+
+| ID | State |
+|---|---|
+| U-01 | disabled |
 MD
 core_row_json="$(python3 "${COUNTER}" --root "${CORE_ROW_REPO}" --home "${CORE_ROW_HOME}" --host claude --json)"
 assert_contains "${core_row_json}" '"total": 2' "same-area core rows with different requirements remain distinct"
+assert_not_contains "${core_row_json}" '"id": "U-01"' "ordinary rule inventories outside the generated marker are ignored"
+
+EQUIVALENT_REPO="${TMP_ROOT}/repo-core-equivalents"
+EQUIVALENT_HOME="${TMP_ROOT}/home-core-equivalents"
+make_home "${EQUIVALENT_HOME}"
+make_repo "${EQUIVALENT_REPO}"
+cat > "${EQUIVALENT_REPO}/AGENTS.md" <<'MD'
+## Core contract
+
+| Area | Default |
+|---|---|
+| Errors | User-visible missing data, malformed input, or wrong output must fail clearly. |
+| Scope | Make the smallest requested change; do not add adjacent improvements. |
+| Safety | Never expose secrets, add hidden AI attribution, force-push, or weaken tests. |
+| Preservation | Preserve unmanaged content in high-context files, settings, and hooks. |
+| Verification | Run a fresh, focused project command before claiming completion. |
+
+## Key detailed rules
+
+<!-- vibeguard-generated-compact-rules:start -->
+| ID | Severity | Rule |
+|---|---|---|
+| SEC-02 | Strict | Secrets. |
+| SEC-13 | Strict | Preservation. |
+| U-04 | Strict | Scope. |
+| U-08 | Strict | Verification. |
+| U-17 | Strict | Errors. |
+| U-29 | Strict | Errors. |
+| W-03 | Strict | Verification. |
+| W-12 | Strict | Safety. |
+| W-16 | Strict | Verification. |
+<!-- vibeguard-generated-compact-rules:end -->
+MD
+equivalent_json="$(python3 "${COUNTER}" --root "${EQUIVALENT_REPO}" --home "${EQUIVALENT_HOME}" --host claude --json)"
+assert_contains "${equivalent_json}" '"total": 5' "Python counter deduplicates all shared-core rule equivalents"
+equivalent_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${EQUIVALENT_REPO}" --home "${EQUIVALENT_HOME}" --host claude --json)"
+assert_contains "${equivalent_runtime_json}" '"total": 5' "production counter matches shared-core rule equivalence"
 
 canonical_ids_for_task_path() {
   local task_path="$1"
@@ -268,9 +312,9 @@ header "GH-541 rule-delivery budget (compact core default vs full-tree opt-in)"
 # The default (core/minimal) Claude profile injects only the shared compact core
 # plus Claude host guidance into ~/.claude/CLAUDE.md; the full rules/claude-rules
 # tree is opt-in under full/strict. This asserts the actual production content:
-# the compact core stays below U-32's block threshold while retaining the
-# truthful >15 advisory, whereas the full common/ tree — the payload the
-# default profile must NOT front-inject — blows past the block threshold.
+# semantic deduplication keeps the compact core at the 15-constraint advisory
+# boundary, while the full common/ tree — the payload the default profile must
+# NOT front-inject — still exceeds the block threshold.
 # See scripts/setup/targets/claude-home.sh Step 5.5.
 
 CLAUDE_COMPACT_SRC="${REPO_DIR}/claude-md/vibeguard-claude-rules.md"
@@ -286,12 +330,12 @@ if [[ -f "${CLAUDE_COMPACT_SRC}" && -f "${CODEX_COMPACT_SRC}" ]]; then
   make_repo "${CLAUDE_CORE_REPO}"
   cp "${CLAUDE_COMPACT_SRC}" "${CLAUDE_CORE_HOME}/.claude/CLAUDE.md"
   claude_core_json="$(python3 "${COUNTER}" --root "${CLAUDE_CORE_REPO}" --home "${CLAUDE_CORE_HOME}" --host claude --json)"
-  assert_contains "${claude_core_json}" '"total": 22' "Python counter sees all 11 compact rules, 7 core defaults, and 4 normative bullets in Claude payload"
-  assert_contains "${claude_core_json}" '"status": "warn"' "Claude payload truthfully crosses the advisory threshold without blocking"
+  assert_contains "${claude_core_json}" '"total": 15' "Python counter deduplicates equivalent core rows in Claude payload"
+  assert_contains "${claude_core_json}" '"status": "ok"' "Claude payload stays below the advisory threshold after semantic deduplication"
   claude_compact_ids="$(printf '%s' "${claude_core_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
-  assert_contains "${claude_compact_ids}" "U-17,U-26,U-29,W-02,W-03,W-12,W-16,SEC-01,SEC-02,SEC-11,SEC-13" "Claude payload exposes the exact compact rule IDs to the counter"
+  assert_contains "${claude_compact_ids}" "U-17,U-26,W-02,W-03,W-12,SEC-01,SEC-11,SEC-13" "Claude payload retains canonical IDs for distinct compact constraints"
   claude_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${CLAUDE_CORE_REPO}" --home "${CLAUDE_CORE_HOME}" --host claude --json)"
-  assert_contains "${claude_runtime_json}" '"total": 22' "production counter matches the exact Claude payload count"
+  assert_contains "${claude_runtime_json}" '"total": 15' "production counter matches the deduplicated Claude payload count"
 
   CODEX_CORE_HOME="${TMP_ROOT}/home-gh541-codex-core"
   CODEX_CORE_REPO="${TMP_ROOT}/repo-gh541-codex-core"
@@ -300,12 +344,12 @@ if [[ -f "${CLAUDE_COMPACT_SRC}" && -f "${CODEX_COMPACT_SRC}" ]]; then
   mkdir -p "${CODEX_CORE_HOME}/.codex"
   cp "${CODEX_COMPACT_SRC}" "${CODEX_CORE_HOME}/.codex/AGENTS.md"
   codex_core_json="$(python3 "${COUNTER}" --root "${CODEX_CORE_REPO}" --home "${CODEX_CORE_HOME}" --host codex --json)"
-  assert_contains "${codex_core_json}" '"total": 22' "Python counter sees all 11 compact rules, 7 core defaults, and 4 normative bullets in Codex payload"
-  assert_contains "${codex_core_json}" '"status": "warn"' "Codex payload truthfully crosses the advisory threshold without blocking"
+  assert_contains "${codex_core_json}" '"total": 15' "Python counter deduplicates equivalent core rows in Codex payload"
+  assert_contains "${codex_core_json}" '"status": "ok"' "Codex payload stays below the advisory threshold after semantic deduplication"
   codex_compact_ids="$(printf '%s' "${codex_core_json}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin)["constraints"] if item["id"]))')"
-  assert_contains "${codex_compact_ids}" "U-17,U-26,U-29,W-02,W-03,W-12,W-16,SEC-01,SEC-02,SEC-11,SEC-13" "Codex payload exposes the exact compact rule IDs to the counter"
+  assert_contains "${codex_compact_ids}" "U-17,U-26,W-02,W-03,W-12,SEC-01,SEC-11,SEC-13" "Codex payload retains canonical IDs for distinct compact constraints"
   codex_runtime_json="$("${RUNTIME_BIN}" active-constraints --root "${CODEX_CORE_REPO}" --home "${CODEX_CORE_HOME}" --host codex --json)"
-  assert_contains "${codex_runtime_json}" '"total": 22' "production counter matches the exact Codex payload count"
+  assert_contains "${codex_runtime_json}" '"total": 15' "production counter matches the deduplicated Codex payload count"
 
   FULL_HOME="${TMP_ROOT}/home-gh541-full"
   FULL_REPO="${TMP_ROOT}/repo-gh541-full"

--- a/tests/setup/install_scheduler_health_tests.sh
+++ b/tests/setup/install_scheduler_health_tests.sh
@@ -542,6 +542,9 @@ assert_cmd "~/.codex/AGENTS.md exists after installation" test -f "${HOME}/.code
 assert_cmd "~/.codex/AGENTS.md includes managed markers after installation" bash -c "grep -q '<!-- vibeguard-start -->' '${HOME}/.codex/AGENTS.md' && grep -q '<!-- vibeguard-end -->' '${HOME}/.codex/AGENTS.md'"
 assert_cmd "~/.codex/AGENTS.md rule banner matches expected rules" assert_codex_rule_banner_matches_expected_rules
 assert_cmd "~/.codex/AGENTS.md includes key Codex-visible anchors" bash -c "grep -qF 'Compact Chat Contract' '${HOME}/.codex/AGENTS.md' && grep -qF '| W-03 |' '${HOME}/.codex/AGENTS.md' && grep -qF '| SEC-13 |' '${HOME}/.codex/AGENTS.md'"
+assert_cmd "Claude receives only Claude host guidance" bash -c "grep -qF '## Claude Code host guidance' '${HOME}/.claude/CLAUDE.md' && ! grep -qF '## Codex host guidance' '${HOME}/.claude/CLAUDE.md'"
+assert_cmd "Codex receives only Codex host guidance" bash -c "grep -qF '## Codex host guidance' '${HOME}/.codex/AGENTS.md' && ! grep -qF '## Claude Code host guidance' '${HOME}/.codex/AGENTS.md'"
+assert_cmd "Codex global contract excludes Claude-only workflow commands" bash -c "! grep -qF '/vibeguard:' '${HOME}/.codex/AGENTS.md' && ! grep -qF 'Corrected 2 times' '${HOME}/.codex/AGENTS.md'"
 assert_cmd "templates/AGENTS.md includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/templates/AGENTS.md"
 assert_cmd "docs/CLAUDE.md.example includes the chat contract anchor" grep -qF "${CHAT_CONTRACT_ANCHOR}" "${REPO_DIR}/docs/CLAUDE.md.example"
 assert_cmd "chat contract block matches across source, installed output, and templates" assert_chat_contract_blocks_match

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -116,8 +116,8 @@ assert_cmd "Pre-existing non-VibeGuard hook remains after cleaning" grep -q "nod
 
 header "setup install default languages before rust filter"
 install_default_lang_out="$(bash "${REPO_DIR}/setup.sh" --yes --profile core)"
-# GH-541: the default (core) profile delivers only the compact L1-L7 + Key
-# Detailed Rules table via ~/.claude/CLAUDE.md and must NOT front-inject the
+# GH-541: the default (core) profile delivers only the shared compact core plus
+# Claude host guidance via ~/.claude/CLAUDE.md and must NOT front-inject the
 # full native rule tree, so the live payload stays within the U-32 budget.
 assert_contains "${install_default_lang_out}" "compact core (core profile)" "core profile install reports compact core delivery"
 assert_cmd "core profile does not front-inject Python native rules" test ! -L "${HOME}/.claude/rules/vibeguard/python/quality.md"

--- a/tests/test_eval_contract.sh
+++ b/tests/test_eval_contract.sh
@@ -75,7 +75,7 @@ assert_contains "${normalized_out}" "Dataset source: ${REPO_DIR_RESOLVED}/eval/d
 assert_contains "${normalized_out}" "Sample digest:" "dry-run reports sample digest"
 assert_contains "${normalized_out}" "Rules source: ${REPO_DIR_RESOLVED}/rules/claude-rules" "dry-run reports repository rule source"
 assert_contains "${normalized_out}" "Rule digest:" "dry-run reports rule digest"
-assert_contains "${normalized_out}" "Core constraint source: ${REPO_DIR_RESOLVED}/claude-md/vibeguard-rules.md" "dry-run reports repository core rules source"
+assert_contains "${normalized_out}" "Core constraint source: ${REPO_DIR_RESOLVED}/claude-md/vibeguard-claude-rules.md" "dry-run reports repository Claude core rules source"
 assert_contains "${normalized_out}" "Requested model: haiku" "dry-run reports requested default model"
 assert_contains "${normalized_out}" "Resolved model: claude-haiku-4-5-20251001" "dry-run resolves default model from baseline"
 assert_contains "${normalized_out}" "Model baseline verified at (UTC): 2026-07-17" "dry-run reports baseline verification date"

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -198,6 +198,11 @@ class CompactRuleGenerationTests(unittest.TestCase):
             "## Codex host\n\nHost rule.\n<!-- vibeguard-end -->\n",
         )
 
+    def test_shared_guidance_uses_host_neutral_project_instruction_wording(self) -> None:
+        shared = generate_rule_docs.COMPACT_RULES_PATH.read_text(encoding="utf-8")
+        self.assertIn("nearest applicable repository instructions", shared)
+        self.assertNotIn("repository-level `AGENTS.md` or `CLAUDE.md`", shared)
+
     def test_codex_host_guidance_respects_configured_home(self) -> None:
         codex_host = generate_rule_docs.CODEX_HOST_RULES_PATH.read_text(encoding="utf-8")
         self.assertIn("When managed VibeGuard skills are installed", codex_host)

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -196,6 +196,11 @@ class CompactRuleGenerationTests(unittest.TestCase):
             "## Codex host\n\nHost rule.\n<!-- vibeguard-end -->\n",
         )
 
+    def test_codex_host_guidance_respects_configured_home(self) -> None:
+        codex_host = generate_rule_docs.CODEX_HOST_RULES_PATH.read_text(encoding="utf-8")
+        self.assertIn("$CODEX_HOME/skills/", codex_host)
+        self.assertIn("defaulting to `~/.codex/skills/`", codex_host)
+
     def test_host_guidance_rejects_empty_or_managed_marker_content(self) -> None:
         shared = "<!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\n"
         for host in ("", "<!-- vibeguard-start -->\nhost", "host\n<!-- vibeguard-end -->"):

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -26,17 +26,12 @@ SPEC.loader.exec_module(generate_rule_docs)
 
 EXPECTED_COMPACT_TABLE = """| ID | Severity | Rule |
 |----|----------|------|
-| U-16 | Guideline | Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. Files above 800 must be split. |
 | U-17 | Strict | Handle errors completely. Do not swallow exceptions silently. |
-| U-22 | Strict | New code minimum 80% line coverage; critical paths 100%. |
-| U-25 | Strict | Fix build failures first before any other edit; do not add new code while build is red. |
 | U-26 | Strict | Declaration-execution completeness: declared Config / Trait / persistence layers must be wired into startup. |
 | U-29 | Strict | No silent degradation: errors causing user-visible missing data or wrong output must `error` or raise, not `warning` + fallback. |
-| W-01 | Strict | No fixes without root cause: reproduce first, then form one hypothesis, then fix. |
 | W-02 | Strict | After 3 consecutive failed fixes on the same problem, stop and challenge the hypothesis or architecture. |
 | W-03 | Strict | Verify before claiming completion: produce fresh command output proving the claim. |
 | W-12 | Strict | Protect test integrity: fix production code, never weaken assertions or tamper with test infrastructure. |
-| W-14 | Strict | At most one writable session may operate on a repository; parallel helpers must remain read-only. |
 | W-16 | Strict | Verification commands must come from this session. "Earlier passed" / "should work" do not count. |
 | SEC-01 | Critical | No SQL / NoSQL / OS command injection: use parameterized queries and array argument lists. |
 | SEC-02 | Critical | No hardcoded keys, credentials, or API tokens. Load from env / secret manager. |
@@ -192,6 +187,22 @@ class CompactRuleGenerationTests(unittest.TestCase):
         second = generate_rule_docs.render_compact_table(rules, ("U-16",))
         self.assertEqual(first, second)
 
+    def test_host_guidance_is_composed_inside_the_managed_block(self) -> None:
+        shared = "<!-- vibeguard-start -->\n# Shared\n<!-- vibeguard-end -->\n"
+        actual = generate_rule_docs.compose_host_rules(shared, "## Codex host\n\nHost rule.\n")
+        self.assertEqual(
+            actual,
+            "<!-- vibeguard-start -->\n# Shared\n\n"
+            "## Codex host\n\nHost rule.\n<!-- vibeguard-end -->\n",
+        )
+
+    def test_host_guidance_rejects_empty_or_managed_marker_content(self) -> None:
+        shared = "<!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\n"
+        for host in ("", "<!-- vibeguard-start -->\nhost", "host\n<!-- vibeguard-end -->"):
+            with self.subTest(host=host):
+                with self.assertRaisesRegex(ValueError, "host guidance"):
+                    generate_rule_docs.compose_host_rules(shared, host)
+
     def test_compact_input_changes_make_snapshot_stale(self) -> None:
         rules = generate_rule_docs.parse_rules()
         current_document = generate_rule_docs.COMPACT_RULES_PATH.read_text(encoding="utf-8")
@@ -209,7 +220,10 @@ class CompactRuleGenerationTests(unittest.TestCase):
             ),
             "severity": (
                 [
-                    dataclasses.replace(rule, severity="Strict")
+                    dataclasses.replace(
+                        rule,
+                        severity="Guideline" if selected_rule.severity != "Guideline" else "Strict",
+                    )
                     if rule is selected_rule
                     else rule
                     for rule in rules

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -198,6 +198,7 @@ class CompactRuleGenerationTests(unittest.TestCase):
 
     def test_codex_host_guidance_respects_configured_home(self) -> None:
         codex_host = generate_rule_docs.CODEX_HOST_RULES_PATH.read_text(encoding="utf-8")
+        self.assertIn("When managed VibeGuard skills are installed", codex_host)
         self.assertIn("$CODEX_HOME/skills/", codex_host)
         self.assertIn("defaulting to `~/.codex/skills/`", codex_host)
 

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -7,6 +7,7 @@ import dataclasses
 import importlib.util
 import io
 import json
+import re
 import sys
 import tempfile
 import unittest
@@ -206,27 +207,20 @@ class CompactRuleGenerationTests(unittest.TestCase):
     def test_codex_host_guidance_matches_profile_hook_contract(self) -> None:
         codex_host = generate_rule_docs.CODEX_HOST_RULES_PATH.read_text(encoding="utf-8")
         self.assertIn(
-            "Every Codex setup profile covers native Bash and `apply_patch` gates.",
+            "Every Codex setup profile covers native Bash and `apply_patch` gates plus "
+            "`Stop` hooks, including `stop-guard`",
             codex_host,
         )
         self.assertIn(
-            "Only the `full` and `strict` profile contracts add `Stop` hooks, "
-            "including `stop-guard`; `minimal` and `core` do not promise Stop coverage.",
+            "unlike Claude Code, Codex hook installation is not profile-filtered",
             codex_host,
         )
-        self.assertNotIn("plus Stop events", codex_host)
 
-        install_schema = json.loads(
-            (ROOT / "schemas" / "install-modules.json").read_text(encoding="utf-8")
+        codex_setup = (ROOT / "scripts" / "setup" / "targets" / "codex-home.sh").read_text(
+            encoding="utf-8"
         )
-        modules = {module["id"]: module for module in install_schema["modules"]}
-        self.assertEqual(
-            modules["hooks-pre"]["profiles"],
-            ["minimal", "core", "full", "strict"],
-        )
-        self.assertIn("hooks/pre-bash-guard.sh", modules["hooks-pre"]["paths"])
-        self.assertEqual(modules["hooks-full"]["profiles"], ["full", "strict"])
-        self.assertIn("hooks/stop-guard.sh", modules["hooks-full"]["paths"])
+        self.assertIn("setup-codex-hooks-upsert", codex_setup)
+        self.assertNotIn('setup-codex-hooks-upsert "${PROFILE}"', codex_setup)
 
     def test_host_guidance_rejects_empty_or_managed_marker_content(self) -> None:
         shared = "<!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\n"
@@ -234,6 +228,48 @@ class CompactRuleGenerationTests(unittest.TestCase):
             with self.subTest(host=host):
                 with self.assertRaisesRegex(ValueError, "host guidance"):
                     generate_rule_docs.compose_host_rules(shared, host)
+
+    def test_host_composition_rejects_unmanaged_shared_content_and_inline_markers(self) -> None:
+        cases = {
+            "content before": (
+                "outside-before\n<!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\n",
+                "outside managed markers",
+            ),
+            "content after": (
+                "<!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\noutside-after\n",
+                "outside managed markers",
+            ),
+            "inline start": (
+                "prefix <!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\n",
+                "own line",
+            ),
+            "inline end": (
+                "<!-- vibeguard-start -->\nshared <!-- vibeguard-end -->\n",
+                "own line",
+            ),
+        }
+        for label, (shared, message) in cases.items():
+            with self.subTest(label=label), self.assertRaisesRegex(ValueError, message):
+                generate_rule_docs.compose_host_rules(shared, "## Host\n")
+
+    def test_render_all_attributes_invalid_host_guidance_to_host_source(self) -> None:
+        rules = generate_rule_docs.parse_rules()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            claude_host = root / "vibeguard-claude.md"
+            codex_host = root / "vibeguard-codex.md"
+            valid_host = "## Host guidance\n"
+            for label, invalid_path in (("claude", claude_host), ("codex", codex_host)):
+                with self.subTest(host=label):
+                    claude_host.write_text(valid_host, encoding="utf-8")
+                    codex_host.write_text(valid_host, encoding="utf-8")
+                    invalid_path.write_text("", encoding="utf-8")
+                    with (
+                        mock.patch.object(generate_rule_docs, "CLAUDE_HOST_RULES_PATH", claude_host),
+                        mock.patch.object(generate_rule_docs, "CODEX_HOST_RULES_PATH", codex_host),
+                        self.assertRaisesRegex(ValueError, rf"{re.escape(str(invalid_path))}: host guidance"),
+                    ):
+                        generate_rule_docs.render_all(rules)
 
     def test_compact_input_changes_make_snapshot_stale(self) -> None:
         rules = generate_rule_docs.parse_rules()

--- a/tests/test_generate_rule_docs.py
+++ b/tests/test_generate_rule_docs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import dataclasses
 import importlib.util
 import io
+import json
 import sys
 import tempfile
 import unittest
@@ -201,6 +202,31 @@ class CompactRuleGenerationTests(unittest.TestCase):
         self.assertIn("When managed VibeGuard skills are installed", codex_host)
         self.assertIn("$CODEX_HOME/skills/", codex_host)
         self.assertIn("defaulting to `~/.codex/skills/`", codex_host)
+
+    def test_codex_host_guidance_matches_profile_hook_contract(self) -> None:
+        codex_host = generate_rule_docs.CODEX_HOST_RULES_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "Every Codex setup profile covers native Bash and `apply_patch` gates.",
+            codex_host,
+        )
+        self.assertIn(
+            "Only the `full` and `strict` profile contracts add `Stop` hooks, "
+            "including `stop-guard`; `minimal` and `core` do not promise Stop coverage.",
+            codex_host,
+        )
+        self.assertNotIn("plus Stop events", codex_host)
+
+        install_schema = json.loads(
+            (ROOT / "schemas" / "install-modules.json").read_text(encoding="utf-8")
+        )
+        modules = {module["id"]: module for module in install_schema["modules"]}
+        self.assertEqual(
+            modules["hooks-pre"]["profiles"],
+            ["minimal", "core", "full", "strict"],
+        )
+        self.assertIn("hooks/pre-bash-guard.sh", modules["hooks-pre"]["paths"])
+        self.assertEqual(modules["hooks-full"]["profiles"], ["full", "strict"])
+        self.assertIn("hooks/stop-guard.sh", modules["hooks-full"]["paths"])
 
     def test_host_guidance_rejects_empty_or_managed_marker_content(self) -> None:
         shared = "<!-- vibeguard-start -->\nshared\n<!-- vibeguard-end -->\n"

--- a/tests/test_paired_eval.sh
+++ b/tests/test_paired_eval.sh
@@ -458,7 +458,7 @@ compact_placebo_out="$(
 compact_placebo_rc=$?
 set -e
 test "${compact_placebo_rc}" -ne 0
-grep -qF "shared compact core retains equivalent semantics in Key detailed rules (SEC-02)" <<<"${compact_placebo_out}"
+grep -qF "shared compact core retains equivalent semantics in Core contract (Safety)" <<<"${compact_placebo_out}"
 test ! -e "${TMP_DIR}/compact-placebo-runs"
 
 set +e

--- a/tests/test_paired_eval.sh
+++ b/tests/test_paired_eval.sh
@@ -421,7 +421,7 @@ placebo_out="$(
   cd "${REPO_DIR}"
   env -u ANTHROPIC_API_KEY python3 eval/run_paired_eval.py \
     --candidate U-21 \
-    --placebo-candidate U-16 \
+    --placebo-candidate U-22 \
     --dry-run \
     --artifact-root "${TMP_DIR}/placebo-runs" 2>&1
 )"
@@ -458,7 +458,7 @@ compact_placebo_out="$(
 compact_placebo_rc=$?
 set -e
 test "${compact_placebo_rc}" -ne 0
-grep -qF "anonymous compact L7" <<<"${compact_placebo_out}"
+grep -qF "shared compact core retains equivalent semantics in Key detailed rules (SEC-02)" <<<"${compact_placebo_out}"
 test ! -e "${TMP_DIR}/compact-placebo-runs"
 
 set +e
@@ -472,7 +472,7 @@ compact_out="$(
 compact_rc=$?
 set -e
 test "${compact_rc}" -ne 0
-grep -qF "anonymous compact L5" <<<"${compact_out}"
+grep -qF "shared compact core retains equivalent semantics in Core contract (Scope)" <<<"${compact_out}"
 test ! -e "${TMP_DIR}/compact-runs"
 
 set +e

--- a/tests/test_payload.sh
+++ b/tests/test_payload.sh
@@ -393,11 +393,13 @@ for profile in minimal core full strict; do
   for language in rust python go typescript; do
     matrix_cases=$((matrix_cases + 1))
     matrix_home="${WORK}/matrix-home/${profile}-${language}"
+    matrix_codex_home="${matrix_home}/.codex"
     mkdir -p "${matrix_home}"
     set +e
     matrix_out="$(
       cd "${WORK}/unpacked" \
         && HOME="${matrix_home}" \
+          CODEX_HOME="${matrix_codex_home}" \
           PATH="${WORK}/fake-bin:${PATH}" \
           VIBEGUARD_TEST_RELEASE_DIR="${WORK}/release-assets" \
           VIBEGUARD_TEST_NETWORK_SENTINEL="${NETWORK_SENTINEL}" \
@@ -424,6 +426,7 @@ set +e
 install_out="$(
   cd "${WORK}/unpacked" \
     && HOME="${WORK}/payload-home" \
+      CODEX_HOME="${WORK}/payload-home/.codex" \
       PATH="${WORK}/fake-bin:${PATH}" \
       VIBEGUARD_TEST_RELEASE_DIR="${WORK}/release-assets" \
       VIBEGUARD_TEST_NETWORK_SENTINEL="${NETWORK_SENTINEL}" \
@@ -444,6 +447,7 @@ set +e
 doctor_out="$(
   cd "${WORK}/unpacked" \
     && HOME="${WORK}/payload-home" \
+      CODEX_HOME="${WORK}/payload-home/.codex" \
       PATH="${WORK}/fake-bin:${PATH}" \
       VIBEGUARD_TEST_NETWORK_SENTINEL="${NETWORK_SENTINEL}" \
       bash setup.sh doctor 2>&1
@@ -459,6 +463,7 @@ set +e
 verify_out="$(
   cd "${WORK}/unpacked" \
     && HOME="${WORK}/payload-home" \
+      CODEX_HOME="${WORK}/payload-home/.codex" \
       PATH="${WORK}/fake-bin:${PATH}" \
       VIBEGUARD_TEST_NETWORK_SENTINEL="${NETWORK_SENTINEL}" \
       bash setup.sh verify-install 2>&1
@@ -490,6 +495,7 @@ set +e
 clean_out="$(
   cd "${WORK}/unpacked" \
     && HOME="${WORK}/payload-home" \
+      CODEX_HOME="${WORK}/payload-home/.codex" \
       PATH="${WORK}/fake-bin:${PATH}" \
       VIBEGUARD_TEST_NETWORK_SENTINEL="${NETWORK_SENTINEL}" \
       bash setup.sh --clean --purge-data 2>&1

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -212,9 +212,6 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
     if options.host.includes_claude() {
         global_rule_roots.push(options.home.join(".claude/rules"));
     }
-    if options.host.includes_codex() {
-        global_rule_roots.push(codex_home.join("rules"));
-    }
     for base in global_rule_roots {
         for path in markdown_files(&base) {
             add_source(&mut sources, &path, "global-rule", options);
@@ -374,11 +371,21 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
                     && !first_cell.is_empty()
                     && !first_cell.chars().all(|ch| matches!(ch, '-' | ':'))
                 {
+                    let normalized_area = first_cell
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                        .to_ascii_lowercase();
+                    let normalized_default = cells[1]
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                        .to_ascii_lowercase();
                     push_constraint(
                         &mut seen,
                         &mut source_constraints,
                         &mut constraints,
-                        format!("core:{}", first_cell.to_ascii_lowercase()),
+                        format!("core:{normalized_area}:{normalized_default}"),
                         format!("Core contract: {first_cell}"),
                     );
                 }
@@ -575,6 +582,8 @@ mod tests {
             .unwrap_or_else(|err| panic!("fallback Codex home should be created: {err}"));
         fs::create_dir_all(&codex_home)
             .unwrap_or_else(|err| panic!("custom Codex home should be created: {err}"));
+        fs::create_dir_all(codex_home.join("rules"))
+            .unwrap_or_else(|err| panic!("Codex rule decoy directory should be created: {err}"));
         fs::create_dir_all(root.join(".claude/rules"))
             .unwrap_or_else(|err| panic!("Claude project rules should be created: {err}"));
         fs::write(
@@ -587,6 +596,11 @@ mod tests {
             "- Must count configured Codex guidance\n",
         )
         .unwrap_or_else(|err| panic!("configured Codex guidance should be written: {err}"));
+        fs::write(
+            codex_home.join("rules/decoy.md"),
+            "- Must not count unsupported Codex native rules\n",
+        )
+        .unwrap_or_else(|err| panic!("Codex rule decoy should be written: {err}"));
         fs::write(root.join("AGENTS.md"), "- Must count project AGENTS\n")
             .unwrap_or_else(|err| panic!("project AGENTS should be written: {err}"));
         fs::write(
@@ -619,6 +633,7 @@ mod tests {
         assert!(labels.contains(&"Must count project AGENTS"));
         assert!(!labels.iter().any(|label| label.contains("Claude")));
         assert!(!labels.iter().any(|label| label.contains("fallback")));
+        assert!(!labels.iter().any(|label| label.contains("native rules")));
 
         fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
     }
@@ -646,6 +661,33 @@ mod tests {
         assert!(labels.contains(&"Core contract: Verification"));
         assert!(labels.contains(&"U-08"));
         assert!(labels.contains(&"W-03"));
+
+        fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
+    }
+
+    #[test]
+    fn core_contract_rows_dedupe_by_area_and_constraint_text() {
+        let dir = temp_dir("core-row-dedupe");
+        let first = dir.join("global.md");
+        let second = dir.join("project.md");
+        fs::write(
+            &first,
+            "## Core contract\n\n| Area | Default |\n|---|---|\n| Scope | Keep changes focused. |\n",
+        )
+        .unwrap_or_else(|err| panic!("global core fixture should be written: {err}"));
+        fs::write(
+            &second,
+            "## Core contract\n\n| Area | Default |\n|---|---|\n| Scope | Do not edit generated files. |\n",
+        )
+        .unwrap_or_else(|err| panic!("project core fixture should be written: {err}"));
+
+        let mut sources = BTreeMap::new();
+        sources.insert(first, "global".to_string());
+        sources.insert(second, "project".to_string());
+        let (reports, constraints) = count_constraints(&sources);
+
+        assert_eq!(constraints.len(), 2);
+        assert_eq!(reports.iter().map(|report| report.count).sum::<usize>(), 2);
 
         fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
     }

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -8,9 +8,7 @@ use std::path::{Path, PathBuf};
 use crate::hook_checks_common::glob_match;
 
 mod source_paths;
-
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
-
 const WARN_THRESHOLD: usize = 15;
 const BLOCK_THRESHOLD: usize = 30;
 const COMPACT_RULES_START: &str = "<!-- vibeguard-generated-compact-rules:start -->";
@@ -203,7 +201,7 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
         add_source(&mut sources, &path, "global", options);
     }
 
-    let mut project_files = vec![options.root.join("AGENTS.md")];
+    let mut project_files = Vec::new();
     if options.host.includes_codex() {
         project_files.extend(source_paths::codex_project_instruction_files(
             &options.root,
@@ -211,6 +209,7 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
         ));
     }
     if options.host.includes_claude() {
+        project_files.push(options.root.join("AGENTS.md"));
         project_files.push(options.root.join("CLAUDE.md"));
         project_files.push(options.root.join(".claude/CLAUDE.md"));
     }
@@ -468,7 +467,6 @@ fn is_rule_id(value: &str) -> bool {
 fn rule_constraint_key(rule_id: &str) -> String {
     format!("rule:{rule_id}")
 }
-
 fn core_constraint_key(area: &str, requirement: &str) -> String {
     match (area, requirement) {
         (

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -310,6 +310,10 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
         Ok(regex) => regex,
         Err(err) => panic!("invalid active constraint bullet regex: {err}"),
     };
+    let table_rule_re = match Regex::new(r"^(?:U|W|SEC|RS|PY|TS|GO|TASTE)-\d+$") {
+        Ok(regex) => regex,
+        Err(err) => panic!("invalid active constraint table rule regex: {err}"),
+    };
     let normative_re = match Regex::new(
         r"(?i)\b(must|must not|should|should not|never|always|require|requires|required|avoid|do not|don't|prohibit|forbid|block|verify)\b|必须|禁止|不要|不得|需要|要求|阻断|验证",
     ) {
@@ -323,13 +327,48 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
         let text = read_text(path);
         let mut source_constraints = Vec::new();
         let mut in_fence = false;
+        let mut in_core_contract = false;
         for line in text.lines() {
             let trimmed = line.trim();
             if trimmed.starts_with("```") {
                 in_fence = !in_fence;
                 continue;
             }
-            if in_fence || trimmed.starts_with('|') {
+            if in_fence {
+                continue;
+            }
+            if trimmed.starts_with("## ") {
+                in_core_contract = trimmed == "## Core contract";
+            }
+            if trimmed.starts_with('|') {
+                let cells = trimmed
+                    .trim_matches('|')
+                    .split('|')
+                    .map(str::trim)
+                    .collect::<Vec<_>>();
+                let first_cell = cells.first().copied().unwrap_or("");
+                if table_rule_re.is_match(first_cell) {
+                    push_constraint(
+                        &mut seen,
+                        &mut source_constraints,
+                        &mut constraints,
+                        format!("rule:{first_cell}"),
+                        first_cell.to_string(),
+                    );
+                } else if in_core_contract
+                    && cells.len() >= 2
+                    && first_cell != "Area"
+                    && !first_cell.is_empty()
+                    && !first_cell.chars().all(|ch| matches!(ch, '-' | ':'))
+                {
+                    push_constraint(
+                        &mut seen,
+                        &mut source_constraints,
+                        &mut constraints,
+                        format!("core:{}", first_cell.to_ascii_lowercase()),
+                        format!("Core contract: {first_cell}"),
+                    );
+                }
                 continue;
             }
             if let Some(caps) = rule_re.captures(line) {
@@ -480,7 +519,7 @@ mod tests {
     }
 
     #[test]
-    fn count_constraints_dedupes_rules_and_ignores_tables_and_fences() {
+    fn count_constraints_dedupes_rules_and_ignores_unrelated_tables_and_fences() {
         let dir = temp_dir("count");
         let first = dir.join("first.md");
         let second = dir.join("second.md");
@@ -509,6 +548,33 @@ mod tests {
         assert!(labels.contains(&"Must verify build"));
         assert!(labels.contains(&"Never swallow errors"));
         assert_eq!(reports.iter().map(|report| report.count).sum::<usize>(), 3);
+
+        fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
+    }
+
+    #[test]
+    fn count_constraints_reads_compact_rule_and_core_contract_tables() {
+        let dir = temp_dir("managed-tables");
+        let source = dir.join("AGENTS.md");
+        fs::write(
+            &source,
+            "## Core contract\n\n| Area | Default |\n|---|---|\n| Scope | Keep changes focused. |\n| Verification | Run focused tests. |\n\n## Key detailed rules\n\n| ID | Severity | Rule |\n|---|---|---|\n| U-08 | Strict | Verify. |\n| W-03 | Strict | Verify. |\n",
+        )
+        .unwrap_or_else(|err| panic!("table fixture should be written: {err}"));
+
+        let mut sources = BTreeMap::new();
+        sources.insert(source, "global".to_string());
+        let (_reports, constraints) = count_constraints(&sources);
+        let labels = constraints
+            .iter()
+            .map(|constraint| constraint.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(constraints.len(), 4);
+        assert!(labels.contains(&"Core contract: Scope"));
+        assert!(labels.contains(&"Core contract: Verification"));
+        assert!(labels.contains(&"U-08"));
+        assert!(labels.contains(&"W-03"));
 
         fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
     }

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -16,12 +16,45 @@ const BLOCK_THRESHOLD: usize = 30;
 struct ActiveConstraintOptions {
     root: PathBuf,
     home: PathBuf,
+    host: HostScope,
     task_paths: Vec<String>,
     skills: Vec<String>,
     json: bool,
     hook_fields: bool,
     warn_threshold: usize,
     block_threshold: usize,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum HostScope {
+    All,
+    Claude,
+    Codex,
+}
+
+impl Default for HostScope {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl HostScope {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "all" => Ok(Self::All),
+            "claude" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            _ => Err(format!("--host must be one of all, claude, or codex: {value}").into()),
+        }
+    }
+
+    fn includes_claude(self) -> bool {
+        matches!(self, Self::All | Self::Claude)
+    }
+
+    fn includes_codex(self) -> bool {
+        matches!(self, Self::All | Self::Codex)
+    }
 }
 
 #[derive(Clone)]
@@ -103,6 +136,10 @@ fn parse_active_args(args: &[String]) -> Result<ActiveConstraintOptions> {
                 index += 1;
                 options.home = PathBuf::from(args.get(index).ok_or("--home requires a path")?);
             }
+            "--host" => {
+                index += 1;
+                options.host = HostScope::parse(args.get(index).ok_or("--host requires a value")?)?;
+            }
             "--task-path" => {
                 index += 1;
                 options.task_paths.push(
@@ -142,32 +179,54 @@ fn parse_active_args(args: &[String]) -> Result<ActiveConstraintOptions> {
 
 fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, String> {
     let mut sources = BTreeMap::new();
-    for (path, kind) in [
-        (options.home.join(".claude/CLAUDE.md"), "global"),
-        (options.home.join(".claude/AGENTS.md"), "global"),
-        (options.home.join(".codex/AGENTS.md"), "global"),
-        (options.root.join("AGENTS.md"), "project"),
-        (options.root.join("CLAUDE.md"), "project"),
-        (options.root.join(".claude/CLAUDE.md"), "project"),
-    ] {
-        add_source(&mut sources, &path, kind, options);
+
+    let mut global_files = Vec::new();
+    if options.host.includes_claude() {
+        global_files.push(options.home.join(".claude/CLAUDE.md"));
+        global_files.push(options.home.join(".claude/AGENTS.md"));
     }
-    for base in [
-        options.home.join(".claude/rules"),
-        options.home.join(".codex/rules"),
-        options.root.join(".claude/rules"),
+    if options.host.includes_codex() {
+        global_files.push(options.home.join(".codex/AGENTS.md"));
+    }
+    for path in global_files {
+        add_source(&mut sources, &path, "global", options);
+    }
+
+    for path in [
+        options.root.join("AGENTS.md"),
+        options.root.join("CLAUDE.md"),
+        options.root.join(".claude/CLAUDE.md"),
     ] {
+        add_source(&mut sources, &path, "project", options);
+    }
+
+    let mut global_rule_roots = Vec::new();
+    if options.host.includes_claude() {
+        global_rule_roots.push(options.home.join(".claude/rules"));
+    }
+    if options.host.includes_codex() {
+        global_rule_roots.push(options.home.join(".codex/rules"));
+    }
+    for base in global_rule_roots {
+        for path in markdown_files(&base) {
+            add_source(&mut sources, &path, "global-rule", options);
+        }
+    }
+
+    for base in [options.root.join(".claude/rules")] {
         for path in markdown_files(&base) {
             add_source(&mut sources, &path, "path-rule", options);
         }
     }
     for skill in &options.skills {
-        for base in [
-            options.root.join("skills"),
-            options.root.join("workflows"),
-            options.home.join(".claude/skills"),
-            options.home.join(".codex/skills"),
-        ] {
+        let mut skill_roots = vec![options.root.join("skills"), options.root.join("workflows")];
+        if options.host.includes_claude() {
+            skill_roots.push(options.home.join(".claude/skills"));
+        }
+        if options.host.includes_codex() {
+            skill_roots.push(options.home.join(".codex/skills"));
+        }
+        for base in skill_roots {
             add_source(
                 &mut sources,
                 &base.join(skill).join("SKILL.md"),
@@ -371,6 +430,48 @@ mod tests {
             panic!("temp dir should be created: {err}");
         }
         dir
+    }
+
+    #[test]
+    fn discover_sources_filters_global_files_by_host() {
+        let dir = temp_dir("host");
+        let root = dir.join("repo");
+        let home = dir.join("home");
+        fs::create_dir_all(home.join(".claude"))
+            .unwrap_or_else(|err| panic!("Claude home should be created: {err}"));
+        fs::create_dir_all(home.join(".codex"))
+            .unwrap_or_else(|err| panic!("Codex home should be created: {err}"));
+        fs::create_dir_all(&root)
+            .unwrap_or_else(|err| panic!("repo root should be created: {err}"));
+        fs::write(
+            home.join(".claude/CLAUDE.md"),
+            "- Must keep Claude global guidance\n",
+        )
+        .unwrap_or_else(|err| panic!("Claude global guidance should be written: {err}"));
+        fs::write(
+            home.join(".codex/AGENTS.md"),
+            "- Must not count Codex global guidance\n",
+        )
+        .unwrap_or_else(|err| panic!("Codex global guidance should be written: {err}"));
+
+        let options = ActiveConstraintOptions {
+            root,
+            home,
+            host: HostScope::Claude,
+            ..ActiveConstraintOptions::default()
+        };
+        let sources = discover_sources(&options);
+        let (_reports, constraints) = count_constraints(&sources);
+        let labels = constraints
+            .iter()
+            .map(|constraint| constraint.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(constraints.len(), 1);
+        assert!(labels.contains(&"Must keep Claude global guidance"));
+        assert!(!labels.contains(&"Must not count Codex global guidance"));
+
+        fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
     }
 
     #[test]

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 
 use crate::hook_checks_common::glob_match;
 
+mod source_paths;
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 const WARN_THRESHOLD: usize = 15;
@@ -202,6 +204,12 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
     }
 
     let mut project_files = vec![options.root.join("AGENTS.md")];
+    if options.host.includes_codex() {
+        project_files.extend(source_paths::codex_project_instruction_files(
+            &options.root,
+            &options.task_paths,
+        ));
+    }
     if options.host.includes_claude() {
         project_files.push(options.root.join("CLAUDE.md"));
         project_files.push(options.root.join(".claude/CLAUDE.md"));
@@ -457,17 +465,8 @@ fn is_rule_id(value: &str) -> bool {
         && number.chars().all(|ch| ch.is_ascii_digit())
 }
 
-// Keep this semantic map aligned with SHARED_CORE_RULE_EQUIVALENTS in
-// eval/paired_runner.py and with scripts/constraints/count_active_constraints.py.
 fn rule_constraint_key(rule_id: &str) -> String {
-    match rule_id {
-        "SEC-02" | "W-12" => "shared-core:safety".to_string(),
-        "SEC-13" => "shared-core:preservation".to_string(),
-        "U-04" => "shared-core:scope".to_string(),
-        "U-08" | "W-03" | "W-16" => "shared-core:verification".to_string(),
-        "U-17" | "U-29" => "shared-core:errors".to_string(),
-        _ => format!("rule:{rule_id}"),
-    }
+    format!("rule:{rule_id}")
 }
 
 fn core_constraint_key(area: &str, requirement: &str) -> String {
@@ -475,20 +474,12 @@ fn core_constraint_key(area: &str, requirement: &str) -> String {
         (
             "errors",
             "user-visible missing data, malformed input, or wrong output must fail clearly.",
-        ) => "shared-core:errors".to_string(),
+        ) => rule_constraint_key("U-29"),
         ("scope", "make the smallest requested change; do not add adjacent improvements.") => {
-            "shared-core:scope".to_string()
+            rule_constraint_key("U-04")
         }
-        (
-            "safety",
-            "never expose secrets, add hidden ai attribution, force-push, or weaken tests.",
-        ) => "shared-core:safety".to_string(),
-        (
-            "preservation",
-            "preserve unmanaged content in high-context files, settings, and hooks.",
-        ) => "shared-core:preservation".to_string(),
         ("verification", "run a fresh, focused project command before claiming completion.") => {
-            "shared-core:verification".to_string()
+            rule_constraint_key("W-03")
         }
         _ => format!("core:{area}:{requirement}"),
     }
@@ -736,7 +727,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_core_rows_dedupe_against_all_equivalent_rule_ids() {
+    fn shared_core_rows_keep_distinct_rule_ids() {
         let dir = temp_dir("shared-core-equivalents");
         let source = dir.join("AGENTS.md");
         fs::write(
@@ -749,11 +740,25 @@ mod tests {
         sources.insert(source, "global".to_string());
         let (_reports, constraints) = count_constraints(&sources);
 
-        assert_eq!(constraints.len(), 5);
-        assert!(
+        assert_eq!(constraints.len(), 11);
+        assert_eq!(
             constraints
                 .iter()
-                .all(|constraint| is_rule_id(&constraint.label))
+                .map(|constraint| constraint.label.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "SEC-02",
+                "SEC-13",
+                "U-04",
+                "U-08",
+                "U-17",
+                "U-29",
+                "W-03",
+                "W-12",
+                "W-16",
+                "Core contract: Safety",
+                "Core contract: Preservation",
+            ]
         );
 
         fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -16,6 +16,7 @@ const BLOCK_THRESHOLD: usize = 30;
 struct ActiveConstraintOptions {
     root: PathBuf,
     home: PathBuf,
+    codex_home: Option<PathBuf>,
     host: HostScope,
     task_paths: Vec<String>,
     skills: Vec<String>,
@@ -116,6 +117,7 @@ fn parse_active_args(args: &[String]) -> Result<ActiveConstraintOptions> {
         home: std::env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(".")),
+        codex_home: std::env::var_os("CODEX_HOME").map(PathBuf::from),
         warn_threshold: WARN_THRESHOLD,
         block_threshold: BLOCK_THRESHOLD,
         ..ActiveConstraintOptions::default()
@@ -130,6 +132,12 @@ fn parse_active_args(args: &[String]) -> Result<ActiveConstraintOptions> {
             "--home" => {
                 index += 1;
                 options.home = PathBuf::from(args.get(index).ok_or("--home requires a path")?);
+            }
+            "--codex-home" => {
+                index += 1;
+                options.codex_home = Some(PathBuf::from(
+                    args.get(index).ok_or("--codex-home requires a path")?,
+                ));
             }
             "--host" => {
                 index += 1;
@@ -174,6 +182,10 @@ fn parse_active_args(args: &[String]) -> Result<ActiveConstraintOptions> {
 
 fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, String> {
     let mut sources = BTreeMap::new();
+    let codex_home = options
+        .codex_home
+        .clone()
+        .unwrap_or_else(|| options.home.join(".codex"));
 
     let mut global_files = Vec::new();
     if options.host.includes_claude() {
@@ -181,17 +193,18 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
         global_files.push(options.home.join(".claude/AGENTS.md"));
     }
     if options.host.includes_codex() {
-        global_files.push(options.home.join(".codex/AGENTS.md"));
+        global_files.push(codex_home.join("AGENTS.md"));
     }
     for path in global_files {
         add_source(&mut sources, &path, "global", options);
     }
 
-    for path in [
-        options.root.join("AGENTS.md"),
-        options.root.join("CLAUDE.md"),
-        options.root.join(".claude/CLAUDE.md"),
-    ] {
+    let mut project_files = vec![options.root.join("AGENTS.md")];
+    if options.host.includes_claude() {
+        project_files.push(options.root.join("CLAUDE.md"));
+        project_files.push(options.root.join(".claude/CLAUDE.md"));
+    }
+    for path in project_files {
         add_source(&mut sources, &path, "project", options);
     }
 
@@ -200,7 +213,7 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
         global_rule_roots.push(options.home.join(".claude/rules"));
     }
     if options.host.includes_codex() {
-        global_rule_roots.push(options.home.join(".codex/rules"));
+        global_rule_roots.push(codex_home.join("rules"));
     }
     for base in global_rule_roots {
         for path in markdown_files(&base) {
@@ -208,8 +221,8 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
         }
     }
 
-    for base in [options.root.join(".claude/rules")] {
-        for path in markdown_files(&base) {
+    if options.host.includes_claude() {
+        for path in markdown_files(&options.root.join(".claude/rules")) {
             add_source(&mut sources, &path, "path-rule", options);
         }
     }
@@ -219,7 +232,7 @@ fn discover_sources(options: &ActiveConstraintOptions) -> BTreeMap<PathBuf, Stri
             skill_roots.push(options.home.join(".claude/skills"));
         }
         if options.host.includes_codex() {
-            skill_roots.push(options.home.join(".codex/skills"));
+            skill_roots.push(codex_home.join("skills"));
         }
         for base in skill_roots {
             add_source(
@@ -548,6 +561,64 @@ mod tests {
         assert!(labels.contains(&"Must verify build"));
         assert!(labels.contains(&"Never swallow errors"));
         assert_eq!(reports.iter().map(|report| report.count).sum::<usize>(), 3);
+
+        fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
+    }
+
+    #[test]
+    fn codex_sources_use_configured_home_and_exclude_claude_project_files() {
+        let dir = temp_dir("codex-home");
+        let root = dir.join("repo");
+        let home = dir.join("home");
+        let codex_home = dir.join("custom-codex");
+        fs::create_dir_all(home.join(".codex"))
+            .unwrap_or_else(|err| panic!("fallback Codex home should be created: {err}"));
+        fs::create_dir_all(&codex_home)
+            .unwrap_or_else(|err| panic!("custom Codex home should be created: {err}"));
+        fs::create_dir_all(root.join(".claude/rules"))
+            .unwrap_or_else(|err| panic!("Claude project rules should be created: {err}"));
+        fs::write(
+            home.join(".codex/AGENTS.md"),
+            "- Must not count fallback Codex guidance\n",
+        )
+        .unwrap_or_else(|err| panic!("fallback Codex guidance should be written: {err}"));
+        fs::write(
+            codex_home.join("AGENTS.md"),
+            "- Must count configured Codex guidance\n",
+        )
+        .unwrap_or_else(|err| panic!("configured Codex guidance should be written: {err}"));
+        fs::write(root.join("AGENTS.md"), "- Must count project AGENTS\n")
+            .unwrap_or_else(|err| panic!("project AGENTS should be written: {err}"));
+        fs::write(
+            root.join("CLAUDE.md"),
+            "- Must not count project Claude guidance\n",
+        )
+        .unwrap_or_else(|err| panic!("project Claude guidance should be written: {err}"));
+        fs::write(
+            root.join(".claude/rules/claude.md"),
+            "- Must not count project Claude rules\n",
+        )
+        .unwrap_or_else(|err| panic!("project Claude rules should be written: {err}"));
+
+        let options = ActiveConstraintOptions {
+            root,
+            home,
+            codex_home: Some(codex_home),
+            host: HostScope::Codex,
+            ..ActiveConstraintOptions::default()
+        };
+        let sources = discover_sources(&options);
+        let (_reports, constraints) = count_constraints(&sources);
+        let labels = constraints
+            .iter()
+            .map(|constraint| constraint.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(constraints.len(), 2);
+        assert!(labels.contains(&"Must count configured Codex guidance"));
+        assert!(labels.contains(&"Must count project AGENTS"));
+        assert!(!labels.iter().any(|label| label.contains("Claude")));
+        assert!(!labels.iter().any(|label| label.contains("fallback")));
 
         fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
     }

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -25,17 +25,12 @@ struct ActiveConstraintOptions {
     block_threshold: usize,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
 enum HostScope {
+    #[default]
     All,
     Claude,
     Codex,
-}
-
-impl Default for HostScope {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl HostScope {

--- a/vibeguard-runtime/src/active_constraints.rs
+++ b/vibeguard-runtime/src/active_constraints.rs
@@ -11,6 +11,8 @@ type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 const WARN_THRESHOLD: usize = 15;
 const BLOCK_THRESHOLD: usize = 30;
+const COMPACT_RULES_START: &str = "<!-- vibeguard-generated-compact-rules:start -->";
+const COMPACT_RULES_END: &str = "<!-- vibeguard-generated-compact-rules:end -->";
 
 #[derive(Default)]
 struct ActiveConstraintOptions {
@@ -96,7 +98,7 @@ pub fn run(args: &[String]) -> Result {
                     "count": report.count,
                 })).collect::<Vec<_>>(),
                 "constraints": constraints.iter().map(|constraint| json!({
-                    "id": if constraint.key.starts_with("rule:") { &constraint.label } else { "" },
+                    "id": if is_rule_id(&constraint.label) { &constraint.label } else { "" },
                     "label": constraint.label,
                 })).collect::<Vec<_>>(),
             }))?
@@ -330,14 +332,13 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
         Ok(regex) => regex,
         Err(err) => panic!("invalid active constraint normative regex: {err}"),
     };
-    let mut seen = HashSet::new();
-    let mut reports = Vec::new();
-    let mut constraints = Vec::new();
+    let mut parsed_sources = Vec::new();
     for (path, kind) in sources {
         let text = read_text(path);
         let mut source_constraints = Vec::new();
         let mut in_fence = false;
         let mut in_core_contract = false;
+        let mut in_compact_rules = false;
         for line in text.lines() {
             let trimmed = line.trim();
             if trimmed.starts_with("```") {
@@ -345,6 +346,14 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
                 continue;
             }
             if in_fence {
+                continue;
+            }
+            if trimmed == COMPACT_RULES_START {
+                in_compact_rules = true;
+                continue;
+            }
+            if trimmed == COMPACT_RULES_END {
+                in_compact_rules = false;
                 continue;
             }
             if trimmed.starts_with("## ") {
@@ -357,14 +366,11 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
                     .map(str::trim)
                     .collect::<Vec<_>>();
                 let first_cell = cells.first().copied().unwrap_or("");
-                if table_rule_re.is_match(first_cell) {
-                    push_constraint(
-                        &mut seen,
-                        &mut source_constraints,
-                        &mut constraints,
-                        format!("rule:{first_cell}"),
-                        first_cell.to_string(),
-                    );
+                if in_compact_rules && table_rule_re.is_match(first_cell) {
+                    source_constraints.push(Constraint {
+                        key: rule_constraint_key(first_cell),
+                        label: first_cell.to_string(),
+                    });
                 } else if in_core_contract
                     && cells.len() >= 2
                     && first_cell != "Area"
@@ -381,25 +387,19 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
                         .collect::<Vec<_>>()
                         .join(" ")
                         .to_ascii_lowercase();
-                    push_constraint(
-                        &mut seen,
-                        &mut source_constraints,
-                        &mut constraints,
-                        format!("core:{normalized_area}:{normalized_default}"),
-                        format!("Core contract: {first_cell}"),
-                    );
+                    source_constraints.push(Constraint {
+                        key: core_constraint_key(&normalized_area, &normalized_default),
+                        label: format!("Core contract: {first_cell}"),
+                    });
                 }
                 continue;
             }
             if let Some(caps) = rule_re.captures(line) {
                 let rule_id = caps[1].to_string();
-                push_constraint(
-                    &mut seen,
-                    &mut source_constraints,
-                    &mut constraints,
-                    format!("rule:{rule_id}"),
-                    rule_id,
-                );
+                source_constraints.push(Constraint {
+                    key: rule_constraint_key(&rule_id),
+                    label: rule_id,
+                });
             } else if let Some(caps) = bullet_re.captures(line)
                 && normative_re.is_match(&caps[1])
             {
@@ -409,39 +409,89 @@ fn count_constraints(sources: &BTreeMap<PathBuf, String>) -> (Vec<SourceReport>,
                     .collect::<Vec<_>>()
                     .join(" ")
                     .to_ascii_lowercase();
-                push_constraint(
-                    &mut seen,
-                    &mut source_constraints,
-                    &mut constraints,
-                    format!("text:{normalized}"),
+                source_constraints.push(Constraint {
+                    key: format!("text:{normalized}"),
                     label,
-                );
+                });
             }
         }
-        if !source_constraints.is_empty() {
-            reports.push(SourceReport {
-                path: path.clone(),
-                kind: kind.clone(),
-                count: source_constraints.len(),
-            });
+        parsed_sources.push((path.clone(), kind.clone(), source_constraints));
+    }
+
+    let mut seen = HashSet::new();
+    let mut source_counts = BTreeMap::<PathBuf, usize>::new();
+    let mut constraints = Vec::new();
+    // Prefer canonical rule IDs to equivalent shared-core rows so JSON and GC
+    // reports retain a useful ID while the semantic requirement counts once.
+    for rule_pass in [true, false] {
+        for (path, _kind, candidates) in &parsed_sources {
+            for candidate in candidates {
+                if is_rule_id(&candidate.label) != rule_pass || !seen.insert(candidate.key.clone())
+                {
+                    continue;
+                }
+                *source_counts.entry(path.clone()).or_default() += 1;
+                constraints.push(candidate.clone());
+            }
         }
     }
+
+    let reports = parsed_sources
+        .into_iter()
+        .filter_map(|(path, kind, _candidates)| {
+            let count = source_counts.get(&path).copied().unwrap_or_default();
+            (count > 0).then_some(SourceReport { path, kind, count })
+        })
+        .collect();
     (reports, constraints)
 }
 
-fn push_constraint(
-    seen: &mut HashSet<String>,
-    source_constraints: &mut Vec<Constraint>,
-    constraints: &mut Vec<Constraint>,
-    key: String,
-    label: String,
-) {
-    if !seen.insert(key.clone()) {
-        return;
+fn is_rule_id(value: &str) -> bool {
+    let Some((prefix, number)) = value.split_once('-') else {
+        return false;
+    };
+    matches!(
+        prefix,
+        "U" | "W" | "SEC" | "RS" | "PY" | "TS" | "GO" | "TASTE"
+    ) && !number.is_empty()
+        && number.chars().all(|ch| ch.is_ascii_digit())
+}
+
+// Keep this semantic map aligned with SHARED_CORE_RULE_EQUIVALENTS in
+// eval/paired_runner.py and with scripts/constraints/count_active_constraints.py.
+fn rule_constraint_key(rule_id: &str) -> String {
+    match rule_id {
+        "SEC-02" | "W-12" => "shared-core:safety".to_string(),
+        "SEC-13" => "shared-core:preservation".to_string(),
+        "U-04" => "shared-core:scope".to_string(),
+        "U-08" | "W-03" | "W-16" => "shared-core:verification".to_string(),
+        "U-17" | "U-29" => "shared-core:errors".to_string(),
+        _ => format!("rule:{rule_id}"),
     }
-    let constraint = Constraint { key, label };
-    source_constraints.push(constraint.clone());
-    constraints.push(constraint);
+}
+
+fn core_constraint_key(area: &str, requirement: &str) -> String {
+    match (area, requirement) {
+        (
+            "errors",
+            "user-visible missing data, malformed input, or wrong output must fail clearly.",
+        ) => "shared-core:errors".to_string(),
+        ("scope", "make the smallest requested change; do not add adjacent improvements.") => {
+            "shared-core:scope".to_string()
+        }
+        (
+            "safety",
+            "never expose secrets, add hidden ai attribution, force-push, or weaken tests.",
+        ) => "shared-core:safety".to_string(),
+        (
+            "preservation",
+            "preserve unmanaged content in high-context files, settings, and hooks.",
+        ) => "shared-core:preservation".to_string(),
+        ("verification", "run a fresh, focused project command before claiming completion.") => {
+            "shared-core:verification".to_string()
+        }
+        _ => format!("core:{area}:{requirement}"),
+    }
 }
 
 fn status_for(total: usize, warn_threshold: usize, block_threshold: usize) -> &'static str {
@@ -644,7 +694,7 @@ mod tests {
         let source = dir.join("AGENTS.md");
         fs::write(
             &source,
-            "## Core contract\n\n| Area | Default |\n|---|---|\n| Scope | Keep changes focused. |\n| Verification | Run focused tests. |\n\n## Key detailed rules\n\n| ID | Severity | Rule |\n|---|---|---|\n| U-08 | Strict | Verify. |\n| W-03 | Strict | Verify. |\n",
+            "## Core contract\n\n| Area | Default |\n|---|---|\n| Scope | Keep changes focused. |\n| Verification | Run focused tests. |\n\n## Key detailed rules\n\n<!-- vibeguard-generated-compact-rules:start -->\n| ID | Severity | Rule |\n|---|---|---|\n| U-10 | Strict | Verify. |\n| W-11 | Strict | Verify. |\n<!-- vibeguard-generated-compact-rules:end -->\n",
         )
         .unwrap_or_else(|err| panic!("table fixture should be written: {err}"));
 
@@ -659,8 +709,52 @@ mod tests {
         assert_eq!(constraints.len(), 4);
         assert!(labels.contains(&"Core contract: Scope"));
         assert!(labels.contains(&"Core contract: Verification"));
-        assert!(labels.contains(&"U-08"));
-        assert!(labels.contains(&"W-03"));
+        assert!(labels.contains(&"U-10"));
+        assert!(labels.contains(&"W-11"));
+
+        fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
+    }
+
+    #[test]
+    fn count_constraints_ignores_rule_inventory_outside_generated_marker() {
+        let dir = temp_dir("ordinary-rule-inventory");
+        let source = dir.join("AGENTS.md");
+        fs::write(
+            &source,
+            "## Rule inventory\n\n| ID | State |\n|---|---|\n| U-01 | disabled |\n",
+        )
+        .unwrap_or_else(|err| panic!("inventory fixture should be written: {err}"));
+
+        let mut sources = BTreeMap::new();
+        sources.insert(source, "global".to_string());
+        let (reports, constraints) = count_constraints(&sources);
+
+        assert!(reports.is_empty());
+        assert!(constraints.is_empty());
+
+        fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
+    }
+
+    #[test]
+    fn shared_core_rows_dedupe_against_all_equivalent_rule_ids() {
+        let dir = temp_dir("shared-core-equivalents");
+        let source = dir.join("AGENTS.md");
+        fs::write(
+            &source,
+            "## Core contract\n\n| Area | Default |\n|---|---|\n| Errors | User-visible missing data, malformed input, or wrong output must fail clearly. |\n| Scope | Make the smallest requested change; do not add adjacent improvements. |\n| Safety | Never expose secrets, add hidden AI attribution, force-push, or weaken tests. |\n| Preservation | Preserve unmanaged content in high-context files, settings, and hooks. |\n| Verification | Run a fresh, focused project command before claiming completion. |\n\n## Key detailed rules\n\n<!-- vibeguard-generated-compact-rules:start -->\n| ID | Severity | Rule |\n|---|---|---|\n| SEC-02 | Strict | Secrets. |\n| SEC-13 | Strict | Preservation. |\n| U-04 | Strict | Scope. |\n| U-08 | Strict | Verification. |\n| U-17 | Strict | Errors. |\n| U-29 | Strict | Errors. |\n| W-03 | Strict | Verification. |\n| W-12 | Strict | Safety. |\n| W-16 | Strict | Verification. |\n<!-- vibeguard-generated-compact-rules:end -->\n",
+        )
+        .unwrap_or_else(|err| panic!("equivalence fixture should be written: {err}"));
+
+        let mut sources = BTreeMap::new();
+        sources.insert(source, "global".to_string());
+        let (_reports, constraints) = count_constraints(&sources);
+
+        assert_eq!(constraints.len(), 5);
+        assert!(
+            constraints
+                .iter()
+                .all(|constraint| is_rule_id(&constraint.label))
+        );
 
         fs::remove_dir_all(dir).unwrap_or_else(|err| panic!("temp dir should be removed: {err}"));
     }

--- a/vibeguard-runtime/src/active_constraints/source_paths.rs
+++ b/vibeguard-runtime/src/active_constraints/source_paths.rs
@@ -1,0 +1,31 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub(super) fn codex_project_instruction_files(root: &Path, task_paths: &[String]) -> Vec<PathBuf> {
+    let resolved_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let mut instruction_files = BTreeSet::new();
+    for task_path in task_paths {
+        let candidate = PathBuf::from(task_path);
+        let candidate = if candidate.is_absolute() {
+            candidate
+        } else {
+            resolved_root.join(candidate)
+        };
+        let candidate = candidate.canonicalize().unwrap_or(candidate);
+        if !candidate.starts_with(&resolved_root) {
+            continue;
+        }
+        let mut directory = if candidate.is_dir() {
+            candidate
+        } else {
+            candidate.parent().unwrap_or(&resolved_root).to_path_buf()
+        };
+        while directory != resolved_root {
+            instruction_files.insert(directory.join("AGENTS.md"));
+            if !directory.pop() {
+                break;
+            }
+        }
+    }
+    instruction_files.into_iter().collect()
+}

--- a/vibeguard-runtime/src/active_constraints/source_paths.rs
+++ b/vibeguard-runtime/src/active_constraints/source_paths.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 pub(super) fn codex_project_instruction_files(root: &Path, task_paths: &[String]) -> Vec<PathBuf> {
     let resolved_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let mut instruction_files = BTreeSet::new();
+    add_instruction_file(&mut instruction_files, &resolved_root);
     for task_path in task_paths {
         let candidate = PathBuf::from(task_path);
         let candidate = if candidate.is_absolute() {
@@ -11,7 +12,9 @@ pub(super) fn codex_project_instruction_files(root: &Path, task_paths: &[String]
         } else {
             resolved_root.join(candidate)
         };
-        let candidate = candidate.canonicalize().unwrap_or(candidate);
+        let Some(candidate) = resolve_nearest_existing(&candidate) else {
+            continue;
+        };
         if !candidate.starts_with(&resolved_root) {
             continue;
         }
@@ -21,11 +24,34 @@ pub(super) fn codex_project_instruction_files(root: &Path, task_paths: &[String]
             candidate.parent().unwrap_or(&resolved_root).to_path_buf()
         };
         while directory != resolved_root {
-            instruction_files.insert(directory.join("AGENTS.md"));
+            add_instruction_file(&mut instruction_files, &directory);
             if !directory.pop() {
                 break;
             }
         }
     }
     instruction_files.into_iter().collect()
+}
+
+fn add_instruction_file(instruction_files: &mut BTreeSet<PathBuf>, directory: &Path) {
+    let override_path = directory.join("AGENTS.override.md");
+    instruction_files.insert(if override_path.is_file() {
+        override_path
+    } else {
+        directory.join("AGENTS.md")
+    });
+}
+
+fn resolve_nearest_existing(candidate: &Path) -> Option<PathBuf> {
+    let mut ancestor = candidate;
+    let mut suffix = Vec::new();
+    while !ancestor.exists() {
+        suffix.push(ancestor.file_name()?.to_os_string());
+        ancestor = ancestor.parent()?;
+    }
+    let mut resolved = ancestor.canonicalize().ok()?;
+    for component in suffix.into_iter().rev() {
+        resolved.push(component);
+    }
+    Some(resolved)
 }

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -191,7 +191,7 @@ static COMMANDS: &[Command] = &[
     },
     Command {
         name: "active-constraints",
-        usage: "--root DIR --home DIR [--task-path PATH] [--skill NAME] [--json|--hook-fields]  — count effective active constraints",
+        usage: "--root DIR --home DIR [--host all|claude|codex] [--task-path PATH] [--skill NAME] [--json|--hook-fields]  — count effective active constraints",
         handler: active_constraints::run,
     },
     Command {

--- a/vibeguard-runtime/src/setup_markdown.rs
+++ b/vibeguard-runtime/src/setup_markdown.rs
@@ -81,7 +81,14 @@ fn render_injected(
     if rule_count.parse::<u64>().is_err() {
         return Err(format!("Invalid rule count: {rule_count}").into());
     }
-    let rules = std::fs::read_to_string(rules_file)?
+    let rules_source = std::fs::read_to_string(rules_file)?;
+    validate_managed_source(&rules_source).map_err(|error| {
+        format!(
+            "Invalid managed rules source {}: {error}",
+            rules_file.display()
+        )
+    })?;
+    let rules = rules_source
         .replace("__VIBEGUARD_DIR__", repo_dir)
         .replace(RULE_COUNT_PLACEHOLDER, rule_count);
     let original = std::fs::read_to_string(target_file).unwrap_or_default();
@@ -97,6 +104,24 @@ fn render_injected(
         format!("{base}\n\n{}\n", rules.trim())
     };
     Ok(("APPENDED".to_string(), original, content))
+}
+
+fn validate_managed_source(text: &str) -> SetupResult<()> {
+    if text.matches(START).count() != 1 || text.matches(END).count() != 1 {
+        return Err("managed source must contain exactly one VibeGuard marker pair".into());
+    }
+    if !text.lines().any(|line| line == START) || !text.lines().any(|line| line == END) {
+        return Err("managed source markers must appear on standalone lines".into());
+    }
+    let start = text.find(START).expect("validated start marker count");
+    let end = text[start + START.len()..]
+        .find(END)
+        .map(|offset| start + START.len() + offset)
+        .ok_or("managed source end marker must follow its start marker")?;
+    if !text[..start].trim().is_empty() || !text[end + END.len()..].trim().is_empty() {
+        return Err("managed source must not contain content outside its marker pair".into());
+    }
+    Ok(())
 }
 
 fn replace_managed_block(original: &str, rules: &str) -> String {

--- a/vibeguard-runtime/src/setup_markdown/tests.rs
+++ b/vibeguard-runtime/src/setup_markdown/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod setup_markdown_tests {
     use super::super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn repo_dir() -> SetupResult<&'static Path> {
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -19,6 +20,42 @@ mod setup_markdown_tests {
         assert!(!next.contains("old"));
         assert!(next.starts_with("a\n\n"));
         assert!(next.ends_with("b\n"));
+    }
+
+    #[test]
+    fn inject_rejects_invalid_managed_source_without_changing_target() -> SetupResult<()> {
+        let unique = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vibeguard-setup-markdown-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir)?;
+        let target = dir.join("AGENTS.md");
+        let source = dir.join("rules.md");
+        let original = "user content\n";
+        std::fs::write(&target, original)?;
+
+        for invalid in [
+            "outside\n<!-- vibeguard-start -->\nrules\n<!-- vibeguard-end -->\n",
+            "<!-- vibeguard-start --> rules <!-- vibeguard-end -->\n",
+            "<!-- vibeguard-start -->\nrules\n",
+            "<!-- vibeguard-start -->\nrules\n<!-- vibeguard-end -->\n<!-- vibeguard-end -->\n",
+        ] {
+            std::fs::write(&source, invalid)?;
+            assert!(
+                inject(&[
+                    target.display().to_string(),
+                    source.display().to_string(),
+                    dir.display().to_string(),
+                    "127".to_string(),
+                ])
+                .is_err()
+            );
+            assert_eq!(std::fs::read_to_string(&target)?, original);
+        }
+
+        std::fs::remove_dir_all(dir)?;
+        Ok(())
     }
 
     #[test]

--- a/vibeguard-runtime/tests/setup_markdown_cli.rs
+++ b/vibeguard-runtime/tests/setup_markdown_cli.rs
@@ -124,6 +124,40 @@ fn markdown_argument_and_missing_rules_errors_are_visible() {
 }
 
 #[test]
+fn invalid_managed_source_fails_before_mutating_the_target() {
+    let fixture = Fixture::new("invalid-source");
+    let target = fixture.write("AGENTS.md", "user content\n");
+
+    for (name, invalid) in [
+        (
+            "outside.md",
+            "outside\n<!-- vibeguard-start -->\nrules\n<!-- vibeguard-end -->\n",
+        ),
+        (
+            "inline.md",
+            "<!-- vibeguard-start --> rules <!-- vibeguard-end -->\n",
+        ),
+        ("missing-end.md", "<!-- vibeguard-start -->\nrules\n"),
+        (
+            "duplicate-end.md",
+            "<!-- vibeguard-start -->\nrules\n<!-- vibeguard-end -->\n<!-- vibeguard-end -->\n",
+        ),
+    ] {
+        let rules = fixture.write(name, invalid);
+        let output = run(
+            &fixture,
+            "setup-md-inject",
+            &[&target, &rules],
+            &["/repo", "127"],
+        );
+        assert_visible_failure(&output, Some("Invalid managed rules source"));
+        assert_eq!(fs::read_to_string(&target).unwrap(), "user content\n");
+    }
+
+    fixture.cleanup();
+}
+
+#[test]
 fn diff_is_non_mutating_and_inject_is_exact_and_idempotent() {
     let fixture = Fixture::new("inject");
     let target = fixture.write("AGENTS.md", "Intro\n");


### PR DESCRIPTION
# Summary

Replace the single cross-host global prompt block with a generated shared core plus a small Claude Code or Codex extension. Each setup target now installs only truthful host capabilities while preserving the existing managed markers and unmanaged user content.

## Linked Work

- Closes #747

## What changed

- define a compact cross-host core for scope, factuality, error visibility, safety, preservation, and verification;
- add Claude Code guidance for native rules, slash commands, and Claude hook coverage;
- add Codex guidance for AGENTS.md precedence, managed skills, and native hook boundaries;
- generate deterministic host-specific managed blocks and route setup/check operations to the matching source;
- update docs, drift validators, setup regressions, and paired-eval terminology.

## Verification

- [x] Focused tests: generator unit tests 18/18; setup protection 127/127; setup profile 95/95; eval contract 58/58
- [x] Broader relevant checks: `bash scripts/local-contract-check.sh --quick`; rule generation, rule validation, doc freshness, doc path, and doc command-path checks
- [x] Screenshots or logs when user-visible: setup fixtures verify Claude/Codex host sections do not cross-install

## Review

- [ ] Concrete correctness, security, and regression findings are addressed.
- [ ] Review stopped at `Findings: 0` plus `PASS`.
- [x] No more than two review rounds were initiated.
- [x] Any remaining process-only decision is explicitly left to a human.

## Paired Prompt-Rule Evaluation

- [x] This PR does not add or change a prompt-injected native rule. No canonical rule ID or native rule text changes; it changes the compact host contract and its distribution only.
- [ ] This PR adds or changes a prompt-injected native rule, and the paired-eval report is attached.
- [ ] Exemption requested for non-prompt-injection changes only.

## Release Notes

- [x] Changelog or release note needed before release because installed global guidance changes.
- [ ] Not user-visible.

## AI assistance

AI-assisted implementation and verification were used; the commit contains no hidden attribution.