### PR TITLE
feat(config): add guided runtime configuration

### DIFF
--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -57,7 +57,27 @@ language marker such as `Cargo.toml`, `tsconfig.json`, `package.json`,
 other unrecognized repositories print `No known language detected, skipping.`
 and do not get git hooks from this command.
 
-## 4. Run One Intercepted Demo
+## 4. Configure Runtime Thresholds
+
+Initialize a persistent override only when needed, then inspect the effective
+values and source layers:
+
+```bash
+vibeguard-runtime config init --scope user
+vibeguard-runtime config show --cwd "$PWD"
+vibeguard-runtime config set churn.warning_edit_count 12 --scope project --cwd "$PWD"
+vibeguard-runtime config reset churn.warning_edit_count --scope project --cwd "$PWD"
+```
+
+Churn guidance defaults to 5 informational edits, 10 warning edits, 20
+review-level edits, and 5 build failures for critical escalation. W-15 defaults
+to a three-edit trail and a latest-delta ceiling of 300 characters. Raising the
+W-15 trail minimum waits for more consecutive edits but still evaluates only
+the latest three deltas. See
+[`vibeguard-config.README.md`](../../templates/vibeguard-config.README.md) for
+all supported fields, environment overrides, and scope rules.
+
+## 5. Run One Intercepted Demo
 
 Start with the live, fail-closed interception demo:
 
@@ -80,7 +100,7 @@ Expected behavior: VibeGuard emits a search-first warning or block with a fix
 instruction. If no hook output appears, use [Troubleshooting](troubleshooting.md)
 before assuming protection is active.
 
-## 5. Inspect Recent Hook Status
+## 6. Inspect Recent Hook Status
 
 ```bash
 vibeguard observe health --limit all

--- a/docs/rule-reference.md
+++ b/docs/rule-reference.md
@@ -24,9 +24,9 @@ Canonical source of truth: `rules/claude-rules/`
 
 Runtime values resolve from lowest to highest precedence: built-in default →
 `~/.vibeguard/config.json` → project `.vibeguard.json` → environment. The user
-and project files use the same JSON paths. Run
-`vibeguard-runtime config explain <json-path-or-env> --cwd <project>` to print
-the effective value and source layer.
+and project files use the same JSON paths. Use `config show`, `config init`,
+`config set`, and `config reset` for guided changes; `config explain
+<json-path-or-env> --cwd <project>` keeps its single-value explanation format.
 
 | JSON path | Supported environment override | Default |
 |-----------|--------------------------------|---------|
@@ -36,6 +36,12 @@ the effective value and source layer.
 | `circuit_breaker.cooldown_seconds` | `VG_CB_COOLDOWN` | `300` |
 | `circuit_breaker.lock_timeout_seconds` | `VG_CB_LOCK_TIMEOUT_SECONDS` | `5` |
 | `w14.cooldown_seconds` | `VIBEGUARD_W14_COOLDOWN_SECONDS` | `3600` |
+| `churn.informational_edit_count` | `VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT` | `5` |
+| `churn.warning_edit_count` | `VIBEGUARD_CHURN_WARNING_EDIT_COUNT` | `10` |
+| `churn.critical_edit_count` | `VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT` | `20` |
+| `churn.critical_build_failure_count` | `VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT` | `5` |
+| `w15.minimum_consecutive_edits` | `VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS` | `3` |
+| `w15.latest_delta_character_ceiling` | `VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING` | `300` |
 | `paralysis.threshold` | `VG_PARALYSIS_THRESHOLD` | `7` |
 | `write_mode` | `VIBEGUARD_WRITE_MODE` | `warn` |
 | `write_escalate_threshold` | `VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD` | `5` |

--- a/schemas/vibeguard-project.schema.json
+++ b/schemas/vibeguard-project.schema.json
@@ -207,6 +207,12 @@
     "w14": {
       "$ref": "vibeguard-runtime-config.schema.json#/properties/w14"
     },
+    "churn": {
+      "$ref": "vibeguard-runtime-config.schema.json#/properties/churn"
+    },
+    "w15": {
+      "$ref": "vibeguard-runtime-config.schema.json#/properties/w15"
+    },
     "paralysis": {
       "$ref": "vibeguard-runtime-config.schema.json#/properties/paralysis"
     },

--- a/schemas/vibeguard-runtime-config.schema.json
+++ b/schemas/vibeguard-runtime-config.schema.json
@@ -65,6 +65,60 @@
         }
       }
     },
+    "churn": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "informational_edit_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "default": 5,
+          "description": "Same-file edit count that starts informational churn guidance. Env override: VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT."
+        },
+        "warning_edit_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "default": 10,
+          "description": "Same-file edit count that raises churn guidance to warning level. Env override: VIBEGUARD_CHURN_WARNING_EDIT_COUNT."
+        },
+        "critical_edit_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "default": 20,
+          "description": "Same-file edit count that enables critical churn classification. Env override: VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT."
+        },
+        "critical_build_failure_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "default": 5,
+          "description": "Consecutive build failures needed with critical churn for escalation. Env override: VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT."
+        }
+      }
+    },
+    "w15": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minimum_consecutive_edits": {
+          "type": "integer",
+          "minimum": 3,
+          "maximum": 1000000,
+          "default": 3,
+          "description": "Minimum same-file edit trail, including the current edit, before W-15 evaluates only the latest three deltas. Env override: VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS."
+        },
+        "latest_delta_character_ceiling": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000,
+          "default": 300,
+          "description": "Largest latest change radius eligible for W-15 micro-tuning detection. Env override: VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING."
+        }
+      }
+    },
     "paralysis": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -70,7 +70,6 @@ def normalize_severity(raw: str) -> str:
         raise ValueError(f"Unknown severity {raw!r}")
     return mapping[value]
 
-
 def strip_markdown(text: str) -> str:
     text = text.replace("**", "").replace("__", "")
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
@@ -269,7 +268,6 @@ def make_table(headers: list[str], rows: list[list[str]]) -> str:
 
 def select_rules(rules: Iterable[Rule], predicate: Callable[[Rule], bool]) -> list[Rule]:
     return [rule for rule in rules if predicate(rule)]
-
 
 def prefix_of(rule_id: str) -> str:
     return rule_id.split("-", 1)[0]
@@ -549,9 +547,9 @@ Canonical source of truth: `rules/claude-rules/`
 
 Runtime values resolve from lowest to highest precedence: built-in default →
 `~/.vibeguard/config.json` → project `.vibeguard.json` → environment. The user
-and project files use the same JSON paths. Run
-`vibeguard-runtime config explain <json-path-or-env> --cwd <project>` to print
-the effective value and source layer.
+and project files use the same JSON paths. Use `config show`, `config init`,
+`config set`, and `config reset` for guided changes; `config explain
+<json-path-or-env> --cwd <project>` keeps its single-value explanation format.
 
 | JSON path | Supported environment override | Default |
 |-----------|--------------------------------|---------|
@@ -561,6 +559,12 @@ the effective value and source layer.
 | `circuit_breaker.cooldown_seconds` | `VG_CB_COOLDOWN` | `300` |
 | `circuit_breaker.lock_timeout_seconds` | `VG_CB_LOCK_TIMEOUT_SECONDS` | `5` |
 | `w14.cooldown_seconds` | `VIBEGUARD_W14_COOLDOWN_SECONDS` | `3600` |
+| `churn.informational_edit_count` | `VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT` | `5` |
+| `churn.warning_edit_count` | `VIBEGUARD_CHURN_WARNING_EDIT_COUNT` | `10` |
+| `churn.critical_edit_count` | `VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT` | `20` |
+| `churn.critical_build_failure_count` | `VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT` | `5` |
+| `w15.minimum_consecutive_edits` | `VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS` | `3` |
+| `w15.latest_delta_character_ceiling` | `VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING` | `300` |
 | `paralysis.threshold` | `VG_PARALYSIS_THRESHOLD` | `7` |
 | `write_mode` | `VIBEGUARD_WRITE_MODE` | `warn` |
 | `write_escalate_threshold` | `VIBEGUARD_PRE_WRITE_ESCALATE_THRESHOLD` | `5` |

--- a/templates/vibeguard-config.README.md
+++ b/templates/vibeguard-config.README.md
@@ -21,6 +21,21 @@ To inspect the effective value and its source:
 vibeguard-runtime config explain u16.limit --cwd /path/to/project
 ```
 
+Use the guided commands to inspect and change configuration without opening
+JSON directly:
+
+```sh
+vibeguard-runtime config show --cwd /path/to/project
+vibeguard-runtime config init --scope user
+vibeguard-runtime config init --scope project --cwd /path/to/project
+vibeguard-runtime config set u16.limit 1200 --scope project --cwd /path/to/project
+vibeguard-runtime config reset u16.limit --scope project --cwd /path/to/project
+```
+
+`show` reports every supported runtime field's effective value, source layer,
+category, and description. User scope accepts registered runtime fields.
+Project scope also accepts `profile`, `enforcement`, and `languages`.
+
 ## Keys
 
 | JSON path | Env var | Default | Effect |
@@ -31,6 +46,12 @@ vibeguard-runtime config explain u16.limit --cwd /path/to/project
 | `circuit_breaker.cooldown_seconds` | `VG_CB_COOLDOWN` | `300` | Seconds an OPEN circuit waits before HALF-OPEN. |
 | `circuit_breaker.lock_timeout_seconds` | `VG_CB_LOCK_TIMEOUT_SECONDS` | `5` | Seconds to wait for the circuit-breaker state lock. |
 | `w14.cooldown_seconds` | `VIBEGUARD_W14_COOLDOWN_SECONDS` | `3600` | Suppresses repeated W-14 reports for the same directed session pair and file; `0` disables suppression. |
+| `churn.informational_edit_count` | `VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT` | `5` | Same-file edit count that starts informational churn guidance; minimum `1`. |
+| `churn.warning_edit_count` | `VIBEGUARD_CHURN_WARNING_EDIT_COUNT` | `10` | Same-file edit count that raises churn guidance to warning level; minimum `1`. |
+| `churn.critical_edit_count` | `VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT` | `20` | Same-file edit count that enables critical churn classification; minimum `1`. |
+| `churn.critical_build_failure_count` | `VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT` | `5` | Consecutive build failures needed with critical churn for escalation; minimum `1`. |
+| `w15.minimum_consecutive_edits` | `VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS` | `3` | Minimum same-file trail length, including the current edit. Values above `3` gate on a longer trail while W-15 still compares only the latest three deltas. |
+| `w15.latest_delta_character_ceiling` | `VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING` | `300` | Exclusive ceiling for the latest absolute character delta in W-15 micro-tuning detection. |
 | _(env only)_ | `VIBEGUARD_W14_SKIP_TEMP` | unset | Set to exactly `0` to keep W-14 **and** churn active on system temp roots (`/tmp`, `/private/tmp`, `/var/folders`). By default those paths are exempt because a session-scoped scratchpad cannot have cross-session write conflicts. Repository paths are never exempt, including a repo-local `scratchpad/` directory. |
 | `paralysis.threshold` | `VG_PARALYSIS_THRESHOLD` | `7` | W-13 read-only-action streak before paralysis warning. |
 | `write_mode` | `VIBEGUARD_WRITE_MODE` | `warn` | `warn` = advisory; `block` = hard reject new source files without prior search. |
