### PR TITLE
feat(observe): explain rule hits in reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ When changing rules, guards, hooks, or script paths, update matching docs in the
 
 - Canonical rule source: `rules/claude-rules/**` is the only canonical rule text. Keep it English-only.
 - Localized docs: translations such as `docs/README_CN.md` belong in the docs layer only. Do not add localized copies of canonical rules.
-- Derived rule docs: `rules/*.md` and `docs/rule-reference.md` are generated artifacts. Do not hand-edit them; regenerate them with `python3 scripts/generate_rule_docs.py`.
+- Derived rule outputs: `rules/*.md`, `rules/rule-descriptions.json`, and `docs/rule-reference.md` are generated artifacts. Do not hand-edit them; regenerate them with `python3 scripts/generate_rule_docs.py` and `python3 scripts/generate_rule_descriptions.py`.
 - Scoped Claude guidance: repository `CLAUDE.md` files are generated from `docs/directory-guidance.md`. Regenerate them with `python3 scripts/generate_directory_guidance.py` instead of editing an output directly.
 - Script moves or renames: update command examples in `README.md`, `docs/README_CN.md`, and any contributor docs that mention them.
 - Canonical rule checks: run `bash scripts/ci/validate-canonical-rule-language.sh` to ensure no CJK text or malformed headings leak into `rules/claude-rules/**`.
