### PR TITLE
feat(observe): add bounded value evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 vibeguard observe summary --limit all        # Project trigger summary (7 days)
 vibeguard observe health --limit all         # Project health snapshot (24 hours)
 vibeguard observe summary --scope global --limit all # Global trigger summary
+vibeguard observe value                       # Bounded local event-stream evidence
 vibeguard observe export prometheus          # Prometheus text export
 bash ~/vibeguard/setup.sh doctor             # Installation and host diagnosis
 ```

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -196,6 +196,7 @@ export PATH="$HOME/.vibeguard/installed/bin:$PATH"
 vibeguard observe summary --limit all
 vibeguard observe health --limit all
 vibeguard observe summary --scope global --limit all
+vibeguard observe value
 vibeguard observe export prometheus
 bash ~/vibeguard/setup.sh doctor
 ```

--- a/docs/command-schemas.md
+++ b/docs/command-schemas.md
@@ -12,6 +12,7 @@ Executable schema sources:
 - `schemas/command-learn-output.schema.json`
 - `schemas/event-log.schema.json`
 - `schemas/session-metrics.schema.json`
+- `schemas/observe-output.schema.json`
 
 ## observability JSONL Schemas
 
@@ -19,6 +20,7 @@ Runtime observability rows are validated one JSONL row at a time:
 
 - `schemas/event-log.schema.json` describes `events.jsonl` hook events.
 - `schemas/session-metrics.schema.json` describes `session-metrics.jsonl` rows emitted by `vibeguard-runtime session-metrics`.
+- `schemas/observe-output.schema.json` describes the common `observe` envelope and the bounded `value` evidence object.
 
 Schema v1 requires current event-log rows to include `schema_version`, `ts`,
 `session`, `hook`, `tool`, `decision`, and `status`. Rows may also include

--- a/docs/reference/observability-harness.md
+++ b/docs/reference/observability-harness.md
@@ -52,9 +52,9 @@ Required event fields are:
 - `decision`
 - `status`
 
-Current rows may also include `event`, `matcher`, `reason`, `detail`, `duration_ms`,
-`elapsed_ms`, `timeout_ms`, `model_context`, `log_path`, `source`, and caller
-identity fields such as `cli`, `client`, and `wrapper`.
+Current rows may also include `record_id`, `event`, `matcher`, `reason`, `detail`,
+`duration_ms`, `elapsed_ms`, `timeout_ms`, `model_context`, `log_path`, `source`,
+and caller identity fields such as `cli`, `client`, and `wrapper`.
 
 Use this log for:
 
@@ -100,9 +100,34 @@ Use the smallest surface that answers the question.
 |---|---|
 | What happened in this project? | `vibeguard observe summary --limit all` |
 | What happened globally? | `vibeguard observe summary --scope global --limit all` |
+| What does the local event stream support? | `vibeguard observe value` |
 | Why did this session have friction? | `session-metrics.jsonl` and `correction_signals` |
 | Which hook is slow? | `vibeguard-runtime hook-status --mode full --slow-ms 2000` |
 | Did eval quality regress? | `python3 eval/run_behavior_eval.py --fail-on-threshold` and `python3 eval/summarize_runs.py` |
+
+### Bounded value view
+
+`vibeguard observe value` reports bounded evidence from the selected local event
+stream. It begins with an evidence boundary and separates `Verified`, `Observed`,
+and `Estimated/unavailable` output. `--json` retains the common observe envelope
+and adds a `value` object. The default window is the last seven days; use
+`--scope`, `--days` or `--hours`, and `--log-file` to select the source and
+window.
+
+Attention counts include only canonical `warn`, `block`, `gate`, `escalate`, and
+`correction` states. Slow or timeout diagnostics alone are not attention events.
+A later follow-up pass requires a non-empty session, parseable timestamps, and a
+strictly later ordinary pass in the same session. A later `post-build-check` pass
+is reported as verified build evidence, but remains an association rather than
+proof that VibeGuard caused the result. Skipped passes are excluded, equal or
+unparseable timestamps do not establish order, and uncorrelatable attention is
+counted visibly.
+
+The view reports observed suppression events and effective hook duration
+statistics when present. Estimated evidence is unavailable by default because
+the local event stream does not provide causal outcome or savings data. Missing
+logs and existing logs with no events in the selected window are distinct JSON
+`data_state` values.
 
 `docs/reference/codex-hook-status.md` documents the focused hook-status surface.
 `docs/reference/hook-latency-contract.md` documents the latency regression gate.

