### PR TITLE
perf: bound pre-write history cost as logs grow

### DIFF
--- a/docs/reference/hook-latency-contract.md
+++ b/docs/reference/hook-latency-contract.md
@@ -28,6 +28,7 @@ These are cross-OS CI budgets, not ideal-machine optimization targets. Static pe
 |---------|------------|
 | `pre-edit-guard` | 300ms |
 | `pre-write-guard` | 500ms |
+| `pre-write-guard (5000)` | 500ms |
 | `pre-bash-guard` | 300ms |
 | `post-edit-guard (100)` | 500ms |
 | `post-write-guard (100)` | 400ms |

--- a/plan/2026-08-13-architecture-remediation.md
+++ b/plan/2026-08-13-architecture-remediation.md
@@ -14,7 +14,7 @@ execution lane per phase; each phase is independently shippable and verified.
 | F3 | Configuration surface: 276 distinct `VIBEGUARD_*`/`VG_*` environment variables plus config.json/profile/language axes, with no layered config module | High |
 | F4 | Process artifacts tracked in git: four `artifacts/triage/issue-*.json` files (and `artifacts/` was not ignored); 40+ historical `docs/specs/GH*` packets on main | Medium |
 | F5 | A second product (specrail) shared the repo root without a documented boundary — resolved upstream: the SpecRail control plane was fully retired and its files removed from main before this plan executed | Medium (resolved) |
-| F6 | `pre-write-guard` P95 is 2065ms while other hooks are 200–400ms; latency contract exists but this hook exceeds interactive budget | Medium |
+| F6 | `pre-write-guard` latency concern; the 2065ms local cold-start sample was not reproducible, and the remaining full-log read was replaced with a bounded 500-line tail | Medium (resolved) |
 | F7 | README first screen leads with two unpublished install channels | Low |
 
 ## Phases
@@ -149,8 +149,14 @@ label, skill, and check files from main (see
 decision remains. The retired design is discoverable through the GH595 row in
 `docs/specs/README.md` and recoverable from Git history.
 
-### Phase 7 — pre-write-guard latency (issue #755)
+### Phase 7 — pre-write-guard latency (issue #755, resolved)
 
-Profile the 2065ms P95 (`bench-output` shows 10x the budget of sibling hooks).
-Likely cause: unindexed search-first scan on every new-file write. Candidate
-fix: cache the project file inventory keyed by git HEAD + dirty-file mtimes.
+Fresh release-runtime profiling measured `pre-write-guard` at P50 102ms and
+P95 107ms against its 500ms budget; the historical 2065ms local cold-start
+sample was not reproducible. The suspected project-tree scan does not exist on
+the pre-write path: same-name detection belongs to `post-write-guard`.
+
+The actual scaling risk was reminder-history lookup: it read the complete
+event log before considering only the newest 500 lines. The runtime now seeks
+and reads a bounded 500-line tail, and the latency harness includes a 5000-line
+pre-write fixture to keep that path under the existing P95 contract.

--- a/tests/bench_hook_latency.sh
+++ b/tests/bench_hook_latency.sh
@@ -233,7 +233,7 @@ budget_for() {
 
   case "$name" in
     pre-edit-guard|pre-bash-guard) printf '%s\n' 300 ;;
-    pre-write-guard) printf '%s\n' 500 ;;
+    pre-write-guard|pre-write-guard\ \(5000\)) printf '%s\n' 500 ;;
     post-edit-guard\ \(100\)) printf '%s\n' 500 ;;
     post-write-guard\ \(100\)) printf '%s\n' 400 ;;
     post-edit-guard\ \(5000\)|post-write-guard\ \(5000\)) printf '%s\n' 500 ;;
@@ -494,8 +494,9 @@ bench_codex_wrapper "codex-wrapper pre-bash-guard" "vibeguard-pre-bash-guard.sh"
 bench_codex_wrapper "codex-wrapper post-edit-guard (100)" "vibeguard-post-edit-guard.sh" "$TMPDIR_BENCH/codex-post-edit-input.json" "$TMPDIR_BENCH/events-100.jsonl"
 echo ""
 
