### PR TITLE
fix(codex): preserve runtime recovery path

### DIFF
--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -105,7 +105,7 @@ if [[ ! -f "${POLICY_PATH}" ]]; then
 fi
 # shellcheck source=hooks/_lib/policy.sh
 source "${POLICY_PATH}"
-vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${INPUT}" || exit 0; export VIBEGUARD_RUNTIME="${VG_POLICY_RUNTIME_PATH}"
+vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${INPUT}" || exit 0; [[ -n "${VIBEGUARD_RUNTIME:-}" ]] || export VIBEGUARD_RUNTIME="${VG_POLICY_RUNTIME_PATH}"
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -105,11 +105,7 @@ if [[ ! -f "${POLICY_PATH}" ]]; then
 fi
 # shellcheck source=hooks/_lib/policy.sh
 source "${POLICY_PATH}"
-vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${INPUT}" || exit 0
-# The policy resolver has already capability-checked this binary. Pass the
-# selected path to thin hook entry points so the recovery runtime remains usable
-# when the replaceable installed snapshot has lost its primary binary.
-export VIBEGUARD_RUNTIME="${VG_POLICY_RUNTIME_PATH}"
+vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${INPUT}" || exit 0; export VIBEGUARD_RUNTIME="${VG_POLICY_RUNTIME_PATH}"
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"

--- a/hooks/run-hook-codex.sh
+++ b/hooks/run-hook-codex.sh
@@ -106,6 +106,10 @@ fi
 # shellcheck source=hooks/_lib/policy.sh
 source "${POLICY_PATH}"
 vg_policy_codex_gate "${HOOK_NAME}" "${EVENT_NAME}" "${INPUT}" || exit 0
+# The policy resolver has already capability-checked this binary. Pass the
+# selected path to thin hook entry points so the recovery runtime remains usable
+# when the replaceable installed snapshot has lost its primary binary.
+export VIBEGUARD_RUNTIME="${VG_POLICY_RUNTIME_PATH}"
 
 if [[ ! -f "$HOOK_PATH" ]]; then
   codex_diag "${HOOK_NAME}" "${EVENT_NAME}" "missing-hook" "${HOOK_PATH}"