--- a/schemas/observe-output.schema.json
+++ b/schemas/observe-output.schema.json
@@ -19,6 +19,7 @@
   ],
   "oneOf": [
     {
+      "not": { "required": ["value"] },
       "properties": {
         "command": { "enum": ["summary", "health", "session"] }
       }
@@ -194,7 +195,6 @@
       "type": "object",
       "required": [
         "ts",
-        "record_id",
         "session",
         "hook",
         "event",
@@ -211,7 +211,6 @@
       "additionalProperties": false,
       "properties": {
         "ts": { "type": "string" },
-        "record_id": { "type": "string" },
         "session": { "type": "string" },
         "hook": { "type": "string" },
         "event": { "type": "string" },

--- a/schemas/observe-output.schema.json
+++ b/schemas/observe-output.schema.json
@@ -17,10 +17,23 @@
     "top_reason_codes",
     "duration_stats"
   ],
+  "oneOf": [
+    {
+      "properties": {
+        "command": { "enum": ["summary", "health", "session"] }
+      }
+    },
+    {
+      "required": ["value"],
+      "properties": {
+        "command": { "const": "value" }
+      }
+    }
+  ],
   "additionalProperties": false,
   "properties": {
     "schema_version": { "const": 1 },
-    "command": { "enum": ["summary", "health", "session"] },
+    "command": { "enum": ["summary", "health", "session", "value"] },
     "source": {
       "type": "object",
       "required": ["log_path", "scope", "period", "limit"],
@@ -93,6 +106,71 @@
     "recent_events": {
       "type": "array",
       "items": { "$ref": "#/$defs/event" }
+    },
+    "value": {
+      "type": "object",
+      "required": ["data_state", "verified", "observed", "estimated", "limitations"],
+      "additionalProperties": false,
+      "properties": {
+        "data_state": { "enum": ["observed", "empty", "missing"] },
+        "verified": {
+          "type": "object",
+          "required": ["sessions_with_later_build_pass", "definition"],
+          "additionalProperties": false,
+          "properties": {
+            "sessions_with_later_build_pass": { "type": "integer", "minimum": 0 },
+            "definition": { "type": "string", "minLength": 1 }
+          }
+        },
+        "observed": {
+          "type": "object",
+          "required": [
+            "attention_events",
+            "sessions_with_attention",
+            "sessions_with_later_follow_up_pass",
+            "sessions_without_later_follow_up_pass",
+            "sessions_with_repeated_attention",
+            "uncorrelatable_attention_events",
+            "suppression_events",
+            "hook_duration_ms"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "attention_events": { "type": "integer", "minimum": 0 },
+            "sessions_with_attention": { "type": "integer", "minimum": 0 },
+            "sessions_with_later_follow_up_pass": { "type": "integer", "minimum": 0 },
+            "sessions_without_later_follow_up_pass": { "type": "integer", "minimum": 0 },
+            "sessions_with_repeated_attention": { "type": "integer", "minimum": 0 },
+            "uncorrelatable_attention_events": { "type": "integer", "minimum": 0 },
+            "suppression_events": { "type": "integer", "minimum": 0 },
+            "hook_duration_ms": {
+              "type": "object",
+              "required": ["count", "total_ms", "avg_ms", "p95_ms"],
+              "additionalProperties": false,
+              "properties": {
+                "count": { "type": "integer", "minimum": 0 },
+                "total_ms": { "type": "integer", "minimum": 0 },
+                "avg_ms": { "type": "integer", "minimum": 0 },
+                "p95_ms": { "type": ["integer", "null"], "minimum": 0 }
+              }
+            }
+          }
+        },
+        "estimated": {
+          "type": "object",
+          "required": ["available", "reason"],
+          "additionalProperties": false,
+          "properties": {
+            "available": { "const": false },
+            "reason": { "type": "string", "minLength": 1 }
+          }
+        },
+        "limitations": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
     }
   },
   "$defs": {
@@ -116,6 +194,7 @@
       "type": "object",
       "required": [
         "ts",
+        "record_id",
         "session",
         "hook",
         "event",
@@ -132,6 +211,7 @@
       "additionalProperties": false,
       "properties": {
         "ts": { "type": "string" },
+        "record_id": { "type": "string" },
         "session": { "type": "string" },
         "hook": { "type": "string" },
         "event": { "type": "string" },

--- a/scripts/lib/workflow_contracts.py
+++ b/scripts/lib/workflow_contracts.py
@@ -112,6 +112,10 @@ def validate_instance(
     if "enum" in schema and instance not in schema["enum"]:
         errors.append(f"{path}: expected one of {schema['enum']}, got {instance!r}")
 
+    excluded = schema.get("not")
+    if isinstance(excluded, dict) and not validate_instance(instance, excluded, path, root_schema):
+        errors.append(f"{path}: must not match the excluded schema")
+
     any_of = schema.get("anyOf")
     if isinstance(any_of, list):
         branch_errors: list[str] = []

--- a/tests/fixtures/observability-schemas/observe-value-current.json
+++ b/tests/fixtures/observability-schemas/observe-value-current.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "command": "value",
+  "source": {
+    "log_path": "~/.vibeguard/events.jsonl",
+    "scope": "project",
+    "period": "last 7 days",
+    "limit": 5000
+  },
+  "time_range": {
+    "first_ts": "2026-08-24T00:00:00Z",
+    "last_ts": "2026-08-30T00:00:00Z"
+  },
+  "event_count": 3,
+  "decision_counts": {
+    "pass": 2,
+    "warn": 1
+  },
+  "block_counts": {
+    "total_blocks": 0,
+    "protocol_errors": 0,
+    "non_protocol_blocks": 0
+  },
+  "hook_counts": {
+    "post-build-check": 1,
+    "post-edit-guard": 2
+  },
+  "client_distribution": {
+    "codex": 3
+  },
+  "attention": {
+    "count": 1,
+    "rate": 0.333,
+    "percent": 33.3
+  },
+  "top_rule_ids": [],
+  "top_reason_codes": [],
+  "duration_stats": {
+    "count": 3,
+    "avg_ms": 20,
+    "min_ms": 10,
+    "p95_ms": 30,
+    "max_ms": 30,
+    "slow_count": 0,
+    "slow_ms": 2000
+  },
+  "value": {
+    "data_state": "observed",
+    "verified": {
+      "sessions_with_later_build_pass": 1,
+      "definition": "A strictly later ordinary pass from post-build-check in the same non-empty session after attention; this is an association, not proof VibeGuard caused the result."
+    },
+    "observed": {
+      "attention_events": 1,
+      "sessions_with_attention": 1,
+      "sessions_with_later_follow_up_pass": 1,
+      "sessions_without_later_follow_up_pass": 0,
+      "sessions_with_repeated_attention": 0,
+      "uncorrelatable_attention_events": 0,
+      "suppression_events": 0,
+      "hook_duration_ms": {
+        "count": 3,
+        "total_ms": 60,
+        "avg_ms": 20,
+        "p95_ms": 30
+      }
+    },
+    "estimated": {
+      "available": false,
+      "reason": "The local event stream has no causal, incident, token, time, or money outcome evidence for estimates."
+    },
+    "limitations": [
+      "Later passes and build checks are associations in the event stream, not proof VibeGuard caused the result.",
+      "Counts consider at most the configured 5000 most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered."
+    ]
+  }
+}

--- a/tests/fixtures/observability-schemas/observe-value-invalid-tier.json
+++ b/tests/fixtures/observability-schemas/observe-value-invalid-tier.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "command": "value",
+  "source": {
+    "log_path": "events.jsonl",
+    "scope": "project",
+    "period": "last 7 days",
+    "limit": 5000
+  },
+  "time_range": {
+    "first_ts": "",
+    "last_ts": ""
+  },
+  "event_count": 0,
+  "decision_counts": {},
+  "hook_counts": {},
+  "client_distribution": {},
+  "attention": {
+    "count": 0,
+    "rate": 0,
+    "percent": 0
+  },
+  "top_rule_ids": [],
+  "top_reason_codes": [],
+  "duration_stats": {
+    "count": 0,
+    "avg_ms": 0,
+    "min_ms": null,
+    "p95_ms": null,
+    "max_ms": null,
+    "slow_count": 0,
+    "slow_ms": 2000
+  },
+  "value": {
+    "data_state": "observed",
+    "verified": {
+      "sessions_with_later_build_pass": 1,
+      "definition": "valid"
+    },
+    "observed": {
+      "attention_events": 1,
+      "sessions_with_attention": 1,
+      "sessions_with_later_follow_up_pass": 1,
+      "sessions_without_later_follow_up_pass": 0,
+      "sessions_with_repeated_attention": 0,
+      "uncorrelatable_attention_events": 0,
+      "suppression_events": 0,
+      "hook_duration_ms": {
+        "count": 0,
+        "total_ms": 0,
+        "avg_ms": 0,
+        "p95_ms": null
+      }
+    },
+    "estimated": {
+      "available": "false",
+      "reason": "valid"
+    },
+    "limitations": ["valid"]
+  }
+}

--- a/tests/fixtures/observability-schemas/observe-value-missing-tier.json
+++ b/tests/fixtures/observability-schemas/observe-value-missing-tier.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "command": "value",
+  "source": {
+    "log_path": "events.jsonl",
+    "scope": "project",
+    "period": "last 7 days",
+    "limit": 5000
+  },
+  "time_range": {
+    "first_ts": "",
+    "last_ts": ""
+  },
+  "event_count": 0,
+  "decision_counts": {},
+  "hook_counts": {},
+  "client_distribution": {},
+  "attention": {
+    "count": 0,
+    "rate": 0,
+    "percent": 0
+  },
+  "top_rule_ids": [],
+  "top_reason_codes": [],
+  "duration_stats": {
+    "count": 0,
+    "avg_ms": 0,
+    "min_ms": null,
+    "p95_ms": null,
+    "max_ms": null,
+    "slow_count": 0,
+    "slow_ms": 2000
+  },
+  "value": {
+    "data_state": "empty",
+    "verified": {
+      "sessions_with_later_build_pass": 0,
+      "definition": "valid"
+    },
+    "observed": {
+      "attention_events": 0,
+      "sessions_with_attention": 0,
+      "sessions_with_later_follow_up_pass": 0,
+      "sessions_without_later_follow_up_pass": 0,
+      "sessions_with_repeated_attention": 0,
+      "uncorrelatable_attention_events": 0,
+      "suppression_events": 0,
+      "hook_duration_ms": {
+        "count": 0,
+        "total_ms": 0,
+        "avg_ms": 0,
+        "p95_ms": null
+      }
+    },
+    "estimated": {
+      "available": false,
+      "reason": "valid"
+    }
+  }
+}

--- a/tests/test_observability_schemas.sh
+++ b/tests/test_observability_schemas.sh
@@ -68,6 +68,8 @@ schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
 if mode == "utf8_lossy_hex":
     raw_lines = [bytes.fromhex(fixture_path.read_text(encoding="ascii").strip())]
+elif mode == "single_json":
+    raw_lines = [fixture_path.read_bytes()]
 else:
     raw_lines = fixture_path.read_bytes().splitlines()
 
@@ -120,6 +122,14 @@ assert_cmd "malformed UTF-8 is recovered before schema validation" \
 header "session metrics schema"
 assert_cmd "current session metrics rows validate" \
   run_schema_check "schemas/session-metrics.schema.json" "${FIXTURES_DIR}/session-metrics-current.jsonl"
+
+header "observe value output schema"
+assert_cmd "current observe value output validates" \
+  run_schema_check "schemas/observe-output.schema.json" "${FIXTURES_DIR}/observe-value-current.json" "single_json"
+assert_fails "invalid observe value evidence tier fails validation" \
+  run_schema_check "schemas/observe-output.schema.json" "${FIXTURES_DIR}/observe-value-invalid-tier.json" "single_json"
+assert_fails "missing observe value evidence tier fails validation" \
+  run_schema_check "schemas/observe-output.schema.json" "${FIXTURES_DIR}/observe-value-missing-tier.json" "single_json"
 
 printf '\n'
 if [[ "$FAIL" -eq 0 ]]; then

--- a/tests/test_observability_schemas.sh
+++ b/tests/test_observability_schemas.sh
@@ -68,7 +68,7 @@ schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
 if mode == "utf8_lossy_hex":
     raw_lines = [bytes.fromhex(fixture_path.read_text(encoding="ascii").strip())]
-elif mode == "single_json":
+elif mode in {"single_json", "single_json_summary_with_value"}:
     raw_lines = [fixture_path.read_bytes()]
 else:
     raw_lines = fixture_path.read_bytes().splitlines()
@@ -89,6 +89,8 @@ for line_number, raw_line in enumerate(raw_lines, start=1):
     if not isinstance(row, dict):
         errors.append(f"{fixture_path}:{line_number}: row must be a JSON object")
         continue
+    if mode == "single_json_summary_with_value":
+        row["command"] = "summary"
     row_errors = module.validate_instance(row, schema)
     if row_errors:
         errors.extend(f"{fixture_path}:{line_number}: {error}" for error in row_errors)
@@ -130,6 +132,11 @@ assert_fails "invalid observe value evidence tier fails validation" \
   run_schema_check "schemas/observe-output.schema.json" "${FIXTURES_DIR}/observe-value-invalid-tier.json" "single_json"
 assert_fails "missing observe value evidence tier fails validation" \
   run_schema_check "schemas/observe-output.schema.json" "${FIXTURES_DIR}/observe-value-missing-tier.json" "single_json"
+assert_fails "non-value command rejects value evidence" \
+  run_schema_check "schemas/observe-output.schema.json" "${FIXTURES_DIR}/observe-value-current.json" "single_json_summary_with_value"
+assert_cmd "schema v1 rendered event contract excludes record_id" \
+  python3 -c 'import json,sys; event=json.load(open(sys.argv[1], encoding="utf-8"))["$defs"]["event"]; assert "record_id" not in event["required"]; assert "record_id" not in event["properties"]' \
+  "${REPO_DIR}/schemas/observe-output.schema.json"
 
 printf '\n'
 if [[ "$FAIL" -eq 0 ]]; then

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -363,9 +363,9 @@ with open(path, "w", encoding="utf-8") as f:
         f.write(json.dumps(event) + "\n")
 PY
 
-stats_sections_out="$(VIBEGUARD_LOG_DIR="${TMP_DIR}/stats-sections-log" bash "${SCRIPT}" --scope global 7 2>&1)"
-assert_contains "${stats_sections_out}" "== Warn compliance rate analysis ==" "Warn compliance section is preserved"
-assert_contains "${stats_sections_out}" "pre-bash-guard: warn=1 pass=1 compliance rate=50% [LOW]" "Warn compliance computes pass ratio"
+stats_sections_out="$(VIBEGUARD_RUNTIME="${RUNTIME}" VIBEGUARD_LOG_DIR="${TMP_DIR}/stats-sections-log" bash "${SCRIPT}" --scope global 7 2>&1)"
+assert_not_contains "${stats_sections_out}" "Warn compliance rate analysis" "Summary omits warn-compliance proxy"
+assert_not_contains "${stats_sections_out}" "upgrade to block" "Summary omits automatic block-upgrade recommendation"
 assert_contains "${stats_sections_out}" "Distributed by file type:" "File type section is preserved"
 assert_contains "${stats_sections_out}" ".rs: 2 times" "File type distribution counts details"
 assert_contains "${stats_sections_out}" "Distributed by time period:" "Time period section is preserved"
@@ -373,7 +373,7 @@ assert_contains "${stats_sections_out}" "working time (09-18): 2 times (50%)" "W
 assert_contains "${stats_sections_out}" "== Performance analysis ==" "Performance section is preserved"
 assert_contains "${stats_sections_out}" "Total number of sessions: 2" "Session count is preserved"
 assert_contains "${stats_sections_out}" "Average triggers per session: 2.0 times" "Average trigger count is preserved"
-assert_contains "${stats_sections_out}" "Deterministic node estimated savings: ~2K tokens" "Token savings estimate is preserved"
+assert_not_contains "${stats_sections_out}" "estimated savings" "Summary omits token-savings proxy"
 assert_contains "${stats_sections_out}" "Conversations with the most questions Top 3:" "Problem sessions section is preserved"
 assert_contains "${stats_sections_out}" "session-b: 2 issues / 2 triggers" "Problem sessions are ranked"
 

--- a/vibeguard-runtime/src/main.rs
+++ b/vibeguard-runtime/src/main.rs
@@ -157,7 +157,7 @@ static COMMANDS: &[Command] = &[
     },
     Command {
         name: "observe",
-        usage: "<summary|health|session|export prometheus> [options]  — query observability summaries or export low-cardinality metrics",
+        usage: "<summary|health|session|value|export prometheus> [options]  — query observability summaries or export low-cardinality metrics",
         handler: observe::run,
     },
     Command {

--- a/vibeguard-runtime/src/observe/aggregate.rs
+++ b/vibeguard-runtime/src/observe/aggregate.rs
@@ -106,7 +106,6 @@ pub(super) fn observe_event_json(event: &Value, slow_ms: u64) -> Value {
         field::STATUS: observe_normalized_status(event, slow_ms),
         field::REASON: observe_string_field(event, field::REASON),
         field::DETAIL: observe_string_field(event, field::DETAIL),
-        field::RECORD_ID: observe_string_field(event, field::RECORD_ID),
         field::DURATION_MS: observe_effective_duration_ms(event),
         "client": observe_client_name(event),
         "diagnostic": observe_diagnostic_kind(event, slow_ms),

--- a/vibeguard-runtime/src/observe/aggregate.rs
+++ b/vibeguard-runtime/src/observe/aggregate.rs
@@ -106,6 +106,7 @@ pub(super) fn observe_event_json(event: &Value, slow_ms: u64) -> Value {
         field::STATUS: observe_normalized_status(event, slow_ms),
         field::REASON: observe_string_field(event, field::REASON),
         field::DETAIL: observe_string_field(event, field::DETAIL),
+        field::RECORD_ID: observe_string_field(event, field::RECORD_ID),
         field::DURATION_MS: observe_effective_duration_ms(event),
         "client": observe_client_name(event),
         "diagnostic": observe_diagnostic_kind(event, slow_ms),
@@ -128,7 +129,7 @@ pub(super) fn observe_numeric_field(value: &Value, key: &str) -> Option<u64> {
         .and_then(|raw| raw.as_u64().or_else(|| raw.as_str()?.parse::<u64>().ok()))
 }
 
-fn observe_effective_duration_ms(event: &Value) -> Option<u64> {
+pub(super) fn observe_effective_duration_ms(event: &Value) -> Option<u64> {
     observe_numeric_field(event, field::DURATION_MS)
         .or_else(|| observe_numeric_field(event, field::ELAPSED_MS))
 }
@@ -165,7 +166,7 @@ pub(super) fn observe_normalized_decision(event: &Value) -> String {
     observe_string_field(event, field::STATUS).to_ascii_lowercase()
 }
 
-fn observe_normalized_status(event: &Value, slow_ms: u64) -> String {
+pub(super) fn observe_normalized_status(event: &Value, slow_ms: u64) -> String {
     let explicit = observe_string_field(event, field::STATUS).to_ascii_lowercase();
     if !explicit.is_empty() {
         return observe_canonical_status(&explicit);

--- a/vibeguard-runtime/src/observe/aggregate.rs
+++ b/vibeguard-runtime/src/observe/aggregate.rs
@@ -235,7 +235,7 @@ fn observe_is_attention_or_diagnostic(event: &Value, slow_ms: u64) -> bool {
     observe_is_attention_state(event, slow_ms) || observe_is_diagnostic_event(event, slow_ms)
 }
 
-fn observe_diagnostic_kind(event: &Value, slow_ms: u64) -> &'static str {
+pub(super) fn observe_diagnostic_kind(event: &Value, slow_ms: u64) -> &'static str {
     let status_value = observe_normalized_status(event, slow_ms);
     let reason = observe_string_field(event, field::REASON).to_ascii_lowercase();
     if status_value == status::TIMEOUT || reason.contains("timeout") {

--- a/vibeguard-runtime/src/observe/mod.rs
+++ b/vibeguard-runtime/src/observe/mod.rs
@@ -28,9 +28,10 @@ pub fn run(args: &[String]) -> Result {
     let rule_descriptions = rule_descriptions::RuleDescriptions::load()?;
     let mut log_events = read::read_log_events(&options)?;
     let cutoff_secs = options.window.cutoff_secs(now_unix_secs());
-    log_events
-        .events
-        .retain(|event| read::event_passes_time_window(event, cutoff_secs));
+    let retain_unparseable_timestamps = matches!(options.command, model::ObserveCommand::Value);
+    log_events.events.retain(|event| {
+        read::event_passes_time_window(event, cutoff_secs, retain_unparseable_timestamps)
+    });
     if let Some(session) = &options.session {
         log_events
             .events

--- a/vibeguard-runtime/src/observe/mod.rs
+++ b/vibeguard-runtime/src/observe/mod.rs
@@ -7,6 +7,7 @@ mod read;
 mod render;
 mod rule_descriptions;
 mod stats_summary;
+mod value;
 
 use crate::event_schema::field;
 use crate::time_utils::now_unix_secs;
@@ -53,6 +54,7 @@ pub fn run(args: &[String]) -> Result {
             render::render_health(&options, &log_events, &aggregate, &rule_descriptions)
         }
         model::ObserveCommand::Session => render::render_session(&options, &log_events, &aggregate),
+        model::ObserveCommand::Value => value::render(&options, &log_events, &aggregate),
     }?;
     print!("{output}");
     Ok(())

--- a/vibeguard-runtime/src/observe/mod.rs
+++ b/vibeguard-runtime/src/observe/mod.rs
@@ -10,7 +10,7 @@ mod stats_summary;
 mod value;
 
 use crate::event_schema::field;
-use crate::time_utils::now_unix_secs;
+use crate::time_utils::{now_unix_secs, parse_iso_ts};
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -27,16 +27,28 @@ pub fn run(args: &[String]) -> Result {
     let options = model::parse_observe_args(args)?;
     let rule_descriptions = rule_descriptions::RuleDescriptions::load()?;
     let mut log_events = read::read_log_events(&options)?;
-    let cutoff_secs = options.window.cutoff_secs(now_unix_secs());
-    let retain_unparseable_timestamps = matches!(options.command, model::ObserveCommand::Value);
-    log_events.events.retain(|event| {
-        read::event_passes_time_window(event, cutoff_secs, retain_unparseable_timestamps)
-    });
     if let Some(session) = &options.session {
         log_events
             .events
             .retain(|event| aggregate::observe_string_field(event, field::SESSION) == *session);
     }
+    let cutoff_secs = options.window.cutoff_secs(now_unix_secs());
+    let unscoped_attention_events =
+        if cutoff_secs.is_some() && matches!(options.command, model::ObserveCommand::Value) {
+            log_events
+                .events
+                .iter()
+                .filter(|event| {
+                    parse_iso_ts(&aggregate::observe_string_field(event, field::TS)).is_none()
+                        && aggregate::observe_is_attention_state(event, options.slow_ms)
+                })
+                .count() as u64
+        } else {
+            0
+        };
+    log_events
+        .events
+        .retain(|event| read::event_passes_time_window(event, cutoff_secs));
     log_events.events.sort_by(|left, right| {
         aggregate::observe_string_field(left, field::TS)
             .cmp(&aggregate::observe_string_field(right, field::TS))
@@ -55,7 +67,9 @@ pub fn run(args: &[String]) -> Result {
             render::render_health(&options, &log_events, &aggregate, &rule_descriptions)
         }
         model::ObserveCommand::Session => render::render_session(&options, &log_events, &aggregate),
-        model::ObserveCommand::Value => value::render(&options, &log_events, &aggregate),
+        model::ObserveCommand::Value => {
+            value::render(&options, &log_events, &aggregate, unscoped_attention_events)
+        }
     }?;
     print!("{output}");
     Ok(())

--- a/vibeguard-runtime/src/observe/model.rs
+++ b/vibeguard-runtime/src/observe/model.rs
@@ -9,6 +9,7 @@ pub(super) enum ObserveCommand {
     Summary,
     Health,
     Session,
+    Value,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -54,7 +55,7 @@ pub(super) struct ObserveOptions {
 impl ObserveOptions {
     fn new(command: ObserveCommand) -> Self {
         let window = match command {
-            ObserveCommand::Summary => TimeWindow::Days(7),
+            ObserveCommand::Summary | ObserveCommand::Value => TimeWindow::Days(7),
             ObserveCommand::Health => TimeWindow::Hours(24),
             ObserveCommand::Session => TimeWindow::All,
         };
@@ -81,6 +82,7 @@ pub(super) fn parse_observe_args(args: &[String]) -> Result<ObserveOptions> {
     match command_name.as_str() {
         "summary" => parse_command(ObserveCommand::Summary, None, &args[1..]),
         "health" => parse_command(ObserveCommand::Health, None, &args[1..]),
+        "value" => parse_command(ObserveCommand::Value, None, &args[1..]),
         "session" => {
             let session = args
                 .get(1)
@@ -200,7 +202,7 @@ fn parse_hours_window(value: &str) -> Result<TimeWindow> {
 }
 
 fn usage() -> &'static str {
-    "Usage: vibeguard-runtime observe <summary|health|session|export prometheus> [--json] [--scope project|global] [--project PATH_OR_HASH] [--log-file PATH] [--days N|all] [--hours N|all] [--limit N|all] [--slow-ms MS] [--top N]"
+    "Usage: vibeguard-runtime observe <summary|health|session|value|export prometheus> [--json] [--scope project|global] [--project PATH_OR_HASH] [--log-file PATH] [--days N|all] [--hours N|all] [--limit N|all] [--slow-ms MS] [--top N]"
 }
 
 #[cfg(test)]
@@ -220,6 +222,17 @@ mod tests {
 
         assert!(matches!(options.command, ObserveCommand::Summary));
         assert!(!options.json);
+        assert_eq!(options.window.label(), "last 7 days");
+    }
+
+    #[test]
+    fn value_defaults_to_seven_days() {
+        let options = match parse_observe_args(&args(&["value"])) {
+            Ok(options) => options,
+            Err(error) => panic!("value options should parse: {error}"),
+        };
+
+        assert!(matches!(options.command, ObserveCommand::Value));
         assert_eq!(options.window.label(), "last 7 days");
     }
 

--- a/vibeguard-runtime/src/observe/read.rs
+++ b/vibeguard-runtime/src/observe/read.rs
@@ -48,15 +48,22 @@ pub(super) fn read_log_events(options: &ObserveOptions) -> Result<LogEvents> {
     })
 }
 
-pub(super) fn event_passes_time_window(event: &Value, cutoff_secs: Option<u64>) -> bool {
+pub(super) fn event_passes_time_window(
+    event: &Value,
+    cutoff_secs: Option<u64>,
+    retain_unparseable_timestamps: bool,
+) -> bool {
     let Some(cutoff) = cutoff_secs else {
         return true;
     };
-    event
+    match event
         .get(field::TS)
         .and_then(Value::as_str)
         .and_then(parse_iso_ts)
-        .is_some_and(|ts| ts >= cutoff)
+    {
+        Some(timestamp) => timestamp >= cutoff,
+        None => retain_unparseable_timestamps,
+    }
 }
 
 fn read_jsonl_file_limited(path: &Path, limit: usize) -> Result<Vec<Value>> {

--- a/vibeguard-runtime/src/observe/read.rs
+++ b/vibeguard-runtime/src/observe/read.rs
@@ -48,11 +48,7 @@ pub(super) fn read_log_events(options: &ObserveOptions) -> Result<LogEvents> {
     })
 }
 
-pub(super) fn event_passes_time_window(
-    event: &Value,
-    cutoff_secs: Option<u64>,
-    retain_unparseable_timestamps: bool,
-) -> bool {
+pub(super) fn event_passes_time_window(event: &Value, cutoff_secs: Option<u64>) -> bool {
     let Some(cutoff) = cutoff_secs else {
         return true;
     };
@@ -62,7 +58,7 @@ pub(super) fn event_passes_time_window(
         .and_then(parse_iso_ts)
     {
         Some(timestamp) => timestamp >= cutoff,
-        None => retain_unparseable_timestamps,
+        None => false,
     }
 }
 

--- a/vibeguard-runtime/src/observe/render.rs
+++ b/vibeguard-runtime/src/observe/render.rs
@@ -289,7 +289,7 @@ pub(super) fn render_session(
     ))
 }
 
-fn observe_summary_json(
+pub(super) fn observe_summary_json(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
@@ -332,6 +332,7 @@ fn observe_command_name(command: ObserveCommand) -> &'static str {
         ObserveCommand::Summary => "summary",
         ObserveCommand::Health => "health",
         ObserveCommand::Session => "session",
+        ObserveCommand::Value => "value",
     }
 }
 
@@ -372,7 +373,7 @@ fn observe_duration_stats_json(durations: &[u64], slow_ms: u64) -> Value {
             "slow_ms": slow_ms,
         });
     }
-    let sum = durations.iter().sum::<u64>();
+    let sum = durations.iter().copied().fold(0_u64, u64::saturating_add);
     let p95_index = ((durations.len() * 95).div_ceil(100)).saturating_sub(1);
     json!({
         "count": durations.len(),

--- a/vibeguard-runtime/src/observe/render.rs
+++ b/vibeguard-runtime/src/observe/render.rs
@@ -431,14 +431,14 @@ fn observe_top_human(map: &BTreeMap<String, u64>, limit: usize) -> String {
         .join(", ")
 }
 
-fn observe_ratio(count: usize, total: usize) -> f64 {
+pub(super) fn observe_ratio(count: usize, total: usize) -> f64 {
     if total == 0 {
         return 0.0;
     }
     ((count as f64 / total as f64) * 1_000.0).round() / 1_000.0
 }
 
-fn observe_percentage(count: usize, total: usize) -> f64 {
+pub(super) fn observe_percentage(count: usize, total: usize) -> f64 {
     if total == 0 {
         return 0.0;
     }

--- a/vibeguard-runtime/src/observe/stats_summary.rs
+++ b/vibeguard-runtime/src/observe/stats_summary.rs
@@ -107,7 +107,6 @@ pub(super) fn render_stats_summary(
     }
 
     append_daily_counts(&mut output, &log_events.events);
-    append_warn_compliance(&mut output, &log_events.events);
     append_file_type_distribution(&mut output, &log_events.events);
     append_time_distribution(&mut output, &log_events.events);
     append_performance_analysis(&mut output, &log_events.events);
@@ -132,58 +131,6 @@ fn append_daily_counts(output: &mut String, events: &[Value]) {
     {
         let bar = std::iter::repeat_n('\u{2588}', (*count).min(50) as usize).collect::<String>();
         output.push_str(&format!("  {day}  {bar} {count}\n"));
-    }
-}
-
-fn append_warn_compliance(output: &mut String, events: &[Value]) {
-    if !events
-        .iter()
-        .any(|event| observe_normalized_decision(event) == decision::WARN)
-    {
-        return;
-    }
-
-    let mut by_hook: BTreeMap<String, (u64, u64)> = BTreeMap::new();
-    for event in events {
-        let decision_value = observe_normalized_decision(event);
-        if !matches!(decision_value.as_str(), decision::WARN | decision::PASS) {
-            continue;
-        }
-        let hook = observe_string_field(event, field::HOOK);
-        let entry = by_hook.entry(hook).or_default();
-        if decision_value == decision::WARN {
-            entry.0 += 1;
-        } else {
-            entry.1 += 1;
-        }
-    }
-
-    output.push_str("\n== Warn compliance rate analysis ==\n");
-    let mut upgrade_candidates = Vec::new();
-    for (hook, (warn_count, pass_count)) in &by_hook {
-        if *warn_count == 0 {
-            continue;
-        }
-        let total = warn_count + pass_count;
-        let compliance = (*pass_count as f64 / total as f64) * 100.0;
-        let indicator = if compliance >= 80.0 { "OK" } else { "LOW" };
-        output.push_str(&format!(
-            " {hook}: warn={warn_count} pass={pass_count} compliance rate={compliance:.0}% [{indicator}]\n"
-        ));
-        if compliance < 50.0 && *warn_count >= 3 {
-            upgrade_candidates.push((hook.clone(), *warn_count, compliance));
-        }
-    }
-
-    if !upgrade_candidates.is_empty() {
-        output.push_str(
-            "\nIt is recommended to upgrade to block (compliance rate < 50% and warn >= 3 times):\n",
-        );
-        for (hook, count, rate) in upgrade_candidates {
-            output.push_str(&format!(
-                " {hook}: {count} times warn, compliance rate {rate:.0}%\n"
-            ));
-        }
     }
 }
 
@@ -268,20 +215,6 @@ fn append_performance_analysis(output: &mut String, events: &[Value]) {
     output.push_str(&format!(
         "Average warning rate per session: {:.1}%\n",
         warn_rate_sum / sessions.len() as f64
-    ));
-
-    let deterministic_checks = events
-        .iter()
-        .filter(|event| {
-            matches!(
-                observe_normalized_decision(event).as_str(),
-                decision::PASS | decision::BLOCK | decision::WARN
-            )
-        })
-        .count() as u64;
-    output.push_str(&format!(
-        "Deterministic node estimated savings: ~{} tokens\n",
-        stats_token_savings_label(deterministic_checks * 500)
     ));
 
     append_problem_sessions(output, &sessions);
@@ -376,16 +309,6 @@ fn stats_file_extension(detail: &str) -> Option<String> {
     None
 }
 
-fn stats_token_savings_label(tokens: u64) -> String {
-    if tokens >= 1_000_000 {
-        format!("{:.1}M", tokens as f64 / 1_000_000.0)
-    } else if tokens >= 1_000 {
-        format!("{}K", tokens / 1_000)
-    } else {
-        tokens.to_string()
-    }
-}
-
 fn stats_ts_prefix(event: &Value) -> String {
     let ts = observe_string_field(event, field::TS);
     if ts.is_empty() {
@@ -475,15 +398,15 @@ mod tests {
             Err(error) => panic!("stats summary should render: {error}"),
         };
 
-        assert!(output.contains("== Warn compliance rate analysis =="));
-        assert!(output.contains("pre-bash-guard: warn=1 pass=1 compliance rate=50% [LOW]"));
+        assert!(!output.contains("Warn compliance"));
+        assert!(!output.contains("upgrade to block"));
         assert!(output.contains("Distributed by file type:"));
         assert!(output.contains(".rs: 2 times"));
         assert!(output.contains("Distributed by time period:"));
         assert!(output.contains("working time (09-18): 2 times (50%)"));
         assert!(output.contains("== Performance analysis =="));
         assert!(output.contains("Average triggers per session: 2.0 times"));
-        assert!(output.contains("Deterministic node estimated savings: ~2K tokens"));
+        assert!(!output.contains("estimated savings"));
         assert!(output.contains("session-b: 2 issues / 2 triggers"));
     }
 

--- a/vibeguard-runtime/src/observe/value.rs
+++ b/vibeguard-runtime/src/observe/value.rs
@@ -6,8 +6,9 @@ use crate::time_utils::parse_iso_ts;
 
 use super::Result;
 use super::aggregate::{
-    ObserveAggregate, observe_effective_duration_ms, observe_is_attention_state,
-    observe_normalized_decision, observe_normalized_status, observe_string_field,
+    ObserveAggregate, observe_diagnostic_kind, observe_effective_duration_ms,
+    observe_is_attention_state, observe_normalized_decision, observe_normalized_status,
+    observe_string_field,
 };
 use super::model::ObserveOptions;
 use super::read::LogEvents;
@@ -216,8 +217,10 @@ fn is_ordinary_pass(event: &Value, slow_ms: u64) -> bool {
         return false;
     }
     let normalized_status = observe_normalized_status(event, slow_ms);
+    let diagnostic_kind = observe_diagnostic_kind(event, slow_ms);
     let reason = observe_string_field(event, field::REASON).to_ascii_lowercase();
     matches!(normalized_status.as_str(), status::PASS | status::SLOW)
+        && matches!(diagnostic_kind, "none" | "slow")
         && !reason.starts_with("skip:")
         && !reason.starts_with("skipped:")
 }

--- a/vibeguard-runtime/src/observe/value.rs
+++ b/vibeguard-runtime/src/observe/value.rs
@@ -1,13 +1,13 @@
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 
-use crate::event_schema::{field, hook, status};
+use crate::event_schema::{UNKNOWN, decision, field, hook, status};
 use crate::time_utils::parse_iso_ts;
 
 use super::Result;
 use super::aggregate::{
     ObserveAggregate, observe_effective_duration_ms, observe_is_attention_state,
-    observe_normalized_status, observe_string_field,
+    observe_normalized_decision, observe_normalized_status, observe_string_field,
 };
 use super::model::ObserveOptions;
 use super::read::LogEvents;
@@ -40,8 +40,12 @@ struct OrdinaryPass {
 }
 
 impl ValueEvidence {
-    fn from_events(events: &[Value], slow_ms: u64) -> Self {
-        let mut evidence = Self::default();
+    fn from_events(events: &[Value], slow_ms: u64, unscoped_attention_events: u64) -> Self {
+        let mut evidence = Self {
+            attention_events: unscoped_attention_events,
+            uncorrelatable_attention_events: unscoped_attention_events,
+            ..Self::default()
+        };
         let mut ordinary_passes: BTreeMap<String, Vec<OrdinaryPass>> = BTreeMap::new();
 
         for event in events {
@@ -61,23 +65,26 @@ impl ValueEvidence {
             if observe_is_attention_state(event, slow_ms) {
                 evidence.attention_events += 1;
                 let timestamp = parse_iso_ts(&observe_string_field(event, field::TS));
-                if session.is_empty() || timestamp.is_none() {
+                let correlatable_session =
+                    !session.is_empty() && !session.eq_ignore_ascii_case(UNKNOWN);
+                if !correlatable_session || timestamp.is_none() {
                     evidence.uncorrelatable_attention_events += 1;
                 }
 
-                if !session.is_empty() {
+                if correlatable_session && let Some(timestamp) = timestamp {
                     let attention_session = evidence
                         .attention_sessions
                         .entry(session.clone())
                         .or_default();
                     attention_session.attention_count += 1;
-                    if let Some(timestamp) = timestamp {
-                        attention_session.attention_timestamps.push(timestamp);
-                    }
+                    attention_session.attention_timestamps.push(timestamp);
                 }
             }
 
-            if !is_ordinary_pass(event, slow_ms) || session.is_empty() {
+            if !is_ordinary_pass(event)
+                || session.is_empty()
+                || session.eq_ignore_ascii_case(UNKNOWN)
+            {
                 continue;
             }
             let Some(timestamp) = parse_iso_ts(&observe_string_field(event, field::TS)) else {
@@ -197,30 +204,38 @@ impl ValueEvidence {
 
 fn read_limitation(limit: usize) -> String {
     if limit == usize::MAX {
-        return "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established.".to_string();
+        return "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered. Attention events with missing or unparseable timestamps are reported only as uncorrelatable and excluded from finite-window aggregates because their time position cannot be established.".to_string();
     }
     format!(
-        "Counts consider at most the configured {limit} most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established."
+        "Counts consider at most the configured {limit} most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered. Attention events with missing or unparseable timestamps are reported only as uncorrelatable and excluded from finite-window aggregates because their time position cannot be established."
     )
 }
 
-fn is_ordinary_pass(event: &Value, slow_ms: u64) -> bool {
-    if observe_normalized_status(event, slow_ms) != status::PASS {
+fn is_ordinary_pass(event: &Value) -> bool {
+    if observe_normalized_decision(event) != decision::PASS {
         return false;
     }
+    let explicit_status = observe_string_field(event, field::STATUS).to_ascii_lowercase();
     let reason = observe_string_field(event, field::REASON).to_ascii_lowercase();
-    !reason.starts_with("skip:") && !reason.starts_with("skipped:")
+    explicit_status != status::SKIPPED
+        && !reason.starts_with("skip:")
+        && !reason.starts_with("skipped:")
 }
 
 pub(super) fn render(
     options: &ObserveOptions,
     log_events: &LogEvents,
     aggregate: &ObserveAggregate,
+    unscoped_attention_events: u64,
 ) -> Result<String> {
-    let evidence = ValueEvidence::from_events(&log_events.events, options.slow_ms);
+    let evidence = ValueEvidence::from_events(
+        &log_events.events,
+        options.slow_ms,
+        unscoped_attention_events,
+    );
     let data_state = if !log_events.source_exists {
         "missing"
-    } else if log_events.events.is_empty() {
+    } else if log_events.events.is_empty() && unscoped_attention_events == 0 {
         "empty"
     } else {
         "observed"
@@ -229,6 +244,12 @@ pub(super) fn render(
 
     if options.json {
         let mut output = super::render::observe_summary_json(options, log_events, aggregate);
+        let attention_count = evidence.attention_events as usize;
+        output["attention"] = json!({
+            "count": evidence.attention_events,
+            "rate": super::render::observe_ratio(attention_count, aggregate.event_count),
+            "percent": super::render::observe_percentage(attention_count, aggregate.event_count),
+        });
         output["value"] = evidence.to_json(data_state, &read_limitation);
         return Ok(format!("{}\n", serde_json::to_string_pretty(&output)?));
     }

--- a/vibeguard-runtime/src/observe/value.rs
+++ b/vibeguard-runtime/src/observe/value.rs
@@ -1,0 +1,333 @@
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+
+use crate::event_schema::{field, hook, status};
+use crate::time_utils::parse_iso_ts;
+
+use super::Result;
+use super::aggregate::{
+    ObserveAggregate, observe_effective_duration_ms, observe_is_attention_state,
+    observe_normalized_status, observe_string_field,
+};
+use super::model::ObserveOptions;
+use super::read::LogEvents;
+
+const EVIDENCE_BOUNDARY: &str = "Evidence boundary: this view reports only associations observable in the local event stream. It does not claim incidents prevented, causal recovery, token savings, time savings, money savings, or compliance.";
+const ESTIMATED_UNAVAILABLE_REASON: &str = "The local event stream has no causal, incident, token, time, or money outcome evidence for estimates.";
+const VERIFIED_DEFINITION: &str = "A strictly later ordinary pass from post-build-check in the same non-empty session after attention; this is an association, not proof VibeGuard caused the result.";
+const ASSOCIATION_LIMITATION: &str = "Later passes and build checks are associations in the event stream, not proof VibeGuard caused the result.";
+
+#[derive(Default)]
+struct ValueEvidence {
+    attention_events: u64,
+    attention_sessions: BTreeMap<String, AttentionSession>,
+    uncorrelatable_attention_events: u64,
+    suppression_events: u64,
+    durations_ms: Vec<u64>,
+}
+
+#[derive(Default)]
+struct AttentionSession {
+    attention_count: u64,
+    attention_timestamps: Vec<u64>,
+    later_follow_up_pass: bool,
+    later_build_pass: bool,
+}
+
+struct OrdinaryPass {
+    timestamp: u64,
+    is_build_check: bool,
+}
+
+impl ValueEvidence {
+    fn from_events(events: &[Value], slow_ms: u64) -> Self {
+        let mut evidence = Self::default();
+        let mut ordinary_passes: BTreeMap<String, Vec<OrdinaryPass>> = BTreeMap::new();
+
+        for event in events {
+            if let Some(duration_ms) = observe_effective_duration_ms(event) {
+                evidence.durations_ms.push(duration_ms);
+            }
+
+            let normalized_status = observe_normalized_status(event, slow_ms);
+            let reason = observe_string_field(event, field::REASON);
+            if normalized_status == status::SKIPPED
+                && reason.to_ascii_lowercase().contains("suppressed")
+            {
+                evidence.suppression_events += 1;
+            }
+
+            let session = observe_string_field(event, field::SESSION);
+            if observe_is_attention_state(event, slow_ms) {
+                evidence.attention_events += 1;
+                let timestamp = parse_iso_ts(&observe_string_field(event, field::TS));
+                if session.is_empty() || timestamp.is_none() {
+                    evidence.uncorrelatable_attention_events += 1;
+                }
+
+                if !session.is_empty() {
+                    let attention_session = evidence
+                        .attention_sessions
+                        .entry(session.clone())
+                        .or_default();
+                    attention_session.attention_count += 1;
+                    if let Some(timestamp) = timestamp {
+                        attention_session.attention_timestamps.push(timestamp);
+                    }
+                }
+            }
+
+            if !is_ordinary_pass(event, slow_ms) || session.is_empty() {
+                continue;
+            }
+            let Some(timestamp) = parse_iso_ts(&observe_string_field(event, field::TS)) else {
+                continue;
+            };
+            ordinary_passes
+                .entry(session)
+                .or_default()
+                .push(OrdinaryPass {
+                    timestamp,
+                    is_build_check: observe_string_field(event, field::HOOK)
+                        == hook::POST_BUILD_CHECK,
+                });
+        }
+
+        for (session, attention_session) in &mut evidence.attention_sessions {
+            let Some(passes) = ordinary_passes.get(session) else {
+                continue;
+            };
+            attention_session.later_follow_up_pass = passes.iter().any(|pass| {
+                attention_session
+                    .attention_timestamps
+                    .iter()
+                    .any(|attention_timestamp| pass.timestamp > *attention_timestamp)
+            });
+            attention_session.later_build_pass = passes.iter().any(|pass| {
+                pass.is_build_check
+                    && attention_session
+                        .attention_timestamps
+                        .iter()
+                        .any(|attention_timestamp| pass.timestamp > *attention_timestamp)
+            });
+        }
+
+        evidence.durations_ms.sort_unstable();
+        evidence
+    }
+
+    fn sessions_with_later_follow_up_pass(&self) -> u64 {
+        self.attention_sessions
+            .values()
+            .filter(|session| session.later_follow_up_pass)
+            .count() as u64
+    }
+
+    fn sessions_without_later_follow_up_pass(&self) -> u64 {
+        self.attention_sessions
+            .values()
+            .filter(|session| !session.later_follow_up_pass)
+            .count() as u64
+    }
+
+    fn sessions_with_repeated_attention(&self) -> u64 {
+        self.attention_sessions
+            .values()
+            .filter(|session| session.attention_count >= 2)
+            .count() as u64
+    }
+
+    fn sessions_with_later_build_pass(&self) -> u64 {
+        self.attention_sessions
+            .values()
+            .filter(|session| session.later_build_pass)
+            .count() as u64
+    }
+
+    fn duration_json(&self) -> Value {
+        let count = self.durations_ms.len() as u64;
+        if count == 0 {
+            return json!({
+                "count": 0,
+                "total_ms": 0,
+                "avg_ms": 0,
+                "p95_ms": null,
+            });
+        }
+
+        let total_ms = self
+            .durations_ms
+            .iter()
+            .copied()
+            .fold(0_u64, u64::saturating_add);
+        let p95_index = ((self.durations_ms.len() * 95).div_ceil(100)).saturating_sub(1);
+        json!({
+            "count": count,
+            "total_ms": total_ms,
+            "avg_ms": total_ms / count,
+            "p95_ms": self.durations_ms.get(p95_index).copied(),
+        })
+    }
+
+    fn to_json(&self, data_state: &str, read_limitation: &str) -> Value {
+        json!({
+            "data_state": data_state,
+            "verified": {
+                "sessions_with_later_build_pass": self.sessions_with_later_build_pass(),
+                "definition": VERIFIED_DEFINITION,
+            },
+            "observed": {
+                "attention_events": self.attention_events,
+                "sessions_with_attention": self.attention_sessions.len(),
+                "sessions_with_later_follow_up_pass": self.sessions_with_later_follow_up_pass(),
+                "sessions_without_later_follow_up_pass": self.sessions_without_later_follow_up_pass(),
+                "sessions_with_repeated_attention": self.sessions_with_repeated_attention(),
+                "uncorrelatable_attention_events": self.uncorrelatable_attention_events,
+                "suppression_events": self.suppression_events,
+                "hook_duration_ms": self.duration_json(),
+            },
+            "estimated": {
+                "available": false,
+                "reason": ESTIMATED_UNAVAILABLE_REASON,
+            },
+            "limitations": [ASSOCIATION_LIMITATION, read_limitation],
+        })
+    }
+}
+
+fn read_limitation(limit: usize) -> String {
+    if limit == usize::MAX {
+        return "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered.".to_string();
+    }
+    format!(
+        "Counts consider at most the configured {limit} most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered."
+    )
+}
+
+fn is_ordinary_pass(event: &Value, slow_ms: u64) -> bool {
+    if observe_normalized_status(event, slow_ms) != status::PASS {
+        return false;
+    }
+    let reason = observe_string_field(event, field::REASON).to_ascii_lowercase();
+    !reason.starts_with("skip:") && !reason.starts_with("skipped:")
+}
+
+pub(super) fn render(
+    options: &ObserveOptions,
+    log_events: &LogEvents,
+    aggregate: &ObserveAggregate,
+) -> Result<String> {
+    let evidence = ValueEvidence::from_events(&log_events.events, options.slow_ms);
+    let data_state = if !log_events.source_exists {
+        "missing"
+    } else if log_events.events.is_empty() {
+        "empty"
+    } else {
+        "observed"
+    };
+    let read_limitation = read_limitation(options.limit);
+
+    if options.json {
+        let mut output = super::render::observe_summary_json(options, log_events, aggregate);
+        output["value"] = evidence.to_json(data_state, &read_limitation);
+        return Ok(format!("{}\n", serde_json::to_string_pretty(&output)?));
+    }
+
+    Ok(render_human(
+        options,
+        log_events,
+        &evidence,
+        data_state,
+        &read_limitation,
+    ))
+}
+
+fn render_human(
+    options: &ObserveOptions,
+    log_events: &LogEvents,
+    evidence: &ValueEvidence,
+    data_state: &str,
+    read_limitation: &str,
+) -> String {
+    let mut output = String::new();
+    output.push_str(EVIDENCE_BOUNDARY);
+    output.push('\n');
+    output.push_str(&format!(
+        "VibeGuard Observe Value ({})\n",
+        options.window.label()
+    ));
+    output.push_str(&format!("Data state: {data_state}\n"));
+    match data_state {
+        "missing" => output.push_str(&format!(
+            "No event log exists at {}.\n",
+            log_events.log_path
+        )),
+        "empty" => output.push_str(&format!(
+            "No events were found in the selected window ({}) at {}.\n",
+            options.window.label(),
+            log_events.log_path
+        )),
+        "observed" => output.push_str(&format!(
+            "Events in selected window: {}\n",
+            log_events.events.len()
+        )),
+        _ => output.push_str("Data state is unavailable.\n"),
+    }
+
+    output.push_str("\nVerified\n");
+    output.push_str(&format!(
+        "  sessions_with_later_build_pass: {}\n",
+        evidence.sessions_with_later_build_pass()
+    ));
+    output.push_str(&format!("  definition: {VERIFIED_DEFINITION}\n"));
+
+    output.push_str("\nObserved\n");
+    output.push_str(&format!(
+        "  attention_events: {}\n",
+        evidence.attention_events
+    ));
+    output.push_str(&format!(
+        "  sessions_with_attention: {}\n",
+        evidence.attention_sessions.len()
+    ));
+    output.push_str(&format!(
+        "  sessions_with_later_follow_up_pass: {}\n",
+        evidence.sessions_with_later_follow_up_pass()
+    ));
+    output.push_str(&format!(
+        "  sessions_without_later_follow_up_pass: {}\n",
+        evidence.sessions_without_later_follow_up_pass()
+    ));
+    output.push_str(&format!(
+        "  sessions_with_repeated_attention: {}\n",
+        evidence.sessions_with_repeated_attention()
+    ));
+    output.push_str(&format!(
+        "  uncorrelatable_attention_events: {}\n",
+        evidence.uncorrelatable_attention_events
+    ));
+    output.push_str(&format!(
+        "  suppression_events: {}\n",
+        evidence.suppression_events
+    ));
+    output.push_str(&format!(
+        "  hook_duration_ms: {}\n",
+        duration_human(&evidence.duration_json())
+    ));
+
+    output.push_str("\nEstimated/unavailable\n");
+    output.push_str("  available: false\n");
+    output.push_str(&format!("  reason: {ESTIMATED_UNAVAILABLE_REASON}\n"));
+
+    output.push_str("\nLimitations\n");
+    output.push_str(&format!("  {ASSOCIATION_LIMITATION}\n"));
+    output.push_str(&format!("  {read_limitation}\n"));
+    output
+}
+
+fn duration_human(duration: &Value) -> String {
+    format!(
+        "count={} total_ms={} avg_ms={} p95_ms={}",
+        duration["count"], duration["total_ms"], duration["avg_ms"], duration["p95_ms"]
+    )
+}

--- a/vibeguard-runtime/src/observe/value.rs
+++ b/vibeguard-runtime/src/observe/value.rs
@@ -81,7 +81,7 @@ impl ValueEvidence {
                 }
             }
 
-            if !is_ordinary_pass(event)
+            if !is_ordinary_pass(event, slow_ms)
                 || session.is_empty()
                 || session.eq_ignore_ascii_case(UNKNOWN)
             {
@@ -211,13 +211,13 @@ fn read_limitation(limit: usize) -> String {
     )
 }
 
-fn is_ordinary_pass(event: &Value) -> bool {
+fn is_ordinary_pass(event: &Value, slow_ms: u64) -> bool {
     if observe_normalized_decision(event) != decision::PASS {
         return false;
     }
-    let explicit_status = observe_string_field(event, field::STATUS).to_ascii_lowercase();
+    let normalized_status = observe_normalized_status(event, slow_ms);
     let reason = observe_string_field(event, field::REASON).to_ascii_lowercase();
-    explicit_status != status::SKIPPED
+    matches!(normalized_status.as_str(), status::PASS | status::SLOW)
         && !reason.starts_with("skip:")
         && !reason.starts_with("skipped:")
 }
@@ -245,10 +245,13 @@ pub(super) fn render(
     if options.json {
         let mut output = super::render::observe_summary_json(options, log_events, aggregate);
         let attention_count = evidence.attention_events as usize;
+        let attention_population = aggregate
+            .event_count
+            .saturating_add(unscoped_attention_events as usize);
         output["attention"] = json!({
             "count": evidence.attention_events,
-            "rate": super::render::observe_ratio(attention_count, aggregate.event_count),
-            "percent": super::render::observe_percentage(attention_count, aggregate.event_count),
+            "rate": super::render::observe_ratio(attention_count, attention_population),
+            "percent": super::render::observe_percentage(attention_count, attention_population),
         });
         output["value"] = evidence.to_json(data_state, &read_limitation);
         return Ok(format!("{}\n", serde_json::to_string_pretty(&output)?));

--- a/vibeguard-runtime/src/observe/value.rs
+++ b/vibeguard-runtime/src/observe/value.rs
@@ -197,10 +197,10 @@ impl ValueEvidence {
 
 fn read_limitation(limit: usize) -> String {
     if limit == usize::MAX {
-        return "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered.".to_string();
+        return "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established.".to_string();
     }
     format!(
-        "Counts consider at most the configured {limit} most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered."
+        "Counts consider at most the configured {limit} most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established."
     )
 }
 

--- a/vibeguard-runtime/tests/observe_value_cli.rs
+++ b/vibeguard-runtime/tests/observe_value_cli.rs
@@ -137,9 +137,9 @@ fn value_json_applies_attention_and_correlation_boundaries() {
 
     assert_eq!(value["data_state"], "observed");
     assert_eq!(observed["attention_events"], 9);
-    assert_eq!(observed["sessions_with_attention"], 6);
+    assert_eq!(observed["sessions_with_attention"], 5);
     assert_eq!(observed["sessions_with_later_follow_up_pass"], 2);
-    assert_eq!(observed["sessions_without_later_follow_up_pass"], 4);
+    assert_eq!(observed["sessions_without_later_follow_up_pass"], 3);
     assert_eq!(observed["sessions_with_repeated_attention"], 1);
     assert_eq!(observed["uncorrelatable_attention_events"], 3);
     assert_eq!(observed["suppression_events"], 1);
@@ -174,7 +174,10 @@ fn value_finite_window_retains_unparseable_attention_as_uncorrelatable() {
     let log = root.join("events.jsonl");
     write_value_log(
         &log,
-        "{\"ts\":\"not-a-timestamp\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
+        concat!(
+            "{\"ts\":\"not-a-timestamp\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"not-a-timestamp\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"status\":\"skipped\",\"decision\":\"pass\",\"reason\":\"suppressed by cooldown\",\"duration_ms\":99}\n"
+        ),
     );
 
     let rendered = output_json(&run(
@@ -191,13 +194,121 @@ fn value_finite_window_retains_unparseable_attention_as_uncorrelatable() {
     ));
 
     assert_eq!(rendered["value"]["data_state"], "observed");
-    assert_eq!(rendered["event_count"], 1);
+    assert_eq!(rendered["event_count"], 0);
+    assert_eq!(rendered["attention"]["count"], 1);
     assert_eq!(rendered["value"]["observed"]["attention_events"], 1);
     assert_eq!(
         rendered["value"]["observed"]["uncorrelatable_attention_events"],
         1
     );
+    assert_eq!(rendered["value"]["observed"]["sessions_with_attention"], 0);
+    assert_eq!(
+        rendered["value"]["observed"]["sessions_without_later_follow_up_pass"],
+        0
+    );
+    assert_eq!(rendered["value"]["observed"]["suppression_events"], 0);
+    assert_eq!(
+        rendered["value"]["observed"]["hook_duration_ms"]["count"],
+        0
+    );
 
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_counts_slow_successful_build_checks_as_later_passes() {
+    let root = case_root("slow_build_success");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"post-build-check\",\"decision\":\"pass\",\"duration_ms\":2500}\n"
+        ),
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+
+    assert_eq!(
+        rendered["value"]["observed"]["sessions_with_later_follow_up_pass"],
+        1
+    );
+    assert_eq!(
+        rendered["value"]["verified"]["sessions_with_later_build_pass"],
+        1
+    );
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_treats_unknown_sessions_as_uncorrelatable() {
+    let root = case_root("unknown_session");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"unknown\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"unknown\",\"hook\":\"post-build-check\",\"decision\":\"pass\"}\n"
+        ),
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    let value = &rendered["value"];
+    assert_eq!(value["observed"]["attention_events"], 1);
+    assert_eq!(value["observed"]["uncorrelatable_attention_events"], 1);
+    assert_eq!(value["observed"]["sessions_with_attention"], 0);
+    assert_eq!(value["observed"]["sessions_with_later_follow_up_pass"], 0);
+    assert_eq!(value["verified"]["sessions_with_later_build_pass"], 0);
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_json_attention_summary_matches_value_semantics() {
+    let root = case_root("attention_consistency");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"status\":\"timeout\",\"decision\":\"pass\"}\n",
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    assert_eq!(rendered["attention"]["count"], 0);
+    assert_eq!(rendered["attention"]["rate"], 0.0);
+    assert_eq!(rendered["attention"]["percent"], 0.0);
+    assert_eq!(rendered["value"]["observed"]["attention_events"], 0);
     fs::remove_dir_all(root).expect("case root should be removed");
 }
 
@@ -362,7 +473,7 @@ fn value_limitations_describe_limit_before_time_window() {
         &root,
         &["observe", "value", "--json", "--log-file", &path_text(&log)],
     ));
-    let bounded_limitation = "Counts consider at most the configured 5000 most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established.";
+    let bounded_limitation = "Counts consider at most the configured 5000 most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered. Attention events with missing or unparseable timestamps are reported only as uncorrelatable and excluded from finite-window aggregates because their time position cannot be established.";
     assert!(
         bounded["value"]["limitations"]
             .as_array()
@@ -386,7 +497,7 @@ fn value_limitations_describe_limit_before_time_window() {
             &path_text(&log),
         ],
     ));
-    let all_limitation = "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established.";
+    let all_limitation = "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered. Attention events with missing or unparseable timestamps are reported only as uncorrelatable and excluded from finite-window aggregates because their time position cannot be established.";
     assert!(
         all["value"]["limitations"]
             .as_array()

--- a/vibeguard-runtime/tests/observe_value_cli.rs
+++ b/vibeguard-runtime/tests/observe_value_cli.rs
@@ -313,6 +313,73 @@ fn value_json_attention_summary_matches_value_semantics() {
 }
 
 #[test]
+fn value_attention_rate_uses_the_same_scoped_and_unscoped_population() {
+    let root = case_root("attention_rate_population");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"not-a-timestamp\",\"session\":\"s2\",\"decision\":\"warn\"}\n"
+        ),
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "7",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    assert_eq!(rendered["event_count"], 1);
+    assert_eq!(rendered["attention"]["count"], 2);
+    assert_eq!(rendered["attention"]["rate"], 1.0);
+    assert_eq!(rendered["attention"]["percent"], 100.0);
+    assert_eq!(rendered["value"]["observed"]["attention_events"], 2);
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_rejects_diagnostic_passes_as_follow_up_evidence() {
+    let root = case_root("diagnostic_pass");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"post-build-check\",\"status\":\"timeout\",\"decision\":\"pass\"}\n"
+        ),
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    assert_eq!(
+        rendered["value"]["observed"]["sessions_with_later_follow_up_pass"],
+        0
+    );
+    assert_eq!(
+        rendered["value"]["verified"]["sessions_with_later_build_pass"],
+        0
+    );
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
 fn value_human_output_leads_with_boundary_and_has_no_success_headline() {
     let root = case_root("human");
     let log = root.join("events.jsonl");

--- a/vibeguard-runtime/tests/observe_value_cli.rs
+++ b/vibeguard-runtime/tests/observe_value_cli.rs
@@ -1,0 +1,497 @@
+mod common;
+
+use common::{bin, path_text, unique_temp_dir};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+fn case_root(label: &str) -> PathBuf {
+    let root = unique_temp_dir(&format!("observe_value_{label}"));
+    fs::create_dir_all(root.join("home")).expect("test home should be created");
+    root
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    let mut command = bin();
+    command
+        .env("HOME", root.join("home"))
+        .env("VIBEGUARD_LOG_DIR", root.join("logs"))
+        .env_remove("VIBEGUARD_LOG_FILE")
+        .current_dir(root);
+    command
+        .args(args)
+        .output()
+        .expect("observe value command should run")
+}
+
+fn write_value_log(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("log parent should be created");
+    }
+    fs::write(path, content).expect("event log should be written");
+}
+
+fn output_json(output: &Output) -> Value {
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("observe value output should be JSON")
+}
+
+fn assert_success(output: &Output) {
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn value_json_reports_observed_follow_up_without_verified_build_evidence() {
+    let root = case_root("generic_follow_up");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"session-a\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\",\"reason\":\"U-16 warning\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"session-a\",\"hook\":\"post-edit-guard\",\"decision\":\"pass\",\"duration_ms\":12}\n"
+        ),
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+
+    assert_eq!(rendered["command"], "value");
+    assert_eq!(rendered["value"]["data_state"], "observed");
+    assert_eq!(rendered["value"]["observed"]["attention_events"], 1);
+    assert_eq!(
+        rendered["value"]["observed"]["sessions_with_later_follow_up_pass"],
+        1
+    );
+    assert_eq!(
+        rendered["value"]["verified"]["sessions_with_later_build_pass"],
+        0
+    );
+    assert_eq!(rendered["value"]["estimated"]["available"], false);
+
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_json_applies_attention_and_correlation_boundaries() {
+    let root = case_root("boundaries");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\",\"reason\":\"warning\",\"duration_ms\":10}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"pass\",\"duration_ms\":11}\n",
+            "{\"ts\":\"2099-01-01T00:00:03Z\",\"session\":\"s2\",\"hook\":\"pre-write-guard\",\"decision\":\"block\",\"duration_ms\":20}\n",
+            "{\"ts\":\"2099-01-01T00:00:04Z\",\"session\":\"s2\",\"hook\":\"post-build-check\",\"decision\":\"pass\",\"elapsed_ms\":\"21\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:05Z\",\"session\":\"s3\",\"hook\":\"pre-edit-guard\",\"status\":\"gate\",\"decision\":\"gate\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:06Z\",\"session\":\"s3\",\"hook\":\"post-edit-guard\",\"status\":\"skipped\",\"decision\":\"pass\",\"reason\":\"suppressed by cooldown\",\"duration_ms\":30}\n",
+            "{\"ts\":\"2099-01-01T00:00:07Z\",\"session\":\"s4\",\"hook\":\"pre-bash-guard\",\"status\":\"escalate\",\"decision\":\"escalate\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:07Z\",\"session\":\"s4\",\"hook\":\"post-edit-guard\",\"decision\":\"pass\",\"duration_ms\":40}\n",
+            "{\"ts\":\"not-a-timestamp\",\"session\":\"s5\",\"hook\":\"post-edit-guard\",\"status\":\"correction\",\"decision\":\"correction\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:10Z\",\"session\":\"s5\",\"hook\":\"post-edit-guard\",\"decision\":\"pass\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:11Z\",\"session\":\"\",\"hook\":\"post-edit-guard\",\"status\":\"correction\",\"decision\":\"correction\"}\n",
+            "{\"ts\":\"not-a-timestamp\",\"session\":\"\",\"hook\":\"post-edit-guard\",\"status\":\"warn\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:12Z\",\"session\":\"s6\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:13Z\",\"session\":\"s6\",\"decision\":\"correction\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:14Z\",\"session\":\"s8\",\"status\":\"slow\",\"decision\":\"pass\",\"duration_ms\":2500}\n",
+            "{\"ts\":\"2099-01-01T00:00:15Z\",\"session\":\"s9\",\"status\":\"timeout\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:16Z\",\"session\":\"s7\",\"status\":\"pass\",\"decision\":\"pass\",\"reason\":\"suppressed text without skipped status\"}\n"
+        ),
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    let value = &rendered["value"];
+    let observed = &value["observed"];
+
+    assert_eq!(value["data_state"], "observed");
+    assert_eq!(observed["attention_events"], 9);
+    assert_eq!(observed["sessions_with_attention"], 6);
+    assert_eq!(observed["sessions_with_later_follow_up_pass"], 2);
+    assert_eq!(observed["sessions_without_later_follow_up_pass"], 4);
+    assert_eq!(observed["sessions_with_repeated_attention"], 1);
+    assert_eq!(observed["uncorrelatable_attention_events"], 3);
+    assert_eq!(observed["suppression_events"], 1);
+    assert_eq!(
+        observed["hook_duration_ms"],
+        serde_json::json!({
+            "count": 7,
+            "total_ms": 2632,
+            "avg_ms": 376,
+            "p95_ms": 2500
+        })
+    );
+    assert_eq!(value["verified"]["sessions_with_later_build_pass"], 1);
+    assert_eq!(value["estimated"]["available"], false);
+    assert!(
+        value["estimated"]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("causal")
+    );
+    assert!(value["limitations"].as_array().unwrap().iter().any(|item| {
+        item.as_str()
+            .is_some_and(|text| text.contains("not proof VibeGuard caused"))
+    }));
+
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_human_output_leads_with_boundary_and_has_no_success_headline() {
+    let root = case_root("human");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"decision\":\"warn\"}\n",
+    );
+
+    let output = run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    );
+    assert_success(&output);
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(text.starts_with("Evidence boundary:"), "{text}");
+    assert!(text.contains("Verified\n"), "{text}");
+    assert!(text.contains("Observed\n"), "{text}");
+    assert!(text.contains("Estimated/unavailable\n"), "{text}");
+    assert!(text.contains("Data state: observed"), "{text}");
+    assert!(!text.to_ascii_lowercase().contains("zero risk"), "{text}");
+    assert!(!text.to_ascii_lowercase().contains("success"), "{text}");
+
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
+fn value_distinguishes_missing_empty_and_no_events_in_window() {
+    let missing_root = case_root("missing");
+    let missing_json = output_json(&run(&missing_root, &["observe", "value", "--json"]));
+    assert_eq!(missing_json["value"]["data_state"], "missing");
+    let missing_human = run(&missing_root, &["observe", "value"]);
+    assert_success(&missing_human);
+    let missing_text = String::from_utf8_lossy(&missing_human.stdout);
+    assert!(
+        missing_text.contains("Data state: missing"),
+        "{missing_text}"
+    );
+    assert!(!missing_text.to_ascii_lowercase().contains("zero risk"));
+    assert!(!missing_text.to_ascii_lowercase().contains("success"));
+    fs::remove_dir_all(missing_root).expect("missing case root should be removed");
+
+    let empty_root = case_root("empty");
+    let empty_log = empty_root.join("empty.jsonl");
+    write_value_log(&empty_log, "\n");
+    let empty_json = output_json(&run(
+        &empty_root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&empty_log),
+        ],
+    ));
+    assert_eq!(empty_json["value"]["data_state"], "empty");
+    fs::remove_dir_all(empty_root).expect("empty case root should be removed");
+
+    let window_root = case_root("window");
+    let old_log = window_root.join("old.jsonl");
+    write_value_log(
+        &old_log,
+        "{\"ts\":\"2000-01-01T00:00:00Z\",\"session\":\"old\",\"decision\":\"warn\"}\n",
+    );
+    let window_json = output_json(&run(
+        &window_root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "7",
+            "--log-file",
+            &path_text(&old_log),
+        ],
+    ));
+    assert_eq!(window_json["value"]["data_state"], "empty");
+    fs::remove_dir_all(window_root).expect("window case root should be removed");
+}
+
+#[test]
+fn value_rejects_bad_explicit_inputs_and_help_lists_the_command() {
+    let root = case_root("input_errors");
+    let missing = root.join("missing.jsonl");
+    let missing_output = run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--log-file",
+            &path_text(&missing),
+        ],
+    );
+    assert_eq!(missing_output.status.code(), Some(1));
+    assert!(missing_output.stdout.is_empty());
+    let missing_stderr = String::from_utf8_lossy(&missing_output.stderr);
+    assert!(missing_stderr.starts_with("vibeguard-runtime error: "));
+    assert!(missing_stderr.contains("Log file does not exist:"));
+
+    let malformed_window = run(&root, &["observe", "value", "--days", "not-a-window"]);
+    assert_eq!(malformed_window.status.code(), Some(1));
+    assert!(malformed_window.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&malformed_window.stderr).starts_with("vibeguard-runtime error: ")
+    );
+
+    let help = run(&root, &["observe", "--help"]);
+    assert_eq!(help.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&help.stderr).contains("value"));
+
+    let main_help = run(&root, &[]);
+    assert_eq!(main_help.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&main_help.stderr)
+            .contains("<summary|health|session|value|export prometheus>")
+    );
+    fs::remove_dir_all(root).expect("input error case root should be removed");
+}
+
+#[test]
+fn value_json_supports_global_scope_and_seven_day_default() {
+    let root = case_root("scope");
+    let log = root.join("events.jsonl");
+    write_value_log(&log, "\n");
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--scope",
+            "global",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    assert_eq!(rendered["source"]["scope"], "global");
+    assert_eq!(rendered["source"]["period"], "last 7 days");
+    fs::remove_dir_all(root).expect("scope case root should be removed");
+}
+
+#[test]
+fn value_limitations_describe_limit_before_time_window() {
+    let root = case_root("limit_boundary");
+    let log = root.join("events.jsonl");
+    write_value_log(&log, "\n");
+
+    let bounded = output_json(&run(
+        &root,
+        &["observe", "value", "--json", "--log-file", &path_text(&log)],
+    ));
+    let bounded_limitation = "Counts consider at most the configured 5000 most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered.";
+    assert!(
+        bounded["value"]["limitations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == bounded_limitation)
+    );
+    let bounded_human = run(&root, &["observe", "value", "--log-file", &path_text(&log)]);
+    assert_success(&bounded_human);
+    assert!(String::from_utf8_lossy(&bounded_human.stdout).contains(bounded_limitation));
+
+    let all = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--limit",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    let all_limitation = "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered.";
+    assert!(
+        all["value"]["limitations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == all_limitation)
+    );
+    let all_human = run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--limit",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    );
+    assert_success(&all_human);
+    assert!(String::from_utf8_lossy(&all_human.stdout).contains(all_limitation));
+
+    fs::remove_dir_all(root).expect("limit boundary case root should be removed");
+}
+
+#[test]
+fn rendered_event_json_preserves_record_ids_and_legacy_empty_values() {
+    let root = case_root("record_ids");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"warn-hook\",\"decision\":\"warn\",\"record_id\":\"VGR-1-2-3\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"pass-hook\",\"decision\":\"pass\"}\n"
+        ),
+    );
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "health",
+            "--json",
+            "--hours",
+            "all",
+            "--top",
+            "10",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    let events = rendered["attention_states"].as_array().unwrap();
+    assert_eq!(events[0]["record_id"], "VGR-1-2-3");
+    assert!(events[0]["record_id"].is_string());
+    assert!(rendered["recent_events"].as_array().is_none());
+
+    let session = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "session",
+            "s1",
+            "--json",
+            "--hours",
+            "all",
+            "--top",
+            "10",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    let recent = session["recent_events"].as_array().unwrap();
+    assert_eq!(recent.len(), 2);
+    assert_eq!(recent[0]["record_id"], "VGR-1-2-3");
+    assert_eq!(recent[1]["record_id"], "");
+    assert!(recent[1]["record_id"].is_string());
+    fs::remove_dir_all(root).expect("record id case root should be removed");
+}
+
+#[test]
+fn old_summary_has_no_compliance_or_token_savings_proxy() {
+    let root = case_root("old_summary");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"warn-hook\",\"decision\":\"warn\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"pass-hook\",\"decision\":\"pass\"}\n"
+        ),
+    );
+    let output = run(
+        &root,
+        &[
+            "observe",
+            "summary",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    );
+    assert_success(&output);
+    let text = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+    assert!(!text.contains("compliance"), "{text}");
+    assert!(!text.contains("token savings"), "{text}");
+    assert!(!text.contains("estimated savings"), "{text}");
+    fs::remove_dir_all(root).expect("summary case root should be removed");
+}
+
+#[test]
+fn value_hook_duration_total_saturates() {
+    let root = case_root("duration_overflow");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        concat!(
+            "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"decision\":\"pass\",\"duration_ms\":18446744073709551615}\n",
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"decision\":\"pass\",\"duration_ms\":1}\n"
+        ),
+    );
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "all",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+    assert_eq!(
+        rendered["value"]["observed"]["hook_duration_ms"],
+        serde_json::json!({
+            "count": 2,
+            "total_ms": 18446744073709551615u64,
+            "avg_ms": 9223372036854775807u64,
+            "p95_ms": 18446744073709551615u64
+        })
+    );
+    fs::remove_dir_all(root).expect("duration case root should be removed");
+}

--- a/vibeguard-runtime/tests/observe_value_cli.rs
+++ b/vibeguard-runtime/tests/observe_value_cli.rs
@@ -352,7 +352,8 @@ fn value_rejects_diagnostic_passes_as_follow_up_evidence() {
         &log,
         concat!(
             "{\"ts\":\"2099-01-01T00:00:01Z\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
-            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"post-build-check\",\"status\":\"timeout\",\"decision\":\"pass\"}\n"
+            "{\"ts\":\"2099-01-01T00:00:02Z\",\"session\":\"s1\",\"hook\":\"post-build-check\",\"status\":\"timeout\",\"decision\":\"pass\"}\n",
+            "{\"ts\":\"2099-01-01T00:00:03Z\",\"session\":\"s1\",\"hook\":\"post-build-check\",\"status\":\"pass\",\"decision\":\"pass\",\"reason\":\"command timeout after 30 seconds\"}\n"
         ),
     );
 

--- a/vibeguard-runtime/tests/observe_value_cli.rs
+++ b/vibeguard-runtime/tests/observe_value_cli.rs
@@ -169,6 +169,39 @@ fn value_json_applies_attention_and_correlation_boundaries() {
 }
 
 #[test]
+fn value_finite_window_retains_unparseable_attention_as_uncorrelatable() {
+    let root = case_root("unparseable_timestamp");
+    let log = root.join("events.jsonl");
+    write_value_log(
+        &log,
+        "{\"ts\":\"not-a-timestamp\",\"session\":\"s1\",\"hook\":\"post-edit-guard\",\"decision\":\"warn\"}\n",
+    );
+
+    let rendered = output_json(&run(
+        &root,
+        &[
+            "observe",
+            "value",
+            "--json",
+            "--days",
+            "7",
+            "--log-file",
+            &path_text(&log),
+        ],
+    ));
+
+    assert_eq!(rendered["value"]["data_state"], "observed");
+    assert_eq!(rendered["event_count"], 1);
+    assert_eq!(rendered["value"]["observed"]["attention_events"], 1);
+    assert_eq!(
+        rendered["value"]["observed"]["uncorrelatable_attention_events"],
+        1
+    );
+
+    fs::remove_dir_all(root).expect("case root should be removed");
+}
+
+#[test]
 fn value_human_output_leads_with_boundary_and_has_no_success_headline() {
     let root = case_root("human");
     let log = root.join("events.jsonl");
@@ -329,7 +362,7 @@ fn value_limitations_describe_limit_before_time_window() {
         &root,
         &["observe", "value", "--json", "--log-file", &path_text(&log)],
     ));
-    let bounded_limitation = "Counts consider at most the configured 5000 most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered.";
+    let bounded_limitation = "Counts consider at most the configured 5000 most-recent parsed events from the selected scope, then apply the selected time window; earlier parsed events and events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established.";
     assert!(
         bounded["value"]["limitations"]
             .as_array()
@@ -353,7 +386,7 @@ fn value_limitations_describe_limit_before_time_window() {
             &path_text(&log),
         ],
     ));
-    let all_limitation = "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered.";
+    let all_limitation = "Because --limit all was explicitly requested, counts consider all parsed events from the selected scope, then apply the selected time window; events outside it are not considered. Events with missing or unparseable timestamps are retained as uncorrelatable because their time position cannot be established.";
     assert!(
         all["value"]["limitations"]
             .as_array()
@@ -379,7 +412,7 @@ fn value_limitations_describe_limit_before_time_window() {
 }
 
 #[test]
-fn rendered_event_json_preserves_record_ids_and_legacy_empty_values() {
+fn schema_v1_rendered_events_do_not_add_record_ids() {
     let root = case_root("record_ids");
     let log = root.join("events.jsonl");
     write_value_log(
@@ -404,8 +437,7 @@ fn rendered_event_json_preserves_record_ids_and_legacy_empty_values() {
         ],
     ));
     let events = rendered["attention_states"].as_array().unwrap();
-    assert_eq!(events[0]["record_id"], "VGR-1-2-3");
-    assert!(events[0]["record_id"].is_string());
+    assert!(events[0].get("record_id").is_none());
     assert!(rendered["recent_events"].as_array().is_none());
 
     let session = output_json(&run(
@@ -425,9 +457,7 @@ fn rendered_event_json_preserves_record_ids_and_legacy_empty_values() {
     ));
     let recent = session["recent_events"].as_array().unwrap();
     assert_eq!(recent.len(), 2);
-    assert_eq!(recent[0]["record_id"], "VGR-1-2-3");
-    assert_eq!(recent[1]["record_id"], "");
-    assert!(recent[1]["record_id"].is_string());
+    assert!(recent.iter().all(|event| event.get("record_id").is_none()));
     fs::remove_dir_all(root).expect("record id case root should be removed");
 }
 


### PR DESCRIPTION
## Summary

Adds `observe value`, a local evidence view that separates verified later build checks, observed follow-up activity, and unavailable estimates. The report explicitly treats session-local follow-up as association rather than causation and distinguishes missing, empty, and observed data.

Also removes the unsupported warn-compliance percentage and fixed token-savings estimate from the existing human summary, while preserving factual activity and performance counts.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## Checklist

- [x] Tests pass (`cargo test` / `go test ./...` / `pytest`)
- [x] Guard scripts tested (if applicable)
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used (`feat:` / `fix:` / `chore:` etc.)

## Related issues

Closes #784

## Screenshots / logs

- Full Rust suite passed
- `observe_value_cli`: 10 passed
- Existing `observe_cli`: 7 passed
- Observability schema suite: 10/10
- Stats shell suite: 61/61
- Observe shell suite: 16/16
- `bash scripts/local-contract-check.sh --quick`: passed with temporary commit signing disabled for test fixtures