-# --- Post-hooks with large log (stress test, should still be <200ms) ---
-echo "[PostToolUse hooks — 5000-line log]"
+# --- Hooks with large log (stress test, should still be <200ms) ---
+echo "[Hooks — 5000-line log]"
+bench_hook "pre-write-guard (5000)" "$HOOKS_DIR/pre-write-guard.sh" "$TMPDIR_BENCH/write-input.json" "$TMPDIR_BENCH/events-5000.jsonl"
 bench_hook "post-edit-guard (5000)" "$HOOKS_DIR/post-edit-guard.sh" "$TMPDIR_BENCH/edit-input.json" "$TMPDIR_BENCH/events-5000.jsonl"
 bench_hook "post-write-guard (5000)" "$HOOKS_DIR/post-write-guard.sh" "$TMPDIR_BENCH/write-input.json" "$TMPDIR_BENCH/events-5000.jsonl"
 echo ""
@@ -626,6 +627,7 @@ bench_action_name() {
   case "$1" in
     "pre-edit-guard") printf "pre-edit" ;;
     "pre-write-guard") printf "pre-write" ;;
+    "pre-write-guard (5000)") printf "pre-write 5000" ;;
     "pre-bash-guard") printf "pre-bash" ;;
     "post-edit-guard (100)") printf "post-edit 100" ;;
     "post-write-guard (100)") printf "post-write 100" ;;

--- a/tests/test_hook_perf_contract.sh
+++ b/tests/test_hook_perf_contract.sh
@@ -321,6 +321,7 @@ assert_file_contains "${TMP_DIR}/slow.out" "hotspot=synthetic sleep fixture" "sl
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper pre-bash-guard" "latency gate includes Codex PreToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "codex-wrapper post-edit-guard (100)" "latency gate includes Codex PostToolUse wrapper fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "post-build-check (fake cargo)" "latency gate includes post-build fake command fixture"
+assert_file_contains "${TMP_DIR}/slow.out" "pre-write-guard (5000)" "latency gate includes pre-write large-log fixture"
 assert_file_contains "${TMP_DIR}/slow.out" "CONFIRMED-REGRESSION" "persistent slow hook reports confirmed regression"
 assert_cmd "persistent slow JSON preserves both batches" python3 -c 'import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
@@ -334,6 +335,13 @@ assert row["confirmation"]["p95"] > row["budget_ms"]
 assert_file_contains "${SLOW_ACTION_TEMP}" "e2e synthetic-slow-hook decision confirmed-regression" "persistent slow action output records confirmed decision"
 assert_file_contains "${SLOW_ACTION_TEMP}" "e2e synthetic-slow-hook confirmation P95" "persistent slow action output records confirmation P95"
 assert_file_contains "${SLOW_ACTION_TEMP}" "e2e synthetic-slow-hook budget" "persistent slow action output records budget"
+assert_cmd "pre-write large-log fixture enforces its normal budget" python3 -c 'import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+row = next(item for item in data["results"] if item["name"] == "pre-write-guard (5000)")
+assert row["budget_ms"] == 500
+assert row["decision"] == "normal_pass"
+assert row["p95"] <= row["budget_ms"]
+' "${SLOW_JSON_TEMP}"
 
 assert_success_contains "transient direct and wrapper outliers are cleared" "PASSED: All hooks within latency budget" "${TMP_DIR}/transient.out" env VIBEGUARD_BENCH_SPAWN_MAX_MS=100000 bash "${BENCH}" --runs=1 --confirmation-runs=1 --include-transient-fixtures --fail-on-regression --json-output="${TRANSIENT_JSON_TEMP}" --bench-action-output="${TRANSIENT_ACTION_TEMP}" --sla=100000
 assert_file_occurrences "${TMP_DIR}/transient.out" "confirming fixture after initial P95 breach" 2 "direct and wrapper fixtures each trigger exactly one confirmation batch"

--- a/vibeguard-runtime/src/hook_checks/history.rs
+++ b/vibeguard-runtime/src/hook_checks/history.rs
@@ -251,7 +251,7 @@ fn current_project_root() -> String {
         })
 }
 