@@ -54,7 +75,11 @@ VG_U16_LIMIT=2000 git commit -m "checkpoint"
 ## How to edit
 
 ```sh
-$EDITOR ~/.vibeguard/config.json
+vibeguard-runtime config set u16.limit 1200 --scope user
 ```
 
-`setup.sh` seeds this file from `templates/vibeguard-config.json.example` on first install and never overwrites your edits afterward. Re-running `setup.sh` is safe.
+Use `config reset <key> --scope user` to return a user value to lower layers.
+Set/reset validates the complete candidate before one atomic replacement and
+preserves unrelated valid keys. `setup.sh` seeds this file from
+`templates/vibeguard-config.json.example` on first install and never overwrites
+your edits afterward. Re-running `setup.sh` is safe.

--- a/templates/vibeguard-config.json.example
+++ b/templates/vibeguard-config.json.example
@@ -12,6 +12,16 @@
   "w14": {
     "cooldown_seconds": 3600
   },
+  "churn": {
+    "informational_edit_count": 5,
+    "warning_edit_count": 10,
+    "critical_edit_count": 20,
+    "critical_build_failure_count": 5
+  },
+  "w15": {
+    "minimum_consecutive_edits": 3,
+    "latest_delta_character_ceiling": 300
+  },
   "paralysis": {
     "threshold": 7
   },

--- a/tests/hooks/test_post_edit_churn.sh
+++ b/tests/hooks/test_post_edit_churn.sh
@@ -17,8 +17,9 @@ source hooks/log.sh
 source hooks/_lib/post_edit_common.sh
 source hooks/_lib/post_edit_history.sh
 