@@ -257,7 +257,7 @@ Before requesting review, verify:
 - [ ] Precision / scoring checks were run when the change affects detection quality (`bash tests/run_precision.sh --all --csv`, `bash tests/test_precision_tracker.sh`)
 - [ ] All CI validation scripts pass (see [Running Validation and Tests](#running-validation-and-tests))
 - [ ] New guard scripts have regression coverage in `tests/unit/` and, when appropriate, higher-level suites in `tests/`
-- [ ] New or changed canonical rules stay in `rules/claude-rules/**` only, and regenerated artifacts in `rules/*.md` and `docs/rule-reference.md` are up to date
+- [ ] New or changed canonical rules stay in `rules/claude-rules/**` only, and regenerated artifacts in `rules/*.md`, `rules/rule-descriptions.json`, and `docs/rule-reference.md` are up to date
 - [ ] Doc freshness passes (`bash scripts/verify/doc-freshness-check.sh --strict`)
 - [ ] Doc paths and shell command paths are valid (`validate-doc-paths.sh` and `validate-doc-command-paths.sh`)
 - [ ] Canonical rule language and generated rule docs checks pass
@@ -304,9 +304,14 @@ scripts.
 
 ### Step 1: Define the rule
 
-Add or update the canonical rule in `rules/claude-rules/**` first. Keep canonical rule text in English. After editing the canonical source, regenerate the derived rule docs with `python3 scripts/generate_rule_docs.py`.
+Add or update the canonical rule in `rules/claude-rules/**` first. Keep canonical rule text in English. After editing the canonical source, regenerate the derived outputs:
 
-Do not hand-edit `rules/*.md` or `docs/rule-reference.md`; they are generated outputs.
+```bash
+python3 scripts/generate_rule_docs.py
+python3 scripts/generate_rule_descriptions.py
+```
+
+Do not hand-edit `rules/*.md`, `rules/rule-descriptions.json`, or `docs/rule-reference.md`; they are generated outputs.
 
 ```markdown
 ## RS-14: Arc<Mutex<Option<T>>> anti-pattern (medium)

--- a/hooks/count_active_constraints.sh
+++ b/hooks/count_active_constraints.sh
@@ -70,13 +70,13 @@ _vg_u32_strict_default() {
 }
 
 if [[ "${STATUS}" == "block" ]]; then
-  vg_log "count-active-constraints" "${HOOK_EVENT}" "block" "constraints=${TOTAL}" "${SUMMARY}"
+  vg_log "count-active-constraints" "${HOOK_EVENT}" "block" "U-32 constraints=${TOTAL}" "${SUMMARY}"
   if [[ "${VIBEGUARD_U32_STRICT:-$(_vg_u32_strict_default)}" == "1" ]]; then
     printf '%s\n' "[BLOCKED] ${MESSAGE}" >&2
     exit 2
   fi
 else
-  vg_log "count-active-constraints" "${HOOK_EVENT}" "warn" "constraints=${TOTAL}" "${SUMMARY}"
+  vg_log "count-active-constraints" "${HOOK_EVENT}" "warn" "U-32 constraints=${TOTAL}" "${SUMMARY}"
 fi
 
 printf '%s' "${MESSAGE}" | "$_VIBEGUARD_RUNTIME" hook-context "${HOOK_EVENT}"

--- a/rules/rule-descriptions.json
+++ b/rules/rule-descriptions.json
@@ -1,0 +1,641 @@
+{
+  "schema_version": 1,
+  "generated_from": "rules/claude-rules/**",
+  "rules": {
+    "GO-01": {
+      "name": "Unchecked error return values",
+      "severity": "High",
+      "description": "Errors are assigned to `_` and discarded."
+    },
+    "PY-01": {
+      "name": "Mutable default parameters",
+      "severity": "High",
+      "description": "`def f(x=[])` shares state across calls."
+    },
+    "RS-01": {
+      "name": "Nested `RwLock` / `Mutex` acquisition",
+      "severity": "High",
+      "description": "Holding multiple locks at once creates deadlock risk."
+    },
+    "SEC-01": {
+      "name": "SQL / NoSQL / OS command injection",
+      "severity": "Critical",
+      "description": "No SQL / NoSQL / OS command injection: use parameterized queries and array argument lists."
+    },
+    "TS-01": {
+      "name": "`any` type escape",
+      "severity": "Medium",
+      "description": "Function parameters or return values use `any`."
+    },
+    "U-01": {
+      "name": "Do not change public API signatures",
+      "severity": "Strict",
+      "description": "Unless the user explicitly requests a breaking change and accepts a MAJOR version bump, do not change public function signatures."
+    },
+    "W-01": {
+      "name": "No fixes without root cause",
+      "severity": "Strict",
+      "description": "No fixes without root cause: reproduce first, then form one hypothesis, then fix."
+    },
+    "GO-02": {
+      "name": "Goroutine leak",
+      "severity": "High",
+      "description": "`go func()` launches work without an exit path."
+    },
+    "PY-02": {
+      "name": "Bare `except` blocks",
+      "severity": "Medium",
+      "description": "`except:` or `except Exception` without logging or re-raising."
+    },
+    "RS-02": {
+      "name": "TOCTOU — `get()` followed by `insert()`",
+      "severity": "High",
+      "description": "The lock is released between read and write, which creates a race."
+    },
+    "SEC-02": {
+      "name": "Hardcoded keys / credentials / API tokens",
+      "severity": "Critical",
+      "description": "No hardcoded keys, credentials, or API tokens. Load from env / secret manager."
+    },
+    "TS-02": {
+      "name": "Unhandled Promise rejections",
+      "severity": "High",
+      "description": "Async calls lack error handling."
+    },
+    "U-02": {
+      "name": "Do not extract abstractions for code that appears only once",
+      "severity": "Strict",
+      "description": "Three lines of duplication are better than one premature abstraction."
+    },
+    "W-02": {
+      "name": "Back off after 3 consecutive failures",
+      "severity": "Strict",
+      "description": "After 3 consecutive failed fixes on the same problem, stop and challenge the hypothesis or architecture."
+    },
+    "GO-03": {
+      "name": "Data race",
+      "severity": "High",
+      "description": "Shared variables are accessed without a mutex or channel protection."
+    },
+    "PY-03": {
+      "name": "`await` inside loops without `gather()` / `TaskGroup`",
+      "severity": "Medium",
+      "description": "Serial waiting wastes time."
+    },
+    "RS-03": {
+      "name": "`unwrap()` in non-test code",
+      "severity": "Medium",
+      "description": "`unwrap()` creates panic risk."
+    },
+    "SEC-03": {
+      "name": "Unescaped user input rendered directly into HTML",
+      "severity": "High",
+      "description": "This creates an XSS vulnerability."
+    },
+    "TS-03": {
+      "name": "`==` instead of `===`",
+      "severity": "Medium",
+      "description": "Loose equality is used outside explicit null checks."
+    },
+    "U-03": {
+      "name": "Do not replace readable duplication with macros",
+      "severity": "Strict",
+      "description": "Macros reduce readability and IDE support."
+    },
+    "W-03": {
+      "name": "Verify before claiming completion",
+      "severity": "Strict",
+      "description": "Verify before claiming completion: produce fresh command output proving the claim."
+    },
+    "GO-04": {
+      "name": "Interface is declared on the implementation side instead of the consumer side",
+      "severity": "Medium",
+      "description": "Interface is declared on the implementation side instead of the consumer side"
+    },
+    "PY-04": {
+      "name": "God class larger than 500 lines",
+      "severity": "Medium",
+      "description": "More than 10 public methods."
+    },
+    "RS-04": {
+      "name": "Multiple `Signal` / `Arc` objects manage the same logical state",
+      "severity": "Medium",
+      "description": "Converge them into a single `Signal<State>` so one structure owns the whole state."
+    },
+    "SEC-04": {
+      "name": "API endpoints missing authentication or authorization checks",
+      "severity": "High",
+      "description": "Unprotected API endpoints."
+    },
+    "TS-04": {
+      "name": "Oversized component larger than 300 lines",
+      "severity": "Medium",
+      "description": "React component is too large."
+    },
+    "U-04": {
+      "name": "Do not add features the user did not ask for",
+      "severity": "Strict",
+      "description": "Keep bug-fix scope tight."
+    },
+    "W-04": {
+      "name": "Test first",
+      "severity": "Guideline",
+      "description": "For new features, prefer writing the failing test first, then writing the minimum implementation needed to pass it."
+    },
+    "GO-05": {
+      "name": "Repeated error-wrapping patterns across multiple places",
+      "severity": "Medium",
+      "description": "Repeated error-wrapping patterns across multiple places"
+    },
+    "PY-05": {
+      "name": "Repeated try/except patterns across many locations",
+      "severity": "Medium",
+      "description": "Repeated try/except patterns across many locations"
+    },
+    "RS-05": {
+      "name": "Same name, different meaning types",
+      "severity": "Medium",
+      "description": "For example, two different `RenderHandle` types."
+    },
+    "SEC-05": {
+      "name": "Dependencies with known CVEs",
+      "severity": "High",
+      "description": "Dependencies with known CVEs"
+    },
+    "TS-05": {
+      "name": "Repeated fetch / API call patterns across the codebase",
+      "severity": "Medium",
+      "description": "Repeated fetch / API call patterns across the codebase"
+    },
+    "U-05": {
+      "name": "Do not delete code that merely looks unused without confirming first",
+      "severity": "Strict",
+      "description": "It may be a work-in-progress feature."
+    },
+    "W-05": {
+      "name": "Sub-agent context isolation",
+      "severity": "Guideline",
+      "description": "When using sub-agents, give each child only the minimum context required for its task."
+    },
+    "GO-06": {
+      "name": "`append` in loops without preallocated capacity",
+      "severity": "Low",
+      "description": "`append` in loops without preallocated capacity"
+    },
+    "PY-06": {
+      "name": "Rebuilding regexes inside loops",
+      "severity": "Low",
+      "description": "Rebuilding regexes inside loops"
+    },
+    "RS-06": {
+      "name": "The same match arm is duplicated across multiple methods",
+      "severity": "Medium",
+      "description": "The same match arm is duplicated across multiple methods"
+    },
+    "SEC-06": {
+      "name": "Weak cryptographic algorithms",
+      "severity": "High",
+      "description": "Using MD5 or SHA1 for password hashing."
+    },
+    "TS-06": {
+      "name": "`useEffect` has missing or overly broad dependencies",
+      "severity": "Medium",
+      "description": "`useEffect` has missing or overly broad dependencies"
+    },
+    "U-06": {
+      "name": "Do not add dependencies for problems the standard library can solve",
+      "severity": "Strict",
+      "description": "Use the standard library first."
+    },
+    "GO-07": {
+      "name": "String concatenation with `+` instead of `strings.Builder`",
+      "severity": "Low",
+      "description": "String concatenation with `+` instead of `strings.Builder`"
+    },
+    "PY-07": {
+      "name": "String concatenation inside loops",
+      "severity": "Low",
+      "description": "String concatenation inside loops"
+    },
+    "RS-07": {
+      "name": "Manual field-by-field copying",
+      "severity": "Low",
+      "description": "Use merge or apply methods instead."
+    },
+    "SEC-07": {
+      "name": "File paths are not validated",
+      "severity": "Medium",
+      "description": "Path traversal risk."
+    },
+    "TS-07": {
+      "name": "Large arrays are mapped during render without memoization",
+      "severity": "Low",
+      "description": "Large arrays are mapped during render without memoization"
+    },
+    "U-07": {
+      "name": "Do not change code style while fixing behavior",
+      "severity": "Strict",
+      "description": "Style-only edits should be a separate commit."
+    },
+    "GO-08": {
+      "name": "`defer` inside loops",
+      "severity": "High",
+      "description": "This risks resource leaks because deferred calls wait until the function returns."
+    },
+    "PY-08": {
+      "name": "Use of `eval()`, `exec()`, or `__import__()`",
+      "severity": "High",
+      "description": "This dynamically executes untrusted code."
+    },
+    "RS-08": {
+      "name": "Unnecessary `clone()` calls",
+      "severity": "Low",
+      "description": "Often appears on `Copy` types or values that could be borrowed."
+    },
+    "SEC-08": {
+      "name": "Server-side requests allow arbitrary target addresses",
+      "severity": "Medium",
+      "description": "SSRF risk."
+    },
+    "TS-08": {
+      "name": "Bypassing type checks with `as any` or `@ts-ignore`",
+      "severity": "High",
+      "description": "Bypassing type checks with `as any` or `@ts-ignore`"
+    },
+    "U-08": {
+      "name": "Do not skip verification steps",
+      "severity": "Strict",
+      "description": "See W-03 and W-16 for canonical verification guidance."
+    },
+    "GO-09": {
+      "name": "Functions longer than 80 lines",
+      "severity": "Medium",
+      "description": "Functions longer than 80 lines"
+    },
+    "PY-09": {
+      "name": "Functions longer than 50 lines",
+      "severity": "Medium",
+      "description": "Functions longer than 50 lines"
+    },
+    "RS-09": {
+      "name": "`format!()` allocation in hot paths",
+      "severity": "Low",
+      "description": "`format!()` allocation in hot paths"
+    },
+    "SEC-09": {
+      "name": "Unsafe deserialization",
+      "severity": "Medium",
+      "description": "Examples include `pickle` and `yaml.load`."
+    },
+    "TS-09": {
+      "name": "Functions with more than 4 parameters",
+      "severity": "Medium",
+      "description": "Functions with more than 4 parameters"
+    },
+    "U-09": {
+      "name": "Do not bundle unrelated fixes into one commit",
+      "severity": "Strict",
+      "description": "Keep commits atomic so they are easy to review and revert."
+    },
+    "GO-10": {
+      "name": "Package-level `init()` has side effects",
+      "severity": "Medium",
+      "description": "Network or file I/O happens in `init()`."
+    },
+    "PY-10": {
+      "name": "Nesting deeper than 4 levels",
+      "severity": "Medium",
+      "description": "Nesting deeper than 4 levels"
+    },
+    "RS-10": {
+      "name": "Meaningful `Result`s are silently discarded",
+      "severity": "High",
+      "description": "Patterns like `let _ =`, `.ok()`, or `.unwrap_or_default()` swallow errors."
+    },
+    "SEC-10": {
+      "name": "Logs contain sensitive information",
+      "severity": "Medium",
+      "description": "Passwords or tokens appear in logs."
+    },
+    "TS-10": {
+      "name": "Callback nesting deeper than 3 levels",
+      "severity": "Medium",
+      "description": "Callback nesting deeper than 3 levels"
+    },
+    "U-10": {
+      "name": "Do not guess user intent",
+      "severity": "Strict",
+      "description": "If the intent is unclear, mark it as DEFER or ask the user to clarify."
+    },
+    "W-10": {
+      "name": "Require four confirmations before publish, deletion, or remote deploy",
+      "severity": "Strict",
+      "description": "Before any irreversible or high-risk action, confirm four items with the user and wait for explicit approval."
+    },
+    "GO-11": {
+      "name": "`context.Background()` is used outside entry points",
+      "severity": "Medium",
+      "description": "`context.Background()` is used outside entry points"
+    },
+    "PY-11": {
+      "name": "File operations without a `with` context manager",
+      "severity": "Medium",
+      "description": "File operations without a `with` context manager"
+    },
+    "RS-11": {
+      "name": "Different modules use different infrastructure for the same system",
+      "severity": "Medium",
+      "description": "Logging, config paths, or DB connection strategies drift across modules."
+    },
+    "SEC-11": {
+      "name": "AI-generated code security defect baseline",
+      "severity": "Strict",
+      "description": "AI-generated code carries higher security risk; mandatory human review for auth, payments, secrets, `innerHTML` / `eval` / `exec`."
+    },
+    "TS-11": {
+      "name": "Unhandled `null` / `undefined`",
+      "severity": "Medium",
+      "description": "Missing optional chaining or null guards."
+    },
+    "U-11": {
+      "name": "Inconsistent default DB/cache paths across binaries",
+      "severity": "High",
+      "description": "Different entry points hardcode different data paths, which splits user data."
+    },
+    "W-11": {
+      "name": "LLM output must separate facts, inferences, and suggestions",
+      "severity": "Strict",
+      "description": "When an agent produces an analysis report, technical judgment, or architecture recommendation, it must label the source of confidence for..."
+    },
+    "GO-12": {
+      "name": "Struct fields are not ordered by size",
+      "severity": "Low",
+      "description": "This wastes memory due to alignment padding."
+    },
+    "PY-12": {
+      "name": "Repeated calls to `len()`, `keys()`, or `values()` inside loops",
+      "severity": "Low",
+      "description": "Repeated calls to `len()`, `keys()`, or `values()` inside loops"
+    },
+    "RS-12": {
+      "name": "Two systems coexist for one responsibility",
+      "severity": "High",
+      "description": "For example, `Todo*` and `TaskManagement*` both handle task state."
+    },
+    "SEC-12": {
+      "name": "Silent drift in MCP tool descriptions",
+      "severity": "Strict",
+      "description": "The description field of an MCP tool is effectively an instruction fed to the LLM."
+    },
+    "TS-12": {
+      "name": "Passing full objects as component props instead of only required fields",
+      "severity": "Low",
+      "description": "Passing full objects as component props instead of only required fields"
+    },
+    "U-12": {
+      "name": "Shared-data fallback creates the wrong file on first boot",
+      "severity": "High",
+      "description": "Fallback logic can create a split file during first startup."
+    },
+    "W-12": {
+      "name": "Protect test integrity",
+      "severity": "Strict",
+      "description": "Protect test integrity: fix production code, never weaken assertions or tamper with test infrastructure."
+    },
+    "PY-13": {
+      "name": "Dead compatibility shim",
+      "severity": "Medium",
+      "description": "A file that only re-exports symbols from another module and adds no behavior should be removed after migration is complete."
+    },
+    "RS-13": {
+      "name": "Action-named functions lack state side effects",
+      "severity": "High",
+      "description": "A function like `mark_done` only returns text but does not persist state."
+    },
+    "SEC-13": {
+      "name": "High-context file integrity protection",
+      "severity": "Strict",
+      "description": "High-context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings*.json`, hooks) must not be silently modified by dependencies or generators."
+    },
+    "TS-13": {
+      "name": "Duplicate component or hook behavior under different names",
+      "severity": "High",
+      "description": "Multiple files define React components or hooks with equivalent behavior but different names."
+    },
+    "U-13": {
+      "name": "Environment variable names diverge across entry points",
+      "severity": "Medium",
+      "description": "For example, `SERVER_DB_PATH` and `DESKTOP_DB_PATH` point at different defaults."
+    },
+    "W-13": {
+      "name": "Analysis paralysis guard",
+      "severity": "Strict",
+      "description": "If there are 7+ consecutive read-only actions (Read / Glob / Grep) with no write action, you must either act or report a blocker."
+    },
+    "RS-14": {
+      "name": "Declaration-execution gap",
+      "severity": "High",
+      "description": "Configs, traits, or persistence layers are declared but never integrated into startup."
+    },
+    "SEC-14": {
+      "name": "MCP tool descriptions must reject authority-claim and override language",
+      "severity": "Strict",
+      "description": "A tool description that claims \"absolute authority\", \"supersedes user requests\", or asks the agent to \"ignore prior instructions\" is func..."
+    },
+    "TS-14": {
+      "name": "Test mocks drift from the real module shape",
+      "severity": "High",
+      "description": "`vi.mock()` and `jest.mock()` factory functions often return `any`, so TypeScript cannot tell when the mock shape drifts from the real mo..."
+    },
+    "U-14": {
+      "name": "CLI default path uses a different base directory than GUI/server",
+      "severity": "Medium",
+      "description": "Different entry points use different base directories."
+    },
+    "W-14": {
+      "name": "Single-writer repository ownership",
+      "severity": "Strict",
+      "description": "At most one writable session may operate on a repository; parallel helpers must remain read-only."
+    },
+    "U-15": {
+      "name": "Prefer immutability",
+      "severity": "Guideline",
+      "description": "Create new objects instead of mutating existing ones."
+    },
+    "W-15": {
+      "name": "Low-information loop detection",
+      "severity": "Strict",
+      "description": "If the information gain shrinks for three consecutive rounds, stop that direction and report it."
+    },
+    "SEC-16": {
+      "name": "CWE-stratified AI patch safety policy",
+      "severity": "Strict",
+      "description": "AI-generated security patches do not have a uniform safety profile."
+    },
+    "U-16": {
+      "name": "Keep file size under control",
+      "severity": "Guideline",
+      "description": "Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. Files above 800 must be split."
+    },
+    "W-16": {
+      "name": "Verification commands must come from this session",
+      "severity": "Strict",
+      "description": "Verification commands must come from this session. \"Earlier passed\" / \"should work\" do not count."
+    },
+    "SEC-17": {
+      "name": "Third-party agent skills require source review, local rebuild, and default-deny controls before enable",
+      "severity": "Strict",
+      "description": "Third-party agent skills are persistent instruction and execution surfaces."
+    },
+    "U-17": {
+      "name": "Handle errors completely",
+      "severity": "Strict",
+      "description": "Handle errors completely. Do not swallow exceptions silently."
+    },
+    "W-17": {
+      "name": "Fewer smarter gates beat more mechanical gates",
+      "severity": "Strict",
+      "description": "When the user asks to add a new gate or rule, first ask whether an existing gate can absorb the new condition instead of creating one mor..."
+    },
+    "SEC-18": {
+      "name": "External agent input safety requires semantic scoring, not keyword filters alone",
+      "severity": "Strict",
+      "description": "External content that reaches an agent can be malicious even when it contains no obvious override keywords."
+    },
+    "U-18": {
+      "name": "Validate inputs",
+      "severity": "Guideline",
+      "description": "Validate all user input at system boundaries."
+    },
+    "W-18": {
+      "name": "Evaluations must validate path, not only output",
+      "severity": "Strict",
+      "description": "Output-only evaluations miss systemic failures."
+    },
+    "U-19": {
+      "name": "Use the Repository pattern",
+      "severity": "Guideline",
+      "description": "Encapsulate data access in a Repository layer."
+    },
+    "W-19": {
+      "name": "AGENTS.md / CLAUDE.md sustainable size and pairing",
+      "severity": "Strict",
+      "description": "Agent-instruction documents (`CLAUDE.md`, `AGENTS.md`) lose effectiveness when they grow past sustainable size, accumulate unpaired prohi..."
+    },
+    "RS-20": {
+      "name": "After changing struct fields or enum variants, inspect the full chain",
+      "severity": "Strict",
+      "description": "If you add, remove, rename, or retag a struct field or enum variant, \"it compiles\" is not enough."
+    },
+    "U-20": {
+      "name": "Keep API response shapes consistent",
+      "severity": "Guideline",
+      "description": "Use a standard envelope such as `{ data, error, meta }`."
+    },
+    "W-20": {
+      "name": "Long tasks must pin runtime, tools, and rules",
+      "severity": "Strict",
+      "description": "Long-running agent tasks must freeze the execution surface at the start of the task so a mid-flight runtime, tool, or rule change cannot..."
+    },
+    "U-21": {
+      "name": "Commit messages must follow the Lore protocol",
+      "severity": "Strict",
+      "description": "Record why the change exists, not just what changed."
+    },
+    "W-21": {
+      "name": "Evidence must be provably executed, not merely cited",
+      "severity": "Strict",
+      "description": "Evidence must be provably executed, not merely cited. Verify \"decisive\" claims through an out-of-session channel before naming a mechanism."
+    },
+    "U-22": {
+      "name": "Test coverage",
+      "severity": "Strict",
+      "description": "New code minimum 80% line coverage; critical paths 100%."
+    },
+    "U-23": {
+      "name": "No silent degradation",
+      "severity": "Strict",
+      "description": "See U-29 for canonical no-silent-degradation guidance."
+    },
+    "U-24": {
+      "name": "No aliases",
+      "severity": "Strict",
+      "description": "Do not keep function, type, command, or directory aliases."
+    },
+    "U-25": {
+      "name": "Fix build failures first",
+      "severity": "Strict",
+      "description": "Fix build failures first before any other edit; do not add new code while build is red."
+    },
+    "U-26": {
+      "name": "Declaration-execution completeness",
+      "severity": "Strict",
+      "description": "Declaration-execution completeness: declared Config / Trait / persistence layers must be wired into startup."
+    },
+    "U-29": {
+      "name": "Error-driven downgrade paths must be observable at error level",
+      "severity": "Strict",
+      "description": "No silent degradation: errors causing user-visible missing data or wrong output must `error` or raise, not `warning` + fallback."
+    },
+    "U-30": {
+      "name": "Cross-boundary Pydantic models must use `extra=\"allow\"`",
+      "severity": "Strict",
+      "description": "Any Pydantic model that receives external or cross-boundary data must set `extra=\"allow\"` so `model_validate()` does not silently drop un..."
+    },
+    "W-30": {
+      "name": "Harness audits must measure boundary, fidelity, and stability",
+      "severity": "Strict",
+      "description": "Agent harness evaluation must audit the trajectory, not only final task completion."
+    },
+    "U-31": {
+      "name": "Cache keys must include code version",
+      "severity": "Strict",
+      "description": "When builder or generation logic changes, old cache entries must invalidate automatically."
+    },
+    "U-32": {
+      "name": "Rule overload threshold + absolute-language detection",
+      "severity": "Strict",
+      "description": "Keep the effective constraint set for a single agent task at 15 or fewer items."
+    },
+    "U-33": {
+      "name": "Code search defaults to glob/grep; large codebases require structural navigation",
+      "severity": "Strict",
+      "description": "For agent code retrieval, plain glob/grep driven by the model remains the default for small and medium single-repository work."
+    },
+    "W-37": {
+      "name": "Agent learning must draw from successful and failed trajectories",
+      "severity": "Strict",
+      "description": "An agent memory or experience layer that feeds future inference must learn from both successful and failed trajectories."
+    },
+    "W-38": {
+      "name": "Tool-need recognition and tool-call execution are separate metrics",
+      "severity": "Strict",
+      "description": "Tool-use evals must distinguish whether an agent recognized that a tool was needed from whether it actually called the tool."
+    },
+    "W-41": {
+      "name": "Long-term vibe coding production should expose five invariants",
+      "severity": "Guideline",
+      "description": "Long-term production workflows that rely on vibe-coding style agent iteration should make five risk-control invariants visible before tre..."
+    },
+    "W-42": {
+      "name": "Long-horizon artifact workflows must measure fidelity at checkpoints",
+      "severity": "Strict",
+      "description": "Agent workflows that repeatedly modify and hand off the same artifact must measure semantic fidelity at fixed checkpoints."
+    },
+    "TASTE-ANSI": {
+      "name": "Hardcoded ANSI escape sequences",
+      "severity": "Medium",
+      "description": "Use a crate like `colored` or `termcolor` instead of hardcoding `\\x1b[` sequences."
+    },
+    "TASTE-ASYNC-UNWRAP": {
+      "name": "`.unwrap()` inside `async fn`",
+      "severity": "Medium",
+      "description": "Async code should propagate errors with `?` instead of panicking with `unwrap()`."
+    },
+    "TASTE-PANIC-MSG": {
+      "name": "`panic!()` without a meaningful message",
+      "severity": "Medium",
+      "description": "`panic!()` or `panic!(\"\")` lacks context."
+    }
+  }
+}

