### PR TITLE
fix: simplify user-facing diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
         shell: bash
         run: bash scripts/ci/validate-doc-command-paths.sh
 
+      - name: Doc command path regression tests
+        shell: bash
+        run: bash tests/test_doc_command_paths.sh
+
       - name: Doc path allowlist regression tests
         shell: bash
         run: bash tests/test_doc_path_allowlist.sh
@@ -561,6 +565,9 @@ jobs:
 
       - name: Validate doc command paths
         run: bash scripts/ci/validate-doc-command-paths.sh
+
+      - name: Doc command path regression tests
+        run: bash tests/test_doc_command_paths.sh
 
       - name: Doc path allowlist regression tests
         run: bash tests/test_doc_path_allowlist.sh

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ These commands prove the install is active before changing another project;
 expected outputs are documented in [Quickstart](docs/how/quickstart.md):
 
 ```bash
+export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 bash ~/vibeguard/setup.sh doctor
 bash ~/vibeguard/setup.sh verify-install
-bash ~/vibeguard/scripts/doctors/codex-doctor.sh
 bash ~/vibeguard/setup.sh demo safe-bash
-bash ~/vibeguard/scripts/hook-health.sh 24
+vibeguard observe health
 ```
 
 To protect another repository after VibeGuard is installed:
@@ -107,7 +107,7 @@ For repository layout ownership, see [Directory Map](docs/directory-map.md).
 
 Real Codex hook output:
 
-![Codex L1 duplicate path interception](docs/assets/codex-l1-duplicate-path-blocked.png)
+![Codex duplicate path interception](docs/assets/codex-l1-duplicate-path-blocked.png)
 
 ```text
 You:  "Add a login endpoint"
@@ -181,7 +181,7 @@ Most hooks trigger automatically during AI operations. `skills-loader` remains a
 | AI tries to finish with unverified changes | `stop-guard` | **Signal** — logs a Stop reminder; the Stop hook exits 0 to avoid feedback loops |
 | Session ends in `full` / `strict` profile | `learn-evaluator` | **Evaluate** — collect metrics and detect correction signals |
 
-U-16 file-size enforcement applies to non-test source files with `.rs`, `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, or `.go` extensions. The default typical-size advisory starts above 400 lines (`u16.warn_limit` in `~/.vibeguard/config.json` / `VG_U16_WARN_LIMIT`), while the hard limit remains 800 lines (`u16.limit` in `~/.vibeguard/config.json` / `VG_U16_LIMIT`). For Codex, `apply_patch Add File` and `apply_patch Update File` are both normalized before the file hook runs. U-16 is baseline-aware: new oversized files, files crossing the hard limit, and legacy oversized files that grow are blocked; legacy oversized files that stay the same size or shrink are allowed with a `U16_LEGACY_DEBT` advisory until they fall below the hard limit. The git pre-commit guard and CI changed-file check call the same runtime decision so oversized imports outside AI tool hooks are caught before submission.
+The source-file size guard advises above 400 lines and blocks new growth above 800 lines while still allowing an oversized legacy file to shrink. Hook, pre-commit, and CI checks share that decision; configuration keys and the canonical rule summary are in the [Rule Reference](docs/rule-reference.md).
 
 ### Static Guards — Run Anytime
 
@@ -193,8 +193,8 @@ bash ~/vibeguard/guards/universal/check_code_slop.sh /path/to/project     # AI c
 python3 ~/vibeguard/guards/universal/check_dependency_layers.py /path      # dependency direction
 python3 ~/vibeguard/guards/universal/check_circular_deps.py /path          # circular deps
 bash ~/vibeguard/guards/universal/check_test_integrity.sh /path            # test shadowing / integrity issues
-bash ~/vibeguard/guards/universal/check_dependency_changes.sh --base origin/main --head HEAD  # SEC-11 dependency review
-bash ~/vibeguard/guards/universal/check_test_weakening.sh --base origin/main --head HEAD      # SEC-11/W-12 test weakening
+bash ~/vibeguard/guards/universal/check_dependency_changes.sh --base origin/main --head HEAD  # dependency security review
+bash ~/vibeguard/guards/universal/check_test_weakening.sh --base origin/main --head HEAD      # test-integrity review
 
 # Rust
 bash ~/vibeguard/guards/rust/check_unwrap_in_prod.sh /path                 # unwrap/expect in prod
@@ -274,16 +274,15 @@ bounded helper. They are not an automatic coordinator/reviewer pipeline:
 ## Observability
 
 ```bash
-bash ~/vibeguard/scripts/quality-grader.sh              # Quality grade (A/B/C/D)
-bash ~/vibeguard/scripts/stats.sh                       # Project hook trigger stats (7 days)
-bash ~/vibeguard/scripts/hook-health.sh 24              # Project hook health snapshot
-bash ~/vibeguard/scripts/stats.sh --scope global        # Global hook trigger stats
-bash ~/vibeguard/scripts/doctors/codex-doctor.sh        # Codex install + hook capability diagnosis
-bash ~/vibeguard/scripts/metrics/metrics-exporter.sh    # Prometheus metrics export
-bash ~/vibeguard/scripts/verify/doc-freshness-check.sh  # Rule-guard coverage check
+export PATH="$HOME/.vibeguard/installed/bin:$PATH"
+vibeguard observe summary                    # Project trigger summary (7 days)
+vibeguard observe health                     # Project health snapshot (24 hours)
+vibeguard observe summary --scope global     # Global trigger summary
+vibeguard observe export prometheus          # Prometheus text export
+bash ~/vibeguard/setup.sh doctor             # Installation and host diagnosis
 ```
 
-Doctors are read-only diagnosis wrappers over the existing defense system. They summarize installation state, capability gaps, noisy hooks, recent events, and repair commands; hooks and guards remain the enforcement layer that blocks or warns during real tool execution.
+`vibeguard observe` is the stable day-to-day command surface; underlying scripts remain available for specialized maintainer diagnostics. Doctor is read-only and summarizes installation state, capability gaps, and repair commands; hooks and guards remain the enforcement layer.
 
 Hook latency is also a product contract. See [Hook Latency Contract](docs/reference/hook-latency-contract.md) for per-hook P95 budgets, hotspot attribution, and the static gates that block expensive hook patterns.
 
@@ -321,19 +320,19 @@ Extracts non-obvious solutions as structured Skill files for future reuse.
 
 ### One-command no-clone install
 