-FILE_PATH="$WORK_DIR/planned_refactor.tsx"
-touch "$FILE_PATH"
+# Keep repository-local paths relative when this worktree itself is under /tmp.
+FILE_PATH="${WORK_DIR#"$REPO_DIR"/}/planned_refactor.tsx"
+touch "$REPO_DIR/$FILE_PATH"
 
 append_event() {
   local hook="$1" tool="$2" decision="$3" reason="$4" detail="$5"
@@ -102,6 +103,8 @@ case "${1:-}" in
 esac
 STUB
 chmod +x "$summary_runtime"
+# Warm the new executable outside the hook's two-second runtime query budget.
+VG_STUB_RUNTIME_CALLS=/dev/null "$summary_runtime" warmup </dev/null >/dev/null
 
 old_runtime="$_VIBEGUARD_RUNTIME"
 _VIBEGUARD_RUNTIME="$summary_runtime"

--- a/tests/test_runtime_config_schema.sh
+++ b/tests/test_runtime_config_schema.sh
@@ -24,6 +24,12 @@ numeric_contract = {
     "circuit_breaker.cooldown_seconds": (0, 31_536_000),
     "circuit_breaker.lock_timeout_seconds": (0, 300),
     "w14.cooldown_seconds": (0, 31_536_000),
+    "churn.informational_edit_count": (1, 1_000_000),
+    "churn.warning_edit_count": (1, 1_000_000),
+    "churn.critical_edit_count": (1, 1_000_000),
+    "churn.critical_build_failure_count": (1, 1_000_000),
+    "w15.minimum_consecutive_edits": (3, 1_000_000),
+    "w15.latest_delta_character_ceiling": (0, 1_000_000),
     "paralysis.threshold": (0, 1_000_000),
     "write_escalate_threshold": (0, 1_000_000),
     "learn.metrics_tail_bytes": (1, 268_435_456),
@@ -133,7 +139,7 @@ assert schema["additionalProperties"] is False
 assert leaf_paths(schema) == expected_paths
 assert value_paths(template) == expected_paths
 
-for object_path in ["u16", "circuit_breaker", "w14", "paralysis", "learn"]:
+for object_path in ["u16", "circuit_breaker", "w14", "churn", "w15", "paralysis", "learn"]:
     assert schema_at(object_path)["additionalProperties"] is False
 
 for path, (minimum, maximum) in numeric_contract.items():
@@ -147,10 +153,13 @@ for path, (minimum, maximum) in numeric_contract.items():
     set_path(fixture, path, maximum + 1)
     assert_invalid(f"{path} max+1", fixture, "range")
 
-for path in numeric_contract.keys() - {"learn.metrics_tail_bytes"}:
+for path, (minimum, _) in numeric_contract.items():
     fixture = {}
     set_path(fixture, path, 0)
-    assert_valid(f"{path} zero", fixture)
+    if minimum == 0:
+        assert_valid(f"{path} zero", fixture)
+    else:
+        assert_invalid(f"{path} zero", fixture, "range")
 
 assert_valid("empty object", {})
 assert_valid("legacy version missing", {"write_mode": "block"})

--- a/vibeguard-runtime/src/hook_checks/history.rs
+++ b/vibeguard-runtime/src/hook_checks/history.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use crate::event_schema::{decision, field, hook, tool};
 use crate::hook_checks::common::{first_detail_path, write_log_event};
 use crate::logging::query::count_build_fail_events;
+use crate::runtime_config::runtime_config_churn_thresholds;
+use crate::runtime_config::runtime_config_int_value_for_path as threshold;
 use crate::time_utils::{now_unix_secs, parse_iso_ts};
 
 const POST_EDIT_HISTORY_LINES: usize = 500;
@@ -21,7 +23,7 @@ pub(crate) struct PostEditHistorySignals {
 
 impl PostEditHistorySignals {
     pub(crate) fn needs_shell_w15_check(&self) -> bool {
-        self.w15_count >= 2
+        self.w15_count.saturating_add(1) >= threshold("w15.minimum_consecutive_edits") as usize
     }
 }
 
@@ -39,6 +41,7 @@ pub(crate) fn post_edit_history_signals(
     agent: &str,
     file_path: &str,
 ) -> io::Result<Option<PostEditHistorySignals>> {
+    let thresholds = runtime_config_churn_thresholds();
     let lines = match read_tail_lines(log_file, POST_EDIT_HISTORY_LINES) {
         Ok(lines) => lines,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
@@ -91,7 +94,7 @@ pub(crate) fn post_edit_history_signals(
         .filter(|e| !is_churn_only_warning(e))
         .filter(|e| first_detail_path(e) == file_path)
         .count();
-    let build_fail_count = if churn_count >= 20 {
+    let build_fail_count = if churn_count >= thresholds.critical_edit_count as usize {
         count_session_build_fail_events(&events, session, &current_project_root())
     } else {
         0
@@ -290,29 +293,29 @@ pub(crate) fn post_edit_history_warnings(
     file_path: &str,
     signals: &PostEditHistorySignals,
 ) -> String {
-    let mut warnings = Vec::new();
+    let (thresholds, mut warnings) = (runtime_config_churn_thresholds(), Vec::new());
     let basename = Path::new(file_path)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or(file_path);
 
-    if signals.churn_count >= 20 && signals.build_fail_count >= 5 {
+    if thresholds.is_critical(signals.churn_count, signals.build_fail_count) {
         warnings.push(format!(
             "[CHURN CRITICAL] [review] [this-file] OBSERVATION: {basename} has been edited {} times and the project has {} consecutive build failures - possible edit->fail->fix loop\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify; if failed loop, stop and re-check root cause (W-02)\nDO NOT: Keep making equivalent fix attempts without fresh build output and a confirmed root cause",
             signals.churn_count,
             signals.build_fail_count
         ));
-    } else if signals.churn_count >= 20 {
+    } else if signals.churn_count >= thresholds.critical_edit_count as usize {
         warnings.push(format!(
             "[CHURN WARNING] [review] [this-file] OBSERVATION: {basename} has been edited {} times - high edit volume without repeated build-failure evidence\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify.\nDO NOT: Treat edit count alone as proof of W-02 failure-loop behavior",
             signals.churn_count
         ));
-    } else if signals.churn_count >= 10 {
+    } else if signals.churn_count >= thresholds.warning_edit_count as usize {
         warnings.push(format!(
             "[CHURN WARNING] [info] [this-file] OBSERVATION: {basename} has been edited {} times, possible correction loop\nFIX: Run full build to see the complete picture, or use /vibeguard:learn to extract patterns\nDO NOT: Take any action - monitor and decide whether to continue",
             signals.churn_count
         ));
-    } else if signals.churn_count >= 5 {
+    } else if signals.churn_count >= thresholds.informational_edit_count as usize {
         warnings.push(format!(
             "[CHURN] [info] [this-file] OBSERVATION: {basename} has been edited {} times\nFIX: Check if you are in a correction loop before continuing\nDO NOT: Take any action - this is informational only",
             signals.churn_count
@@ -331,7 +334,7 @@ pub(crate) fn post_edit_history_warnings(
         ));
     }
 
-    if signals.w15_count >= 2 {
+    if signals.w15_count.saturating_add(1) >= threshold("w15.minimum_consecutive_edits") as usize {
         let total = signals.w15_count + 1;
         warnings.push(format!(
             "[W-15] [review] [this-file] OBSERVATION: {total} consecutive edits to {basename} with no edits to other files in between (low-info loop suspect)\nFIX: Pause - are these {total} edits solving the same problem? If change scope shrinks each round, report a blocker instead of continuing to round {}\nDO NOT: Toggle between equivalent rewrites; do not continue same-direction micro-tuning without reporting",
@@ -376,14 +379,19 @@ fn fast_warning_decision(
     warn_count: usize,
     history: Option<&PostEditHistorySignals>,
 ) -> &'static str {
+    let thresholds = runtime_config_churn_thresholds();
     if warn_count >= 3 {
         return decision::ESCALATE;
     }
-    if history.is_some_and(|signals| signals.churn_count >= 20 && signals.build_fail_count >= 5) {
+    if history.is_some_and(|signals| {
+        thresholds.is_critical(signals.churn_count, signals.build_fail_count)
+    }) {
         return decision::ESCALATE;
     }
     if history.is_some_and(|signals| {
-        signals.churn_count >= 5 && signals.overlap.is_none() && signals.w15_count < 2
+        signals.churn_count >= thresholds.informational_edit_count as usize
+            && signals.overlap.is_none()
+            && !signals.needs_shell_w15_check()
     }) {
         return decision::CORRECTION;
     }

--- a/vibeguard-runtime/src/hook_orchestrator/post_edit_history.rs
+++ b/vibeguard-runtime/src/hook_orchestrator/post_edit_history.rs
@@ -12,7 +12,9 @@ use crate::hook_orchestrator::{
     HookKind, append_hook_event, append_hook_event_with_status, elapsed_ms,
 };
 use crate::logging::query::count_build_fail_events;
-use crate::runtime_config::runtime_config_int_value;
+use crate::runtime_config::{
+    runtime_config_churn_thresholds, runtime_config_int_value, runtime_config_int_value_for_path,
+};
 use crate::setup::support::sha256_text;
 use crate::time_utils::{now_unix_secs, parse_iso_ts};
 
@@ -69,6 +71,11 @@ fn detect_churn(
     events: &[Value],
     warnings: &mut Vec<String>,
 ) {
+    let thresholds = runtime_config_churn_thresholds();
+    let informational_edit_count = thresholds.informational_edit_count as usize;
+    let warning_edit_count = thresholds.warning_edit_count as usize;
+    let critical_edit_count = thresholds.critical_edit_count as usize;
+    let critical_build_failure_count = thresholds.critical_build_failure_count;
     let churn_count = session_events
         .iter()
         .filter(|event| {
@@ -83,7 +90,7 @@ fn detect_churn(
     // leave evidence only when churn would actually have warned, so ordinary
     // temp writes add no log volume.
     if session_temp {
-        if churn_count >= 5 {
+        if churn_count >= informational_edit_count {
             let detail = format!("{file_path}||churn={churn_count}");
             let detail_limit = detail.chars().count();
             if let Err(err) = append_hook_event_with_status(
@@ -101,9 +108,9 @@ fn detect_churn(
         return;
     }
     let basename = post_edit_history_file_name(file_path);
-    if churn_count >= 20 {
+    if churn_count >= critical_edit_count {
         let build_fail_count = count_build_failures(events);
-        if build_fail_count >= 5 {
+        if u64::from(build_fail_count) >= critical_build_failure_count {
             let warning = format!(
                 "[CHURN CRITICAL] [review] [this-file] OBSERVATION: {basename} has been edited {churn_count} times and the project has {build_fail_count} consecutive build failures — possible edit->fail->fix loop\nFIX: Pause and classify: planned refactor vs failed repair loop. If planned, make one scoped finishing edit and verify; if failed loop, stop and re-check root cause (W-02)\nDO NOT: Keep making equivalent fix attempts without fresh build output and a confirmed root cause"
             );
@@ -130,7 +137,7 @@ fn detect_churn(
                 )
             });
         }
-    } else if churn_count >= 10 {
+    } else if churn_count >= warning_edit_count {
         let warning = format!(
             "[CHURN WARNING] [info] [this-file] OBSERVATION: {basename} has been edited {churn_count} times — high edit volume\nFIX: Run full build to see the complete picture, or classify whether this is a planned refactor before continuing\nDO NOT: Take any action — monitor and decide whether to continue"
         );
@@ -143,7 +150,7 @@ fn detect_churn(
                 file_path,
             )
         });
-    } else if churn_count >= 5 {
+    } else if churn_count >= informational_edit_count {
         let warning = format!(
             "[CHURN] [info] [this-file] OBSERVATION: {basename} has been edited {churn_count} times\nFIX: Check if you are in a correction loop before continuing\nDO NOT: Take any action — this is informational only"
         );
@@ -365,17 +372,22 @@ fn detect_w15(
         return;
     }
     let current_delta = new_string.chars().count() as i64 - old_string.chars().count() as i64;
+    let minimum_consecutive_edits =
+        runtime_config_int_value_for_path("w15.minimum_consecutive_edits") as usize;
+    let latest_delta_character_ceiling =
+        runtime_config_int_value_for_path("w15.latest_delta_character_ceiling");
     let trail = same_file_edit_trail(events, &ctx.session_id, file_path);
-    if trail.consecutive < 2 || trail.deltas.len() < 2 {
+    let required_prior_edits = minimum_consecutive_edits.saturating_sub(1);
+    if trail.consecutive < required_prior_edits || trail.deltas.len() < 2 {
         return;
     }
     let prev = trail.deltas[0].unsigned_abs();
     let prev2 = trail.deltas[1].unsigned_abs();
     let cur = current_delta.unsigned_abs();
-    if prev2 >= prev && prev >= cur && cur < 300 {
+    if prev2 >= prev && prev >= cur && cur < latest_delta_character_ceiling {
         let total = trail.consecutive + 1;
         let warning = format!(
-            "[W-15] [review] [this-file] OBSERVATION: {total} consecutive edits to {} with shrinking change radius (|Δ| {prev2}→{prev}→{cur} chars; latest <300)\nFIX: Pause — are these {total} edits solving the same problem? If radius keeps shrinking, report a blocker instead of continuing to round {}\nDO NOT: Toggle between equivalent rewrites; do not continue same-direction micro-tuning without reporting\nESCAPE: set VIBEGUARD_SUPPRESS_W15=1 to suppress (e.g. for long-document writing)",
+            "[W-15] [review] [this-file] OBSERVATION: {total} consecutive edits to {} with shrinking change radius (|Δ| {prev2}→{prev}→{cur} chars; latest <{latest_delta_character_ceiling})\nFIX: Pause — are these {total} edits solving the same problem? If radius keeps shrinking, report a blocker instead of continuing to round {}\nDO NOT: Toggle between equivalent rewrites; do not continue same-direction micro-tuning without reporting\nESCAPE: set VIBEGUARD_SUPPRESS_W15=1 to suppress (e.g. for long-document writing)",
             post_edit_history_file_name(file_path),
             total + 1
         );

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -297,7 +297,7 @@ static COMMANDS: &[Command] = &[
     },
     Command {
         name: "config",
-        usage: "explain <key-or-env> [--cwd <path>] [--json]  — explain a layered runtime configuration value",
+        usage: "show|init|set|reset|explain ...  — inspect or edit layered runtime configuration",
         handler: runtime_config::config,
     },
     Command {

--- a/vibeguard-runtime/src/project_config/mod.rs
+++ b/vibeguard-runtime/src/project_config/mod.rs
@@ -207,7 +207,7 @@ fn read_project_config_json(path: &Path) -> Result<Value, String> {
     })
 }
 
-fn validate_project_config_value(path: &Path, value: &Value) -> Result<(), String> {
+pub(crate) fn validate_project_config_value(path: &Path, value: &Value) -> Result<(), String> {
     let Some(object) = value.as_object() else {
         return Err(format_project_config_errors(
             path,

--- a/vibeguard-runtime/src/runtime_config/commands.rs
+++ b/vibeguard-runtime/src/runtime_config/commands.rs
@@ -1,0 +1,544 @@
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::HandlerResult;
+use crate::git_root::git_root_for;
+use crate::project_config::{
+    project_config_path, validate_project_config_value, validated_project_config_json,
+};
+use crate::runtime_config::fields::{
+    FieldKind, RUNTIME_CONFIG_FIELDS, RuntimeConfigField, field_for_key,
+};
+use crate::runtime_config::resolution;
+use crate::runtime_config::validation::{RuntimeConfigDecision, validate_runtime_config_overlay};
+use crate::setup::support::write_json_atomic;
+#[cfg(unix)]
+use crate::setup::support::write_json_atomic_private;
+
+use super::{is_nonnegative_digits, runtime_config_file};
+
+const SHOW_USAGE: &str = "Usage: vibeguard-runtime config show [--cwd <path>] [--json]";
+const INIT_USAGE: &str = "Usage: vibeguard-runtime config init --scope user|project [--cwd <path>]";
+const SET_USAGE: &str =
+    "Usage: vibeguard-runtime config set <key> <value> --scope user|project [--cwd <path>]";
+const RESET_USAGE: &str =
+    "Usage: vibeguard-runtime config reset <key> --scope user|project [--cwd <path>]";
+
+type CommandResult<T> = Result<T, String>;
+
+#[derive(Clone, Copy)]
+enum Scope {
+    User,
+    Project,
+}
+
+enum EditableField {
+    Runtime(&'static RuntimeConfigField),
+    Profile,
+    Enforcement,
+    Languages,
+}
+
+pub(super) fn run(args: &[String]) -> HandlerResult {
+    match args.first().map(String::as_str) {
+        Some("show") => {
+            let (cwd, json_output) = parse_show_args(&args[1..])?;
+            show(cwd.as_deref(), json_output)
+        }
+        Some("init") => {
+            let (scope, cwd) = parse_scope_and_cwd(&args[1..], 0, INIT_USAGE)?;
+            init(scope, cwd.as_deref()).map_err(Into::into)
+        }
+        Some("set") => {
+            if args.len() < 4 {
+                return Err(SET_USAGE.into());
+            }
+            let key = &args[1];
+            let value = &args[2];
+            let (scope, cwd) = parse_scope_and_cwd(&args[3..], 0, SET_USAGE)?;
+            set(scope, key, value, cwd.as_deref()).map_err(Into::into)
+        }
+        Some("reset") => {
+            if args.len() < 3 {
+                return Err(RESET_USAGE.into());
+            }
+            let key = &args[1];
+            let (scope, cwd) = parse_scope_and_cwd(&args[2..], 0, RESET_USAGE)?;
+            reset(scope, key, cwd.as_deref()).map_err(Into::into)
+        }
+        _ => Err(format!("{SHOW_USAGE}\n{INIT_USAGE}\n{SET_USAGE}\n{RESET_USAGE}").into()),
+    }
+}
+
+fn parse_show_args(args: &[String]) -> CommandResult<(Option<String>, bool)> {
+    let mut cwd = None;
+    let mut json_output = false;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--cwd" if index + 1 < args.len() => {
+                cwd = Some(args[index + 1].clone());
+                index += 2;
+            }
+            "--json" => {
+                json_output = true;
+                index += 1;
+            }
+            _ => return Err(SHOW_USAGE.to_string()),
+        }
+    }
+    Ok((cwd, json_output))
+}
+
+fn parse_scope_and_cwd(
+    args: &[String],
+    start: usize,
+    usage: &str,
+) -> CommandResult<(Scope, Option<String>)> {
+    let mut scope = None;
+    let mut cwd = None;
+    let mut index = start;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--scope" if index + 1 < args.len() => {
+                scope = Some(match args[index + 1].as_str() {
+                    "user" => Scope::User,
+                    "project" => Scope::Project,
+                    _ => return Err(usage.to_string()),
+                });
+                index += 2;
+            }
+            "--cwd" if index + 1 < args.len() => {
+                cwd = Some(args[index + 1].clone());
+                index += 2;
+            }
+            _ => return Err(usage.to_string()),
+        }
+    }
+    scope
+        .map(|scope| (scope, cwd))
+        .ok_or_else(|| usage.to_string())
+}
+
+fn show(cwd: Option<&str>, json_output: bool) -> HandlerResult {
+    resolution::resolve_effective_churn_thresholds(cwd, None).map_err(|error| error.message)?;
+    let mut records = Vec::with_capacity(RUNTIME_CONFIG_FIELDS.len());
+    for field in RUNTIME_CONFIG_FIELDS {
+        let resolved = resolution::resolve_field(field, cwd).map_err(|error| error.message)?;
+        records.push(json!({
+            "key": field.path,
+            "value": resolved.value,
+            "source": resolved.source.source_name(),
+            "source_detail": resolved.detail,
+            "environment": field.env,
+            "category": field.category,
+            "description": field.description,
+        }));
+    }
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&records).map_err(|error| error.to_string())?
+        );
+    } else {
+        for record in records {
+            println!(
+                "{}: value={} source={} category={} description={}",
+                record["key"].as_str().unwrap_or(""),
+                resolution::display_value(&record["value"]),
+                record["source"].as_str().unwrap_or(""),
+                record["category"].as_str().unwrap_or(""),
+                record["description"].as_str().unwrap_or("")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn init(scope: Scope, cwd: Option<&str>) -> CommandResult<()> {
+    let path = target_path(scope, cwd)?;
+    match fs::symlink_metadata(&path) {
+        Ok(_) => {
+            return Err(format!(
+                "cannot initialize config: target already exists: {}",
+                path.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(path_error(&path, "inspect", error)),
+    }
+
+    let parent = config_parent(&path);
+    fs::create_dir_all(parent).map_err(|error| path_error(&path, "create parent", error))?;
+    match scope {
+        Scope::User => write_new_user_json(&path, &json!({"version": 1}))?,
+        Scope::Project => write_new_project_json(&path, &json!({"version": 1}))?,
+    }
+    println!("initialized path={}", path.display());
+    Ok(())
+}
+
+fn set(scope: Scope, key: &str, raw_value: &str, cwd: Option<&str>) -> CommandResult<()> {
+    let field = editable_field(scope, key)?;
+    let value = parse_value(&field, key, raw_value)?;
+    let path = target_path(scope, cwd)?;
+    let mut document = load_document(scope, &path)?.unwrap_or_else(|| json!({}));
+    set_json_path(&mut document, key, value)?;
+    validate_candidate(scope, &path, &document, cwd)?;
+    write_candidate(scope, &path, &document)?;
+    println!("set key={key} path={}", path.display());
+    Ok(())
+}
+
+fn reset(scope: Scope, key: &str, cwd: Option<&str>) -> CommandResult<()> {
+    let _field = editable_field(scope, key)?;
+    let path = target_path(scope, cwd)?;
+    let Some(mut document) = load_document(scope, &path)? else {
+        println!("reset key={key} path={} unchanged=true", path.display());
+        return Ok(());
+    };
+    if !remove_json_path(&mut document, key) {
+        println!("reset key={key} path={} unchanged=true", path.display());
+        return Ok(());
+    }
+    validate_candidate(scope, &path, &document, cwd)?;
+    write_candidate(scope, &path, &document)?;
+    println!("reset key={key} path={}", path.display());
+    Ok(())
+}
+
+fn editable_field(scope: Scope, key: &str) -> CommandResult<EditableField> {
+    if let Some(field) = field_for_key(key).filter(|field| field.path == key) {
+        return Ok(EditableField::Runtime(field));
+    }
+    if matches!(scope, Scope::Project) {
+        return match key {
+            "profile" => Ok(EditableField::Profile),
+            "enforcement" => Ok(EditableField::Enforcement),
+            "languages" => Ok(EditableField::Languages),
+            _ => Err(format!(
+                "unknown config key {key}; use a supported JSON path"
+            )),
+        };
+    }
+    Err(format!(
+        "unknown user config key {key}; user scope accepts registered runtime JSON paths only"
+    ))
+}
+
+fn parse_value(field: &EditableField, key: &str, raw_value: &str) -> CommandResult<Value> {
+    match field {
+        EditableField::Runtime(field) => match field.kind {
+            FieldKind::Integer { minimum, maximum } => {
+                let value = parse_decimal_integer(key, raw_value)?;
+                if !(minimum..=maximum).contains(&value) {
+                    return Err(command_error(
+                        key,
+                        "config_range_error",
+                        &format!("integer_range={minimum}..={maximum}"),
+                    ));
+                }
+                Ok(Value::from(value))
+            }
+            FieldKind::Version => {
+                let value = parse_decimal_integer(key, raw_value)?;
+                if value != 1 {
+                    return Err(command_error(
+                        key,
+                        "config_version_error",
+                        "supported_version=1",
+                    ));
+                }
+                Ok(Value::from(value))
+            }
+            FieldKind::StringEnum { allowed } => {
+                if !allowed.contains(&raw_value) {
+                    return Err(command_error(
+                        key,
+                        "config_enum_error",
+                        &format!("allowed={}", allowed.join("|")),
+                    ));
+                }
+                Ok(Value::String(raw_value.to_string()))
+            }
+            FieldKind::StringArray { maximum_items } => parse_string_array(
+                key,
+                raw_value,
+                Some(maximum_items),
+                field.path == "disabled_skills",
+            ),
+        },
+        EditableField::Profile | EditableField::Enforcement => {
+            Ok(Value::String(raw_value.to_string()))
+        }
+        EditableField::Languages => parse_string_array(key, raw_value, None, false),
+    }
+}
+
+fn parse_decimal_integer(key: &str, raw_value: &str) -> CommandResult<u64> {
+    if !is_nonnegative_digits(raw_value) {
+        return Err(command_error(
+            key,
+            "config_type_error",
+            "decimal_nonnegative_integer",
+        ));
+    }
+    raw_value
+        .parse::<u64>()
+        .map_err(|_| command_error(key, "config_range_error", "unsigned_64_bit_integer"))
+}
+
+fn parse_string_array(
+    key: &str,
+    raw_value: &str,
+    maximum_items: Option<usize>,
+    skills: bool,
+) -> CommandResult<Value> {
+    if raw_value.is_empty() {
+        return Ok(Value::Array(Vec::new()));
+    }
+    let items = raw_value
+        .split(',')
+        .map(str::trim)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if items.iter().any(String::is_empty) {
+        return Err(command_error(
+            key,
+            "config_type_error",
+            "comma_separated_strings_or_empty",
+        ));
+    }
+    if maximum_items.is_some_and(|maximum| items.len() > maximum) {
+        return Err(command_error(key, "config_range_error", "array_max_items"));
+    }
+    if skills
+        && items
+            .iter()
+            .any(|item| !super::validation::is_skill_name(item))
+    {
+        return Err(command_error(key, "config_value_error", "skill_name"));
+    }
+    Ok(Value::Array(items.into_iter().map(Value::String).collect()))
+}
+
+fn command_error(key: &str, category: &str, expected: &str) -> String {
+    format!("VibeGuard config command invalid: key={key} category={category} expected={expected}")
+}
+
+fn target_path(scope: Scope, cwd: Option<&str>) -> CommandResult<PathBuf> {
+    match scope {
+        Scope::User => Ok(runtime_config_file()),
+        Scope::Project => project_target_path(cwd),
+    }
+}
+
+fn project_target_path(cwd: Option<&str>) -> CommandResult<PathBuf> {
+    if let Some(configured) = std::env::var("VIBEGUARD_PROJECT_CONFIG")
+        .ok()
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(PathBuf::from(configured));
+    }
+
+    let effective_cwd = resolution::resolution_cwd(cwd);
+    if let Some(path) = project_config_path(effective_cwd.as_deref(), &HashMap::new()) {
+        return Ok(path);
+    }
+    let cwd_path = effective_cwd
+        .as_deref()
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
+        .ok_or_else(|| {
+            "cannot resolve project config path: current directory unavailable".to_string()
+        })?;
+    if let Some(git_root) = git_root_for(&cwd_path) {
+        return Ok(git_root.join(".vibeguard.json"));
+    }
+    Ok(cwd_path.join(".vibeguard.json"))
+}
+
+fn load_document(scope: Scope, path: &Path) -> CommandResult<Option<Value>> {
+    match scope {
+        Scope::User => {
+            let path_text = path.to_string_lossy();
+            let (decision, document) = super::validation::classify_runtime_config_file(&path_text)
+                .map_err(|error| error.message)?;
+            match decision {
+                RuntimeConfigDecision::Missing => Ok(None),
+                RuntimeConfigDecision::Valid => document
+                    .ok_or_else(|| "runtime config validator returned no document".to_string())
+                    .map(Some),
+            }
+        }
+        Scope::Project => match fs::symlink_metadata(path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(path_error(path, "inspect", error)),
+            Ok(_) => validated_project_config_json(path)
+                .map(Some)
+                .map_err(|error| error.to_string()),
+        },
+    }
+}
+
+fn validate_candidate(
+    scope: Scope,
+    path: &Path,
+    candidate: &Value,
+    cwd: Option<&str>,
+) -> CommandResult<()> {
+    match scope {
+        Scope::User => {
+            validate_runtime_config_overlay(path, candidate).map_err(|error| error.message)
+        }
+        Scope::Project => validate_project_config_value(path, candidate),
+    }?;
+    let effective_candidate = match scope {
+        Scope::User => resolution::EffectiveCandidate::User(candidate),
+        Scope::Project => resolution::EffectiveCandidate::Project(candidate),
+    };
+    resolution::resolve_effective_churn_thresholds(cwd, Some(effective_candidate))
+        .map(|_| ())
+        .map_err(|error| error.message)
+}
+
+fn write_candidate(scope: Scope, path: &Path, candidate: &Value) -> CommandResult<()> {
+    let result = match scope {
+        Scope::User => write_user_json_atomic(path, candidate),
+        Scope::Project => write_json_atomic(path, candidate),
+    };
+    result.map_err(|error| path_error(path, "atomically replace", error))
+}
+
+#[cfg(unix)]
+fn write_user_json_atomic(
+    path: &Path,
+    candidate: &Value,
+) -> crate::setup::support::SetupResult<()> {
+    write_json_atomic_private(path, candidate)
+}
+
+#[cfg(not(unix))]
+fn write_user_json_atomic(
+    path: &Path,
+    candidate: &Value,
+) -> crate::setup::support::SetupResult<()> {
+    write_json_atomic(path, candidate)
+}
+
+fn set_json_path(document: &mut Value, path: &str, value: Value) -> CommandResult<()> {
+    let parts = path.split('.').collect::<Vec<_>>();
+    let Some(last) = parts.last().copied() else {
+        return Err("config key cannot be empty".to_string());
+    };
+    let mut node = document;
+    for part in &parts[..parts.len() - 1] {
+        let object = node
+            .as_object_mut()
+            .ok_or_else(|| format!("cannot set {path}: parent is not an object"))?;
+        node = object
+            .entry((*part).to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+    }
+    node.as_object_mut()
+        .ok_or_else(|| format!("cannot set {path}: parent is not an object"))?
+        .insert(last.to_string(), value);
+    Ok(())
+}
+
+fn remove_json_path(document: &mut Value, path: &str) -> bool {
+    let parts = path.split('.').collect::<Vec<_>>();
+    remove_json_parts(document, &parts)
+}
+
+fn remove_json_parts(document: &mut Value, parts: &[&str]) -> bool {
+    let Some(first) = parts.first().copied() else {
+        return false;
+    };
+    let Some(object) = document.as_object_mut() else {
+        return false;
+    };
+    if parts.len() == 1 {
+        return object.remove(first).is_some();
+    }
+    let changed = object
+        .get_mut(first)
+        .is_some_and(|child| remove_json_parts(child, &parts[1..]));
+    if changed
+        && object
+            .get(first)
+            .and_then(Value::as_object)
+            .is_some_and(Map::is_empty)
+    {
+        object.remove(first);
+    }
+    changed
+}
+
+fn config_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn write_new_user_json(path: &Path, value: &Value) -> CommandResult<()> {
+    let mut options = new_json_options();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    write_new_json_with_options(path, value, options)
+}
+
+fn write_new_project_json(path: &Path, value: &Value) -> CommandResult<()> {
+    write_new_json_with_options(path, value, new_json_options())
+}
+
+fn new_json_options() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    options
+}
+
+fn write_new_json_with_options(
+    path: &Path,
+    value: &Value,
+    options: OpenOptions,
+) -> CommandResult<()> {
+    let mut bytes = serde_json::to_vec_pretty(value).map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    let mut created = false;
+    let result = (|| {
+        let mut file = options
+            .open(path)
+            .map_err(|error| path_error(path, "create", error))?;
+        created = true;
+        file.write_all(&bytes)
+            .map_err(|error| path_error(path, "write", error))?;
+        file.sync_all()
+            .map_err(|error| path_error(path, "sync", error))?;
+        Ok::<(), String>(())
+    })();
+    if let Err(error) = result {
+        if created
+            && let Err(cleanup_error) = fs::remove_file(path)
+            && cleanup_error.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(format!("{error}; cleanup failed: {cleanup_error}"));
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn path_error(path: &Path, operation: &str, error: impl std::fmt::Display) -> String {
+    format!(
+        "VibeGuard config command could not {operation} {}: {error}",
+        path.display()
+    )
+}

--- a/vibeguard-runtime/src/runtime_config/fields.rs
+++ b/vibeguard-runtime/src/runtime_config/fields.rs
@@ -12,6 +12,8 @@ pub(crate) struct RuntimeConfigField {
     pub env: Option<&'static str>,
     pub default: &'static str,
     pub kind: FieldKind,
+    pub category: &'static str,
+    pub description: &'static str,
 }
 
 pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
@@ -20,6 +22,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
         env: None,
         default: "1",
         kind: FieldKind::Version,
+        category: "schema",
+        description: "Runtime configuration schema version.",
     },
     RuntimeConfigField {
         path: "u16.warn_limit",
@@ -29,6 +33,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 1_000_000,
         },
+        category: "u16",
+        description: "Source-file line count that produces a U-16 advisory.",
     },
     RuntimeConfigField {
         path: "u16.limit",
@@ -38,6 +44,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 1_000_000,
         },
+        category: "u16",
+        description: "Source-file line count that reaches the U-16 hard limit.",
     },
     RuntimeConfigField {
         path: "circuit_breaker.threshold",
@@ -47,6 +55,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 1_000_000,
         },
+        category: "circuit_breaker",
+        description: "Consecutive blocks before the hook circuit opens.",
     },
     RuntimeConfigField {
         path: "circuit_breaker.cooldown_seconds",
@@ -56,6 +66,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 31_536_000,
         },
+        category: "circuit_breaker",
+        description: "Seconds an open circuit waits before a half-open probe.",
     },
     RuntimeConfigField {
         path: "circuit_breaker.lock_timeout_seconds",
@@ -65,6 +77,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 300,
         },
+        category: "circuit_breaker",
+        description: "Seconds to wait for the circuit-breaker state lock.",
     },
     RuntimeConfigField {
         path: "w14.cooldown_seconds",
@@ -74,6 +88,74 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 31_536_000,
         },
+        category: "history",
+        description: "Seconds before the same W-14 overlap may be reported again.",
+    },
+    RuntimeConfigField {
+        path: "churn.informational_edit_count",
+        env: Some("VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT"),
+        default: "5",
+        kind: FieldKind::Integer {
+            minimum: 1,
+            maximum: 1_000_000,
+        },
+        category: "churn",
+        description: "Same-file edit count that starts informational churn guidance.",
+    },
+    RuntimeConfigField {
+        path: "churn.warning_edit_count",
+        env: Some("VIBEGUARD_CHURN_WARNING_EDIT_COUNT"),
+        default: "10",
+        kind: FieldKind::Integer {
+            minimum: 1,
+            maximum: 1_000_000,
+        },
+        category: "churn",
+        description: "Same-file edit count that raises churn guidance to warning level.",
+    },
+    RuntimeConfigField {
+        path: "churn.critical_edit_count",
+        env: Some("VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT"),
+        default: "20",
+        kind: FieldKind::Integer {
+            minimum: 1,
+            maximum: 1_000_000,
+        },
+        category: "churn",
+        description: "Same-file edit count that enables critical churn classification.",
+    },
+    RuntimeConfigField {
+        path: "churn.critical_build_failure_count",
+        env: Some("VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT"),
+        default: "5",
+        kind: FieldKind::Integer {
+            minimum: 1,
+            maximum: 1_000_000,
+        },
+        category: "churn",
+        description: "Consecutive build failures needed with critical churn for escalation.",
+    },
+    RuntimeConfigField {
+        path: "w15.minimum_consecutive_edits",
+        env: Some("VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS"),
+        default: "3",
+        kind: FieldKind::Integer {
+            minimum: 3,
+            maximum: 1_000_000,
+        },
+        category: "w15",
+        description: "Minimum same-file edit trail, including the current edit, before W-15 evaluates only the latest three deltas.",
+    },
+    RuntimeConfigField {
+        path: "w15.latest_delta_character_ceiling",
+        env: Some("VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING"),
+        default: "300",
+        kind: FieldKind::Integer {
+            minimum: 0,
+            maximum: 1_000_000,
+        },
+        category: "w15",
+        description: "Largest latest change radius eligible for W-15 micro-tuning detection.",
     },
     RuntimeConfigField {
         path: "paralysis.threshold",
@@ -83,6 +165,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 1_000_000,
         },
+        category: "paralysis",
+        description: "Read-only action streak that starts W-13 paralysis guidance.",
     },
     RuntimeConfigField {
         path: "write_mode",
@@ -91,6 +175,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
         kind: FieldKind::StringEnum {
             allowed: &["warn", "block"],
         },
+        category: "write_policy",
+        description: "Whether new-source write guidance warns or blocks.",
     },
     RuntimeConfigField {
         path: "write_escalate_threshold",
@@ -100,6 +186,8 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 0,
             maximum: 1_000_000,
         },
+        category: "write_policy",
+        description: "Search-first reminders in one session before write guidance escalates.",
     },
     RuntimeConfigField {
         path: "learn.metrics_tail_bytes",
@@ -109,12 +197,16 @@ pub(crate) const RUNTIME_CONFIG_FIELDS: &[RuntimeConfigField] = &[
             minimum: 1,
             maximum: 268_435_456,
         },
+        category: "learning",
+        description: "Maximum recent metrics bytes read by the learn evaluator.",
     },
     RuntimeConfigField {
         path: "disabled_skills",
         env: Some("VIBEGUARD_DISABLED_SKILLS"),
         default: "[]",
         kind: FieldKind::StringArray { maximum_items: 256 },
+        category: "workflow",
+        description: "Managed Codex workflow skill directory names to skip.",
     },
 ];
 

--- a/vibeguard-runtime/src/runtime_config/mod.rs
+++ b/vibeguard-runtime/src/runtime_config/mod.rs
@@ -1,3 +1,4 @@
+mod commands;
 pub(crate) mod fields;
 mod resolution;
 pub mod validation;
@@ -6,6 +7,8 @@ use crate::HandlerResult;
 use crate::runtime_config::validation::{
     RuntimeConfigDecision, RuntimeConfigError, classify_runtime_config_file,
 };
+use fields::{FieldKind, field_for_key};
+pub(crate) use resolution::ChurnThresholds;
 use serde_json::Value;
 use std::io::ErrorKind;
 use std::path::PathBuf;
@@ -43,7 +46,11 @@ pub fn runtime_config_validate(args: &[String]) -> HandlerResult {
 }
 
 pub fn config(args: &[String]) -> HandlerResult {
-    resolution::config_command(args)
+    if args.first().map(String::as_str) == Some("explain") {
+        resolution::config_command(args)
+    } else {
+        commands::run(args)
+    }
 }
 
 pub fn runtime_config_get_int(args: &[String]) -> HandlerResult {
@@ -125,6 +132,27 @@ pub(crate) fn runtime_config_str_value(
     default_value: &str,
 ) -> String {
     resolve_runtime_config_str(env_name, json_path, default_value)
+        .unwrap_or_else(exit_runtime_config_error)
+}
+
+pub(crate) fn runtime_config_int_value_for_path(json_path: &str) -> u64 {
+    let Some(field) = field_for_key(json_path) else {
+        eprintln!(
+            "VibeGuard runtime config internal error: undeclared integer path {json_path}: category=config_internal_error"
+        );
+        process::exit(20);
+    };
+    if !matches!(field.kind, FieldKind::Integer { .. } | FieldKind::Version) {
+        eprintln!(
+            "VibeGuard runtime config internal error: non-integer path {json_path}: category=config_internal_error"
+        );
+        process::exit(20);
+    }
+    runtime_config_int_value(field.env.unwrap_or(""), field.path, field.default)
+}
+
+pub(crate) fn runtime_config_churn_thresholds() -> ChurnThresholds {
+    resolution::resolve_effective_churn_thresholds(None, None)
         .unwrap_or_else(exit_runtime_config_error)
 }
 

--- a/vibeguard-runtime/src/runtime_config/resolution.rs
+++ b/vibeguard-runtime/src/runtime_config/resolution.rs
@@ -8,7 +8,10 @@ use crate::HandlerResult;
 use crate::project_config::{project_config_path, validated_project_config_json};
 
 use super::fields::{FieldKind, RuntimeConfigField, field_for_key};
-use super::validation::{RuntimeConfigError, is_skill_name, nonnegative_json_integer};
+use super::validation::{
+    RuntimeConfigError, is_skill_name, nonnegative_json_integer,
+    validate_effective_churn_threshold_order,
+};
 use super::{is_nonnegative_digits, loaded_runtime_config, runtime_config_file, value_at_path};
 
 type LoadedProjectDocument = Result<Option<ProjectDocument>, RuntimeConfigError>;
@@ -25,7 +28,7 @@ pub(super) enum ConfigSource {
 }
 
 impl ConfigSource {
-    fn source_name(self) -> &'static str {
+    pub(super) fn source_name(self) -> &'static str {
         match self {
             Self::Default => "default",
             Self::UserConfig => "user_config",
@@ -37,8 +40,29 @@ impl ConfigSource {
 
 pub(super) struct Resolved<T> {
     pub value: T,
-    source: ConfigSource,
-    detail: String,
+    pub(super) source: ConfigSource,
+    pub(super) detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ChurnThresholds {
+    pub(crate) informational_edit_count: u64,
+    pub(crate) warning_edit_count: u64,
+    pub(crate) critical_edit_count: u64,
+    pub(crate) critical_build_failure_count: u64,
+}
+
+impl ChurnThresholds {
+    pub(crate) fn is_critical(self, churn_count: usize, build_fail_count: u32) -> bool {
+        churn_count >= self.critical_edit_count as usize
+            && u64::from(build_fail_count) >= self.critical_build_failure_count
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum EffectiveCandidate<'a> {
+    User(&'a Value),
+    Project(&'a Value),
 }
 
 pub(super) fn resolve_int(
@@ -47,7 +71,29 @@ pub(super) fn resolve_int(
     default_value: &str,
     cwd: Option<&str>,
 ) -> Result<Resolved<u64>, RuntimeConfigError> {
-    let layers = config_layers(json_path, cwd)?;
+    resolve_int_with_candidate(env_name, json_path, default_value, cwd, None)
+}
+
+fn resolve_int_with_candidate(
+    env_name: &str,
+    json_path: &str,
+    default_value: &str,
+    cwd: Option<&str>,
+    candidate: Option<EffectiveCandidate<'_>>,
+) -> Result<Resolved<u64>, RuntimeConfigError> {
+    let mut layers = config_layers(json_path, cwd)?;
+    if let Some(candidate) = candidate {
+        match candidate {
+            EffectiveCandidate::User(value) => {
+                layers.user = value_at_path(value, json_path).cloned();
+            }
+            EffectiveCandidate::Project(value) => {
+                layers.project = value_at_path(value, json_path)
+                    .cloned()
+                    .map(|value| (value, format!("in-memory project candidate#$.{json_path}")));
+            }
+        }
+    }
     if let Ok(raw) = std::env::var(env_name)
         && !raw.is_empty()
     {
@@ -67,6 +113,50 @@ pub(super) fn resolve_int(
         exit_code: 20,
     })?;
     Ok(resolved(value, ConfigSource::Default, "built-in"))
+}
+
+pub(super) fn resolve_effective_churn_thresholds(
+    cwd: Option<&str>,
+    candidate: Option<EffectiveCandidate<'_>>,
+) -> Result<ChurnThresholds, RuntimeConfigError> {
+    let informational_edit_count =
+        resolve_churn_integer("churn.informational_edit_count", cwd, candidate)?;
+    let warning_edit_count = resolve_churn_integer("churn.warning_edit_count", cwd, candidate)?;
+    let critical_edit_count = resolve_churn_integer("churn.critical_edit_count", cwd, candidate)?;
+    let critical_build_failure_count =
+        resolve_churn_integer("churn.critical_build_failure_count", cwd, candidate)?;
+    validate_effective_churn_threshold_order(
+        informational_edit_count,
+        warning_edit_count,
+        critical_edit_count,
+    )?;
+    Ok(ChurnThresholds {
+        informational_edit_count,
+        warning_edit_count,
+        critical_edit_count,
+        critical_build_failure_count,
+    })
+}
+
+fn resolve_churn_integer(
+    path: &str,
+    cwd: Option<&str>,
+    candidate: Option<EffectiveCandidate<'_>>,
+) -> Result<u64, RuntimeConfigError> {
+    let field = field_for_key(path).ok_or_else(|| RuntimeConfigError {
+        message: format!(
+            "VibeGuard runtime config internal error: undeclared churn path {path}: category=config_internal_error"
+        ),
+        exit_code: 20,
+    })?;
+    resolve_int_with_candidate(
+        field.env.unwrap_or(""),
+        field.path,
+        field.default,
+        cwd,
+        candidate,
+    )
+    .map(|resolved| resolved.value)
 }
 
 pub(super) fn resolve_str(
@@ -296,7 +386,7 @@ fn cached_project_document(
     loaded
 }
 
-fn resolution_cwd(explicit: Option<&str>) -> Option<String> {
+pub(super) fn resolution_cwd(explicit: Option<&str>) -> Option<String> {
     explicit
         .filter(|value| !value.is_empty())
         .map(str::to_string)
@@ -312,7 +402,7 @@ fn resolution_cwd(explicit: Option<&str>) -> Option<String> {
         })
 }
 
-fn resolve_field(
+pub(super) fn resolve_field(
     field: &RuntimeConfigField,
     cwd: Option<&str>,
 ) -> Result<Resolved<Value>, RuntimeConfigError> {
@@ -449,7 +539,7 @@ fn string_items(items: &[Value]) -> Vec<String> {
         .collect()
 }
 
-fn display_value(value: &Value) -> String {
+pub(super) fn display_value(value: &Value) -> String {
     match value {
         Value::String(text) => text.clone(),
         _ => serde_json::to_string(value).unwrap_or_else(|_| "null".to_string()),

--- a/vibeguard-runtime/src/runtime_config/validation.rs
+++ b/vibeguard-runtime/src/runtime_config/validation.rs
@@ -132,6 +132,38 @@ pub(crate) fn validate_runtime_config_overlay(
     validate_runtime_config_value(path, value)
 }
 
+pub(crate) fn validate_effective_churn_threshold_order(
+    informational: u64,
+    warning: u64,
+    critical: u64,
+) -> Result<(), RuntimeConfigError> {
+    validate_churn_threshold_values(
+        "effective configuration",
+        informational,
+        warning,
+        critical,
+        POLICY_ERROR,
+    )
+}
+
+fn validate_churn_threshold_values(
+    source: &str,
+    informational: u64,
+    warning: u64,
+    critical: u64,
+    exit_code: i32,
+) -> Result<(), RuntimeConfigError> {
+    if informational <= warning && warning <= critical {
+        return Ok(());
+    }
+    Err(RuntimeConfigError {
+        message: format!(
+            "VibeGuard runtime config invalid: {source}: path=$.churn category=config_range_error expected=ordered=informational_edit_count<=warning_edit_count<=critical_edit_count actual={informational},{warning},{critical}"
+        ),
+        exit_code,
+    })
+}
+
 fn validate_object(
     file_path: &Path,
     display_path: &str,

--- a/vibeguard-runtime/tests/cli_hook_post_edit.rs
+++ b/vibeguard-runtime/tests/cli_hook_post_edit.rs
@@ -54,6 +54,62 @@ fn run_post_edit_with(
     child.wait_with_output().unwrap()
 }
 
+fn run_post_edit_fast_with(
+    repo: &Path,
+    log_root: &Path,
+    log_file: &Path,
+    input: &str,
+    configure: impl FnOnce(&mut Command),
+) -> Output {
+    let mut command = post_edit_command(repo, log_root, log_file);
+    command
+        .args(["post-edit-fast-check", "800", "post-edit-session", "codex"])
+        .arg(log_file)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure(&mut command);
+    let mut child = command.spawn().unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn seed_post_edit_history(log_file: &Path, file_path: &str, deltas: &[i64]) {
+    let history = deltas
+        .iter()
+        .map(|delta| {
+            json!({
+                "session": "post-edit-session",
+                "hook": "post-edit-guard",
+                "tool": "Edit",
+                "decision": "pass",
+                "detail": format!("{file_path}||delta={delta}"),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(log_file, format!("{history}\n")).unwrap();
+}
+
+fn clear_history_threshold_env(command: &mut Command) {
+    for name in [
+        "VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT",
+        "VIBEGUARD_CHURN_WARNING_EDIT_COUNT",
+        "VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT",
+        "VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT",
+        "VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS",
+        "VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING",
+    ] {
+        command.env_remove(name);
+    }
+}
+
 fn case_paths(label: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     let root = unique_temp_dir(label);
     let repo = root.join("repo");
@@ -357,6 +413,233 @@ fn post_edit_warning_survives_log_failure_with_internal_error() {
     assert!(stdout.contains("VIBEGUARD quality warning"), "{stdout}");
     assert!(stdout.contains("[RS-03]"), "{stdout}");
     assert!(!log_file.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_history_uses_configured_churn_thresholds() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-configured-churn");
+    let config = root.join("runtime-config.json");
+    fs::write(
+        &config,
+        json!({
+            "churn": {
+                "informational_edit_count": 4,
+                "warning_edit_count": 8,
+                "critical_edit_count": 16,
+                "critical_build_failure_count": 2
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    seed_post_edit_history(&log_file, "src/lib.rs", &[1, 1, 1, 1]);
+
+    let out = run_post_edit_with(
+        &repo,
+        &log_root,
+        &log_file,
+        &edit_input("src/lib.rs", "fn old() {}", "fn clean() {}"),
+        |command| {
+            clear_history_threshold_env(command);
+            command.env("VIBEGUARD_CONFIG_FILE", &config);
+        },
+    );
+    assert_eq!(out.status.code(), Some(0), "{out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[CHURN]"), "{stdout}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_history_uses_environment_churn_threshold() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-fast-configured-churn");
+    let missing_config = root.join("missing-runtime-config.json");
+    seed_post_edit_history(&log_file, "src/lib.rs", &[1, 1, 1, 1]);
+    let other_event = json!({
+        "session": "post-edit-session",
+        "hook": "post-edit-guard",
+        "tool": "Edit",
+        "decision": "pass",
+        "detail": "src/other.rs||delta=1"
+    });
+    let mut history = fs::OpenOptions::new().append(true).open(&log_file).unwrap();
+    writeln!(history, "{other_event}").unwrap();
+
+    let out = run_post_edit_fast_with(
+        &repo,
+        &log_root,
+        &log_file,
+        &edit_input("src/lib.rs", "fn old() {}", "fn clean() {}"),
+        |command| {
+            clear_history_threshold_env(command);
+            command
+                .env("VIBEGUARD_CONFIG_FILE", &missing_config)
+                .env("VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT", "4");
+        },
+    );
+    assert_eq!(out.status.code(), Some(0), "{out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("FAST_OUTPUT"), "{stdout}");
+    assert!(stdout.contains("[CHURN]"), "{stdout}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_paths_reject_conflicting_effective_churn_environment() {
+    for fast in [false, true] {
+        let label = if fast {
+            "post-edit-fast-conflicting-churn"
+        } else {
+            "post-edit-conflicting-churn"
+        };
+        let (root, repo, log_root, log_file) = case_paths(label);
+        let missing_config = root.join("missing-runtime-config.json");
+        let input = edit_input("src/lib.rs", "fn old() {}", "fn clean() {}");
+        let configure = |command: &mut Command| {
+            clear_history_threshold_env(command);
+            command
+                .env("VIBEGUARD_CONFIG_FILE", &missing_config)
+                .env("VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT", "11");
+        };
+        let output = if fast {
+            run_post_edit_fast_with(&repo, &log_root, &log_file, &input, configure)
+        } else {
+            run_post_edit_with(&repo, &log_root, &log_file, &input, configure)
+        };
+        assert_eq!(output.status.code(), Some(20), "{output:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("config_range_error"), "{stderr}");
+        assert!(output.stdout.is_empty(), "{output:?}");
+        let _ = fs::remove_dir_all(root);
+    }
+}
+
+#[test]
+fn post_edit_history_uses_configured_w15_minimum_and_delta_ceiling() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-configured-w15");
+    let missing_config = root.join("missing-runtime-config.json");
+
+    seed_post_edit_history(&log_file, "src/lib.rs", &[100, 80]);
+    let minimum_out = run_post_edit_with(
+        &repo,
+        &log_root,
+        &log_file,
+        &edit_input("src/lib.rs", "", &"x".repeat(40)),
+        |command| {
+            clear_history_threshold_env(command);
+            command
+                .env("VIBEGUARD_CONFIG_FILE", &missing_config)
+                .env("VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS", "4");
+        },
+    );
+    assert_eq!(minimum_out.status.code(), Some(0), "{minimum_out:?}");
+    assert!(!String::from_utf8_lossy(&minimum_out.stdout).contains("[W-15]"));
+
+    seed_post_edit_history(&log_file, "src/lib.rs", &[100, 80]);
+    let ceiling_out = run_post_edit_with(
+        &repo,
+        &log_root,
+        &log_file,
+        &edit_input("src/lib.rs", "", &"x".repeat(70)),
+        |command| {
+            clear_history_threshold_env(command);
+            command
+                .env("VIBEGUARD_CONFIG_FILE", &missing_config)
+                .env("VIBEGUARD_W15_LATEST_DELTA_CHARACTER_CEILING", "60");
+        },
+    );
+    assert_eq!(ceiling_out.status.code(), Some(0), "{ceiling_out:?}");
+    assert!(!String::from_utf8_lossy(&ceiling_out.stdout).contains("[W-15]"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_history_extended_w15_trail_uses_only_latest_three_deltas() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-extended-w15-trail");
+    let missing_config = root.join("missing-runtime-config.json");
+    let events = [
+        json!({
+            "session": "post-edit-session",
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "pass",
+            "detail": "src/lib.rs"
+        }),
+        json!({
+            "session": "post-edit-session",
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "pass",
+            "detail": "src/lib.rs"
+        }),
+        json!({
+            "session": "post-edit-session",
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "pass",
+            "detail": "src/lib.rs||delta=100"
+        }),
+        json!({
+            "session": "post-edit-session",
+            "hook": "post-edit-guard",
+            "tool": "Edit",
+            "decision": "pass",
+            "detail": "src/lib.rs||delta=80"
+        }),
+    ];
+    let history = events
+        .iter()
+        .map(Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&log_file, format!("{history}\n")).expect("history should be written");
+
+    let output = run_post_edit_with(
+        &repo,
+        &log_root,
+        &log_file,
+        &edit_input("src/lib.rs", "", &"x".repeat(40)),
+        |command| {
+            clear_history_threshold_env(command);
+            command
+                .env("VIBEGUARD_CONFIG_FILE", &missing_config)
+                .env("VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS", "5");
+        },
+    );
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[W-15]"), "{stdout}");
+    assert!(stdout.contains("100→80→40"), "{stdout}");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn post_edit_fast_history_uses_configured_w15_minimum_before_shell_fallback() {
+    let (root, repo, log_root, log_file) = case_paths("post-edit-fast-configured-w15");
+    let missing_config = root.join("missing-runtime-config.json");
+    seed_post_edit_history(&log_file, "src/lib.rs", &[100, 80]);
+
+    let out = run_post_edit_fast_with(
+        &repo,
+        &log_root,
+        &log_file,
+        &edit_input("src/lib.rs", "", &"x".repeat(70)),
+        |command| {
+            clear_history_threshold_env(command);
+            command
+                .env("VIBEGUARD_CONFIG_FILE", &missing_config)
+                .env("VIBEGUARD_W15_MINIMUM_CONSECUTIVE_EDITS", "4");
+        },
+    );
+    assert_eq!(out.status.code(), Some(0), "{out:?}");
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("FAST_LOGGED"),
+        "{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
     let _ = fs::remove_dir_all(root);
 }
 

--- a/vibeguard-runtime/tests/runtime_config_guided_cli.rs
+++ b/vibeguard-runtime/tests/runtime_config_guided_cli.rs
@@ -1,0 +1,700 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use serde_json::{Value, json};
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vibeguard-runtime"))
+}
+
+fn guided_config_command(home: &PathBuf, cwd: &PathBuf, args: &[&str]) -> Command {
+    let mut command = bin();
+    command
+        .args(args)
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env_remove("VIBEGUARD_CONFIG_FILE")
+        .env_remove("VG_INTERNAL_CONFIG_FILE")
+        .env_remove("_VG_CONFIG_FILE")
+        .env_remove("VIBEGUARD_PROJECT_CONFIG")
+        .env_remove("VG_INTERNAL_POLICY_CWD")
+        .env_remove("VIBEGUARD_POLICY_CWD")
+        .env_remove("VIBEGUARD_PROJECT_ROOT")
+        .env_remove("VIBEGUARD_PROJECT_CWD")
+        .env_remove("VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT")
+        .env_remove("VIBEGUARD_CHURN_WARNING_EDIT_COUNT")
+        .env_remove("VIBEGUARD_CHURN_CRITICAL_EDIT_COUNT")
+        .env_remove("VIBEGUARD_CHURN_CRITICAL_BUILD_FAILURE_COUNT");
+    command
+}
+
+fn json_at_path<'a>(value: &'a Value, path: &str) -> &'a Value {
+    path.split('.').fold(value, |node, key| &node[key])
+}
+
+fn runtime_config_temp_dir(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "vibeguard-runtime-config-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn assert_config_failure(output: &Output, category: &str) {
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(category),
+        "expected {category} in stderr: {stderr}"
+    );
+}
+
+#[test]
+fn guided_config_commands_init_show_set_reset_and_preserve_layers() {
+    let root = runtime_config_temp_dir("guided_commands");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    fs::create_dir_all(&home).expect("home should be created");
+    fs::create_dir_all(&repo).expect("repo should be created");
+    assert!(
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init should run")
+            .success()
+    );
+
+    let repo_text = repo.to_string_lossy().into_owned();
+    let user_path = home.join(".vibeguard/config.json");
+    let init_user = guided_config_command(
+        &home,
+        &repo,
+        &["config", "init", "--scope", "user", "--cwd", &repo_text],
+    )
+    .output()
+    .expect("user config init should run");
+    assert!(init_user.status.success(), "{init_user:?}");
+    assert!(String::from_utf8_lossy(&init_user.stdout).contains(&user_path.display().to_string()));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&fs::read(&user_path).expect("user config should exist"))
+            .expect("initialized user config should be JSON"),
+        json!({"version": 1})
+    );
+
+    let before_existing_init = fs::read(&user_path).expect("user config should be readable");
+    let existing_init = guided_config_command(
+        &home,
+        &repo,
+        &["config", "init", "--scope", "user", "--cwd", &repo_text],
+    )
+    .output()
+    .expect("second user config init should run");
+    assert_eq!(existing_init.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&existing_init.stderr).contains("already exists"));
+    assert!(
+        String::from_utf8_lossy(&existing_init.stderr).contains(&user_path.display().to_string())
+    );
+    assert_eq!(
+        fs::read(&user_path).expect("user config should remain"),
+        before_existing_init
+    );
+
+    let show = guided_config_command(
+        &home,
+        &repo,
+        &["config", "show", "--cwd", &repo_text, "--json"],
+    )
+    .output()
+    .expect("config show should run");
+    assert!(show.status.success(), "{show:?}");
+    let entries = serde_json::from_slice::<Vec<Value>>(&show.stdout)
+        .expect("config show JSON should be an array");
+    let u16_limit = entries
+        .iter()
+        .find(|entry| entry["key"] == "u16.limit")
+        .expect("config show should include u16.limit");
+    assert_eq!(u16_limit["value"], 800);
+    assert_eq!(u16_limit["source"], "default");
+    assert!(
+        u16_limit["category"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert!(
+        u16_limit["description"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+
+    let set_user = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "set",
+            "u16.limit",
+            "1234",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("user config set should run");
+    assert!(set_user.status.success(), "{set_user:?}");
+    assert!(String::from_utf8_lossy(&set_user.stdout).contains("u16.limit"));
+    assert!(String::from_utf8_lossy(&set_user.stdout).contains(&user_path.display().to_string()));
+    let user_value = serde_json::from_slice::<Value>(&fs::read(&user_path).unwrap())
+        .expect("user config should remain JSON");
+    assert_eq!(json_at_path(&user_value, "u16.limit"), &json!(1234));
+    assert_eq!(user_value["version"], 1);
+
+    let set_skills = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "set",
+            "disabled_skills",
+            "plan-flow,fixflow",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("string-array config set should run");
+    assert!(set_skills.status.success(), "{set_skills:?}");
+    let user_value = serde_json::from_slice::<Value>(&fs::read(&user_path).unwrap())
+        .expect("user config should remain JSON");
+    assert_eq!(
+        user_value["disabled_skills"],
+        json!(["plan-flow", "fixflow"])
+    );
+
+    let reset_skills = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "set",
+            "disabled_skills",
+            "",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("empty string-array config set should run");
+    assert!(reset_skills.status.success(), "{reset_skills:?}");
+    let user_value = serde_json::from_slice::<Value>(&fs::read(&user_path).unwrap())
+        .expect("user config should remain JSON");
+    assert_eq!(user_value["disabled_skills"], json!([]));
+
+    let reset_user = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "reset",
+            "u16.limit",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("user config reset should run");
+    assert!(reset_user.status.success(), "{reset_user:?}");
+    assert!(String::from_utf8_lossy(&reset_user.stdout).contains("u16.limit"));
+    let user_value = serde_json::from_slice::<Value>(&fs::read(&user_path).unwrap())
+        .expect("user config should remain JSON");
+    assert!(user_value["u16"].get("limit").is_none());
+    assert_eq!(user_value["version"], 1);
+
+    let project_path = repo.join(".vibeguard.json");
+    let init_project = guided_config_command(
+        &home,
+        &repo,
+        &["config", "init", "--scope", "project", "--cwd", &repo_text],
+    )
+    .output()
+    .expect("project config init should run");
+    assert!(init_project.status.success(), "{init_project:?}");
+    assert!(
+        String::from_utf8_lossy(&init_project.stdout).contains(&project_path.display().to_string())
+    );
+
+    for (key, value) in [
+        ("profile", "strict"),
+        ("enforcement", "warn"),
+        ("languages", "rust,typescript"),
+        ("u16.limit", "1200"),
+    ] {
+        let output = guided_config_command(
+            &home,
+            &repo,
+            &[
+                "config", "set", key, value, "--scope", "project", "--cwd", &repo_text,
+            ],
+        )
+        .output()
+        .expect("project config set should run");
+        assert!(output.status.success(), "{key}: {output:?}");
+    }
+    let project_value = serde_json::from_slice::<Value>(&fs::read(&project_path).unwrap())
+        .expect("project config should remain JSON");
+    assert_eq!(project_value["profile"], "strict");
+    assert_eq!(project_value["enforcement"], "warn");
+    assert_eq!(project_value["languages"], json!(["rust", "typescript"]));
+    assert_eq!(json_at_path(&project_value, "u16.limit"), &json!(1200));
+    assert_eq!(project_value["version"], 1);
+
+    for key in ["profile", "enforcement", "languages", "u16.limit"] {
+        let output = guided_config_command(
+            &home,
+            &repo,
+            &[
+                "config", "reset", key, "--scope", "project", "--cwd", &repo_text,
+            ],
+        )
+        .output()
+        .expect("project config reset should run");
+        assert!(output.status.success(), "{key}: {output:?}");
+    }
+    let project_value = serde_json::from_slice::<Value>(&fs::read(&project_path).unwrap())
+        .expect("project config should remain JSON");
+    assert!(project_value.get("profile").is_none());
+    assert!(project_value.get("enforcement").is_none());
+    assert!(project_value.get("languages").is_none());
+    assert!(project_value.get("u16").is_none());
+    assert_eq!(project_value["version"], 1);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn guided_config_show_json_reports_all_source_layers_with_metadata() {
+    let root = runtime_config_temp_dir("guided_show_sources");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    let user_path = home.join(".vibeguard/config.json");
+    fs::create_dir_all(user_path.parent().unwrap()).expect("user config parent should exist");
+    fs::create_dir_all(&repo).expect("repo should exist");
+    assert!(
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init should run")
+            .success()
+    );
+    fs::write(&user_path, r#"{"u16":{"warn_limit":450}}"#).expect("user config should be written");
+    fs::write(repo.join(".vibeguard.json"), r#"{"u16":{"limit":900}}"#)
+        .expect("project config should be written");
+    let repo_text = repo.to_string_lossy().into_owned();
+
+    let output = guided_config_command(
+        &home,
+        &repo,
+        &["config", "show", "--cwd", &repo_text, "--json"],
+    )
+    .env_remove("VG_U16_WARN_LIMIT")
+    .env_remove("VG_U16_LIMIT")
+    .env("VG_CB_THRESHOLD", "9")
+    .output()
+    .expect("config show should run");
+    assert!(output.status.success(), "{output:?}");
+    let entries = serde_json::from_slice::<Vec<Value>>(&output.stdout)
+        .expect("config show should emit JSON entries");
+    let entry = |key: &str| {
+        entries
+            .iter()
+            .find(|entry| entry["key"] == key)
+            .unwrap_or_else(|| panic!("missing show entry for {key}"))
+    };
+    assert_eq!(entry("version")["source"], "default");
+    assert_eq!(entry("u16.warn_limit")["source"], "user_config");
+    assert_eq!(entry("u16.limit")["source"], "project_config");
+    assert_eq!(entry("circuit_breaker.threshold")["source"], "environment");
+    for item in &entries {
+        assert!(
+            item["category"]
+                .as_str()
+                .is_some_and(|text| !text.is_empty())
+        );
+        assert!(
+            item["description"]
+                .as_str()
+                .is_some_and(|text| !text.is_empty())
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn guided_user_config_creation_and_replacement_are_private() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = runtime_config_temp_dir("guided_private_user_config");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    fs::create_dir_all(&home).expect("home should exist");
+    fs::create_dir_all(&repo).expect("repo should exist");
+    let repo_text = repo.to_string_lossy().into_owned();
+    let user_path = home.join(".vibeguard/config.json");
+
+    let set = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "set",
+            "u16.limit",
+            "900",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("user config set should run");
+    assert!(set.status.success(), "{set:?}");
+    assert_eq!(
+        fs::metadata(&user_path)
+            .expect("user config should exist")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let reset = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "reset",
+            "u16.limit",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("user config reset should run");
+    assert!(reset.status.success(), "{reset:?}");
+    assert_eq!(
+        fs::metadata(&user_path)
+            .expect("user config should remain")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    fs::remove_file(&user_path).expect("user config should be removable");
+    let init = guided_config_command(
+        &home,
+        &repo,
+        &["config", "init", "--scope", "user", "--cwd", &repo_text],
+    )
+    .output()
+    .expect("user config init should run");
+    assert!(init.status.success(), "{init:?}");
+    assert_eq!(
+        fs::metadata(&user_path)
+            .expect("initialized user config should exist")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn guided_config_invalid_set_and_reset_leave_existing_bytes_unchanged() {
+    let root = runtime_config_temp_dir("guided_atomic_failure");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    let user_path = home.join(".vibeguard/config.json");
+    fs::create_dir_all(&repo).expect("repo should be created");
+    fs::create_dir_all(user_path.parent().unwrap()).expect("user config parent should be created");
+    fs::write(
+        &user_path,
+        "{\n  \"version\": 1,\n  \"u16\": {\"limit\": 900}\n}\n",
+    )
+    .expect("user config should be written");
+    let repo_text = repo.to_string_lossy().into_owned();
+
+    let cases: Vec<Vec<&str>> = vec![
+        vec![
+            "config",
+            "set",
+            "u16.limit",
+            "not-an-integer",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+        vec![
+            "config",
+            "set",
+            "churn.informational_edit_count",
+            "11",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+        vec![
+            "config",
+            "set",
+            "churn.informational_edit_count",
+            "0",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+        vec![
+            "config", "reset", "profile", "--scope", "user", "--cwd", &repo_text,
+        ],
+    ];
+    for args in cases {
+        let before = fs::read(&user_path).expect("user config should be readable");
+        let output = guided_config_command(&home, &repo, &args)
+            .output()
+            .expect("invalid guided config command should run");
+        assert_eq!(output.status.code(), Some(1), "{output:?}");
+        assert!(!output.stdout.is_empty() || !output.stderr.is_empty());
+        assert_eq!(
+            fs::read(&user_path).expect("user config should remain readable"),
+            before,
+            "failed command changed user config for {args:?}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn guided_config_show_rejects_effective_churn_conflicts() {
+    let root = runtime_config_temp_dir("guided_effective_churn_show");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    let user_path = home.join(".vibeguard/config.json");
+    let project_path = repo.join(".vibeguard.json");
+    fs::create_dir_all(user_path.parent().unwrap()).expect("user config parent should exist");
+    fs::create_dir_all(&repo).expect("repo should exist");
+    assert!(
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init should run")
+            .success()
+    );
+    fs::write(
+        &user_path,
+        r#"{"churn":{"informational_edit_count":15,"warning_edit_count":15,"critical_edit_count":20}}"#,
+    )
+    .expect("user config should be written");
+    fs::write(&project_path, r#"{"churn":{"warning_edit_count":12}}"#)
+        .expect("project config should be written");
+    let repo_text = repo.to_string_lossy().into_owned();
+
+    let cross_layer = guided_config_command(
+        &home,
+        &repo,
+        &["config", "show", "--cwd", &repo_text, "--json"],
+    )
+    .output()
+    .expect("config show should run");
+    assert_config_failure(&cross_layer, "config_range_error");
+
+    fs::write(&user_path, "{}\n").expect("user config should be replaced");
+    fs::write(&project_path, "{}\n").expect("project config should be replaced");
+    let environment = guided_config_command(
+        &home,
+        &repo,
+        &["config", "show", "--cwd", &repo_text, "--json"],
+    )
+    .env("VIBEGUARD_CHURN_INFORMATIONAL_EDIT_COUNT", "11")
+    .output()
+    .expect("config show should run");
+    assert_config_failure(&environment, "config_range_error");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn guided_config_show_accepts_valid_partial_churn_layers() {
+    let root = runtime_config_temp_dir("guided_valid_partial_churn_layers");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    let user_path = home.join(".vibeguard/config.json");
+    fs::create_dir_all(user_path.parent().unwrap()).expect("user config parent should exist");
+    fs::create_dir_all(&repo).expect("repo should exist");
+    assert!(
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init should run")
+            .success()
+    );
+    fs::write(&user_path, r#"{"churn":{"informational_edit_count":15}}"#)
+        .expect("user config should be written");
+    fs::write(
+        repo.join(".vibeguard.json"),
+        r#"{"churn":{"warning_edit_count":20,"critical_edit_count":20}}"#,
+    )
+    .expect("project config should be written");
+    let repo_text = repo.to_string_lossy().into_owned();
+
+    let output = guided_config_command(
+        &home,
+        &repo,
+        &["config", "show", "--cwd", &repo_text, "--json"],
+    )
+    .output()
+    .expect("config show should run");
+    assert!(output.status.success(), "{output:?}");
+    let entries = serde_json::from_slice::<Vec<Value>>(&output.stdout)
+        .expect("config show should emit JSON entries");
+    let entry = |key: &str| {
+        entries
+            .iter()
+            .find(|entry| entry["key"] == key)
+            .unwrap_or_else(|| panic!("missing show entry for {key}"))
+    };
+    assert_eq!(entry("churn.informational_edit_count")["value"], 15);
+    assert_eq!(
+        entry("churn.informational_edit_count")["source"],
+        "user_config"
+    );
+    assert_eq!(entry("churn.warning_edit_count")["value"], 20);
+    assert_eq!(
+        entry("churn.warning_edit_count")["source"],
+        "project_config"
+    );
+    assert_eq!(entry("churn.critical_edit_count")["value"], 20);
+    assert_eq!(
+        entry("churn.critical_edit_count")["source"],
+        "project_config"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn guided_user_set_rejects_effective_churn_conflict_without_writing() {
+    let root = runtime_config_temp_dir("guided_effective_user_set");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    let user_path = home.join(".vibeguard/config.json");
+    fs::create_dir_all(user_path.parent().unwrap()).expect("user config parent should exist");
+    fs::create_dir_all(repo.join(".git")).expect("git marker should exist");
+    fs::write(
+        &user_path,
+        "{\n  \"churn\": {\"informational_edit_count\": 5, \"warning_edit_count\": 15, \"critical_edit_count\": 20}\n}\n",
+    )
+    .expect("user config should be written");
+    fs::write(
+        repo.join(".vibeguard.json"),
+        r#"{"churn":{"warning_edit_count":12}}"#,
+    )
+    .expect("project config should be written");
+    let before = fs::read(&user_path).expect("user config should be readable");
+    let repo_text = repo.to_string_lossy().into_owned();
+
+    let output = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "set",
+            "churn.informational_edit_count",
+            "15",
+            "--scope",
+            "user",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("config set should run");
+    assert_config_failure(&output, "config_range_error");
+    assert_eq!(
+        fs::read(&user_path).expect("user config should remain readable"),
+        before
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn guided_project_set_rejects_effective_churn_conflict_without_writing() {
+    let root = runtime_config_temp_dir("guided_effective_project_set");
+    let home = root.join("home");
+    let repo = root.join("repo");
+    let user_path = home.join(".vibeguard/config.json");
+    let project_path = repo.join(".vibeguard.json");
+    fs::create_dir_all(user_path.parent().unwrap()).expect("user config parent should exist");
+    fs::create_dir_all(repo.join(".git")).expect("git marker should exist");
+    fs::write(
+        &user_path,
+        r#"{"churn":{"informational_edit_count":9,"warning_edit_count":15,"critical_edit_count":20}}"#,
+    )
+    .expect("user config should be written");
+    fs::write(
+        &project_path,
+        "{\n  \"churn\": {\"warning_edit_count\": 12}\n}\n",
+    )
+    .expect("project config should be written");
+    let before = fs::read(&project_path).expect("project config should be readable");
+    let repo_text = repo.to_string_lossy().into_owned();
+
+    let output = guided_config_command(
+        &home,
+        &repo,
+        &[
+            "config",
+            "set",
+            "churn.warning_edit_count",
+            "8",
+            "--scope",
+            "project",
+            "--cwd",
+            &repo_text,
+        ],
+    )
+    .output()
+    .expect("config set should run");
+    assert_config_failure(&output, "config_range_error");
+    assert_eq!(
+        fs::read(&project_path).expect("project config should remain readable"),
+        before
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/vibeguard-runtime/tests/runtime_config_schema.rs
+++ b/vibeguard-runtime/tests/runtime_config_schema.rs
@@ -92,3 +92,24 @@ fn schema_and_runtime_reject_non_integral_numbers() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("category=config_type_error"));
     let _ = fs::remove_file(path);
 }
+
+#[test]
+fn published_schema_includes_guided_history_thresholds() {
+    let schema = published_schema();
+    for (path, minimum, maximum, default) in [
+        ("churn.informational_edit_count", 1, 1_000_000, 5),
+        ("churn.warning_edit_count", 1, 1_000_000, 10),
+        ("churn.critical_edit_count", 1, 1_000_000, 20),
+        ("churn.critical_build_failure_count", 1, 1_000_000, 5),
+        ("w15.minimum_consecutive_edits", 3, 1_000_000, 3),
+        ("w15.latest_delta_character_ceiling", 0, 1_000_000, 300),
+    ] {
+        let field = path
+            .split('.')
+            .fold(&schema, |node, key| &node["properties"][key]);
+        assert_eq!(field["type"], "integer", "{path}");
+        assert_eq!(field["minimum"], minimum, "{path}");
+        assert_eq!(field["maximum"], maximum, "{path}");
+        assert_eq!(field["default"], default, "{path}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a guided configuration surface so users can inspect effective values and their sources, initialize user or project configuration, and safely set or reset supported fields. It also makes churn and W-15 thresholds configurable while validating the fully resolved default/user/project/environment precedence chain before writes or hook decisions.

This deliberately keeps VibeGuard's fixed agent-message core intact and exposes bounded numeric/policy controls rather than arbitrary prompt injection.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## Checklist

- [x] Tests pass (`cargo test` / `go test ./...` / `pytest`)
- [x] Guard scripts tested (if applicable)
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used (`feat:` / `fix:` / `chore:` etc.)

## Related issues

Closes #783

## Screenshots / logs

- `cargo fmt --check`, `cargo check`, and `cargo clippy --all-targets -- -D warnings`
- Runtime config CLI: 12 legacy + 8 guided tests passed
- Runtime config schema: 4 passed
- Post-edit CLI: 23 passed
- Churn shell suite: 23 passed
- W-15 shell suite: 10 passed
- `bash scripts/local-contract-check.sh --quick`: passed