--- a/scripts/lib/install-state.sh
+++ b/scripts/lib/install-state.sh
@@ -56,6 +56,7 @@ state_runtime_path() {
     "${VIBEGUARD_SETUP_RUNTIME:-}" \
     "${_INSTALL_TMP:-}/bin/vibeguard-runtime" \
     "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${HOME}/.vibeguard/vibeguard-runtime" \
     "${repo_root}/vibeguard-runtime/target/release/vibeguard-runtime" \
     "${repo_root}/vibeguard-runtime/target/debug/vibeguard-runtime" \
     "vibeguard-runtime"; do

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -437,6 +437,11 @@ _check_execution_sources() {
   else
     red "[BROKEN] Runtime execution source missing: installed snapshot (${HOME}/.vibeguard/installed/bin/vibeguard-runtime)"
   fi
+  if [[ -x "${HOME}/.vibeguard/vibeguard-runtime" ]]; then
+    green "[OK] Runtime recovery source: ${HOME}/.vibeguard/vibeguard-runtime"
+  else
+    red "[BROKEN] Runtime recovery source missing: ${HOME}/.vibeguard/vibeguard-runtime (run: bash setup.sh --yes)"
+  fi
 }
 
 _check_git_hook() {

--- a/scripts/setup/clean.sh
+++ b/scripts/setup/clean.sh
@@ -122,6 +122,7 @@ clean_vibeguard_home() {
     "${vibeguard_home}/run-hook.sh" \
     "${vibeguard_home}/run-hook-codex.sh" \
     "${vibeguard_home}/run-hook-gemini.sh" \
+    "${vibeguard_home}/vibeguard-runtime" \
     "${vibeguard_home}/gemini-enabled" \
     "${vibeguard_home}/pre-commit" \
     "${vibeguard_home}/pre-push"

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -401,15 +401,9 @@ validate_project_config_for_install() {
   echo
 }
 cleanup_install_temps() {
-  if [[ -n "${_INSTALL_TMP:-}" ]]; then
-    rm -rf "${_INSTALL_TMP}" 2>/dev/null || true
-  fi
-  if [[ -n "${_INSTALL_FINAL_TMP:-}" ]]; then
-    rm -rf "${_INSTALL_FINAL_TMP}" 2>/dev/null || true
-  fi
-  if [[ -n "${_INSTALL_RECOVERY_TMP:-}" ]]; then
-    rm -f "${_INSTALL_RECOVERY_TMP}" 2>/dev/null || true
-  fi
+  [[ -z "${_INSTALL_TMP:-}" ]] || rm -rf "${_INSTALL_TMP}" 2>/dev/null || true
+  [[ -z "${_INSTALL_FINAL_TMP:-}" ]] || rm -rf "${_INSTALL_FINAL_TMP}" 2>/dev/null || true
+  [[ -z "${_INSTALL_RECOVERY_TMP:-}" ]] || rm -f "${_INSTALL_RECOVERY_TMP}" 2>/dev/null || true
 }
 stage_install_snapshot() {
   if [[ -n "${_INSTALL_TMP}" ]]; then
@@ -438,31 +432,6 @@ stage_install_snapshot() {
   prepare_runtime_binary
   ln -s vibeguard-runtime "${_INSTALL_TMP}/bin/vibeguard"
   write_runtime_provenance_state "${_INSTALL_TMP}/runtime-provenance"
-}
-
-publish_recovery_runtime() {
-  local source="${_INSTALL_TMP}/bin/vibeguard-runtime"
-  local destination="${VIBEGUARD_HOME}/vibeguard-runtime"
-  if [[ -L "${destination}" || (-e "${destination}" && ! -f "${destination}") ]]; then
-    red "ERROR: recovery runtime destination must be a regular file or absent: ${destination}"
-    return 1
-  fi
-  if ! _INSTALL_RECOVERY_TMP="$(mktemp "${VIBEGUARD_HOME}/.vibeguard-runtime.next.XXXXXX")"; then
-    red "ERROR: failed to allocate recovery runtime staging file"
-    return 1
-  fi
-  if ! cp "${source}" "${_INSTALL_RECOVERY_TMP}" \
-    || ! chmod +x "${_INSTALL_RECOVERY_TMP}"; then
-    red "ERROR: failed to stage recovery runtime"
-    return 1
-  fi
-  verify_prepared_runtime_version "${_INSTALL_RECOVERY_TMP}" || return 1
-  if ! mv "${_INSTALL_RECOVERY_TMP}" "${destination}"; then
-    red "ERROR: failed to publish recovery runtime: ${destination}"
-    return 1
-  fi
-  _INSTALL_RECOVERY_TMP=""
-  green "  ~/.vibeguard/vibeguard-runtime recovery runtime ready"
 }
 echo "=============================="
 echo "VibeGuard Setup"
@@ -519,7 +488,6 @@ if [[ "${VIBEGUARD_SETUP_DRY_RUN}" == "1" ]]; then
 fi
 # Staging may precede this gate; active install mutation may not.
 setup_preflight_and_lock || exit 1
-# 1. Make sure the directory exists
 echo "Step 1: Prepare directories"
 mkdir -p "${CLAUDE_DIR}"
 green "  ~/.claude/ ready"

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -43,6 +43,7 @@ VIBEGUARD_SETUP_GEMINI="${VIBEGUARD_SETUP_GEMINI:-0}"
 VIBEGUARD_HOME="${HOME}/.vibeguard"
 _INSTALL_TMP=""
 _INSTALL_FINAL_TMP=""
+_INSTALL_RECOVERY_TMP=""
 RUNTIME_VERSION_OVERRIDE=""
 RUNTIME_VERSION_OVERRIDE_SET=0
 RUNTIME_PROVENANCE_STATUS=""
@@ -406,6 +407,9 @@ cleanup_install_temps() {
   if [[ -n "${_INSTALL_FINAL_TMP:-}" ]]; then
     rm -rf "${_INSTALL_FINAL_TMP}" 2>/dev/null || true
   fi
+  if [[ -n "${_INSTALL_RECOVERY_TMP:-}" ]]; then
+    rm -f "${_INSTALL_RECOVERY_TMP}" 2>/dev/null || true
+  fi
 }
 stage_install_snapshot() {
   if [[ -n "${_INSTALL_TMP}" ]]; then
@@ -434,6 +438,31 @@ stage_install_snapshot() {
   prepare_runtime_binary
   ln -s vibeguard-runtime "${_INSTALL_TMP}/bin/vibeguard"
   write_runtime_provenance_state "${_INSTALL_TMP}/runtime-provenance"
+}
+
+publish_recovery_runtime() {
+  local source="${_INSTALL_TMP}/bin/vibeguard-runtime"
+  local destination="${VIBEGUARD_HOME}/vibeguard-runtime"
+  if [[ -L "${destination}" || (-e "${destination}" && ! -f "${destination}") ]]; then
+    red "ERROR: recovery runtime destination must be a regular file or absent: ${destination}"
+    return 1
+  fi
+  if ! _INSTALL_RECOVERY_TMP="$(mktemp "${VIBEGUARD_HOME}/.vibeguard-runtime.next.XXXXXX")"; then
+    red "ERROR: failed to allocate recovery runtime staging file"
+    return 1
+  fi
+  if ! cp "${source}" "${_INSTALL_RECOVERY_TMP}" \
+    || ! chmod +x "${_INSTALL_RECOVERY_TMP}"; then
+    red "ERROR: failed to stage recovery runtime"
+    return 1
+  fi
+  verify_prepared_runtime_version "${_INSTALL_RECOVERY_TMP}" || return 1
+  if ! mv "${_INSTALL_RECOVERY_TMP}" "${destination}"; then
+    red "ERROR: failed to publish recovery runtime: ${destination}"
+    return 1
+  fi
+  _INSTALL_RECOVERY_TMP=""
+  green "  ~/.vibeguard/vibeguard-runtime recovery runtime ready"
 }
 echo "=============================="
 echo "VibeGuard Setup"
@@ -496,6 +525,8 @@ mkdir -p "${CLAUDE_DIR}"
 green "  ~/.claude/ ready"
 #Write repo path + install hook wrapper (compatible with all platforms, no symlink dependencies)
 mkdir -p "${VIBEGUARD_HOME}"
+stage_install_snapshot
+publish_recovery_runtime || exit 1
 printf '%s' "${REPO_DIR}" > "${VIBEGUARD_HOME}/repo-path"
 if [[ "${DEV_LINKED}" == "1" ]]; then
   printf '%s\n' "dev-linked-repo" > "${VIBEGUARD_HOME}/execution-mode"
@@ -575,6 +606,7 @@ fi
 # Initialize install state tracking
 state_init "$PROFILE" "$LANGUAGES"
 state_record_tree "${INSTALLED_DIR}" "installed"
+state_record_file "${VIBEGUARD_HOME}/vibeguard-runtime" "generated/recovery-runtime" "copy"
 state_record_file "${VIBEGUARD_HOME}/repo-path" "generated/repo-path" "copy"
 state_record_file "${VIBEGUARD_HOME}/execution-mode" "generated/execution-mode" "copy"
 state_record_file "${VIBEGUARD_HOME}/run-hook.sh" "hooks/run-hook.sh" "copy"

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -26,6 +26,7 @@ setup_runtime_path() {
     "${VIBEGUARD_SETUP_RUNTIME:-}" \
     "${_INSTALL_TMP:-}/bin/vibeguard-runtime" \
     "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" \
+    "${HOME}/.vibeguard/vibeguard-runtime" \
     "${REPO_DIR}/vibeguard-runtime/target/release/vibeguard-runtime" \
     "${REPO_DIR}/vibeguard-runtime/target/debug/vibeguard-runtime" \
     "vibeguard-runtime"; do

--- a/scripts/setup/runtime-clean-pin.sh
+++ b/scripts/setup/runtime-clean-pin.sh
@@ -28,16 +28,24 @@ setup_runtime_physical_path() {
 }
 
 pin_setup_runtime_for_clean() {
-  local runtime managed_root physical_runtime tmp dest
+  local runtime managed_root recovery_runtime physical_runtime tmp dest
   runtime="$(setup_runtime_path)" || return 1
   managed_root="${HOME}/.vibeguard/installed"
-  [[ -d "${managed_root}" ]] || return 0
-  managed_root="$(cd -P "${managed_root}" && pwd)" || return 1
   physical_runtime="$(setup_runtime_physical_path "${runtime}")" || return 1
-  case "${physical_runtime}" in
-    "${managed_root}/"*) ;;
-    *) return 0 ;;
-  esac
+  recovery_runtime="${HOME}/.vibeguard/vibeguard-runtime"
+  if [[ -e "${recovery_runtime}" ]]; then
+    recovery_runtime="$(setup_runtime_physical_path "${recovery_runtime}")" || return 1
+  fi
+  if [[ -d "${managed_root}" ]]; then
+    managed_root="$(cd -P "${managed_root}" && pwd)" || return 1
+    case "${physical_runtime}" in
+      "${managed_root}/"*) ;;
+      "${recovery_runtime}") ;;
+      *) return 0 ;;
+    esac
+  elif [[ "${physical_runtime}" != "${recovery_runtime}" ]]; then
+    return 0
+  fi
 
   tmp="$(mktemp -d "${TMPDIR:-/tmp}/vibeguard-runtime-clean_XXXXXX")"
   dest="${tmp}/vibeguard-runtime"

--- a/scripts/setup/runtime-install.sh
+++ b/scripts/setup/runtime-install.sh
@@ -1,6 +1,31 @@
 #!/usr/bin/env bash
 # Runtime binary acquisition and provenance helpers for setup/install.sh.
 
+publish_recovery_runtime() {
+  local source="${_INSTALL_TMP}/bin/vibeguard-runtime"
+  local destination="${VIBEGUARD_HOME}/vibeguard-runtime"
+  if [[ -L "${destination}" || (-e "${destination}" && ! -f "${destination}") ]]; then
+    red "ERROR: recovery runtime destination must be a regular file or absent: ${destination}"
+    return 1
+  fi
+  if ! _INSTALL_RECOVERY_TMP="$(mktemp "${VIBEGUARD_HOME}/.vibeguard-runtime.next.XXXXXX")"; then
+    red "ERROR: failed to allocate recovery runtime staging file"
+    return 1
+  fi
+  if ! cp "${source}" "${_INSTALL_RECOVERY_TMP}" \
+    || ! chmod +x "${_INSTALL_RECOVERY_TMP}"; then
+    red "ERROR: failed to stage recovery runtime"
+    return 1
+  fi
+  verify_prepared_runtime_version "${_INSTALL_RECOVERY_TMP}" || return 1
+  if ! mv "${_INSTALL_RECOVERY_TMP}" "${destination}"; then
+    red "ERROR: failed to publish recovery runtime: ${destination}"
+    return 1
+  fi
+  _INSTALL_RECOVERY_TMP=""
+  green "  ~/.vibeguard/vibeguard-runtime recovery runtime ready"
+}
+
 runtime_release_target() {
   local os arch
   os="$(uname -s)"

--- a/tests/hooks/test_runtime_policy.sh
+++ b/tests/hooks/test_runtime_policy.sh
@@ -212,6 +212,39 @@ resolver_out="$(
 )"
 assert_contains "${resolver_out}" "${installed_wrapper_home}/.vibeguard/installed/bin/vibeguard-runtime" "runtime policy resolver prefers installed runtime for installed wrapper"
 
+header "runtime policy — missing installed runtime recovery"
+recovery_home="${WORK_DIR}/home-runtime-recovery"
+recovery_project="${WORK_DIR}/project-runtime-recovery"
+mkdir -p "${recovery_home}/.vibeguard/installed" "${recovery_project}"
+cp -R "${REPO_DIR}/hooks" "${recovery_home}/.vibeguard/installed/"
+cp "${REPO_DIR}/hooks/run-hook-codex.sh" "${recovery_home}/.vibeguard/run-hook-codex.sh"
+cp "${RUNTIME_BIN}" "${recovery_home}/.vibeguard/vibeguard-runtime"
+chmod +x "${recovery_home}/.vibeguard/run-hook-codex.sh" "${recovery_home}/.vibeguard/vibeguard-runtime"
+printf '%s\n' "installed-snapshot" > "${recovery_home}/.vibeguard/execution-mode"
+printf '%s\n' '{"version":1,"generation":2,"complete":false,"profile":"full","files":{}}' \
+  > "${recovery_home}/.vibeguard/install-state.json"
+printf '%s\n' '{"version":1,"generation":1,"complete":true,"profile":"core","files":{}}' \
+  > "${recovery_home}/.vibeguard/install-state.previous.json"
+
+recovery_safe_out="$(
+  cd "${recovery_project}"
+  printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status"}}' \
+    | env -u VIBEGUARD_POLICY_RUNTIME -u VIBEGUARD_RUNTIME \
+      HOME="${recovery_home}" VIBEGUARD_LOG_DIR="${recovery_home}/.vibeguard" \
+      bash "${recovery_home}/.vibeguard/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_empty_success 0 "${recovery_safe_out}" "recovery runtime avoids self-lock for a safe command"
+
+recovery_danger_out="$(
+  cd "${recovery_project}"
+  printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git clean -f"}}' \
+    | env -u VIBEGUARD_POLICY_RUNTIME -u VIBEGUARD_RUNTIME \
+      HOME="${recovery_home}" VIBEGUARD_LOG_DIR="${recovery_home}/.vibeguard" \
+      bash "${recovery_home}/.vibeguard/run-hook-codex.sh" vibeguard-pre-bash-guard.sh
+)"
+assert_contains "${recovery_danger_out}" '"permissionDecision": "deny"' "recovery runtime keeps destructive commands fail-closed"
+assert_contains "${recovery_danger_out}" "Disable git clean -f" "recovery runtime preserves the normal policy reason"
+
 partial_runtime="${WORK_DIR}/partial-runtime"
 cat > "${partial_runtime}" <<'SH'
 #!/usr/bin/env bash

--- a/tests/setup/install_core_flow_tests.sh
+++ b/tests/setup/install_core_flow_tests.sh
@@ -683,6 +683,25 @@ assert_not_contains "${no_python_check_out}" "python3 unexpectedly executed" "no
 rm -f "${no_python_home}/.vibeguard/installed/bin/vibeguard-runtime"
 printf '#!/usr/bin/env bash\nexit 127\n' > "${no_python_bin}/vibeguard-runtime"
 chmod +x "${no_python_bin}/vibeguard-runtime"
+set +e
+recovery_check_out="$(
+  HOME="${no_python_home}" PATH="${no_python_path}" \
+    VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1 \
+    bash "${REPO_DIR}/setup.sh" --check --strict 2>&1
+)"
+recovery_check_rc=$?
+set -e
+assert_cmd "setup --check reaches normal health reporting through recovery runtime" test "${recovery_check_rc}" -eq 2
+assert_not_contains "${recovery_check_out}" "cannot determine installed profile" "setup --check resolves install state through recovery runtime"
+recovery_state_fixture="${TMP_HOME}/recovery-state-fixture"
+mkdir -p "${recovery_state_fixture}/scripts/lib"
+cp "${REPO_DIR}/scripts/lib/install-state.sh" "${recovery_state_fixture}/scripts/lib/install-state.sh"
+recovery_profile="$(
+  HOME="${no_python_home}" PATH="${no_python_path}" \
+    bash -c 'source "$1/scripts/lib/install-state.sh"; state_installed_profile' \
+    _ "${recovery_state_fixture}"
+)"
+assert_eq "${recovery_profile}" "core" "install-state profile resolver uses recovery runtime when the installed runtime is missing"
 no_python_clean_out="$(
   HOME="${no_python_home}" PATH="${no_python_path}" \
     VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1 \