-On supported macOS and Linux targets, the hosted seed downloads one exact
-release payload, verifies its checksum, and delegates to the canonical
-no-clone bootstrap contained in that verified payload:
+On supported macOS and Linux targets, the hosted seed downloads one exact release
+payload, verifies its checksum, and delegates to the canonical no-clone bootstrap. Replace `X.Y.Z` with the
+version shown on the [latest release](https://github.com/majiayu000/vibeguard/releases/latest):
 
 ```bash
-bash -o pipefail -c 'curl -fsSL https://raw.githubusercontent.com/majiayu000/vibeguard/main/install.sh | bash -s -- --version 1.1.15'
+bash -o pipefail -c 'curl -fsSL https://raw.githubusercontent.com/majiayu000/vibeguard/main/install.sh | bash -s -- --version X.Y.Z'
 ```
 
 Require GitHub release attestation verification and forward `setup.sh` options
 after the second `--`:
 
 ```bash
-bash -o pipefail -c 'curl -fsSL https://raw.githubusercontent.com/majiayu000/vibeguard/main/install.sh | bash -s -- --version 1.1.15 --require-provenance -- --profile full --with-scheduler'
+bash -o pipefail -c 'curl -fsSL https://raw.githubusercontent.com/majiayu000/vibeguard/main/install.sh | bash -s -- --version X.Y.Z --require-provenance -- --profile full --with-scheduler'
 ```
 
 Then verify:
@@ -398,7 +397,7 @@ and derives the expected README numerators and denominators from the report.
 bash ~/vibeguard/setup.sh                              # Install (default: core profile)
 bash ~/vibeguard/setup.sh --profile minimal           # Minimal: Bash/file gates + file post-hooks
 bash ~/vibeguard/setup.sh --profile full              # Full: adds Stop signal + Build Check + learning
-bash ~/vibeguard/setup.sh --profile strict            # Strict: full hooks + Claude Code U-32 SessionStart constraint budget
+bash ~/vibeguard/setup.sh --profile strict            # Strict: full hooks + Claude Code session constraint budget
 
 # Language selection (only install rules/guards for specified languages)
 bash ~/vibeguard/setup.sh --languages rust,python
@@ -423,7 +422,8 @@ bash ~/vibeguard/setup.sh --clean                     # Uninstall
 
 `doctor` / `--check` reports a structured rollup (OK / INFO / WARN / FAIL /
 BROKEN / MISSING) plus a final `Verdict` line of `HEALTHY`, `DEGRADED`, or
-`BROKEN`. It always exits 0 for backwards compatibility unless the checker
+`BROKEN`. Recovery-only and explicitly optional gaps produce `DEGRADED`, and the Verdict names the first issue.
+`doctor` always exits 0 for backwards compatibility unless the checker
 itself cannot run. CI should use `verify-install` for post-install health gates
 or `verify-project --json` when it needs machine-readable strict project output.
 
@@ -436,7 +436,7 @@ Migration: `--check --strict` remains supported and maps to `verify-project`;
 | `minimal` | pre-write, pre-edit, pre-bash + post-edit, post-write | Lightweight Bash/file protection |
 | `core` (default) | minimal + Claude Code analysis-paralysis (unsupported by native Codex hooks) | Standard development |
 | `full` | core + stop-guard, learn-evaluator, post-build-check | Full defense + learning |
-| `strict` | full + Claude Code count-active-constraints (SessionStart/U-32); Codex native hooks remain full | Maximum enforcement |
+| `strict` | full + Claude Code session-start constraint counting; Codex native hooks remain full | Maximum enforcement |
 
 `setup.sh` also prepares the shared pre-commit wrapper at `~/.vibeguard/pre-commit` and installs this repository's git `pre-commit` and `pre-push` hooks during setup. The git `pre-push` hook owns force-push / branch-deletion protection; `pre-bash-guard` does not regex-match `git push --force`. To attach the wrapper to another repository, use `scripts/project-init.sh` or that repository's own install step.
 
@@ -486,7 +486,7 @@ the native Codex path. Use Claude Code when read-only exploration gating is
 required; the optional app-server wrapper is only for external orchestrators
 that already require `codex app-server`.
 
-Codex hook command names are namespaced as `vibeguard-*.sh` to avoid collisions with other toolchains sharing `~/.codex/hooks.json`. Output format differences are handled by the `run-hook-codex.sh` wrapper (Claude Code `decision:block` -> Codex deny payloads). Codex sends `apply_patch` as a patch command, so the wrapper normalizes that payload into Edit/Write-shaped inputs before calling the existing VibeGuard file hooks. For `Update File` patches, the wrapper also passes the line delta so `pre-edit-guard.sh` can enforce U-16 before Codex mutates the file. When a hook suggests `updatedInput`, the Codex CLI wrapper cannot apply it automatically, so VibeGuard emits an explicit note with the suggested replacement command instead of silently dropping it.
+Codex hook command names are namespaced as `vibeguard-*.sh` to avoid collisions with other toolchains sharing `~/.codex/hooks.json`. Output format differences are handled by the `run-hook-codex.sh` wrapper (Claude Code `decision:block` -> Codex deny payloads). Codex sends `apply_patch` as a patch command, so the wrapper normalizes that payload into Edit/Write-shaped inputs before calling the existing VibeGuard file hooks. For `Update File` patches, the wrapper also passes the line delta so the source-file size guard can run before Codex mutates the file. When a hook suggests `updatedInput`, the Codex CLI wrapper cannot apply it automatically, so VibeGuard emits an explicit note with the suggested replacement command instead of silently dropping it.
 
 Hook status is a separate human diagnostics surface. Use `vibeguard-runtime hook-status --mode focused` inside a git repository to inspect the matching project log, or add `--scope global` for `~/.vibeguard/events.jsonl`. `--log-file PATH` always wins for explicit fixtures or one-off diagnosis. The command reports recent `pass`, `skipped`, `slow`, `timeout`, and adapter-error states without adding successful hook summaries to the model context. Only actionable `warn` / `block` results should continue through `hookSpecificOutput.additionalContext`. See `docs/reference/codex-hook-status.md`.
 

--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ bounded helper. They are not an automatic coordinator/reviewer pipeline:
 
 ```bash
 export PATH="$HOME/.vibeguard/installed/bin:$PATH"
-vibeguard observe summary                    # Project trigger summary (7 days)
+vibeguard observe summary --limit all        # Project trigger summary (7 days)
 vibeguard observe health --limit all         # Project health snapshot (24 hours)
-vibeguard observe summary --scope global     # Global trigger summary
+vibeguard observe summary --scope global --limit all # Global trigger summary
 vibeguard observe export prometheus          # Prometheus text export
 bash ~/vibeguard/setup.sh doctor             # Installation and host diagnosis
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 bash ~/vibeguard/setup.sh doctor
 bash ~/vibeguard/setup.sh verify-install
 bash ~/vibeguard/setup.sh demo safe-bash
-vibeguard observe health
+vibeguard observe health --limit all
 ```
 
 To protect another repository after VibeGuard is installed:
@@ -276,7 +276,7 @@ bounded helper. They are not an automatic coordinator/reviewer pipeline:
 ```bash
 export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 vibeguard observe summary                    # Project trigger summary (7 days)
-vibeguard observe health                     # Project health snapshot (24 hours)
+vibeguard observe health --limit all         # Project health snapshot (24 hours)
 vibeguard observe summary --scope global     # Global trigger summary
 vibeguard observe export prometheus          # Prometheus text export
 bash ~/vibeguard/setup.sh doctor             # Installation and host diagnosis
@@ -397,7 +397,7 @@ and derives the expected README numerators and denominators from the report.
 bash ~/vibeguard/setup.sh                              # Install (default: core profile)
 bash ~/vibeguard/setup.sh --profile minimal           # Minimal: Bash/file gates + file post-hooks
 bash ~/vibeguard/setup.sh --profile full              # Full: adds Stop signal + Build Check + learning
-bash ~/vibeguard/setup.sh --profile strict            # Strict: full hooks + Claude Code session constraint budget
+bash ~/vibeguard/setup.sh --profile strict            # Strict: full hooks + Claude Code U-32 SessionStart constraint budget
 
 # Language selection (only install rules/guards for specified languages)
 bash ~/vibeguard/setup.sh --languages rust,python
@@ -436,7 +436,7 @@ Migration: `--check --strict` remains supported and maps to `verify-project`;
 | `minimal` | pre-write, pre-edit, pre-bash + post-edit, post-write | Lightweight Bash/file protection |
 | `core` (default) | minimal + Claude Code analysis-paralysis (unsupported by native Codex hooks) | Standard development |
 | `full` | core + stop-guard, learn-evaluator, post-build-check | Full defense + learning |
-| `strict` | full + Claude Code session-start constraint counting; Codex native hooks remain full | Maximum enforcement |
+| `strict` | full + Claude Code count-active-constraints (SessionStart/U-32); Codex native hooks remain full | Maximum enforcement |
 
 `setup.sh` also prepares the shared pre-commit wrapper at `~/.vibeguard/pre-commit` and installs this repository's git `pre-commit` and `pre-push` hooks during setup. The git `pre-push` hook owns force-push / branch-deletion protection; `pre-bash-guard` does not regex-match `git push --force`. To attach the wrapper to another repository, use `scripts/project-init.sh` or that repository's own install step.
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -200,7 +200,7 @@ vibeguard observe export prometheus
 bash ~/vibeguard/setup.sh doctor
 ```
 
-Doctor 是现有防御系统之上的只读诊断入口，不替代 hooks 或 guards。它负责汇总安装状态、能力差异、噪声 hook、最近事件和修复命令；真正的拦截/告警仍然发生在 hook 和 guard 执行层。
+Doctor 是现有防御系统之上的只读诊断入口，不替代 hooks 或 guards。它负责汇总安装状态、能力差异和修复命令；真正的拦截/告警仍然发生在 hook 和 guard 执行层。
 
 学习系统分两种模式：
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -192,12 +192,12 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 ## 可观测性与学习闭环
 
 ```bash
-bash ~/vibeguard/scripts/quality-grader.sh
-bash ~/vibeguard/scripts/stats.sh
-bash ~/vibeguard/scripts/hook-health.sh 24
-bash ~/vibeguard/scripts/doctors/codex-doctor.sh
-bash ~/vibeguard/scripts/metrics/metrics-exporter.sh
-bash ~/vibeguard/scripts/verify/doc-freshness-check.sh
+export PATH="$HOME/.vibeguard/installed/bin:$PATH"
+vibeguard observe summary
+vibeguard observe health
+vibeguard observe summary --scope global
+vibeguard observe export prometheus
+bash ~/vibeguard/setup.sh doctor
 ```
 
 Doctor 是现有防御系统之上的只读诊断入口，不替代 hooks 或 guards。它负责汇总安装状态、能力差异、噪声 hook、最近事件和修复命令；真正的拦截/告警仍然发生在 hook 和 guard 执行层。

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -193,9 +193,9 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 
 ```bash
 export PATH="$HOME/.vibeguard/installed/bin:$PATH"
-vibeguard observe summary
+vibeguard observe summary --limit all
 vibeguard observe health --limit all
-vibeguard observe summary --scope global
+vibeguard observe summary --scope global --limit all
 vibeguard observe export prometheus
 bash ~/vibeguard/setup.sh doctor
 ```

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -194,7 +194,7 @@ python3 ~/vibeguard/guards/python/check_dead_shims.py /path
 ```bash
 export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 vibeguard observe summary
-vibeguard observe health
+vibeguard observe health --limit all
 vibeguard observe summary --scope global
 vibeguard observe export prometheus
 bash ~/vibeguard/setup.sh doctor

--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -78,7 +78,7 @@ before assuming protection is active.
 ## 5. Inspect Recent Hook Status
 
 ```bash
-vibeguard observe health
+vibeguard observe health --limit all
 ```
 
 This summarizes recent local hook events for the current project. See

--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -19,6 +19,7 @@ targets, offline installs, explicit `--build-from-source` runs, or unreleased
 ## 2. Verify
 
 ```bash
+export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 bash ~/vibeguard/setup.sh doctor
 bash ~/vibeguard/setup.sh verify-install
 ```
@@ -77,11 +78,9 @@ before assuming protection is active.
 ## 5. Inspect Recent Hook Status
 
 ```bash
-bash ~/vibeguard/scripts/hook-health.sh 24
-~/.vibeguard/installed/bin/vibeguard-runtime hook-status --mode focused
+vibeguard observe health
 ```
 
-`hook-health.sh` summarizes recent local hook events. `hook-status` shows the
-project-scoped hook log for the current git repository; see
+This summarizes recent local hook events for the current project. See
 [Codex Hook Status](../reference/codex-hook-status.md) for JSON and global-scope
 diagnostics.

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -124,7 +124,7 @@ state before enabling it across a team.
 
 ```bash
 export PATH="$HOME/.vibeguard/installed/bin:$PATH"
-vibeguard observe summary
+vibeguard observe summary --limit all
 vibeguard observe health --limit all
 ```
 

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -125,7 +125,7 @@ state before enabling it across a team.
 ```bash
 export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 vibeguard observe summary
-vibeguard observe health
+vibeguard observe health --limit all
 ```
 
 Use [Observability Harness Contract](../reference/observability-harness.md) for

--- a/docs/how/team-rollout.md
+++ b/docs/how/team-rollout.md
@@ -123,9 +123,9 @@ state before enabling it across a team.
 ## Observability
 
 ```bash
-bash ~/vibeguard/scripts/stats.sh
-bash ~/vibeguard/scripts/hook-health.sh 24
-~/.vibeguard/installed/bin/vibeguard-runtime hook-status --mode focused
+export PATH="$HOME/.vibeguard/installed/bin:$PATH"
+vibeguard observe summary
+vibeguard observe health
 ```
 
 Use [Observability Harness Contract](../reference/observability-harness.md) for

--- a/docs/reference/observability-harness.md
+++ b/docs/reference/observability-harness.md
@@ -98,10 +98,10 @@ Use the smallest surface that answers the question.
 
 | Question | Surface |
 |---|---|
-| What happened in this project? | `bash ~/vibeguard/scripts/stats.sh` or `vibeguard-runtime hook-status --mode focused` |
-| What happened globally? | `bash ~/vibeguard/scripts/stats.sh --scope global` |
+| What happened in this project? | `vibeguard observe summary` |
+| What happened globally? | `vibeguard observe summary --scope global` |
 | Why did this session have friction? | `session-metrics.jsonl` and `correction_signals` |
-| Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` or `bash ~/vibeguard/scripts/hook-health.sh 24` |
+| Which hook is slow? | `vibeguard observe health --slow-ms 2000` |
 | Did eval quality regress? | `python3 eval/run_behavior_eval.py --fail-on-threshold` and `python3 eval/summarize_runs.py` |
 
 `docs/reference/codex-hook-status.md` documents the focused hook-status surface.
@@ -162,7 +162,7 @@ is local evidence without background network egress, credential setup, or
 sensitive-label risk. Local logs also preserve deterministic repro data without
 depending on a remote collector.
 
-`scripts/metrics/metrics-exporter.sh` is a manual bridge for Prometheus-format
+`vibeguard observe export prometheus` is the manual bridge for Prometheus-format
 experiments. Do not schedule or enable remote push by default until the emitted
 series satisfy the metric label contract above. In particular, raw diagnostic
 labels must be removed or reduced to bounded categories before default external

--- a/docs/reference/observability-harness.md
+++ b/docs/reference/observability-harness.md
@@ -98,8 +98,8 @@ Use the smallest surface that answers the question.
 
 | Question | Surface |
 |---|---|
-| What happened in this project? | `vibeguard observe summary` |
-| What happened globally? | `vibeguard observe summary --scope global` |
+| What happened in this project? | `vibeguard observe summary --limit all` |
+| What happened globally? | `vibeguard observe summary --scope global --limit all` |
 | Why did this session have friction? | `session-metrics.jsonl` and `correction_signals` |
 | Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` |
 | Did eval quality regress? | `python3 eval/run_behavior_eval.py --fail-on-threshold` and `python3 eval/summarize_runs.py` |

--- a/docs/reference/observability-harness.md
+++ b/docs/reference/observability-harness.md
@@ -101,7 +101,7 @@ Use the smallest surface that answers the question.
 | What happened in this project? | `vibeguard observe summary` |
 | What happened globally? | `vibeguard observe summary --scope global` |
 | Why did this session have friction? | `session-metrics.jsonl` and `correction_signals` |
-| Which hook is slow? | `vibeguard observe health --slow-ms 2000` |
+| Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` |
 | Did eval quality regress? | `python3 eval/run_behavior_eval.py --fail-on-threshold` and `python3 eval/summarize_runs.py` |
 
 `docs/reference/codex-hook-status.md` documents the focused hook-status surface.

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -32,8 +32,16 @@ renamed_targets = [
     repo_root / "scripts" / "setup" / "install.sh",
     repo_root / "scripts" / "project-init.sh",
 ]
+renamed_targets.extend(
+    sorted(
+        path
+        for path in (repo_root / "docs").rglob("*.md")
+        if "internal" not in path.relative_to(repo_root / "docs").parts
+    )
+)
 renamed_targets.extend(sorted((repo_root / "workflows").rglob("*.md")))
 renamed_targets.extend(command_doc_targets)
+renamed_targets = sorted(set(renamed_targets))
 
 renamed_command_paths = {
     "scripts/compliance_check.sh": "scripts/verify/compliance_check.sh",
@@ -43,7 +51,7 @@ stale_public_commands = [
     re.compile(r"\brun install\.sh\b", re.IGNORECASE),
 ]
 hardcoded_release_pin = re.compile(
-    r"install\.sh.*--version\s+v?\d+\.\d+\.\d+"
+    r"install\.sh.*--version(?:\s+|=)v?\d+\.\d+\.\d+"
 )
 
 path_pattern = re.compile(r"~/vibeguard/([A-Za-z0-9_./-]+)")

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -42,6 +42,9 @@ stale_public_commands = [
     re.compile(r"\bbash\s+install\.sh\b"),
     re.compile(r"\brun install\.sh\b", re.IGNORECASE),
 ]
+hardcoded_release_pin = re.compile(
+    r"install\.sh.*--version\s+v?\d+\.\d+\.\d+"
+)
 
 path_pattern = re.compile(r"~/vibeguard/([A-Za-z0-9_./-]+)")
 failures = []
@@ -81,6 +84,11 @@ for md_file in renamed_targets:
                 failures.append(
                     f"{display_path(md_file)}:{idx} stale public install command; use setup.sh"
                 )
+        if hardcoded_release_pin.search(line):
+            failures.append(
+                f"{display_path(md_file)}:{idx} hardcoded release version in public install command; "
+                "use an X.Y.Z placeholder and link the latest release"
+            )
 
 
 def command_output(args: list[str]) -> str:

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -63,6 +63,23 @@ def display_path(path: Path) -> str:
     return path.relative_to(repo_root).as_posix()
 
 
+def logical_command_lines(lines: list[str]):
+    start_line = 0
+    parts = []
+    for idx, line in enumerate(lines, 1):
+        if not parts:
+            start_line = idx
+        stripped = line.rstrip()
+        if stripped.endswith("\\"):
+            parts.append(stripped[:-1])
+            continue
+        parts.append(line)
+        yield start_line, " ".join(parts)
+        parts = []
+    if parts:
+        yield start_line, " ".join(parts)
+
+
 for md_file in targets:
     if not md_file.exists():
         continue
@@ -81,7 +98,8 @@ for md_file in targets:
 for md_file in renamed_targets:
     if not md_file.exists():
         continue
-    for idx, line in enumerate(md_file.read_text(encoding="utf-8").splitlines(), 1):
+    lines = md_file.read_text(encoding="utf-8").splitlines()
+    for idx, line in enumerate(lines, 1):
         for old_path, new_path in renamed_command_paths.items():
             if old_path in line:
                 failures.append(
@@ -92,7 +110,8 @@ for md_file in renamed_targets:
                 failures.append(
                     f"{display_path(md_file)}:{idx} stale public install command; use setup.sh"
                 )
-        if hardcoded_release_pin.search(line):
+    for idx, command in logical_command_lines(lines):
+        if hardcoded_release_pin.search(command):
             failures.append(
                 f"{display_path(md_file)}:{idx} hardcoded release version in public install command; "
                 "use an X.Y.Z placeholder and link the latest release"

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -66,14 +66,28 @@ def display_path(path: Path) -> str:
 def logical_command_lines(lines: list[str]):
     start_line = 0
     parts = []
+    fence_marker = None
+    in_shell_fence = False
     for idx, line in enumerate(lines, 1):
+        fence = re.match(r"^\s*(```+|~~~+)\s*([A-Za-z0-9_-]*)\s*$", line)
+        if fence:
+            marker = fence.group(1)[0]
+            language = fence.group(2).lower()
+            if fence_marker == marker:
+                fence_marker = None
+                in_shell_fence = False
+            elif fence_marker is None:
+                fence_marker = marker
+                in_shell_fence = language in {"bash", "sh", "shell", "zsh"}
+            yield idx, line
+            continue
         if not parts:
             start_line = idx
         stripped = line.rstrip()
         if stripped.endswith("\\"):
             parts.append(stripped[:-1])
             continue
-        if stripped.endswith(("|", "|&", "&&")):
+        if in_shell_fence and stripped.endswith(("|", "|&", "&&")):
             parts.append(stripped)
             continue
         parts.append(line)

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -51,7 +51,7 @@ stale_public_commands = [
     re.compile(r"\brun install\.sh\b", re.IGNORECASE),
 ]
 hardcoded_release_pin = re.compile(
-    r"install\.sh.*--version(?:\s+|=)v?\d+\.\d+\.\d+"
+    r"install\.sh.*--version(?:\s+|=)[\"']?v?\d+\.\d+\.\d+[\"']?"
 )
 
 path_pattern = re.compile(r"~/vibeguard/([A-Za-z0-9_./-]+)")

--- a/scripts/ci/validate-doc-command-paths.sh
+++ b/scripts/ci/validate-doc-command-paths.sh
@@ -73,6 +73,9 @@ def logical_command_lines(lines: list[str]):
         if stripped.endswith("\\"):
             parts.append(stripped[:-1])
             continue
+        if stripped.endswith(("|", "|&", "&&")):
+            parts.append(stripped)
+            continue
         parts.append(line)
         yield start_line, " ".join(parts)
         parts = []

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -172,12 +172,18 @@ require_present "README.md" '| `strict` | full + Claude Code count-active-constr
   "README strict profile table must describe the strict-only U-32 hook"
 require_present "README.md" 'vibeguard observe health --limit all         # Project health snapshot (24 hours)' \
   "README project health command must preserve the complete 24-hour event window"
+require_present "docs/how/quickstart.md" 'vibeguard observe health --limit all' \
+  "quickstart project health command must preserve the complete event window"
+require_present "docs/how/team-rollout.md" 'vibeguard observe health --limit all' \
+  "team rollout project health command must preserve the complete event window"
 require_absent "docs/README_CN.md" '与 `full` 相同 hook 集合' \
   "Chinese README strict profile table must not hide the strict-only U-32 hook"
 require_absent "docs/README_CN.md" '与 full 相同 hook 集合' \
   "Chinese README strict profile table must not hide the old unquoted strict wording"
 require_present "docs/README_CN.md" '`full` + Claude Code `count-active-constraints` (SessionStart/U-32)；Codex 原生 hooks 仍为 `full`' \
   "Chinese README strict profile table must describe the strict-only U-32 hook"
+require_present "docs/README_CN.md" 'vibeguard observe health --limit all' \
+  "Chinese README project health command must preserve the complete event window"
 require_present "docs/reference/observability-harness.md" '| Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` |' \
   "observability guide must use a duration-reporting slow-hook command"
 require_absent "schemas/install-modules.json" 'same hook set as full' \

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -194,6 +194,10 @@ require_present "docs/README_CN.md" 'vibeguard observe summary --limit all' \
   "Chinese README project summary must preserve the complete event window"
 require_present "docs/README_CN.md" 'vibeguard observe summary --scope global --limit all' \
   "Chinese README global summary must preserve the complete event window"
+require_absent "docs/README_CN.md" '噪声 hook、最近事件' \
+  "Chinese README must not claim setup doctor reports event-level diagnostics"
+require_present "docs/README_CN.md" '它负责汇总安装状态、能力差异和修复命令' \
+  "Chinese README must describe setup doctor installation diagnostics accurately"
 require_present "docs/reference/observability-harness.md" '`vibeguard observe summary --limit all`' \
   "observability guide project summary must preserve the complete event window"
 require_present "docs/reference/observability-harness.md" '`vibeguard observe summary --scope global --limit all`' \

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -170,12 +170,16 @@ require_absent "README.md" '| `strict` | same hook set as full |' \
   "README strict profile table must not hide the strict-only U-32 hook"
 require_present "README.md" '| `strict` | full + Claude Code count-active-constraints (SessionStart/U-32); Codex native hooks remain full | Maximum enforcement |' \
   "README strict profile table must describe the strict-only U-32 hook"
+require_present "README.md" 'vibeguard observe health --limit all         # Project health snapshot (24 hours)' \
+  "README project health command must preserve the complete 24-hour event window"
 require_absent "docs/README_CN.md" '与 `full` 相同 hook 集合' \
   "Chinese README strict profile table must not hide the strict-only U-32 hook"
 require_absent "docs/README_CN.md" '与 full 相同 hook 集合' \
   "Chinese README strict profile table must not hide the old unquoted strict wording"
 require_present "docs/README_CN.md" '`full` + Claude Code `count-active-constraints` (SessionStart/U-32)；Codex 原生 hooks 仍为 `full`' \
   "Chinese README strict profile table must describe the strict-only U-32 hook"
+require_present "docs/reference/observability-harness.md" '| Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` |' \
+  "observability guide must use a duration-reporting slow-hook command"
 require_absent "schemas/install-modules.json" 'same hook set as full' \
   "install modules profile description must not hide the strict-only U-32 hook"
 require_present "schemas/install-modules.json" 'Maximum enforcement — full hooks plus Claude Code U-32 SessionStart constraint budget; Codex native hooks remain full' \

--- a/scripts/ci/validate-hook-behavior-docs.sh
+++ b/scripts/ci/validate-hook-behavior-docs.sh
@@ -172,10 +172,16 @@ require_present "README.md" '| `strict` | full + Claude Code count-active-constr
   "README strict profile table must describe the strict-only U-32 hook"
 require_present "README.md" 'vibeguard observe health --limit all         # Project health snapshot (24 hours)' \
   "README project health command must preserve the complete 24-hour event window"
+require_present "README.md" 'vibeguard observe summary --limit all' \
+  "README project summary must preserve the complete seven-day event window"
+require_present "README.md" 'vibeguard observe summary --scope global --limit all' \
+  "README global summary must preserve the complete event window"
 require_present "docs/how/quickstart.md" 'vibeguard observe health --limit all' \
   "quickstart project health command must preserve the complete event window"
 require_present "docs/how/team-rollout.md" 'vibeguard observe health --limit all' \
   "team rollout project health command must preserve the complete event window"
+require_present "docs/how/team-rollout.md" 'vibeguard observe summary --limit all' \
+  "team rollout summary must preserve the complete event window"
 require_absent "docs/README_CN.md" '与 `full` 相同 hook 集合' \
   "Chinese README strict profile table must not hide the strict-only U-32 hook"
 require_absent "docs/README_CN.md" '与 full 相同 hook 集合' \
@@ -184,6 +190,14 @@ require_present "docs/README_CN.md" '`full` + Claude Code `count-active-constrai
   "Chinese README strict profile table must describe the strict-only U-32 hook"
 require_present "docs/README_CN.md" 'vibeguard observe health --limit all' \
   "Chinese README project health command must preserve the complete event window"
+require_present "docs/README_CN.md" 'vibeguard observe summary --limit all' \
+  "Chinese README project summary must preserve the complete event window"
+require_present "docs/README_CN.md" 'vibeguard observe summary --scope global --limit all' \
+  "Chinese README global summary must preserve the complete event window"
+require_present "docs/reference/observability-harness.md" '`vibeguard observe summary --limit all`' \
+  "observability guide project summary must preserve the complete event window"
+require_present "docs/reference/observability-harness.md" '`vibeguard observe summary --scope global --limit all`' \
+  "observability guide global summary must preserve the complete event window"
 require_present "docs/reference/observability-harness.md" '| Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` |' \
   "observability guide must use a duration-reporting slow-hook command"
 require_absent "schemas/install-modules.json" 'same hook set as full' \

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -94,6 +94,9 @@ status_classify_line() {
 status_optional_missing_line() {
   local line="$1"
   local plain
+  # The minimal profile intentionally omits Claude agents, skills, and
+  # context profiles. Every other supported profile installs them.
+  [[ "${PROFILE:-core}" == "minimal" ]] || return 1
   plain="$(status_plain_line "$line")"
   case "$plain" in
     *"VibeGuard agent(s) missing in ~/.claude/agents/:"*|\

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -96,7 +96,7 @@ status_optional_missing_line() {
   local plain
   plain="$(status_plain_line "$line")"
   case "$plain" in
-    *"agents not in ~/.claude/agents/"*|\
+    *"VibeGuard agent(s) missing in ~/.claude/agents/:"*|\
     *"context profiles not in ~/.claude/context-profiles/"*|\
     *"eval-harness skill not in ~/.claude/skills/"*|\
     *"iterative-retrieval skill not in ~/.claude/skills/"*)

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -21,7 +21,7 @@
 #
 # Exit-code policy
 #   0 — no [WARN]/[DRIFT]/[FAIL]/[BROKEN]/[MISSING]
-#   1 — only [WARN] (degraded but functional)
+#   1 — only [WARN] or optional [MISSING] (degraded but functional)
 #   2 — at least one [DRIFT]/[FAIL]/[BROKEN]/required [MISSING] (broken — needs repair)
 #
 # Per the VibeGuard "no silent degradation" rule (U-29), [INFO] is treated
@@ -97,7 +97,9 @@ status_optional_missing_line() {
   plain="$(status_plain_line "$line")"
   case "$plain" in
     *"agents not in ~/.claude/agents/"*|\
-    *"context profiles not in ~/.claude/context-profiles/"*)
+    *"context profiles not in ~/.claude/context-profiles/"*|\
+    *"eval-harness skill not in ~/.claude/skills/"*|\
+    *"iterative-retrieval skill not in ~/.claude/skills/"*)
       return 0
       ;;
     *)
@@ -116,6 +118,61 @@ status_required_missing_count() {
     fi
   done < "${_VG_STATUS_BUFFER}"
   printf '%d\n' "$required"
+}
+
+status_optional_missing_count() {
+  local required
+  required="$(status_required_missing_count)"
+  printf '%d\n' "$((_VG_STATUS_MISSING - required))"
+}
+
+status_install_required_warning_line() {
+  local line="$1"
+  local plain
+  plain="$(status_plain_line "$line")"
+  case "$plain" in
+    "[WARN] Runtime recovery source missing:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+status_install_required_warning_count() {
+  local required=0 line level
+  [[ -n "${_VG_STATUS_BUFFER}" && -f "${_VG_STATUS_BUFFER}" ]] || { printf '0\n'; return 0; }
+  while IFS= read -r line; do
+    level="$(status_classify_line "$line")"
+    if [[ "$level" == "WARN" ]] && status_install_required_warning_line "$line"; then
+      required=$((required + 1))
+    fi
+  done < "${_VG_STATUS_BUFFER}"
+  printf '%d\n' "$required"
+}
+
+status_first_attention_message() {
+  local wanted="$1" line level plain
+  [[ -n "${_VG_STATUS_BUFFER}" && -f "${_VG_STATUS_BUFFER}" ]] || return 0
+  while IFS= read -r line; do
+    level="$(status_classify_line "$line")"
+    case "$wanted:$level" in
+      broken:DRIFT|broken:FAIL|broken:BROKEN)
+        ;;
+      broken:MISSING)
+        status_optional_missing_line "$line" && continue
+        ;;
+      degraded:WARN)
+        ;;
+      degraded:MISSING)
+        status_optional_missing_line "$line" || continue
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    plain="$(status_plain_line "$line")"
+    plain="${plain#*] }"
+    printf '%s\n' "$plain"
+    return 0
+  done < "${_VG_STATUS_BUFFER}"
 }
 
 # status_record_buffer