-pub(crate) fn read_tail_lines(path: &str, max_lines: usize) -> io::Result<String> {
+pub(crate) fn read_tail_lines(path: impl AsRef<Path>, max_lines: usize) -> io::Result<String> {
     let mut file = File::open(path)?;
     let mut pos = file.metadata()?.len();
     let mut buf = Vec::new();

--- a/vibeguard-runtime/src/hook_orchestrator/dispatch.rs
+++ b/vibeguard-runtime/src/hook_orchestrator/dispatch.rs
@@ -1,11 +1,11 @@
 use serde_json::{Value, json};
-use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
 
 use crate::circuit_breaker::{self, CircuitCheckOutcome, CircuitRecordBlockOutcome};
 use crate::event_schema::{decision, field, status, tool};
 use crate::hook_checks::common::{append_jsonl, nested_str, read_stdin, truncate_chars};
+use crate::hook_checks::history::read_tail_lines;
 use crate::hook_checks::{PreWriteCheck, evaluate_pre_write_input};
 use crate::hook_orchestrator::context::RuntimeContext;
 use crate::runtime_config::{runtime_config_int_value, runtime_config_str_value};
@@ -350,7 +350,7 @@ fn run_source_new(
         "5",
     );
     let prior_count = if threshold > 0 {
-        count_unheeded_source_new_reminders(ctx).unwrap_or(0)
+        count_unheeded_source_new_reminders(ctx)?
     } else {
         0
     };
@@ -544,7 +544,7 @@ fn breaker_config(ctx: &RuntimeContext, hook: &str) -> BreakerConfig {
 }
 
 fn count_unheeded_source_new_reminders(ctx: &RuntimeContext) -> Result<u64> {
-    let text = match fs::read_to_string(&ctx.log_file) {
+    let text = match read_tail_lines(&ctx.log_file, 500) {
         Ok(text) => text,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
         Err(err) => return Err(err.into()),

--- a/vibeguard-runtime/src/hook_orchestrator/post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator/post_edit_history.rs
@@ -487,7 +487,7 @@ fn preserve_warning_after_append<E: std::fmt::Display>(
 
 pub(crate) fn read_post_edit_history_events(ctx: &RuntimeContext) -> std::io::Result<Vec<Value>> {
     let log_file = ctx.log_file.to_string_lossy();
-    let text = match read_tail_lines(&log_file, POST_EDIT_HISTORY_LINES) {
+    let text = match read_tail_lines(log_file.as_ref(), POST_EDIT_HISTORY_LINES) {
         Ok(text) => text,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),

--- a/vibeguard-runtime/src/hook_orchestrator/stop.rs
+++ b/vibeguard-runtime/src/hook_orchestrator/stop.rs
@@ -70,7 +70,7 @@ fn detect_unverified_stop(ctx: &RuntimeContext, git_root: &Path, start: Instant)
         return Ok(());
     };
     let log_file = ctx.log_file.to_string_lossy();
-    let Ok(lines) = read_tail_lines(&log_file, STOP_VERIFY_HISTORY_LINES) else {
+    let Ok(lines) = read_tail_lines(log_file.as_ref(), STOP_VERIFY_HISTORY_LINES) else {
         return Ok(());
     };
     let mut edited: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary

The reported 2065ms P95 was not reproducible on the current release runtime, and the proposed project-inventory cache targeted the wrong hook. This change removes the real scaling risk by reading only the latest 500 event-log lines on the pre-write reminder path and adds large-log latency coverage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## What changed

- Reuse the bounded tail reader without lossy path conversion.
- Propagate history-read failures instead of silently resetting escalation state.
- Benchmark pre-write-guard (5000) under its normal 500ms P95 budget.
- Correct the stale Phase 7 diagnosis and document the fixture contract.

## Measured result

20-sample release-runtime run:

- pre-write-guard: P50 106ms, P95 116ms
- pre-write-guard (5000): P50 103ms, P95 107ms
- Budget: 500ms
- Spawn baseline: 2ms
- Overall benchmark verdict: PASS

## Checklist

- [x] Tests pass (cargo check and cargo test)
- [x] Guard scripts tested (pre-write-guard: 87/87)
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used
- [x] Hook performance contract passes (119/119)
- [x] Local quick contract gate passes
- [x] Independent review completed (Findings: 0, PASS)

## Related issues

Closes #755

## Screenshots / logs

Not applicable; exact benchmark results are included above.