--- a/tests/setup/install_core_flow_tests.sh
+++ b/tests/setup/install_core_flow_tests.sh
@@ -407,6 +407,39 @@ assert_cmd "invalid setup install does not write Codex run-hook wrapper" test ! 
 assert_cmd "invalid setup install does not seed runtime config" test ! -e "${invalid_project_install_home}/.vibeguard/config.json"
 assert_cmd "invalid setup install does not install snapshot" test ! -e "${invalid_project_install_home}/.vibeguard/installed"
 
+recovery_publish_failure_home="${TMP_HOME}/recovery-publish-failure-home"
+recovery_publish_failure_bin="${TMP_HOME}/recovery-publish-failure-bin"
+mkdir -p "${recovery_publish_failure_home}" "${recovery_publish_failure_bin}"
+recovery_publish_real_mv="$(command -v mv)"
+cat > "${recovery_publish_failure_bin}/mv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+destination="${!#}"
+if [[ "${destination}" == "${VIBEGUARD_TEST_RECOVERY_DEST}" ]]; then
+  exit 91
+fi
+exec "${VIBEGUARD_TEST_REAL_MV}" "$@"
+SH
+chmod +x "${recovery_publish_failure_bin}/mv"
+set +e
+recovery_publish_failure_out="$(
+  HOME="${recovery_publish_failure_home}" \
+    PATH="${recovery_publish_failure_bin}:${PATH}" \
+    VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 \
+    VIBEGUARD_TEST_REAL_MV="${recovery_publish_real_mv}" \
+    VIBEGUARD_TEST_RECOVERY_DEST="${recovery_publish_failure_home}/.vibeguard/vibeguard-runtime" \
+    bash "${REPO_DIR}/setup.sh" --yes 2>&1
+)"
+recovery_publish_failure_rc=$?
+set -e
+assert_cmd "setup fails when recovery runtime publish rename fails" test "${recovery_publish_failure_rc}" -ne 0
+assert_contains "${recovery_publish_failure_out}" "failed to publish recovery runtime" "recovery runtime rename failure is explicit"
+assert_not_contains "${recovery_publish_failure_out}" "Setup complete! All components installed." "recovery runtime rename failure never reports install success"
+assert_cmd "failed recovery runtime publish leaves no active or staged recovery binary" bash -c \
+  'test ! -e "$1" && ! compgen -G "$2" >/dev/null' _ \
+  "${recovery_publish_failure_home}/.vibeguard/vibeguard-runtime" \
+  "${recovery_publish_failure_home}/.vibeguard/.vibeguard-runtime.next.*"
+
 runtime_key_project_config="${TMP_HOME}/runtime-key-vibeguard.json"
 cat > "${runtime_key_project_config}" <<'JSON'
 {
@@ -647,10 +680,18 @@ no_python_check_rc=$?
 set -e
 assert_cmd "no-Python setup --check --strict exits 0" test "${no_python_check_rc}" -eq 0
 assert_not_contains "${no_python_check_out}" "python3 unexpectedly executed" "no-Python setup --check does not execute python3"
-no_python_clean_out="$(HOME="${no_python_home}" PATH="${no_python_path}" bash "${REPO_DIR}/setup.sh" --clean 2>&1)"
-assert_contains "${no_python_clean_out}" "VibeGuard cleaned." "no-Python setup --clean succeeds"
+rm -f "${no_python_home}/.vibeguard/installed/bin/vibeguard-runtime"
+printf '#!/usr/bin/env bash\nexit 127\n' > "${no_python_bin}/vibeguard-runtime"
+chmod +x "${no_python_bin}/vibeguard-runtime"
+no_python_clean_out="$(
+  HOME="${no_python_home}" PATH="${no_python_path}" \
+    VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1 \
+    bash "${REPO_DIR}/setup.sh" --clean 2>&1
+)"
+assert_contains "${no_python_clean_out}" "VibeGuard cleaned." "no-Python setup --clean succeeds through recovery runtime when the installed runtime is missing"
 assert_not_contains "${no_python_clean_out}" "python3 unexpectedly executed" "no-Python setup --clean does not execute python3"
 assert_cmd "no-Python setup --clean removes install state" test ! -e "${no_python_home}/.vibeguard/install-state.json"