@@ -167,8 +224,11 @@ status_filter_problems() {
 status_print_summary() {
   local quiet=0
   [[ "${1:-}" == "--quiet" ]] && quiet=1
-  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
-  local total_warnings=${_VG_STATUS_WARN}
+  local required_missing optional_missing total_problems total_warnings attention
+  required_missing="$(status_required_missing_count)"
+  optional_missing="$(status_optional_missing_count)"
+  total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
+  total_warnings=$((_VG_STATUS_WARN + optional_missing))
 
   if [[ "${quiet}" -eq 1 ]] && (( total_problems + total_warnings > 0 )); then
     printf '\nProblems\n'
@@ -189,9 +249,13 @@ status_print_summary() {
 
   printf '\nVerdict : '
   if (( total_problems > 0 )); then
-    printf '\033[31mBROKEN\033[0m (run: bash setup.sh)\n'
+    attention="$(status_first_attention_message broken)"
+    printf '\033[31mBROKEN\033[0m (%d required issue(s); first: %s; run: bash setup.sh)\n' \
+      "${total_problems}" "${attention:-see Problems above}"
   elif (( total_warnings > 0 )); then
-    printf '\033[33mDEGRADED\033[0m (functional, optional features missing)\n'
+    attention="$(status_first_attention_message degraded)"
+    printf '\033[33mDEGRADED\033[0m (%d recovery/optional issue(s); first: %s)\n' \
+      "${total_warnings}" "${attention:-see Problems above}"
   else
     printf '\033[32mHEALTHY\033[0m\n'
   fi
@@ -201,11 +265,13 @@ status_print_summary() {
 #   Emit a stable JSON document with counts, verdict, and the full event
 #   list. Designed for CI consumers and the /vibeguard:check skill.
 status_emit_json() {
-  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
+  local required_missing total_problems
+  required_missing="$(status_required_missing_count)"
+  total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
   local verdict
   if (( total_problems > 0 )); then
     verdict="broken"
-  elif (( _VG_STATUS_WARN > 0 )); then
+  elif (( _VG_STATUS_WARN + _VG_STATUS_MISSING > 0 )); then
     verdict="degraded"
   else
     verdict="healthy"
@@ -287,10 +353,12 @@ PY
 
 # status_exit_code — echo 0|1|2 per the policy at top of file.
 status_exit_code() {
-  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + _VG_STATUS_MISSING))
+  local required_missing total_problems
+  required_missing="$(status_required_missing_count)"
+  total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
   if (( total_problems > 0 )); then
     printf '2\n'
-  elif (( _VG_STATUS_WARN > 0 )); then
+  elif (( _VG_STATUS_WARN + _VG_STATUS_MISSING > 0 )); then
     printf '1\n'
   else
     printf '0\n'
@@ -301,9 +369,10 @@ status_exit_code() {
 # WARN rows are allowed here because optional integrations can be degraded
 # without making the freshly written required runtime unusable.
 status_install_exit_code() {
-  local required_missing
+  local required_missing required_warning
   required_missing="$(status_required_missing_count)"
-  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
+  required_warning="$(status_install_required_warning_count)"
+  local total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing + required_warning))
   if (( total_problems > 0 )); then
     printf '2\n'
   else

--- a/scripts/lib/status_report.sh
+++ b/scripts/lib/status_report.sh
@@ -21,8 +21,8 @@
 #
 # Exit-code policy
 #   0 — no [WARN]/[DRIFT]/[FAIL]/[BROKEN]/[MISSING]
-#   1 — only [WARN] or optional [MISSING] (degraded but functional)
-#   2 — at least one [DRIFT]/[FAIL]/[BROKEN]/required [MISSING] (broken — needs repair)
+#   1 — only [WARN] (degraded but functional)
+#   2 — at least one [DRIFT]/[FAIL]/[BROKEN]/[MISSING] (broken — needs repair)
 #
 # Per the VibeGuard "no silent degradation" rule (U-29), [INFO] is treated
 # as neutral and never affects exit code or verdict.
@@ -91,42 +91,16 @@ status_classify_line() {
   esac
 }
 
-status_optional_missing_line() {
-  local line="$1"
-  local plain
-  # The minimal profile intentionally omits Claude agents, skills, and
-  # context profiles. Every other supported profile installs them.
-  [[ "${PROFILE:-core}" == "minimal" ]] || return 1
-  plain="$(status_plain_line "$line")"
-  case "$plain" in
-    *"VibeGuard agent(s) missing in ~/.claude/agents/:"*|\
-    *"context profiles not in ~/.claude/context-profiles/"*|\
-    *"eval-harness skill not in ~/.claude/skills/"*|\
-    *"iterative-retrieval skill not in ~/.claude/skills/"*)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 status_required_missing_count() {
   local required=0 line level
   [[ -n "${_VG_STATUS_BUFFER}" && -f "${_VG_STATUS_BUFFER}" ]] || { printf '0\n'; return 0; }
   while IFS= read -r line; do
     level="$(status_classify_line "$line")"
-    if [[ "$level" == "MISSING" ]] && ! status_optional_missing_line "$line"; then
+    if [[ "$level" == "MISSING" ]]; then
       required=$((required + 1))
     fi
   done < "${_VG_STATUS_BUFFER}"
   printf '%d\n' "$required"
-}
-
-status_optional_missing_count() {
-  local required
-  required="$(status_required_missing_count)"
-  printf '%d\n' "$((_VG_STATUS_MISSING - required))"
 }
 
 status_install_required_warning_line() {
@@ -160,12 +134,11 @@ status_first_attention_message() {
       broken:DRIFT|broken:FAIL|broken:BROKEN)
         ;;
       broken:MISSING)
-        status_optional_missing_line "$line" && continue
         ;;
       degraded:WARN)
         ;;
       degraded:MISSING)
-        status_optional_missing_line "$line" || continue
+        continue
         ;;
       *)
         continue
@@ -227,11 +200,10 @@ status_filter_problems() {
 status_print_summary() {
   local quiet=0
   [[ "${1:-}" == "--quiet" ]] && quiet=1
-  local required_missing optional_missing total_problems total_warnings attention
+  local required_missing total_problems total_warnings attention
   required_missing="$(status_required_missing_count)"
-  optional_missing="$(status_optional_missing_count)"
   total_problems=$((_VG_STATUS_DRIFT + _VG_STATUS_FAIL + _VG_STATUS_BROKEN + required_missing))
-  total_warnings=$((_VG_STATUS_WARN + optional_missing))
+  total_warnings="${_VG_STATUS_WARN}"
 
   if [[ "${quiet}" -eq 1 ]] && (( total_problems + total_warnings > 0 )); then
     printf '\nProblems\n'

--- a/scripts/local-contract-check.sh
+++ b/scripts/local-contract-check.sh
@@ -67,6 +67,7 @@ HOME="${LOCAL_CONTRACT_HOME}" run_check "validate-hooks" "$REPO_DIR/scripts/ci/v
 run_check "validate-rules"           "$REPO_DIR/scripts/ci/validate-rules.sh"           "true"
 run_check "validate-doc-paths"       "$REPO_DIR/scripts/ci/validate-doc-paths.sh"       "false"
 run_check "validate-doc-command-paths" "$REPO_DIR/scripts/ci/validate-doc-command-paths.sh" "false"
+run_check "test-doc-command-paths" "$REPO_DIR/tests/test_doc_command_paths.sh" "false"
 run_check "validate-generated-directory-guidance" "$REPO_DIR/scripts/ci/validate-generated-directory-guidance.sh" "false"
 run_check "test-directory-guidance" "$REPO_DIR/tests/test_directory_guidance.sh" "false"
 run_check "validate-no-personal-paths" "$REPO_DIR/scripts/ci/validate-no-personal-paths.sh" "false"

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -440,7 +440,7 @@ _check_execution_sources() {
   if [[ -x "${HOME}/.vibeguard/vibeguard-runtime" ]]; then
     green "[OK] Runtime recovery source: ${HOME}/.vibeguard/vibeguard-runtime"
   else
-    red "[BROKEN] Runtime recovery source missing: ${HOME}/.vibeguard/vibeguard-runtime (run: bash setup.sh --yes)"
+    yellow "[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)"
   fi
 }
 

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -439,8 +439,10 @@ _check_execution_sources() {
   fi
   if [[ -x "${HOME}/.vibeguard/vibeguard-runtime" ]]; then
     green "[OK] Runtime recovery source: ${HOME}/.vibeguard/vibeguard-runtime"
-  else
+  elif [[ -x "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" ]]; then
     yellow "[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)"
+  else
+    yellow "[WARN] Runtime recovery source missing: installed runtime is unavailable; repair is required (run: bash setup.sh --yes)"
   fi
 }
 

--- a/scripts/setup/check.sh
+++ b/scripts/setup/check.sh
@@ -390,6 +390,17 @@ _execution_source_label() {
   fi
 }
 
+_installed_runtime_is_healthy() {
+  local runtime_path="${HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+  local expected actual
+  [[ -x "${runtime_path}" ]] || return 1
+  expected="$(setup_runtime_expected_version 2>/dev/null)" || return 1
+  actual="$("${runtime_path}" version 2>/dev/null)" || return 1
+  actual="${actual%%$'\n'*}"
+  actual="${actual//$'\r'/}"
+  [[ "${actual}" == "${expected}" ]]
+}
+
 _check_execution_source_dir() {
   local surface="$1" rel_path="$2"
   local path
@@ -439,7 +450,7 @@ _check_execution_sources() {
   fi
   if [[ -x "${HOME}/.vibeguard/vibeguard-runtime" ]]; then
     green "[OK] Runtime recovery source: ${HOME}/.vibeguard/vibeguard-runtime"
-  elif [[ -x "${HOME}/.vibeguard/installed/bin/vibeguard-runtime" ]]; then
+  elif _installed_runtime_is_healthy; then
     yellow "[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)"
   else
     yellow "[WARN] Runtime recovery source missing: installed runtime is unavailable; repair is required (run: bash setup.sh --yes)"

--- a/tests/setup/check_status_tests.sh
+++ b/tests/setup/check_status_tests.sh
@@ -455,6 +455,15 @@ doctor_out="$(bash "${SETUP_SCRIPT}" doctor 2>&1 || true)"
 assert_contains "$doctor_out" "VibeGuard Installation Status" "doctor: legacy header preserved"
 assert_contains "$doctor_out" "Summary" "doctor: summary block present"
 
+BROKEN_HOME="$(mktemp -d)"
+broken_runtime_out="$(HOME="${BROKEN_HOME}" bash "${SETUP_SCRIPT}" --check 2>&1 || true)"
+assert_contains "$broken_runtime_out" \
+  "Runtime recovery source missing: installed runtime is unavailable; repair is required" \
+  "missing runtimes: recovery warning requires repair"
+assert_not_contains "$broken_runtime_out" \
+  "Runtime recovery source missing: current protection can still run" \
+  "missing runtimes: recovery warning does not claim protection can run"
+
 AWK_PORTABILITY_FIXTURE="${REPO_DIR}/guards/universal/vg-test-non-posix-awk.sh"
 cat > "${AWK_PORTABILITY_FIXTURE}" <<'SH'
 #!/usr/bin/env bash

--- a/tests/setup/check_status_tests.sh
+++ b/tests/setup/check_status_tests.sh
@@ -267,21 +267,21 @@ drift_install_rc="$(run_with_buffer "$drift_buf" 'status_install_exit_code')"
 assert_eq "$drift_install_rc" "2" "drift: install exit code 2"
 
 PROFILE="minimal"
-optional_missing_buf=$'[OK] base\n[MISSING] eval-harness skill not in ~/.claude/skills/\n[MISSING] iterative-retrieval skill not in ~/.claude/skills/\n'
-optional_missing_summary="$(run_with_buffer "$optional_missing_buf" 'status_print_summary')"
-assert_contains "$optional_missing_summary" "DEGRADED" "optional missing: verdict is degraded"
-assert_contains "$optional_missing_summary" "first: eval-harness skill not in ~/.claude/skills/" "optional missing: verdict names the first issue"
-optional_missing_rc="$(run_with_buffer "$optional_missing_buf" 'status_exit_code')"
-assert_eq "$optional_missing_rc" "1" "optional missing: strict exit code is degraded"
-optional_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
-assert_eq "$optional_install_rc" "0" "install mode: optional missing rows do not fail"
-optional_integration_buf=$'[OK] base\n[MISSING] 1/2 VibeGuard agent(s) missing in ~/.claude/agents/: reviewer.md\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
-optional_integration_rc="$(run_with_buffer "$optional_integration_buf" 'status_install_exit_code')"
-assert_eq "$optional_integration_rc" "0" "install mode: optional agent/profile rows do not fail"
+managed_skill_missing_buf=$'[OK] base\n[MISSING] eval-harness skill not in ~/.claude/skills/\n[MISSING] iterative-retrieval skill not in ~/.claude/skills/\n'
+managed_skill_missing_summary="$(run_with_buffer "$managed_skill_missing_buf" 'status_print_summary')"
+assert_contains "$managed_skill_missing_summary" "BROKEN" "minimal profile: missing installed skills is broken"
+assert_contains "$managed_skill_missing_summary" "first: eval-harness skill not in ~/.claude/skills/" "missing installed skill: verdict names the first issue"
+managed_skill_missing_rc="$(run_with_buffer "$managed_skill_missing_buf" 'status_exit_code')"
+assert_eq "$managed_skill_missing_rc" "2" "minimal profile: missing installed skills fails strict check"
+managed_skill_install_rc="$(run_with_buffer "$managed_skill_missing_buf" 'status_install_exit_code')"
+assert_eq "$managed_skill_install_rc" "2" "minimal install mode: missing installed skills fails"
+managed_assets_missing_buf=$'[OK] base\n[MISSING] 1/2 VibeGuard agent(s) missing in ~/.claude/agents/: reviewer.md\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
+managed_assets_install_rc="$(run_with_buffer "$managed_assets_missing_buf" 'status_install_exit_code')"
+assert_eq "$managed_assets_install_rc" "2" "minimal install mode: missing installed agents/profiles fails"
 PROFILE="core"
-core_skill_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
+core_skill_install_rc="$(run_with_buffer "$managed_skill_missing_buf" 'status_install_exit_code')"
 assert_eq "$core_skill_install_rc" "2" "core install mode: missing required skills fail"
-core_integration_install_rc="$(run_with_buffer "$optional_integration_buf" 'status_install_exit_code')"
+core_integration_install_rc="$(run_with_buffer "$managed_assets_missing_buf" 'status_install_exit_code')"
 assert_eq "$core_integration_install_rc" "2" "core install mode: missing required agents/profiles fail"
 recovery_missing_buf=$'[OK] installed runtime active\n[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)\n'
 recovery_missing_summary="$(run_with_buffer "$recovery_missing_buf" 'status_print_summary')"
@@ -357,8 +357,8 @@ assert_json_path "$disabled_json" 'd["counts"]["disabled"]' "1" "json: disabled 
 assert_json_path "$disabled_json" 'd["verdict"]' "healthy" "json: disabled verdict"
 assert_json_path "$disabled_json" 'd["events"][1]["level"]' "DISABLED" "json: disabled event level"
 PROFILE="minimal"
-optional_missing_json="$(run_with_buffer "$optional_missing_buf" 'status_emit_json')"
-assert_json_path "$optional_missing_json" 'd["verdict"]' "degraded" "json: optional missing verdict is degraded"
+managed_skill_missing_json="$(run_with_buffer "$managed_skill_missing_buf" 'status_emit_json')"
+assert_json_path "$managed_skill_missing_json" 'd["verdict"]' "broken" "json: missing installed skill verdict is broken"
 
 # JSON must be parseable.
 TOTAL=$((TOTAL + 1))

--- a/tests/setup/check_status_tests.sh
+++ b/tests/setup/check_status_tests.sh
@@ -241,6 +241,7 @@ degraded_buf=$'[OK] base\n[WARN] something optional\n'
 deg_summary="$(run_with_buffer "$degraded_buf" 'status_print_summary')"
 assert_contains "$deg_summary" "WARN    : 1"  "degraded: warn count"
 assert_contains "$deg_summary" "DEGRADED"     "degraded: verdict is DEGRADED"
+assert_contains "$deg_summary" "first: something optional" "degraded: verdict names the first issue"
 deg_rc="$(run_with_buffer "$degraded_buf" 'status_exit_code')"
 assert_eq "$deg_rc" "1" "degraded: exit code 1"
 
@@ -251,6 +252,7 @@ assert_contains "$broken_summary" "BROKEN  : 1"  "broken: broken count"
 assert_contains "$broken_summary" "FAIL    : 1"  "broken: fail count"
 assert_contains "$broken_summary" "MISSING : 1"  "broken: missing count"
 assert_contains "$broken_summary" "BROKEN"       "broken: verdict is BROKEN"
+assert_contains "$broken_summary" "first: hook wrapper missing" "broken: verdict names the first required issue"
 broken_rc="$(run_with_buffer "$broken_buf" 'status_exit_code')"
 assert_eq "$broken_rc" "2" "broken: exit code 2"
 
@@ -264,9 +266,23 @@ assert_eq "$drift_rc" "2" "drift: strict exit code 2"
 drift_install_rc="$(run_with_buffer "$drift_buf" 'status_install_exit_code')"
 assert_eq "$drift_install_rc" "2" "drift: install exit code 2"
 
-optional_missing_buf=$'[OK] base\n[MISSING] agents not in ~/.claude/agents/\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
+optional_missing_buf=$'[OK] base\n[MISSING] eval-harness skill not in ~/.claude/skills/\n[MISSING] iterative-retrieval skill not in ~/.claude/skills/\n'
+optional_missing_summary="$(run_with_buffer "$optional_missing_buf" 'status_print_summary')"
+assert_contains "$optional_missing_summary" "DEGRADED" "optional missing: verdict is degraded"
+assert_contains "$optional_missing_summary" "first: eval-harness skill not in ~/.claude/skills/" "optional missing: verdict names the first issue"
+optional_missing_rc="$(run_with_buffer "$optional_missing_buf" 'status_exit_code')"
+assert_eq "$optional_missing_rc" "1" "optional missing: strict exit code is degraded"
 optional_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
 assert_eq "$optional_install_rc" "0" "install mode: optional missing rows do not fail"
+optional_integration_buf=$'[OK] base\n[MISSING] agents not in ~/.claude/agents/\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
+optional_integration_rc="$(run_with_buffer "$optional_integration_buf" 'status_install_exit_code')"
+assert_eq "$optional_integration_rc" "0" "install mode: optional agent/profile rows do not fail"
+recovery_missing_buf=$'[OK] installed runtime active\n[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)\n'
+recovery_missing_summary="$(run_with_buffer "$recovery_missing_buf" 'status_print_summary')"
+assert_contains "$recovery_missing_summary" "DEGRADED" "recovery missing: human verdict is degraded"
+assert_contains "$recovery_missing_summary" "first: Runtime recovery source missing" "recovery missing: verdict names the recovery gap"
+recovery_install_rc="$(run_with_buffer "$recovery_missing_buf" 'status_install_exit_code')"
+assert_eq "$recovery_install_rc" "2" "recovery missing: install verification still fails"
 codex_required_missing_buf=$'[OK] base\n[MISSING] Codex hooks.json not installed\n[MISSING] Codex hook wrapper not installed\n[MISSING] hooks feature not enabled in ~/.codex/config.toml\n'
 codex_required_install_rc="$(run_with_buffer "$codex_required_missing_buf" 'status_install_exit_code')"
 assert_eq "$codex_required_install_rc" "2" "install mode: Codex missing rows fail"
@@ -334,6 +350,8 @@ disabled_json="$(run_with_buffer "$disabled_buf" 'status_emit_json')"
 assert_json_path "$disabled_json" 'd["counts"]["disabled"]' "1" "json: disabled count"
 assert_json_path "$disabled_json" 'd["verdict"]' "healthy" "json: disabled verdict"
 assert_json_path "$disabled_json" 'd["events"][1]["level"]' "DISABLED" "json: disabled event level"
+optional_missing_json="$(run_with_buffer "$optional_missing_buf" 'status_emit_json')"
+assert_json_path "$optional_missing_json" 'd["verdict"]' "degraded" "json: optional missing verdict is degraded"
 
 # JSON must be parseable.
 TOTAL=$((TOTAL + 1))

--- a/tests/setup/check_status_tests.sh
+++ b/tests/setup/check_status_tests.sh
@@ -266,6 +266,7 @@ assert_eq "$drift_rc" "2" "drift: strict exit code 2"
 drift_install_rc="$(run_with_buffer "$drift_buf" 'status_install_exit_code')"
 assert_eq "$drift_install_rc" "2" "drift: install exit code 2"
 
+PROFILE="minimal"
 optional_missing_buf=$'[OK] base\n[MISSING] eval-harness skill not in ~/.claude/skills/\n[MISSING] iterative-retrieval skill not in ~/.claude/skills/\n'
 optional_missing_summary="$(run_with_buffer "$optional_missing_buf" 'status_print_summary')"
 assert_contains "$optional_missing_summary" "DEGRADED" "optional missing: verdict is degraded"
@@ -277,6 +278,11 @@ assert_eq "$optional_install_rc" "0" "install mode: optional missing rows do not
 optional_integration_buf=$'[OK] base\n[MISSING] 1/2 VibeGuard agent(s) missing in ~/.claude/agents/: reviewer.md\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
 optional_integration_rc="$(run_with_buffer "$optional_integration_buf" 'status_install_exit_code')"
 assert_eq "$optional_integration_rc" "0" "install mode: optional agent/profile rows do not fail"
+PROFILE="core"
+core_skill_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
+assert_eq "$core_skill_install_rc" "2" "core install mode: missing required skills fail"
+core_integration_install_rc="$(run_with_buffer "$optional_integration_buf" 'status_install_exit_code')"
+assert_eq "$core_integration_install_rc" "2" "core install mode: missing required agents/profiles fail"
 recovery_missing_buf=$'[OK] installed runtime active\n[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)\n'
 recovery_missing_summary="$(run_with_buffer "$recovery_missing_buf" 'status_print_summary')"
 assert_contains "$recovery_missing_summary" "DEGRADED" "recovery missing: human verdict is degraded"
@@ -350,6 +356,7 @@ disabled_json="$(run_with_buffer "$disabled_buf" 'status_emit_json')"
 assert_json_path "$disabled_json" 'd["counts"]["disabled"]' "1" "json: disabled count"
 assert_json_path "$disabled_json" 'd["verdict"]' "healthy" "json: disabled verdict"
 assert_json_path "$disabled_json" 'd["events"][1]["level"]' "DISABLED" "json: disabled event level"
+PROFILE="minimal"
 optional_missing_json="$(run_with_buffer "$optional_missing_buf" 'status_emit_json')"
 assert_json_path "$optional_missing_json" 'd["verdict"]' "degraded" "json: optional missing verdict is degraded"
 
@@ -463,6 +470,20 @@ assert_contains "$broken_runtime_out" \
 assert_not_contains "$broken_runtime_out" \
   "Runtime recovery source missing: current protection can still run" \
   "missing runtimes: recovery warning does not claim protection can run"
+
+mkdir -p "${BROKEN_HOME}/.vibeguard/installed/bin"
+cat > "${BROKEN_HOME}/.vibeguard/installed/bin/vibeguard-runtime" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "${BROKEN_HOME}/.vibeguard/installed/bin/vibeguard-runtime"
+broken_executable_runtime_out="$(HOME="${BROKEN_HOME}" bash "${SETUP_SCRIPT}" --check 2>&1 || true)"
+assert_contains "$broken_executable_runtime_out" \
+  "Runtime recovery source missing: installed runtime is unavailable; repair is required" \
+  "broken executable runtime: recovery warning requires repair"
+assert_not_contains "$broken_executable_runtime_out" \
+  "Runtime recovery source missing: current protection can still run" \
+  "broken executable runtime: recovery warning does not claim protection can run"
 
 AWK_PORTABILITY_FIXTURE="${REPO_DIR}/guards/universal/vg-test-non-posix-awk.sh"
 cat > "${AWK_PORTABILITY_FIXTURE}" <<'SH'

--- a/tests/setup/check_status_tests.sh
+++ b/tests/setup/check_status_tests.sh
@@ -274,7 +274,7 @@ optional_missing_rc="$(run_with_buffer "$optional_missing_buf" 'status_exit_code
 assert_eq "$optional_missing_rc" "1" "optional missing: strict exit code is degraded"
 optional_install_rc="$(run_with_buffer "$optional_missing_buf" 'status_install_exit_code')"
 assert_eq "$optional_install_rc" "0" "install mode: optional missing rows do not fail"
-optional_integration_buf=$'[OK] base\n[MISSING] agents not in ~/.claude/agents/\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
+optional_integration_buf=$'[OK] base\n[MISSING] 1/2 VibeGuard agent(s) missing in ~/.claude/agents/: reviewer.md\n[MISSING] context profiles not in ~/.claude/context-profiles/\n'
 optional_integration_rc="$(run_with_buffer "$optional_integration_buf" 'status_install_exit_code')"
 assert_eq "$optional_integration_rc" "0" "install mode: optional agent/profile rows do not fail"
 recovery_missing_buf=$'[OK] installed runtime active\n[WARN] Runtime recovery source missing: current protection can still run, but repair and uninstall recovery are unavailable (run: bash setup.sh --yes)\n'

--- a/tests/test_doc_command_paths.sh
+++ b/tests/test_doc_command_paths.sh
@@ -70,6 +70,15 @@ assert_fails_with "numeric release pin in docs/how fails" \
   "docs/how/quickstart.md:1 hardcoded release version" \
   bash "${VALIDATOR}" "${public_docs_fixture}"
 
+continued_fixture="$(new_fixture continued-command)"
+cat > "${continued_fixture}/docs/how/quickstart.md" <<'MD'
+curl -fsSL https://example.test/install.sh \
+  | bash -s -- --version=1.2.3
+MD
+assert_fails_with "numeric release pin in a continued command fails" \
+  "docs/how/quickstart.md:1 hardcoded release version" \
+  bash "${VALIDATOR}" "${continued_fixture}"
+
 placeholder_fixture="$(new_fixture placeholder)"
 printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version=X.Y.Z' \
   > "${placeholder_fixture}/docs/how/quickstart.md"

--- a/tests/test_doc_command_paths.sh
+++ b/tests/test_doc_command_paths.sh
@@ -63,6 +63,20 @@ assert_fails_with "equals-form numeric release pin fails" \
   "README.md:2 hardcoded release version" \
   bash "${VALIDATOR}" "${equals_fixture}"
 
+quoted_equals_fixture="$(new_fixture quoted-equals-form)"
+printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version="1.2.3"' \
+  >> "${quoted_equals_fixture}/README.md"
+assert_fails_with "quoted equals-form numeric release pin fails" \
+  "README.md:2 hardcoded release version" \
+  bash "${VALIDATOR}" "${quoted_equals_fixture}"
+
+quoted_separate_fixture="$(new_fixture quoted-separate-form)"
+printf '%s\n' "curl -fsSL https://example.test/install.sh | bash -s -- --version '1.2.3'" \
+  >> "${quoted_separate_fixture}/README.md"
+assert_fails_with "quoted separate numeric release pin fails" \
+  "README.md:2 hardcoded release version" \
+  bash "${VALIDATOR}" "${quoted_separate_fixture}"
+
 public_docs_fixture="$(new_fixture public-docs)"
 printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version 1.2.3' \
   > "${public_docs_fixture}/docs/how/quickstart.md"

--- a/tests/test_doc_command_paths.sh
+++ b/tests/test_doc_command_paths.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Focused regression tests for public documentation command validation.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VALIDATOR="${REPO_DIR}/scripts/ci/validate-doc-command-paths.sh"
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+red()   { printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+
+assert_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@" >/dev/null 2>&1; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fails_with() {
+  local desc="$1" expected="$2"
+  shift 2
+  TOTAL=$((TOTAL + 1))
+  local output
+  if output="$("$@" 2>&1)"; then
+    red "$desc (expected failure)"
+    FAIL=$((FAIL + 1))
+  elif grep -qF -- "$expected" <<< "$output"; then
+    green "$desc"
+    PASS=$((PASS + 1))
+  else
+    red "$desc (expected output to contain: $expected)"
+    printf '%s\n' "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+new_fixture() {
+  local name="$1"
+  local root="${TMP_DIR}/${name}"
+  mkdir -p "${root}/docs/how"
+  printf '# README\n' > "${root}/README.md"
+  printf '# Contributing\n' > "${root}/CONTRIBUTING.md"
+  printf '# 中文\n' > "${root}/docs/README_CN.md"
+  printf '%s\n' "${root}"
+}
+
+equals_fixture="$(new_fixture equals-form)"
+printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version=1.2.3' \
+  >> "${equals_fixture}/README.md"
+assert_fails_with "equals-form numeric release pin fails" \
+  "README.md:2 hardcoded release version" \
+  bash "${VALIDATOR}" "${equals_fixture}"
+
+public_docs_fixture="$(new_fixture public-docs)"
+printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version 1.2.3' \
+  > "${public_docs_fixture}/docs/how/quickstart.md"
+assert_fails_with "numeric release pin in docs/how fails" \
+  "docs/how/quickstart.md:1 hardcoded release version" \
+  bash "${VALIDATOR}" "${public_docs_fixture}"
+
+placeholder_fixture="$(new_fixture placeholder)"
+printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version=X.Y.Z' \
+  > "${placeholder_fixture}/docs/how/quickstart.md"
+assert_cmd "placeholder release version passes" \
+  bash "${VALIDATOR}" "${placeholder_fixture}"
+
+printf '\nTotal: %d  Pass: %d  Fail: %d\n' "$TOTAL" "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test_doc_command_paths.sh
+++ b/tests/test_doc_command_paths.sh
@@ -79,6 +79,15 @@ assert_fails_with "numeric release pin in a continued command fails" \
   "docs/how/quickstart.md:1 hardcoded release version" \
   bash "${VALIDATOR}" "${continued_fixture}"
 
+pipeline_fixture="$(new_fixture pipeline-continuation)"
+cat > "${pipeline_fixture}/docs/how/quickstart.md" <<'MD'
+curl -fsSL https://example.test/install.sh |
+  bash -s -- --version=1.2.3
+MD
+assert_fails_with "numeric release pin in a continued pipeline fails" \
+  "docs/how/quickstart.md:1 hardcoded release version" \
+  bash "${VALIDATOR}" "${pipeline_fixture}"
+
 placeholder_fixture="$(new_fixture placeholder)"
 printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version=X.Y.Z' \
   > "${placeholder_fixture}/docs/how/quickstart.md"

--- a/tests/test_doc_command_paths.sh
+++ b/tests/test_doc_command_paths.sh
@@ -81,12 +81,24 @@ assert_fails_with "numeric release pin in a continued command fails" \
 
 pipeline_fixture="$(new_fixture pipeline-continuation)"
 cat > "${pipeline_fixture}/docs/how/quickstart.md" <<'MD'
+```bash
 curl -fsSL https://example.test/install.sh |
   bash -s -- --version=1.2.3
+```
 MD
 assert_fails_with "numeric release pin in a continued pipeline fails" \
-  "docs/how/quickstart.md:1 hardcoded release version" \
+  "docs/how/quickstart.md:2 hardcoded release version" \
   bash "${VALIDATOR}" "${pipeline_fixture}"
+
+table_fixture="$(new_fixture markdown-table)"
+cat > "${table_fixture}/docs/how/quickstart.md" <<'MD'
+| Field | Example |
+|---|---|
+| Installer | `install.sh` |
+| Version syntax | `--version=1.2.3` |
+MD
+assert_cmd "Markdown table rows are not folded into a command" \
+  bash "${VALIDATOR}" "${table_fixture}"
 
 placeholder_fixture="$(new_fixture placeholder)"
 printf '%s\n' 'curl -fsSL https://example.test/install.sh | bash -s -- --version=X.Y.Z' \


### PR DESCRIPTION
## Summary

- replace the stale numeric no-clone install pin with an explicit `X.Y.Z` placeholder, a latest-release link, and a CI check that rejects future hardcoded release pins
- remove internal rule IDs from README explanations and route day-to-day observability through the installed `vibeguard observe` command surface
- make doctor classify recovery-only and optional Claude skill gaps as `DEGRADED`, name the first actionable issue in the Verdict, and keep `verify-install` strict when the recovery runtime is missing

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## Checklist

- [x] Tests pass (`cargo test` / `go test ./...` / `pytest`)
- [x] Guard scripts tested (if applicable)
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used (`feat:` / `fix:` / `chore:` etc.)

## Related issues

None.

## Screenshots / logs

- `bash tests/test_setup.sh`: 1352/1352 passed
- `bash tests/test_setup_check.sh`: 292/292 passed
- `bash tests/test_stats.sh`: 61/61 passed
- `bash tests/test_observe.sh`: 16/16 passed
- `bash scripts/local-contract-check.sh --quick`: passed
- `bash scripts/ci/validate-doc-paths.sh`: passed
- `bash scripts/ci/validate-doc-command-paths.sh`: passed