--- a/scripts/ci/validate-generated-rule-docs.sh
+++ b/scripts/ci/validate-generated-rule-docs.sh
@@ -7,6 +7,7 @@ REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 
 cd "$REPO_DIR"
 python3 scripts/generate_rule_docs.py --check
+python3 scripts/generate_rule_descriptions.py --check
 
 expected_l1='| L1 | Search before create | `pre-write-guard.sh` hook (warn by default; block via `VIBEGUARD_WRITE_MODE=block`, `write_mode=block` in `~/.vibeguard/config.json`, or escalation) |'
 if ! grep -Fq "${expected_l1}" docs/rule-reference.md; then

--- a/scripts/generate_rule_descriptions.py
+++ b/scripts/generate_rule_descriptions.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Generate the runtime rule-description catalog from canonical rules."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from generate_rule_docs import Rule, parse_rules, sort_rules  # noqa: E402
+
+
+RULE_DESCRIPTIONS_PATH = ROOT / "rules" / "rule-descriptions.json"
+
+
+def render_rule_descriptions(rules: list[Rule]) -> str:
+    descriptions: dict[str, dict[str, str]] = {}
+    for rule in sort_rules(rules):
+        if rule.id in descriptions:
+            raise ValueError(f"duplicate canonical rule id for description catalog: {rule.id}")
+        descriptions[rule.id] = {
+            "name": rule.name,
+            "severity": rule.severity,
+            "description": rule.compact_guidance or rule.summary,
+        }
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_from": "rules/claude-rules/**",
+                "rules": descriptions,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def check_catalog(expected: str) -> int:
+    actual = RULE_DESCRIPTIONS_PATH.read_text(encoding="utf-8")
+    if actual == expected:
+        return 0
+    print(
+        f"Generated file drift detected: {RULE_DESCRIPTIONS_PATH.relative_to(ROOT)}",
+        file=sys.stderr,
+    )
+    for line in difflib.unified_diff(
+        actual.splitlines(),
+        expected.splitlines(),
+        fromfile=str(RULE_DESCRIPTIONS_PATH.relative_to(ROOT)),
+        tofile=f"{RULE_DESCRIPTIONS_PATH.relative_to(ROOT)} (generated)",
+        lineterm="",
+    ):
+        print(line, file=sys.stderr)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Fail if the catalog is out of date")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        expected = render_rule_descriptions(parse_rules())
+        if args.check:
+            return check_catalog(expected)
+        RULE_DESCRIPTIONS_PATH.write_text(expected, encoding="utf-8")
+        print(f"Updated {RULE_DESCRIPTIONS_PATH.relative_to(ROOT)}")
+        return 0
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -305,6 +305,20 @@ JSON
 )"
 assert_contains "${hook_warn_out}" "hookSpecificOutput" "hook emits additional context on warning"
 assert_contains "${hook_warn_out}" "effective task constraints=16" "hook warning includes constraint count"
+hook_warn_reason="$(python3 - "${TMP_ROOT}/logs-warn" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+events = [
+    json.loads(line)
+    for path in Path(sys.argv[1]).rglob("events.jsonl")
+    for line in path.read_text(encoding="utf-8").splitlines()
+]
+print(events[-1]["reason"])
+PY
+)"
+assert_exit_zero "hook warning log carries the U-32 rule id" test "${hook_warn_reason}" = "U-32 constraints=16"
 
 # GH-683: without a strict profile, exceeding the block budget must surface as
 # injected context (exit 0), not a failed hook — core/full users still see it.

--- a/tests/hooks/test_count_active_constraints.sh
+++ b/tests/hooks/test_count_active_constraints.sh
@@ -305,21 +305,7 @@ JSON
 )"
 assert_contains "${hook_warn_out}" "hookSpecificOutput" "hook emits additional context on warning"
 assert_contains "${hook_warn_out}" "effective task constraints=16" "hook warning includes constraint count"
-hook_warn_reason="$(python3 - "${TMP_ROOT}/logs-warn" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-events = [
-    json.loads(line)
-    for path in Path(sys.argv[1]).rglob("events.jsonl")
-    for line in path.read_text(encoding="utf-8").splitlines()
-]
-print(events[-1]["reason"])
-PY
-)"
-assert_exit_zero "hook warning log carries the U-32 rule id" test "${hook_warn_reason}" = "U-32 constraints=16"
-
+assert_exit_zero "hook warning log carries the U-32 rule id" python3 -c 'import json, pathlib, sys; events = [json.loads(line) for path in pathlib.Path(sys.argv[1]).rglob("events.jsonl") for line in path.read_text(encoding="utf-8").splitlines()]; raise SystemExit(not events or events[-1].get("reason") != "U-32 constraints=16")' "${TMP_ROOT}/logs-warn"
 # GH-683: without a strict profile, exceeding the block budget must surface as
 # injected context (exit 0), not a failed hook — core/full users still see it.
 hook_softblock_out="$(env "${hook_no_ci_env[@]}" HOME="${BLOCK_HOME}" VIBEGUARD_PROJECT_ROOT="${BLOCK_REPO}" VIBEGUARD_LOG_DIR="${TMP_ROOT}/logs-softblock" bash "${HOOK}" <<'JSON'
@@ -354,7 +340,6 @@ hook_override_out="$(env "${hook_no_ci_env[@]}" HOME="${BLOCK_HOME}" VIBEGUARD_U
 JSON
 )"
 assert_contains "${hook_override_out}" "hookSpecificOutput" "VIBEGUARD_U32_STRICT=0 downgrades strict block to context"
-
 header "GH-541 rule-delivery budget (compact core default vs full-tree opt-in)"
 # The default (core/minimal) Claude profile injects only the shared compact core
 # plus Claude host guidance into ~/.claude/CLAUDE.md; the full rules/claude-rules

--- a/tests/test_generate_rule_descriptions.py
+++ b/tests/test_generate_rule_descriptions.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Regression tests for the generated runtime rule-description catalog."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR_PATH = ROOT / "scripts" / "generate_rule_descriptions.py"
+SPEC = importlib.util.spec_from_file_location("generate_rule_descriptions", GENERATOR_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load generator module: {GENERATOR_PATH}")
+generate_rule_descriptions = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = generate_rule_descriptions
+SPEC.loader.exec_module(generate_rule_descriptions)
+
+
+class RuleDescriptionGenerationTests(unittest.TestCase):
+    def test_catalog_covers_every_canonical_rule_deterministically(self) -> None:
+        rules = generate_rule_descriptions.parse_rules()
+
+        first = generate_rule_descriptions.render_rule_descriptions(rules)
+        second = generate_rule_descriptions.render_rule_descriptions(rules)
+        catalog = json.loads(first)
+
+        self.assertEqual(first, second)
+        self.assertEqual(catalog["schema_version"], 1)
+        self.assertEqual(catalog["generated_from"], "rules/claude-rules/**")
+        self.assertEqual(set(catalog["rules"]), {rule.id for rule in rules})
+        self.assertEqual(
+            catalog["rules"]["U-32"],
+            {
+                "name": "Rule overload threshold + absolute-language detection",
+                "severity": "Strict",
+                "description": (
+                    "Keep the effective constraint set for a single agent task at 15 or fewer items."
+                ),
+            },
+        )
+        self.assertEqual(
+            catalog["rules"]["W-03"]["description"],
+            "Verify before claiming completion: produce fresh command output proving the claim.",
+        )
+
+    def test_checked_in_catalog_is_current(self) -> None:
+        expected = generate_rule_descriptions.render_rule_descriptions(
+            generate_rule_descriptions.parse_rules()
+        )
+
+        self.assertEqual(
+            generate_rule_descriptions.RULE_DESCRIPTIONS_PATH.read_text(encoding="utf-8"),
+            expected,
+        )
+
+    def test_generated_rule_docs_gate_checks_catalog_freshness(self) -> None:
+        validator = (ROOT / "scripts" / "ci" / "validate-generated-rule-docs.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("python3 scripts/generate_rule_descriptions.py --check", validator)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vibeguard-runtime/src/observe/aggregate.rs
+++ b/vibeguard-runtime/src/observe/aggregate.rs
@@ -255,7 +255,7 @@ fn observe_diagnostic_kind(event: &Value, slow_ms: u64) -> &'static str {
     "none"
 }
 
-fn observe_extract_rule_ids(text: &str) -> Vec<String> {
+pub(super) fn observe_extract_rule_ids(text: &str) -> Vec<String> {
     text.split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '-'))
         .filter_map(|token| {
             let token = token.to_ascii_uppercase();

--- a/vibeguard-runtime/src/observe/mod.rs
+++ b/vibeguard-runtime/src/observe/mod.rs
@@ -5,6 +5,7 @@ mod model;
 mod prometheus;
 mod read;
 mod render;
+mod rule_descriptions;
 mod stats_summary;
 
 use crate::event_schema::field;
@@ -23,6 +24,7 @@ pub fn run(args: &[String]) -> Result {
     }
 
     let options = model::parse_observe_args(args)?;
+    let rule_descriptions = rule_descriptions::RuleDescriptions::load()?;
     let mut log_events = read::read_log_events(&options)?;
     let cutoff_secs = options.window.cutoff_secs(now_unix_secs());
     log_events
@@ -44,8 +46,12 @@ pub fn run(args: &[String]) -> Result {
 
     let aggregate = aggregate::aggregate_events(&log_events.events, options.slow_ms);
     let output = match options.command {
-        model::ObserveCommand::Summary => render::render_summary(&options, &log_events, &aggregate),
-        model::ObserveCommand::Health => render::render_health(&options, &log_events, &aggregate),
+        model::ObserveCommand::Summary => {
+            render::render_summary(&options, &log_events, &aggregate, &rule_descriptions)
+        }
+        model::ObserveCommand::Health => {
+            render::render_health(&options, &log_events, &aggregate, &rule_descriptions)
+        }
         model::ObserveCommand::Session => render::render_session(&options, &log_events, &aggregate),
     }?;
     print!("{output}");

--- a/vibeguard-runtime/src/observe/render.rs
+++ b/vibeguard-runtime/src/observe/render.rs
@@ -14,12 +14,14 @@ use super::aggregate::{
 };
 use super::model::{ObserveCommand, ObserveOptions, TimeWindow};
 use super::read::LogEvents;
+use super::rule_descriptions::RuleDescriptions;
 use super::stats_summary;
 
 pub(super) fn render_summary(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
+    rule_descriptions: &RuleDescriptions,
 ) -> Result<String> {
     if options.json {
         return Ok(format!(
@@ -27,13 +29,14 @@ pub(super) fn render_summary(
             serde_json::to_string_pretty(&observe_summary_json(options, log_events, aggregate))?
         ));
     }
-    stats_summary::render_stats_summary(options, log_events, aggregate)
+    stats_summary::render_stats_summary(options, log_events, aggregate, rule_descriptions)
 }
 
 pub(super) fn render_health(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
+    rule_descriptions: &RuleDescriptions,
 ) -> Result<String> {
     let attention_states = observe_recent_events_json(
         &log_events.events,
@@ -54,13 +57,14 @@ pub(super) fn render_health(
         output["diagnostics"] = Value::Array(diagnostics);
         return Ok(format!("{}\n", serde_json::to_string_pretty(&output)?));
     }
-    render_health_human(options, log_events, aggregate)
+    render_health_human(options, log_events, aggregate, rule_descriptions)
 }
 
 fn render_health_human(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
+    rule_descriptions: &RuleDescriptions,
 ) -> Result<String> {
     if aggregate.event_count == 0 {
         if !log_events.source_exists {
@@ -155,12 +159,12 @@ fn render_health_human(
                 client,
                 observe_non_empty_or(observe_string_field(event, field::SESSION), "?")
             ));
-            let reason = observe_clean_detail(&observe_string_field(event, field::REASON));
+            let reason = observe_clean_detail(&rule_descriptions.human_reason(event));
             let detail = observe_clean_detail(&observe_string_field(event, field::DETAIL));
             if !reason.is_empty() {
                 output.push_str(&format!(
                     "     reason: {}\n",
-                    observe_truncate(&reason, 100)
+                    observe_truncate(&reason, 180)
                 ));
             }
             if !detail.is_empty() {

--- a/vibeguard-runtime/src/observe/rule_descriptions.rs
+++ b/vibeguard-runtime/src/observe/rule_descriptions.rs
@@ -80,10 +80,10 @@ fn rule_id_for_event(event: &Value, reason: &str) -> Option<String> {
         return Some(rule_id);
     }
     let hook = observe_string_field(event, field::HOOK);
-    if hook == "post-edit-guard" {
-        if let Some(rule_id) = legacy_post_edit_rule_id(reason) {
-            return Some(rule_id.to_string());
-        }
+    if hook == "post-edit-guard"
+        && let Some(rule_id) = legacy_post_edit_rule_id(reason)
+    {
+        return Some(rule_id.to_string());
     }
     (hook == "count-active-constraints" && reason.starts_with("constraints="))
         .then(|| "U-32".to_string())

--- a/vibeguard-runtime/src/observe/rule_descriptions.rs
+++ b/vibeguard-runtime/src/observe/rule_descriptions.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use crate::event_schema::field;
 
 use super::Result;
-use super::aggregate::{observe_extract_rule_ids, observe_string_field};
+use super::aggregate::observe_string_field;
 
 const CATALOG_JSON: &str = include_str!("../../../rules/rule-descriptions.json");
 const CATALOG_SCHEMA_VERSION: u64 = 1;
@@ -51,7 +51,7 @@ impl RuleDescriptions {
 
     pub(super) fn human_reason(&self, event: &Value) -> String {
         let raw_reason = observe_string_field(event, field::REASON);
-        let Some(rule_id) = rule_id_for_event(event, &raw_reason) else {
+        let Some(rule_id) = self.rule_id_for_event(event, &raw_reason) else {
             return raw_reason;
         };
         let Some(description) = self.descriptions.get(&rule_id) else {
@@ -69,24 +69,28 @@ impl RuleDescriptions {
             format!("{rule_id}: {description} ({detail})")
         }
     }
-}
 
-fn rule_id_for_event(event: &Value, reason: &str) -> Option<String> {
-    let structured = observe_string_field(event, field::RULE_ID).to_ascii_uppercase();
-    if !structured.is_empty() {
-        return Some(structured);
+    fn rule_id_for_event(&self, event: &Value, reason: &str) -> Option<String> {
+        let structured = observe_string_field(event, field::RULE_ID).to_ascii_uppercase();
+        if !structured.is_empty() {
+            return Some(structured);
+        }
+        if let Some(rule_id) = reason
+            .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '-'))
+            .map(str::to_ascii_uppercase)
+            .find(|candidate| self.descriptions.contains_key(candidate.as_str()))
+        {
+            return Some(rule_id);
+        }
+        let hook = observe_string_field(event, field::HOOK);
+        if hook == "post-edit-guard"
+            && let Some(rule_id) = legacy_post_edit_rule_id(reason)
+        {
+            return Some(rule_id.to_string());
+        }
+        (hook == "count-active-constraints" && reason.starts_with("constraints="))
+            .then(|| "U-32".to_string())
     }
-    if let Some(rule_id) = observe_extract_rule_ids(reason).into_iter().next() {
-        return Some(rule_id);
-    }
-    let hook = observe_string_field(event, field::HOOK);
-    if hook == "post-edit-guard"
-        && let Some(rule_id) = legacy_post_edit_rule_id(reason)
-    {
-        return Some(rule_id.to_string());
-    }
-    (hook == "count-active-constraints" && reason.starts_with("constraints="))
-        .then(|| "U-32".to_string())
 }
 
 fn legacy_post_edit_rule_id(reason: &str) -> Option<&'static str> {

--- a/vibeguard-runtime/src/observe/rule_descriptions.rs
+++ b/vibeguard-runtime/src/observe/rule_descriptions.rs
@@ -1,0 +1,85 @@
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+use crate::event_schema::field;
+
+use super::Result;
+use super::aggregate::{observe_extract_rule_ids, observe_string_field};
+
+const CATALOG_JSON: &str = include_str!("../../../rules/rule-descriptions.json");
+const CATALOG_SCHEMA_VERSION: u64 = 1;
+
+pub(super) struct RuleDescriptions {
+    descriptions: BTreeMap<String, String>,
+}
+
+impl RuleDescriptions {
+    pub(super) fn load() -> Result<Self> {
+        let catalog: Value = serde_json::from_str(CATALOG_JSON)?;
+        if catalog.get("schema_version").and_then(Value::as_u64) != Some(CATALOG_SCHEMA_VERSION) {
+            return Err("rule description catalog has an unsupported schema_version".into());
+        }
+        let rules = catalog
+            .get("rules")
+            .and_then(Value::as_object)
+            .ok_or("rule description catalog is missing the rules object")?;
+        if rules.is_empty() {
+            return Err("rule description catalog must contain at least one rule".into());
+        }
+
+        let mut descriptions = BTreeMap::new();
+        for (rule_id, entry) in rules {
+            for field_name in ["name", "severity", "description"] {
+                let value = entry
+                    .get(field_name)
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty());
+                if value.is_none() {
+                    return Err(format!(
+                        "rule description catalog entry {rule_id} has no {field_name}"
+                    )
+                    .into());
+                }
+            }
+            let description = entry["description"]
+                .as_str()
+                .ok_or_else(|| format!("rule description catalog entry {rule_id} is invalid"))?;
+            descriptions.insert(rule_id.clone(), description.to_string());
+        }
+        Ok(Self { descriptions })
+    }
+
+    pub(super) fn human_reason(&self, event: &Value) -> String {
+        let raw_reason = observe_string_field(event, field::REASON);
+        let Some(rule_id) = rule_id_for_event(event, &raw_reason) else {
+            return raw_reason;
+        };
+        let Some(description) = self.descriptions.get(&rule_id) else {
+            return raw_reason;
+        };
+        let detail = raw_reason
+            .strip_prefix(&rule_id)
+            .unwrap_or(&raw_reason)
+            .trim_start_matches(|ch: char| {
+                ch.is_ascii_whitespace() || matches!(ch, ':' | '-' | '|')
+            });
+        if detail.is_empty() {
+            format!("{rule_id}: {description}")
+        } else {
+            format!("{rule_id}: {description} ({detail})")
+        }
+    }
+}
+
+fn rule_id_for_event(event: &Value, reason: &str) -> Option<String> {
+    let structured = observe_string_field(event, field::RULE_ID).to_ascii_uppercase();
+    if !structured.is_empty() {
+        return Some(structured);
+    }
+    if let Some(rule_id) = observe_extract_rule_ids(reason).into_iter().next() {
+        return Some(rule_id);
+    }
+    let hook = observe_string_field(event, field::HOOK);
+    (hook == "count-active-constraints" && reason.starts_with("constraints="))
+        .then(|| "U-32".to_string())
+}

--- a/vibeguard-runtime/src/observe/rule_descriptions.rs
+++ b/vibeguard-runtime/src/observe/rule_descriptions.rs
@@ -80,6 +80,22 @@ fn rule_id_for_event(event: &Value, reason: &str) -> Option<String> {
         return Some(rule_id);
     }
     let hook = observe_string_field(event, field::HOOK);
+    if hook == "post-edit-guard" {
+        if let Some(rule_id) = legacy_post_edit_rule_id(reason) {
+            return Some(rule_id.to_string());
+        }
+    }
     (hook == "count-active-constraints" && reason.starts_with("constraints="))
         .then(|| "U-32".to_string())
+}
+
+fn legacy_post_edit_rule_id(reason: &str) -> Option<&'static str> {
+    let token = reason.split_ascii_whitespace().next()?;
+    if token.eq_ignore_ascii_case("w14") {
+        Some("W-14")
+    } else if token.eq_ignore_ascii_case("w15") {
+        Some("W-15")
+    } else {
+        None
+    }
 }

--- a/vibeguard-runtime/src/observe/stats_summary.rs
+++ b/vibeguard-runtime/src/observe/stats_summary.rs
@@ -13,11 +13,13 @@ use super::render::{
     observe_blank_as_unknown, observe_count_by, observe_decision_count, observe_increment,
     observe_sorted_counts, observe_truncate,
 };
+use super::rule_descriptions::RuleDescriptions;
 
 pub(super) fn render_stats_summary(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
+    rule_descriptions: &RuleDescriptions,
 ) -> Result<String> {
     if aggregate.event_count == 0 {
         if !log_events.source_exists {
@@ -40,10 +42,10 @@ pub(super) fn render_stats_summary(
         observe_non_empty_or(observe_string_field(event, field::CLI), UNKNOWN)
     });
     let block_reasons = stats_count_by_matching(&log_events.events, decision::BLOCK, |event| {
-        observe_non_empty_or(observe_string_field(event, field::REASON), "Unknown")
+        observe_non_empty_or(rule_descriptions.human_reason(event), "Unknown")
     });
     let warn_reasons = stats_count_by_matching(&log_events.events, decision::WARN, |event| {
-        observe_non_empty_or(observe_string_field(event, field::REASON), "Unknown")
+        observe_non_empty_or(rule_descriptions.human_reason(event), "Unknown")
     });
 
     let mut output = String::new();
@@ -93,14 +95,14 @@ pub(super) fn render_stats_summary(
     if !block_reasons.is_empty() {
         output.push_str("\nInterception reasons Top 5:\n");
         for (reason, count) in observe_sorted_counts(&block_reasons).into_iter().take(5) {
-            output.push_str(&format!("  {count}x  {}\n", observe_truncate(&reason, 60)));
+            output.push_str(&format!("  {count}x  {}\n", observe_truncate(&reason, 180)));
         }
     }
 
     if !warn_reasons.is_empty() {
         output.push_str("\nWarning reasons Top 5:\n");
         for (reason, count) in observe_sorted_counts(&warn_reasons).into_iter().take(5) {
-            output.push_str(&format!("  {count}x  {}\n", observe_truncate(&reason, 60)));
+            output.push_str(&format!("  {count}x  {}\n", observe_truncate(&reason, 180)));
         }
     }
 
@@ -405,6 +407,13 @@ mod tests {
         values.iter().map(|value| (*value).to_string()).collect()
     }
 
+    fn rule_descriptions() -> RuleDescriptions {
+        match RuleDescriptions::load() {
+            Ok(descriptions) => descriptions,
+            Err(error) => panic!("rule descriptions should load: {error}"),
+        }
+    }
+
     #[test]
     fn stats_summary_includes_analysis_sections() {
         let events = vec![
@@ -460,7 +469,8 @@ mod tests {
         };
         let aggregate = aggregate_events(&log_events.events, 2_000);
 
-        let output = match render_stats_summary(&options, &log_events, &aggregate) {
+        let descriptions = rule_descriptions();
+        let output = match render_stats_summary(&options, &log_events, &aggregate, &descriptions) {
             Ok(output) => output,
             Err(error) => panic!("stats summary should render: {error}"),
         };
@@ -532,7 +542,8 @@ mod tests {
         };
         let aggregate = aggregate_events(&log_events.events, 2_000);
 
-        let output = match render_stats_summary(&options, &log_events, &aggregate) {
+        let descriptions = rule_descriptions();
+        let output = match render_stats_summary(&options, &log_events, &aggregate, &descriptions) {
             Ok(output) => output,
             Err(error) => panic!("stats summary should render: {error}"),
         };

--- a/vibeguard-runtime/tests/observe_cli.rs
+++ b/vibeguard-runtime/tests/observe_cli.rs
@@ -406,7 +406,10 @@ fn summary_human_and_json_render_deterministic_counts_and_durations() {
         "pre-bash-guard: 2 times",
         "codex: 2 times",
         "1x  force push denied",
-        "1x  U-16 file too large",
+        concat!(
+            "1x  U-16: Keep file size under control: 200-400 lines typical, 800 lines hard ",
+            "ceiling. Files above 800 must be split. (file too large)"
+        ),
     ] {
         assert!(
             human_text.contains(expected),
@@ -503,8 +506,12 @@ fn health_human_renders_risk_distributions_unknowns_and_truncation() {
         text.contains("Risk Hook Top 5:\n  beta: 2\n  unknown: 1\n"),
         "{text}"
     );
-    let cleaned = format!("U-16 {} secret", "x".repeat(120));
-    let expected_reason = format!("{}...", cleaned.chars().take(97).collect::<String>());
+    let cleaned = format!(
+        "U-16: Keep file size under control: 200-400 lines typical, 800 lines hard ceiling. \
+         Files above 800 must be split. ({} secret)",
+        "x".repeat(120)
+    );
+    let expected_reason = format!("{}...", cleaned.chars().take(177).collect::<String>());
     assert!(
         text.contains(&format!("reason: {expected_reason}")),
         "{text}"

--- a/vibeguard-runtime/tests/rule_descriptions.rs
+++ b/vibeguard-runtime/tests/rule_descriptions.rs
@@ -16,6 +16,14 @@ fn fixture_log() -> PathBuf {
             "\"decision\":\"warn\",\"reason\":\"constraints=31\",",
             "\"detail\":\"project AGENTS.md=31\",\"client\":\"codex\"}\n",
             "{\"ts\":\"2026-06-01T00:00:02Z\",\"session\":\"s1\",",
+            "\"hook\":\"post-edit-guard\",\"tool\":\"Edit\",\"decision\":\"warn\",",
+            "\"reason\":\"w14 overlap recent session s2 agent codex\",",
+            "\"detail\":\"src/lib.rs\",\"client\":\"codex\"}\n",
+            "{\"ts\":\"2026-06-01T00:00:03Z\",\"session\":\"s1\",",
+            "\"hook\":\"post-edit-guard\",\"tool\":\"Edit\",\"decision\":\"warn\",",
+            "\"reason\":\"w15 shrinking radius 12>8>3\",",
+            "\"detail\":\"src/lib.rs\",\"client\":\"codex\"}\n",
+            "{\"ts\":\"2026-06-01T00:00:04Z\",\"session\":\"s1\",",
             "\"hook\":\"custom-hook\",\"tool\":\"Edit\",\"decision\":\"warn\",",
             "\"reason\":\"custom policy hit\",\"detail\":\"src/lib.rs\",",
             "\"client\":\"codex\"}\n"
@@ -52,12 +60,24 @@ fn summary_and_health_translate_rule_reasons_without_hiding_unknown_reasons() {
         "U-32: Keep the effective constraint set for a single agent task at 15 or fewer items. ",
         "(constraints=31)"
     );
+    let legacy_w14 = concat!(
+        "W-14: At most one writable session may operate on a repository; ",
+        "parallel helpers must remain read-only."
+    );
+    let legacy_w15 = concat!(
+        "W-15: If the information gain shrinks for three consecutive rounds, ",
+        "stop that direction and report it."
+    );
 
     let summary = observe("summary", "--days", &log_path);
     let health = observe("health", "--hours", &log_path);
 
     assert!(summary.contains(expected), "summary output:\n{summary}");
     assert!(health.contains(expected), "health output:\n{health}");
+    assert!(summary.contains(legacy_w14), "summary output:\n{summary}");
+    assert!(health.contains(legacy_w14), "health output:\n{health}");
+    assert!(summary.contains(legacy_w15), "summary output:\n{summary}");
+    assert!(health.contains(legacy_w15), "health output:\n{health}");
     assert!(
         summary.contains("custom policy hit"),
         "summary output:\n{summary}"

--- a/vibeguard-runtime/tests/rule_descriptions.rs
+++ b/vibeguard-runtime/tests/rule_descriptions.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde_json::json;
+
 fn fixture_log() -> PathBuf {
     let path = std::env::temp_dir().join(format!(
         "vibeguard-rule-descriptions-{}-{}.jsonl",
@@ -53,6 +55,26 @@ fn observe(command: &str, window_flag: &str, log_path: &Path) -> String {
     String::from_utf8(output.stdout).expect("observe output should be UTF-8")
 }
 
+fn fixture_log_with_reason(reason: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "vibeguard-rule-reason-{}-{}.jsonl",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("test")
+    ));
+    let event = json!({
+        "ts": "2026-06-01T00:00:01Z",
+        "session": "s1",
+        "hook": "rust-guard",
+        "tool": "Edit",
+        "decision": "warn",
+        "reason": reason,
+        "detail": "src/lib.rs",
+        "client": "codex"
+    });
+    fs::write(&path, format!("{event}\n")).expect("fixture log should be writable");
+    path
+}
+
 #[test]
 fn summary_and_health_translate_rule_reasons_without_hiding_unknown_reasons() {
     let log_path = fixture_log();
@@ -88,4 +110,27 @@ fn summary_and_health_translate_rule_reasons_without_hiding_unknown_reasons() {
     );
 
     fs::remove_file(log_path).expect("fixture log should be removable");
+}
+
+#[test]
+fn summary_and_health_translate_nonnumeric_catalog_rule_ids() {
+    for (reason, expected) in [
+        ("[TASTE-ANSI] hardcoded escape", "TASTE-ANSI: Use a crate"),
+        (
+            "[TASTE-ASYNC-UNWRAP] async panic",
+            "TASTE-ASYNC-UNWRAP: Async code should propagate errors",
+        ),
+        (
+            "[TASTE-PANIC-MSG] missing context",
+            "TASTE-PANIC-MSG: `panic!()` or `panic!(\"\")` lacks context.",
+        ),
+    ] {
+        let log_path = fixture_log_with_reason(reason);
+        let summary = observe("summary", "--days", &log_path);
+        let health = observe("health", "--hours", &log_path);
+
+        assert!(summary.contains(expected), "summary output:\n{summary}");
+        assert!(health.contains(expected), "health output:\n{health}");
+        fs::remove_file(log_path).expect("fixture log should be removable");
+    }
 }

--- a/vibeguard-runtime/tests/rule_descriptions.rs
+++ b/vibeguard-runtime/tests/rule_descriptions.rs
@@ -1,0 +1,71 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixture_log() -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "vibeguard-rule-descriptions-{}-{}.jsonl",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("test")
+    ));
+    fs::write(
+        &path,
+        concat!(
+            "{\"ts\":\"2026-06-01T00:00:01Z\",\"session\":\"s1\",",
+            "\"hook\":\"count-active-constraints\",\"tool\":\"SessionStart\",",
+            "\"decision\":\"warn\",\"reason\":\"constraints=31\",",
+            "\"detail\":\"project AGENTS.md=31\",\"client\":\"codex\"}\n",
+            "{\"ts\":\"2026-06-01T00:00:02Z\",\"session\":\"s1\",",
+            "\"hook\":\"custom-hook\",\"tool\":\"Edit\",\"decision\":\"warn\",",
+            "\"reason\":\"custom policy hit\",\"detail\":\"src/lib.rs\",",
+            "\"client\":\"codex\"}\n"
+        ),
+    )
+    .expect("fixture log should be writable");
+    path
+}
+
+fn observe(command: &str, window_flag: &str, log_path: &Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+        .args([
+            "observe",
+            command,
+            window_flag,
+            "all",
+            "--log-file",
+            log_path.to_str().expect("fixture path should be UTF-8"),
+        ])
+        .output()
+        .expect("observe command should run");
+    assert!(
+        output.status.success(),
+        "observe {command} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("observe output should be UTF-8")
+}
+
+#[test]
+fn summary_and_health_translate_rule_reasons_without_hiding_unknown_reasons() {
+    let log_path = fixture_log();
+    let expected = concat!(
+        "U-32: Keep the effective constraint set for a single agent task at 15 or fewer items. ",
+        "(constraints=31)"
+    );
+
+    let summary = observe("summary", "--days", &log_path);
+    let health = observe("health", "--hours", &log_path);
+
+    assert!(summary.contains(expected), "summary output:\n{summary}");
+    assert!(health.contains(expected), "health output:\n{health}");
+    assert!(
+        summary.contains("custom policy hit"),
+        "summary output:\n{summary}"
+    );
+    assert!(
+        health.contains("custom policy hit"),
+        "health output:\n{health}"
+    );
+
+    fs::remove_file(log_path).expect("fixture log should be removable");
+}


### PR DESCRIPTION
## Summary

Generate a deterministic description catalog for all 127 canonical rules and embed it in the Rust observe runtime. `stats.sh` and `hook-health.sh` now translate known rule hits into plain-language explanations, preserve raw details and unknown reasons, and remain compatible with historical `constraints=N` U-32 events.

New constraint-budget warnings and blocks now log the U-32 rule ID directly. CI checks catalog freshness whenever canonical rule text changes.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## Checklist

- [x] Tests pass
- [x] Guard scripts tested
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Commit follows the repository Lore Commit Protocol

## Related issues

None.

## How to test

- `cargo check --manifest-path vibeguard-runtime/Cargo.toml`
- `cargo test --manifest-path vibeguard-runtime/Cargo.toml`
- `bash tests/test_stats.sh` — 61/61
- `bash tests/test_hook_health.sh` — 34/34
- `bash tests/hooks/test_count_active_constraints.sh` — 58/58
- `bash tests/test_observe.sh` — 16/16
- `bash scripts/ci/validate-generated-rule-docs.sh`
- `bash scripts/local-contract-check.sh --quick` — 60/60; payload 47/47

## Screenshots / logs

Representative translated output:

```text
U-32: Keep the effective constraint set for a single agent task at 15 or fewer items. (constraints=31)
```

Unknown and custom reasons remain unchanged. Rendering against private historical event logs outside repository fixtures was not tested.