+assert_cmd "no-Python setup --clean removes recovery runtime" test ! -e "${no_python_home}/.vibeguard/vibeguard-runtime"
 
 install_out="$(VIBEGUARD_TEST_CARGO_UNAVAILABLE=1 CARGO_TARGET_DIR="${CUSTOM_CARGO_TARGET_DIR}" bash "${REPO_DIR}/setup.sh" --yes)"
 assert_contains "${install_out}" "Setup complete! All components installed." "Default route to installation process"
@@ -667,6 +708,8 @@ assert_cmd "setup install removes tracked retired Claude skill" test ! -L "${HOM
 assert_cmd "setup install removes tracked retired Codex skill" test ! -L "${HOME}/.codex/skills/old-flow"
 assert_cmd "vg shortcut commands are installed after setup" test -L "${HOME}/.claude/commands/vg"
 assert_cmd "vibeguard-runtime binary installed after setup" test -x "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+assert_cmd "recovery runtime installed outside the replaceable snapshot" test -x "${HOME}/.vibeguard/vibeguard-runtime"
+assert_cmd "recovery runtime matches the installed runtime" cmp -s "${HOME}/.vibeguard/vibeguard-runtime" "${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
 assert_cmd "vibeguard command installed after setup" test -x "${HOME}/.vibeguard/installed/bin/vibeguard"
 assert_cmd "vibeguard command targets the installed runtime" bash -c '
   [[ "$(readlink "$1")" == "vibeguard-runtime" ]]

--- a/tests/setup/install_core_flow_tests.sh
+++ b/tests/setup/install_core_flow_tests.sh
@@ -701,7 +701,8 @@ recovery_profile="$(
     bash -c 'source "$1/scripts/lib/install-state.sh"; state_installed_profile' \
     _ "${recovery_state_fixture}"
 )"
-assert_eq "${recovery_profile}" "core" "install-state profile resolver uses recovery runtime when the installed runtime is missing"
+assert_cmd "install-state profile resolver uses recovery runtime when the installed runtime is missing" \
+  test "${recovery_profile}" = "core"
 no_python_clean_out="$(
   HOME="${no_python_home}" PATH="${no_python_path}" \
     VIBEGUARD_SETUP_SKIP_REPO_RUNTIME=1 \

--- a/vibeguard-runtime/src/installed_profile.rs
+++ b/vibeguard-runtime/src/installed_profile.rs
@@ -25,15 +25,42 @@ pub(crate) fn installed_profile(home: &Path) -> Result<Option<String>, String> {
     let current_state = read_validated_state(&current)?;
     let (current_complete, current_generation) =
         state_generation(&current_state).map_err(|error| state_error(&current, error))?;
+    let previous_state = previous_exists
+        .then(|| read_validated_state(&previous))
+        .transpose()?;
+
     if !current_complete {
-        return Err(format!(
-            "VibeGuard policy error: install-state is incomplete: {}",
-            current.display()
-        ));
+        profile_from_state(&current, &current_state)?;
+        let Some(previous_state) = previous_state else {
+            if current_generation == 1 {
+                return Ok(None);
+            }
+            return Err(format!(
+                "VibeGuard policy error: incomplete first install-state must use generation 1: {}",
+                current.display()
+            ));
+        };
+        let (previous_complete, previous_generation) =
+            state_generation(&previous_state).map_err(|error| state_error(&previous, error))?;
+        if !previous_complete {
+            return Err(format!(
+                "VibeGuard policy error: previous install-state is incomplete: {}",
+                previous.display()
+            ));
+        }
+        let expected_generation = previous_generation.checked_add(1).ok_or_else(|| {
+            "VibeGuard policy error: previous install-state generation cannot advance".to_string()
+        })?;
+        if current_generation != expected_generation {
+            return Err(
+                "VibeGuard policy error: incomplete current install-state must be exactly one generation newer than previous snapshot"
+                    .to_string()
+            );
+        }
+        return profile_from_state(&previous, &previous_state).map(Some);
     }
 
-    if previous_exists {
-        let previous_state = read_validated_state(&previous)?;
+    if let Some(previous_state) = previous_state {
         let (previous_complete, previous_generation) =
             state_generation(&previous_state).map_err(|error| state_error(&previous, error))?;
         if !previous_complete {
@@ -50,13 +77,17 @@ pub(crate) fn installed_profile(home: &Path) -> Result<Option<String>, String> {
         }
     }
 
-    let profile = current_state
+    profile_from_state(&current, &current_state).map(Some)
+}
+
+fn profile_from_state(path: &Path, state: &serde_json::Value) -> Result<String, String> {
+    let profile = state
         .get("profile")
         .and_then(|value| value.as_str())
         .ok_or_else(|| {
             format!(
                 "VibeGuard policy error: install-state profile must be a string: {}",
-                current.display()
+                path.display()
             )
         })?;
     if !PROFILE_VALUES.contains(&profile) {
@@ -64,7 +95,7 @@ pub(crate) fn installed_profile(home: &Path) -> Result<Option<String>, String> {
             "VibeGuard policy error: unsupported install-state profile={profile} (expected minimal|core|full|strict)"
         ));
     }
-    Ok(Some(profile.to_string()))
+    Ok(profile.to_string())
 }
 
 fn ensure_optional_regular_file(path: &Path) -> Result<bool, String> {

--- a/vibeguard-runtime/src/installed_profile_tests.rs
+++ b/vibeguard-runtime/src/installed_profile_tests.rs
@@ -65,17 +65,64 @@ fn rejects_previous_only_state() {
 }
 
 #[test]
-fn rejects_incomplete_current_state() {
-    let home = temp_install_profile_home("incomplete");
+fn incomplete_upgrade_uses_previous_complete_profile() {
+    let home = temp_install_profile_home("incomplete_upgrade");
     write_state(&home, "install-state.json", &state(json!("full"), 2, false));
     write_state(
         &home,
         "install-state.previous.json",
         &state(json!("core"), 1, true),
     );
-    let error = installed_profile(&home).expect_err("incomplete state should fail");
-    assert!(error.contains("install-state is incomplete"));
+    assert_eq!(installed_profile(&home), Ok(Some("core".to_string())));
     fs::remove_dir_all(home).expect("temp home should be removed");
+}
+
+#[test]
+fn incomplete_first_install_uses_default_profile() {
+    let home = temp_install_profile_home("incomplete_first_install");
+    write_state(
+        &home,
+        "install-state.json",
+        &state(json!("strict"), 1, false),
+    );
+    assert_eq!(installed_profile(&home), Ok(None));
+    fs::remove_dir_all(home).expect("temp home should be removed");
+}
+
+#[test]
+fn rejects_incomplete_state_with_invalid_generation_relationship() {
+    for (name, current_generation, previous_generation, expected) in [
+        ("first_generation_two", 2, None, "must use generation 1"),
+        (
+            "skipped_generation",
+            4,
+            Some(2),
+            "exactly one generation newer",
+        ),
+        (
+            "repeated_generation",
+            2,
+            Some(2),
+            "exactly one generation newer",
+        ),
+    ] {
+        let home = temp_install_profile_home(name);
+        write_state(
+            &home,
+            "install-state.json",
+            &state(json!("full"), current_generation, false),
+        );
+        if let Some(previous_generation) = previous_generation {
+            write_state(
+                &home,
+                "install-state.previous.json",
+                &state(json!("core"), previous_generation, true),
+            );
+        }
+        let error = installed_profile(&home).expect_err("invalid generation should fail");
+        assert!(error.contains(expected), "unexpected error: {error}");
+        fs::remove_dir_all(home).expect("temp home should be removed");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #771

## Summary
- atomically publish a verified recovery runtime outside the replaceable installed snapshot
- reuse the capability-checked recovery runtime for Codex hooks and setup/clean lifecycles
- recover only from rigorously validated incomplete install-state generations while keeping destructive commands fail-closed
- report and clean the recovery runtime as a managed install surface

## Verification
- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/hooks/test_runtime_policy.sh` (34/34)
- `bash scripts/ci/validate-hooks.sh`
- `bash scripts/ci/validate-hooks-manifest.sh`
- `bash scripts/local-contract-check.sh --quick`
- focused setup assertions passed for recovery publish failure, recovery-only clean, installation, and binary equality

## Local environment note
The full install shard was stopped after more than one hour while continuing unrelated scheduler/stale-hook cases. The repository has local `core.hooksPath=/dev/null`; the run used an isolated environment override. CI remains the exhaustive setup matrix.