### PR TITLE
feat(observe): add first-win dashboard experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,12 @@ vibeguard observe summary --limit all        # Project trigger summary (7 days)
 vibeguard observe health --limit all         # Project health snapshot (24 hours)
 vibeguard observe summary --scope global --limit all # Global trigger summary
 vibeguard observe value                       # Bounded local event-stream evidence
+bash ~/vibeguard/plugins/vibeguard/scripts/vibeguard-plugin.sh dashboard # Local first-win dashboard
 vibeguard observe export prometheus          # Prometheus text export
 bash ~/vibeguard/setup.sh doctor             # Installation and host diagnosis
 ```
 
-`vibeguard observe` is the stable day-to-day command surface; underlying scripts remain available for specialized maintainer diagnostics. Doctor is read-only and summarizes installation state, capability gaps, and repair commands; hooks and guards remain the enforcement layer.
+`vibeguard observe` is the stable day-to-day command surface; underlying scripts remain available for specialized maintainer diagnostics. `observe value --json` is the dashboard's headline evidence source. The dashboard separates verified later build-pass associations from observed follow-up, unresolved attention, hook overhead, and friction; it keeps missing, empty, partial, failed, and unsupported evidence visible instead of substituting zero. It is local-only and makes no claims about causality, incidents prevented, token/time/money savings, or compliance. Doctor is read-only and summarizes installation state, capability gaps, and repair commands; hooks and guards remain the enforcement layer.
 
 Hook latency is also a product contract. See [Hook Latency Contract](docs/reference/hook-latency-contract.md) for per-hook P95 budgets, hotspot attribution, and the static gates that block expensive hook patterns.
 
@@ -390,6 +391,9 @@ production-surface `warn` or `block`; latency is native runtime command wall tim
 over five fresh-state measured runs per case after one warmup. Release CI runs
 the benchmark from both the raw native binary and a fresh no-clone installation,
 and derives the expected README numerators and denominators from the report.
+The built-in 5-positive/5-negative benchmark is a small reproducible corpus, not
+evidence of impact on the user's project. Keep it separate from local
+`observe value` event-stream evidence.
 
 ### Profiles and languages
 
@@ -463,9 +467,12 @@ bash plugins/vibeguard/scripts/vibeguard-plugin.sh stats all
 bash plugins/vibeguard/scripts/vibeguard-plugin.sh install --yes
 ```
 
-The dashboard is generated as a local HTML artifact from the existing VibeGuard
-diagnostic commands. It is not remote telemetry and does not replace behavior
-eval gates.
+The dashboard is generated as a standalone local HTML artifact. Its headline
+cards consume `vibeguard observe value --json`; installation state and human
+status/stats/health output are secondary collapsible diagnostics. The page is
+not remote telemetry, does not upload data, and does not replace behavior eval
+gates. If the selected runtime lacks `observe value`, it renders an explicit
+evidence-unavailable state with an update/build action.
 
 Hooks live in `~/.codex/hooks.json` (requires `[features].hooks = true` in `config.toml`). All profiles install the Bash/apply_patch gates and file post-hooks below; the `post-build-check` and `Stop` rows are installed only by `full` and `strict`:
 

--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -65,10 +65,13 @@ Start with the live, fail-closed interception demo:
 bash ~/vibeguard/setup.sh demo safe-bash
 ```
 
-This creates a temporary `HOME`, submits `rm -rf $HOME` through the real
-`PreToolUse(Bash)` hook, and verifies that the hook returns `block` while a
-sandbox marker remains intact. The dangerous command is never handed to a
-shell executor; malformed, failed, or non-block hook results stop the demo.
+This protects the demo's temporary `HOME` directory from the destructive
+`rm -rf $HOME` request. That matters because the same command could erase a
+user's local state. The sandbox marker verifies that the protected temporary
+directory remains intact after the real `PreToolUse(Bash)` hook returns
+`block`; the dangerous command is never handed to a shell executor. A
+malformed, failed, or non-block hook result stops the demo. This is isolated
+demo evidence, not evidence from your real project.
 
 Then try one live agent action in a disposable branch or scratch project:
 
@@ -89,3 +92,19 @@ vibeguard observe health --limit all
 This summarizes recent local hook events for the current project. See
 [Codex Hook Status](../reference/codex-hook-status.md) for JSON and global-scope
 diagnostics.
+
+## 6. Find the First Win in Your Project
+
+After a protected action has run in the project, inspect the bounded local
+event evidence:
+
+```bash
+vibeguard observe value --json
+bash ~/vibeguard/plugins/vibeguard/scripts/vibeguard-plugin.sh dashboard
+```
+
+The dashboard reads its headline cards from `observe value --json`. It keeps
+verified later build-pass associations separate from observed follow-up,
+unresolved attention sessions, and hook overhead. Missing, empty, partial, or
+unavailable evidence stays visible; the dashboard does not claim causality,
+incidents prevented, savings, or compliance.

--- a/plugins/vibeguard/README.md
+++ b/plugins/vibeguard/README.md
@@ -49,6 +49,26 @@ For headless validation:
 bash plugins/vibeguard/scripts/vibeguard-plugin.sh dashboard --no-open --output /tmp/vibeguard-dashboard.html --log-file /dev/null
 ```
 
-The generated dashboard is local-only. It renders the same human-facing status,
-stats, and health outputs that VibeGuard already provides; it does not enable
-remote telemetry or hosted deployment.
+The generated dashboard is local-only and standalone. Its headline evidence is
+read from the selected runtime's `observe value --json` output, never inferred
+from human stats or health text. The first screen keeps these tiers separate:
+
+- **Verified association:** a strictly later `post-build-check` pass in the
+  same session after attention. This is time-ordered local evidence, not proof
+  that VibeGuard caused the pass.
+- **Observed signals:** later ordinary follow-up passes, unresolved attention
+  sessions, and observed hook duration.
+- **Observed friction:** repeated-attention sessions, suppressions, and
+  uncorrelatable attention events.
+
+Installation state and human status/stats/health output remain secondary in
+collapsible diagnostic details. Raw output is HTML-escaped. Missing, empty,
+partial, malformed, failed, and unsupported evidence states are shown
+explicitly; unavailable evidence is never replaced with zero. The page makes
+no claims about incidents prevented, token/time/money savings, or compliance.
+
+The built-in 5-positive/5-negative benchmark is a small reproducible corpus,
+not evidence of impact on the user's project. If the selected runtime does not
+support `observe value`, the dashboard shows an actionable update/build
+message while preserving the existing dashboard flags, including the explicit
+rejection of `--project` with `--scope global`.

--- a/plugins/vibeguard/assets/dashboard-template.html
+++ b/plugins/vibeguard/assets/dashboard-template.html
@@ -345,7 +345,7 @@ pre.command { border-top: 0; color: var(--cyan); }
           <p class="metric-note">{{FOLLOW_NOTE}}</p>
         </article>
         <article class="metric-card">
-          <div class="metric-label">Guardrail signals without follow-up</div>
+          <div class="metric-label">Sessions without later follow-up</div>
           <h3 class="metric-value"><span data-evidence="unresolved-attention">{{UNRESOLVED}}</span></h3>
           <p class="metric-note">{{UNRESOLVED_NOTE}}</p>
         </article>

--- a/plugins/vibeguard/assets/dashboard-template.html
+++ b/plugins/vibeguard/assets/dashboard-template.html
@@ -1,0 +1,421 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>VibeGuard — first win</title>
+<style>
+:root {
+  color-scheme: dark;
+  --night: #0b1115;
+  --night-raised: #121b21;
+  --night-deep: #080d10;
+  --paper: #f4f0e5;
+  --paper-muted: #c7c7b9;
+  --line: #344149;
+  --line-bright: #60727a;
+  --cyan: #75e3d1;
+  --lime: #d4ed79;
+  --coral: #ff9584;
+  --ink: #162126;
+  --ink-muted: #506068;
+  --display: Georgia, "Times New Roman", serif;
+  --mono: "Courier New", Courier, monospace;
+}
+* { box-sizing: border-box; }
+html { background: var(--night); scroll-behavior: smooth; }
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 86% 9%, rgba(117,227,209,.13), transparent 26rem),
+    linear-gradient(135deg, var(--night-deep), var(--night) 52%, #101a20);
+  color: var(--paper);
+  font-family: var(--mono);
+  line-height: 1.55;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: .22;
+  background-image: radial-gradient(rgba(244,240,229,.2) .6px, transparent .6px);
+  background-size: 7px 7px;
+  mask-image: linear-gradient(to bottom, black, transparent 72%);
+}
+a { color: inherit; }
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 12px;
+  z-index: 4;
+  padding: 8px 12px;
+  background: var(--lime);
+  color: var(--ink);
+}
+.skip-link:focus { left: 12px; }
+.shell {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 28px 0 56px;
+}
+.masthead {
+  border-top: 1px solid var(--line-bright);
+  border-bottom: 1px solid var(--line);
+  padding: 16px 0 28px;
+}
+.brandline, .scope-stamp, .section-kicker, .tier-label, .metric-label, summary, .command {
+  font-size: 11px;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+.brandline {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  color: var(--cyan);
+}
+.state-label { color: var(--paper-muted); }
+.mast-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 250px;
+  gap: 40px;
+  align-items: end;
+  margin-top: 30px;
+}
+h1, h2, h3, p { margin-top: 0; }
+h1 {
+  max-width: 12ch;
+  margin-bottom: 18px;
+  color: var(--paper);
+  font-family: var(--display);
+  font-size: clamp(3.3rem, 8vw, 7.3rem);
+  font-weight: 400;
+  letter-spacing: -.065em;
+  line-height: .87;
+}
+.lede {
+  max-width: 62ch;
+  margin-bottom: 0;
+  color: var(--paper-muted);
+  font-size: 14px;
+}
+.scope-stamp {
+  display: grid;
+  gap: 7px;
+  padding: 15px;
+  border: 1px solid var(--line-bright);
+  border-left: 4px solid var(--cyan);
+  color: var(--paper-muted);
+  line-height: 1.35;
+}
+.scope-stamp strong { color: var(--paper); font-size: 13px; letter-spacing: .04em; }
+.scope-stamp span { color: var(--cyan); }
+.section { margin-top: 28px; }
+.story-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(240px, .7fr);
+  gap: 14px;
+}
+.story-card, .boundary-card, .tier, .friction, .limits, .benchmark, .diagnostics {
+  border: 1px solid var(--line);
+  background: rgba(18, 27, 33, .88);
+}
+.story-card {
+  position: relative;
+  min-height: 260px;
+  padding: 27px;
+  border-color: var(--cyan);
+  box-shadow: 12px 12px 0 rgba(117,227,209,.08);
+}
+.story-card::before {
+  content: "01";
+  position: absolute;
+  top: 20px;
+  right: 24px;
+  color: rgba(117,227,209,.26);
+  font-size: 3.5rem;
+  font-weight: 700;
+  letter-spacing: -.1em;
+}
+.section-kicker, .tier-label { color: var(--cyan); }
+.story-card h2 {
+  max-width: 18ch;
+  margin: 28px 0 15px;
+  color: var(--paper);
+  font-family: var(--display);
+  font-size: clamp(2rem, 4vw, 3.8rem);
+  font-weight: 400;
+  letter-spacing: -.045em;
+  line-height: .98;
+}
+.story-card p { max-width: 67ch; color: var(--paper-muted); font-size: 14px; }
+.next-action {
+  display: grid;
+  gap: 5px;
+  margin: 26px 0 0 !important;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+  color: var(--paper) !important;
+}
+.next-action strong { color: var(--lime); font-size: 11px; letter-spacing: .13em; text-transform: uppercase; }
+.boundary-card {
+  padding: 23px;
+  background: var(--paper);
+  color: var(--ink);
+}
+.boundary-card .section-kicker { color: #277c72; }
+.boundary-card p { margin-bottom: 12px; font-family: var(--display); font-size: 20px; line-height: 1.18; }
+.boundary-card p:last-child { margin-bottom: 0; color: var(--ink-muted); font-family: var(--mono); font-size: 12px; }
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 18px;
+  margin-bottom: 12px;
+}
+.section-heading h2 { margin: 0; font-family: var(--display); font-size: 28px; font-weight: 400; letter-spacing: -.03em; }
+.section-heading p { margin: 0; color: var(--paper-muted); font-size: 12px; }
+.tier { padding: 22px; }
+.tier.verified { border-color: var(--lime); }
+.tier.verified .tier-label { color: var(--lime); }
+.metric-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.metric-card {
+  min-height: 158px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  background: var(--night-deep);
+}
+.metric-card h3 { margin: 18px 0 9px; color: var(--paper); font-family: var(--display); font-size: 22px; font-weight: 400; line-height: 1.04; }
+.metric-card .metric-value { margin: 0; color: var(--cyan); font-family: var(--display); font-size: 42px; line-height: 1; letter-spacing: -.05em; }
+.verified .metric-card .metric-value { color: var(--lime); }
+.metric-card .metric-note { margin: 12px 0 0; color: var(--paper-muted); font-size: 12px; line-height: 1.45; }
+.metric-label { color: var(--paper-muted); }
+.friction { padding: 22px; border-color: var(--coral); }
+.friction .section-heading .tier-label { color: var(--coral); }
+.friction-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.friction-item { padding: 18px; border-top: 2px solid var(--coral); background: rgba(255,149,132,.06); }
+.friction-item strong { display: block; color: var(--coral); font-family: var(--display); font-size: 35px; font-weight: 400; line-height: 1; }
+.friction-item span { display: block; margin-top: 10px; color: var(--paper-muted); font-size: 12px; }
+.friction-note { margin: 17px 0 0; color: var(--paper-muted); font-size: 12px; }
+.limits, .benchmark, .diagnostics { padding: 22px; }
+.limits { border-color: var(--line-bright); }
+.limits h2, .benchmark h2, .diagnostics h2 { margin-bottom: 10px; font-family: var(--display); font-size: 29px; font-weight: 400; letter-spacing: -.03em; }
+.unavailable {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: start;
+  padding: 15px;
+  border-left: 3px solid var(--coral);
+  background: rgba(255,149,132,.06);
+}
+.unavailable .tier-label { color: var(--coral); }
+.unavailable p { margin: 0; color: var(--paper-muted); font-size: 13px; }
+.limit-list { margin: 16px 0 0; padding-left: 20px; color: var(--paper-muted); font-size: 12px; }
+.limit-list li + li { margin-top: 6px; }
+.benchmark { background: var(--paper); color: var(--ink); }
+.benchmark .section-kicker { color: #277c72; }
+.benchmark p { max-width: 70ch; margin-bottom: 0; font-family: var(--display); font-size: 21px; line-height: 1.23; }
+.benchmark small { display: block; margin-top: 13px; color: var(--ink-muted); font-family: var(--mono); font-size: 12px; }
+.diagnostics > p { margin-bottom: 17px; color: var(--paper-muted); font-size: 13px; }
+details { border-top: 1px solid var(--line); }
+summary { padding: 14px 0; cursor: pointer; color: var(--cyan); }
+summary:hover { color: var(--paper); }
+pre {
+  margin: 0;
+  padding: 14px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  background: var(--night-deep);
+  color: var(--paper-muted);
+  font: 12px/1.5 var(--mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+pre.command { border-top: 0; color: var(--cyan); }
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 30px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  color: var(--paper-muted);
+  font-size: 11px;
+}
+.muted { color: var(--paper-muted); }
+@media (max-width: 900px) {
+  .mast-grid, .story-grid { grid-template-columns: 1fr; }
+  .scope-stamp { grid-template-columns: repeat(3, auto); justify-content: start; align-items: baseline; }
+  .scope-stamp strong { margin-right: 10px; }
+}
+@media (max-width: 760px) {
+  .shell { width: min(100% - 24px, 640px); padding-top: 14px; }
+  .brandline { display: block; }
+  .state-label { display: block; margin-top: 7px; }
+  .mast-grid { gap: 24px; margin-top: 22px; }
+  h1 { font-size: clamp(3.4rem, 18vw, 6rem); }
+  .scope-stamp { grid-template-columns: 1fr; gap: 3px; }
+  .scope-stamp strong { margin: 0 0 8px; }
+  .story-card, .boundary-card, .tier, .friction, .limits, .benchmark, .diagnostics { padding: 17px; }
+  .story-card { min-height: 0; }
+  .story-card h2 { font-size: 2.6rem; }
+  .section-heading { display: block; }
+  .section-heading p { margin-top: 7px; }
+  .metric-grid, .friction-grid { grid-template-columns: 1fr; }
+  .metric-card { min-height: 0; }
+  .unavailable { grid-template-columns: 1fr; }
+  .footer { display: block; }
+  .footer span { display: block; margin-top: 7px; word-break: break-word; }
+}
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: .01ms !important;
+  }
+}
+</style>
+</head>
+<body>
+<a class="skip-link" href="#evidence">Skip to evidence</a>
+<main class="shell" aria-labelledby="dashboard-title" data-state="{{DATA_STATE}}">
+  <header class="masthead">
+    <div class="brandline">
+      <span>VIBEGUARD / LOCAL SIGNAL BOARD</span>
+      <span class="state-label">{{STATE_LABEL}}</span>
+    </div>
+    <div class="mast-grid">
+      <div>
+        <h1 id="dashboard-title">See what happened after VibeGuard stepped in.</h1>
+        <p class="lede">A first-win view for one local event stream: what was observed, what can be verified by order, what remains unresolved, and what to look at next.</p>
+      </div>
+      <div class="scope-stamp" aria-label="Dashboard scope and generation time">
+        <span>scope</span><strong>{{SCOPE}}</strong>
+        <span>window</span><strong>{{PERIOD}}</strong>
+        <span>generated</span><strong>{{GENERATED_AT}}</strong>
+      </div>
+    </div>
+  </header>
+
+  <section class="section story-grid" aria-labelledby="first-win-title">
+    <div class="story-card">
+      <div class="section-kicker">FIRST WIN / HONEST READ</div>
+      <h2 id="first-win-title">{{STORY_HEADLINE}}</h2>
+      <p>{{STORY_BODY}}</p>
+      <p class="next-action"><strong>Next action</strong><span>{{NEXT_ACTION}}</span></p>
+    </div>
+    <aside class="boundary-card" aria-label="Evidence boundary">
+      <div class="section-kicker">READ THIS FIRST</div>
+      <p>Local-only evidence, kept close to the event stream.</p>
+      <p>Associations are not causality. This page does not claim incidents prevented, savings, or compliance.</p>
+    </aside>
+  </section>
+
+  <section class="section" id="evidence" aria-labelledby="evidence-title">
+    <div class="section-heading">
+      <h2 id="evidence-title">Evidence in two tiers</h2>
+      <p>Headline evidence comes only from <code>observe value --json</code>.</p>
+    </div>
+    <div class="tier verified" data-state="{{DATA_STATE}}">
+      <div class="section-heading">
+        <span class="tier-label">VERIFIED ASSOCIATION</span>
+        <p>Time order in one non-empty session; not proof of cause.</p>
+      </div>
+      <div class="metric-grid">
+        <article class="metric-card">
+          <div class="metric-label">Later build pass after intervention</div>
+          <h3 class="metric-value"><span data-evidence="verified-build-pass">{{VERIFIED_BUILD}}</span></h3>
+          <p class="metric-note">{{VERIFIED_NOTE}}</p>
+        </article>
+      </div>
+    </div>
+    <div class="section tier" data-state="{{DATA_STATE}}">
+      <div class="section-heading">
+        <span class="tier-label">OBSERVED SIGNALS</span>
+        <p>What the selected local event stream contains.</p>
+      </div>
+      <div class="metric-grid">
+        <article class="metric-card">
+          <div class="metric-label">Follow-up after intervention</div>
+          <h3 class="metric-value"><span data-evidence="observed-follow-up">{{FOLLOW_UP}}</span></h3>
+          <p class="metric-note">{{FOLLOW_NOTE}}</p>
+        </article>
+        <article class="metric-card">
+          <div class="metric-label">Guardrail signals without follow-up</div>
+          <h3 class="metric-value"><span data-evidence="unresolved-attention">{{UNRESOLVED}}</span></h3>
+          <p class="metric-note">{{UNRESOLVED_NOTE}}</p>
+        </article>
+        <article class="metric-card">
+          <div class="metric-label">Observed hook overhead</div>
+          <h3 class="metric-value"><span data-evidence="hook-overhead">{{OVERHEAD}}</span></h3>
+          <p class="metric-note">{{OVERHEAD_NOTE}}</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="section friction" aria-labelledby="friction-title">
+    <div class="section-heading">
+      <h2 id="friction-title">Friction, kept separate</h2>
+      <span class="tier-label">OBSERVED FRICTION / NOT OUTCOME EVIDENCE</span>
+    </div>
+    <div class="friction-grid">
+      <div class="friction-item"><strong data-friction="repeated-attention">{{REPEATED}}</strong><span>sessions with repeated guardrail signals</span></div>
+      <div class="friction-item"><strong data-friction="suppressions">{{SUPPRESSIONS}}</strong><span>suppressed guardrail signals</span></div>
+      <div class="friction-item"><strong data-friction="uncorrelatable">{{UNCORRELATABLE}}</strong><span>signals missing session/time correlation</span></div>
+    </div>
+    <p class="friction-note">{{FRICTION_NOTE}}</p>
+  </section>
+
+  <section class="section limits" aria-labelledby="limits-title">
+    <h2 id="limits-title">What this page cannot tell you</h2>
+    <div class="unavailable">
+      <span class="tier-label">ESTIMATED / UNAVAILABLE</span>
+      <p>{{ESTIMATED_REASON}}</p>
+    </div>
+    {{LIMITATIONS}}
+  </section>
+
+  <section class="section benchmark" aria-labelledby="benchmark-title">
+    <div class="section-kicker">BOUNDARY / BUILT-IN CHECK</div>
+    <h2 id="benchmark-title">A reproducible corpus is not a project result.</h2>
+    <p>The built-in 5-positive/5-negative benchmark is a small reproducible corpus, not evidence of impact on your project.</p>
+    <small>Keep benchmark behavior checks separate from this local event-stream evidence.</small>
+  </section>
+
+  <section class="section diagnostics" aria-labelledby="diagnostics-title">
+    <h2 id="diagnostics-title">Installation and health diagnostics</h2>
+    <p>Secondary context for troubleshooting. Raw local output is shown only inside expandable details and is escaped before rendering.</p>
+    <details>
+      <summary>Codex installation status</summary>
+      <pre>{{STATUS_OUT}}</pre>
+      <pre class="command">{{STATUS_COMMAND}}</pre>
+    </details>
+    <details>
+      <summary>Hook health output</summary>
+      <pre>{{HEALTH_OUT}}</pre>
+      <pre class="command">{{HEALTH_COMMAND}}</pre>
+    </details>
+    <details>
+      <summary>Trigger stats output</summary>
+      <pre>{{STATS_OUT}}</pre>
+      <pre class="command">{{STATS_COMMAND}}</pre>
+    </details>
+    <details>
+      <summary>Observe-value command output</summary>
+      <pre>{{VALUE_OUT}}</pre>
+      <pre class="command">{{VALUE_COMMAND}}</pre>
+    </details>
+  </section>
+
+  <footer class="footer">
+    <span>LOCAL-ONLY / NO UPLOAD / NO TELEMETRY</span>
+    <span>repo: {{REPO_DIR}} · generated: {{GENERATED_AT}}</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/plugins/vibeguard/scripts/vibeguard-plugin.sh
+++ b/plugins/vibeguard/scripts/vibeguard-plugin.sh
@@ -407,6 +407,11 @@ USAGE
     return 2
   fi
 
+  local explicit_log_missing=0
+  if [[ -n "${log_file}" && ! -e "${log_file}" ]]; then
+    explicit_log_missing=1
+  fi
+
   local repo_dir dashboard_dir generated_at period_label
   repo_dir="$(resolve_repo_dir)"
   dashboard_dir="${PLUGIN_DATA:-${VIBEGUARD_PLUGIN_DATA:-${HOME}/.vibeguard/plugin}}"
@@ -494,7 +499,17 @@ USAGE
   local partial=0 parse_status=0
 
   limitations_html='<p class="muted">No additional limitations were provided.</p>'
-  if [[ "${value_status}" -ne 0 ]]; then
+  if [[ "${explicit_log_missing}" -eq 1 ]]; then
+    state="missing"
+    state_label="Event source missing"
+    headline="The selected local event source is missing."
+    body="The selected log path does not exist, so this dashboard cannot treat the window as empty or report zero evidence."
+    next_action="Check the selected log path and VibeGuard setup, then regenerate the dashboard."
+    overhead="No data"
+    overhead_note="No timing data in the selected source."
+    friction_note="Friction cannot be assessed until the selected event source exists."
+    estimated_reason="The selected event source is missing, so outcome evidence is unavailable."
+  elif [[ "${value_status}" -ne 0 ]]; then
     if [[ "${value_resolution_status}" -eq 0 ]]; then
       headline="Evidence command failed; no headline evidence was rendered."
       body="The selected runtime was available, but observe value --json did not complete successfully."

--- a/plugins/vibeguard/scripts/vibeguard-plugin.sh
+++ b/plugins/vibeguard/scripts/vibeguard-plugin.sh
@@ -66,6 +66,19 @@ capture_dashboard_command() {
   printf '%s\n' "${output}"
 }
 
+capture_dashboard_value_command() {
+  local output status
+  status=0
+  output="$("$@" 2>&1)" || status=$?
+  if [[ "${status}" -ne 0 ]]; then
+    printf 'COMMAND FAILED (%s):' "${status}"
+    printf ' %q' "$@"
+    printf '\n%s\n' "${output}"
+    return "${status}"
+  fi
+  printf '%s\n' "${output}"
+}
+
 canonical_dir() {
   local candidate="$1"
   if [[ -d "${candidate}" ]]; then
@@ -226,9 +239,9 @@ Options:
   --no-open              Do not open the generated dashboard
   --days N|all           Stats window, default 7
   --hours N              Health window, default 24
-  --scope project|global Pass scope through to stats and health
-  --project PATH_OR_HASH Pass project through to stats and health
-  --log-file PATH        Read observe events from PATH
+  --scope project|global Select value evidence, stats, and health scope
+  --project PATH_OR_HASH Select project for value evidence, stats, and health
+  --log-file PATH        Read value evidence, stats, and health from PATH
 USAGE
         return 0
         ;;
@@ -256,7 +269,7 @@ USAGE
     return 2
   fi
 
-  local repo_dir dashboard_dir generated_at
+  local repo_dir dashboard_dir generated_at period_label
   repo_dir="$(resolve_repo_dir)"
   dashboard_dir="${PLUGIN_DATA:-${VIBEGUARD_PLUGIN_DATA:-${HOME}/.vibeguard/plugin}}"
   if [[ -z "${output_path}" ]]; then
@@ -279,196 +292,361 @@ USAGE
     health_args=(--log-file "${log_file}" "${health_args[@]}")
   fi
 
-  local status_out stats_out health_out
+  local -a value_args=(observe value --json --limit all --days "${days}")
+  if [[ -n "${scope}" ]]; then
+    value_args+=(--scope "${scope}")
+  fi
+  if [[ -n "${project}" ]]; then
+    value_args+=(--project "${project}")
+  fi
+  if [[ -n "${log_file}" ]]; then
+    value_args+=(--log-file "${log_file}")
+  fi
+
+  local status_out stats_out health_out value_out value_runtime=""
+  local value_resolution_status value_status
+  value_resolution_status=0
+  value_status=0
   status_out="$(capture_dashboard_command bash "${repo_dir}/setup.sh" --codex-status)"
   stats_out="$(capture_dashboard_command bash "${repo_dir}/scripts/stats.sh" "${stats_args[@]}")"
   health_out="$(capture_dashboard_command bash "${repo_dir}/scripts/hook-health.sh" "${health_args[@]}")"
+
+  if [[ ! -f "${repo_dir}/scripts/lib/runtime.sh" ]]; then
+    value_resolution_status=2
+    value_status=2
+    value_out="RUNTIME CAPABILITY UNAVAILABLE: shared runtime resolver is missing from ${repo_dir}/scripts/lib/runtime.sh"
+  elif ! source "${repo_dir}/scripts/lib/runtime.sh"; then
+    value_resolution_status=2
+    value_status=2
+    value_out="RUNTIME RESOLVER FAILED: could not load ${repo_dir}/scripts/lib/runtime.sh"
+  elif value_runtime="$(vg_resolve_runtime "${repo_dir}" observe_value 2>&1)"; then
+    value_out="$(capture_dashboard_value_command "${value_runtime}" "${value_args[@]}")" || value_status=$?
+  else
+    value_resolution_status=$?
+    value_status="${value_resolution_status}"
+    value_out="RUNTIME CAPABILITY UNAVAILABLE (${value_resolution_status}): ${value_runtime}"
+  fi
+
   generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [[ "${days}" == "all" ]]; then
+    period_label="all available history"
+  else
+    period_label="last ${days} days"
+  fi
 
-  local status_html stats_html health_html repo_html generated_html
-  local stats_cmd_html health_cmd_html status_cmd_html
-  status_html="$(printf '%s\n' "${status_out}" | strip_ansi | html_escape)"
-  stats_html="$(printf '%s\n' "${stats_out}" | strip_ansi | html_escape)"
-  health_html="$(printf '%s\n' "${health_out}" | strip_ansi | html_escape)"
-  repo_html="$(printf '%s\n' "${repo_dir}" | html_escape)"
-  generated_html="$(printf '%s\n' "${generated_at}" | html_escape)"
-  status_cmd_html="$(printf 'bash %q --codex-status' "${repo_dir}/setup.sh" | html_escape)"
-  stats_cmd_html="$({ printf 'bash %q' "${repo_dir}/scripts/stats.sh"; printf ' %q' "${stats_args[@]}"; printf '\n'; } | html_escape)"
-  health_cmd_html="$({ printf 'bash %q' "${repo_dir}/scripts/hook-health.sh"; printf ' %q' "${health_args[@]}"; printf '\n'; } | html_escape)"
+  local status_clean stats_clean health_clean value_clean
+  local stats_cmd health_cmd status_cmd value_cmd
+  status_clean="$(printf '%s\n' "${status_out}" | strip_ansi)"
+  stats_clean="$(printf '%s\n' "${stats_out}" | strip_ansi)"
+  health_clean="$(printf '%s\n' "${health_out}" | strip_ansi)"
+  value_clean="$(printf '%s\n' "${value_out}" | strip_ansi)"
+  status_cmd="bash ${repo_dir}/setup.sh --codex-status"
+  stats_cmd="$({ printf 'bash %q' "${repo_dir}/scripts/stats.sh"; printf ' %q' "${stats_args[@]}"; printf '\n'; } )"
+  health_cmd="$({ printf 'bash %q' "${repo_dir}/scripts/hook-health.sh"; printf ' %q' "${health_args[@]}"; printf '\n'; } )"
+  if [[ -n "${value_runtime}" ]]; then
+    value_cmd="$({ printf '%q' "${value_runtime}"; printf ' %q' "${value_args[@]}"; printf '\n'; } )"
+  else
+    value_cmd="vibeguard-runtime observe value --json --limit all --days ${days}"
+  fi
 
-  cat > "${output_path}" <<HTML
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>VibeGuard Observability</title>
-<style>
-:root {
-  color-scheme: light;
-  --bg: #f7f8fb;
-  --panel: #ffffff;
-  --text: #18212f;
-  --muted: #5c6676;
-  --line: #d9dee8;
-  --green: #178a4f;
-  --amber: #b76b00;
-  --red: #b42318;
-  --blue: #2358c2;
-}
-* { box-sizing: border-box; }
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-main {
-  width: min(1180px, calc(100% - 32px));
-  margin: 0 auto;
-  padding: 32px 0 40px;
-}
-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-  align-items: flex-start;
-  padding-bottom: 20px;
-  border-bottom: 1px solid var(--line);
-}
-h1 {
-  margin: 0 0 8px;
-  font-size: 32px;
-  line-height: 1.1;
-  letter-spacing: 0;
-}
-.sub {
-  margin: 0;
-  color: var(--muted);
-  font-size: 14px;
-  line-height: 1.5;
-}
-.badge {
-  border: 1px solid var(--line);
-  background: var(--panel);
-  border-radius: 8px;
-  padding: 8px 10px;
-  color: var(--muted);
-  font-size: 12px;
-  white-space: nowrap;
-}
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
-  margin: 20px 0;
-}
-.card {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 16px;
-  min-height: 116px;
-}
-.card h2 {
-  margin: 0 0 8px;
-  font-size: 16px;
-  letter-spacing: 0;
-}
-.card p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.45;
-}
-.ok { color: var(--green); }
-.warn { color: var(--amber); }
-.risk { color: var(--red); }
-section {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  margin-top: 14px;
-  overflow: hidden;
-}
-section h2 {
-  margin: 0;
-  padding: 14px 16px;
-  font-size: 15px;
-  border-bottom: 1px solid var(--line);
-}
-pre {
-  margin: 0;
-  padding: 16px;
-  overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  color: #172033;
-  background: #fbfcff;
-}
-.cmd {
-  color: var(--blue);
-  border-top: 1px solid var(--line);
-  background: #f5f8ff;
-}
-@media (max-width: 860px) {
-  header { display: block; }
-  .badge { display: inline-block; margin-top: 12px; white-space: normal; }
-  .grid { grid-template-columns: 1fr; }
-  h1 { font-size: 26px; }
-}
-</style>
-</head>
-<body>
-<main>
-  <header>
-    <div>
-      <h1>VibeGuard Observability</h1>
-      <p class="sub">Local hook health, trigger stats, and Codex setup state generated from VibeGuard diagnostics.</p>
-      <p class="sub">Repo: ${repo_html}</p>
-    </div>
-    <div class="badge">Generated ${generated_html}</div>
-  </header>
+  if \
+    DASHBOARD_TEMPLATE_PATH="${PLUGIN_DIR}/assets/dashboard-template.html" \
+    DASHBOARD_OUTPUT_PATH="${output_path}" \
+    DASHBOARD_REPO_DIR="${repo_dir}" \
+    DASHBOARD_GENERATED_AT="${generated_at}" \
+    DASHBOARD_SCOPE="${scope:-project}" \
+    DASHBOARD_PERIOD="${period_label}" \
+    DASHBOARD_STATUS_OUT="${status_clean}" \
+    DASHBOARD_STATS_OUT="${stats_clean}" \
+    DASHBOARD_HEALTH_OUT="${health_clean}" \
+    DASHBOARD_VALUE_OUT="${value_clean}" \
+    DASHBOARD_VALUE_STATUS="${value_status}" \
+    DASHBOARD_VALUE_RESOLUTION_STATUS="${value_resolution_status}" \
+    DASHBOARD_STATUS_COMMAND="${status_cmd}" \
+    DASHBOARD_STATS_COMMAND="${stats_cmd}" \
+    DASHBOARD_HEALTH_COMMAND="${health_cmd}" \
+    DASHBOARD_VALUE_COMMAND="${value_cmd}" \
+    python3 - <<'PY'
+import html
+import json
+import os
+import sys
+from pathlib import Path
 
-  <div class="grid">
-    <div class="card">
-      <h2 class="ok">Runtime Health</h2>
-      <p>Shows installed hook state, warnings, repair hints, and recent Codex hook activity.</p>
-    </div>
-    <div class="card">
-      <h2 class="warn">Hook Friction</h2>
-      <p>Use health and stats together to separate noisy hooks from missing installation state.</p>
-    </div>
-    <div class="card">
-      <h2 class="risk">Eval Boundary</h2>
-      <p>This dashboard is runtime evidence. It does not replace behavior eval gates.</p>
-    </div>
-  </div>
 
-  <section>
-    <h2>Codex Status</h2>
-    <pre>${status_html}</pre>
-    <pre class="cmd">${status_cmd_html}</pre>
-  </section>
+def escape(value):
+    return html.escape(str(value), quote=True)
 
-  <section>
-    <h2>Hook Health</h2>
-    <pre>${health_html}</pre>
-    <pre class="cmd">${health_cmd_html}</pre>
-  </section>
 
-  <section>
-    <h2>Trigger Stats</h2>
-    <pre>${stats_html}</pre>
-    <pre class="cmd">${stats_cmd_html}</pre>
-  </section>
-</main>
-</body>
-</html>
-HTML
+def count_value(section, key):
+    if not isinstance(section, dict):
+        return None
+    value = section.get(key)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
 
-  printf '%s\n' "${output_path}"
+
+def count_text(value, state):
+    if state in {"missing", "empty"}:
+        return "No data"
+    if value is None:
+        return "Unavailable"
+    return str(value)
+
+
+def plural_count(value, noun):
+    return f"{value} {noun}" if value == 1 else f"{value} {noun}s"
+
+
+def diagnostic_list(items):
+    if not isinstance(items, list):
+        return '<p class="muted">No additional limitations were provided.</p>'
+    values = [escape(item) for item in items if isinstance(item, str) and item]
+    if not values:
+        return '<p class="muted">No additional limitations were provided.</p>'
+    return '<ul class="limit-list">' + ''.join(f"<li>{item}</li>" for item in values) + '</ul>'
+
+
+def metric_note(value, state, missing_text, zero_text, observed_text):
+    if state in {"missing", "empty"}:
+        return missing_text
+    if value is None:
+        return "This value was not available in the observe-value JSON."
+    if value == 0:
+        return zero_text
+    return observed_text
+
+
+def render_evidence():
+    raw = os.environ.get("DASHBOARD_VALUE_OUT", "")
+    try:
+        command_status = int(os.environ.get("DASHBOARD_VALUE_STATUS", "2"))
+    except ValueError:
+        command_status = 2
+    try:
+        resolution_status = int(os.environ.get("DASHBOARD_VALUE_RESOLUTION_STATUS", command_status))
+    except ValueError:
+        resolution_status = command_status
+
+    if command_status != 0:
+        return {
+            "state": "unavailable",
+            "state_label": "Evidence unavailable",
+            "headline": "Evidence command failed; no headline evidence was rendered." if resolution_status == 0 else "First-win evidence is unavailable.",
+            "body": "The selected runtime was available, but observe value --json did not complete successfully." if resolution_status == 0 else "The selected runtime could not provide observe value --json, so no headline evidence is shown.",
+            "next_action": "Check the escaped command output below, then update or build the VibeGuard runtime if needed." if resolution_status == 0 else "Update or build the VibeGuard runtime, then regenerate this dashboard.",
+            "verified_build": "Unavailable",
+            "verified_note": "No JSON evidence was available.",
+            "follow_up": "Unavailable",
+            "follow_note": "No JSON evidence was available.",
+            "unresolved": "Unavailable",
+            "unresolved_note": "No JSON evidence was available.",
+            "overhead": "Unavailable",
+            "overhead_note": "No JSON evidence was available.",
+            "repeated": "Unavailable",
+            "suppressions": "Unavailable",
+            "uncorrelatable": "Unavailable",
+            "friction_note": "Friction cannot be assessed until the JSON evidence command succeeds.",
+            "estimated_reason": "The evidence command did not produce usable output." if resolution_status == 0 else "The selected runtime does not support observe-value evidence.",
+            "limitations": diagnostic_list([]),
+            "raw": raw,
+        }
+
+    try:
+        payload = json.loads(raw)
+        value = payload["value"]
+        if not isinstance(payload, dict) or not isinstance(value, dict):
+            raise ValueError("observe value JSON does not contain an object value")
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        return {
+            "state": "unavailable",
+            "state_label": "Evidence unavailable",
+            "headline": "Evidence output could not be parsed; no headline evidence was rendered.",
+            "body": "The runtime returned output, but it was not the expected observe-value JSON envelope.",
+            "next_action": "Update or build the VibeGuard runtime, then regenerate this dashboard.",
+            "verified_build": "Unavailable",
+            "verified_note": "The JSON output could not be parsed.",
+            "follow_up": "Unavailable",
+            "follow_note": "The JSON output could not be parsed.",
+            "unresolved": "Unavailable",
+            "unresolved_note": "The JSON output could not be parsed.",
+            "overhead": "Unavailable",
+            "overhead_note": "The JSON output could not be parsed.",
+            "repeated": "Unavailable",
+            "suppressions": "Unavailable",
+            "uncorrelatable": "Unavailable",
+            "friction_note": "Friction cannot be assessed until the JSON evidence output is valid.",
+            "estimated_reason": f"The observe-value JSON could not be parsed ({error}).",
+            "limitations": diagnostic_list([]),
+            "raw": raw,
+        }
+
+    data_state = value.get("data_state")
+    state = data_state if isinstance(data_state, str) and data_state in {"missing", "empty", "observed"} else "partial"
+    verified = value.get("verified", {})
+    observed = value.get("observed", {})
+    verified_build = count_value(verified, "sessions_with_later_build_pass")
+    follow_up = count_value(observed, "sessions_with_later_follow_up_pass")
+    unresolved = count_value(observed, "sessions_without_later_follow_up_pass")
+    repeated = count_value(observed, "sessions_with_repeated_attention")
+    suppressions = count_value(observed, "suppression_events")
+    uncorrelatable = count_value(observed, "uncorrelatable_attention_events")
+    attention_events = count_value(observed, "attention_events")
+    attention_sessions = count_value(observed, "sessions_with_attention")
+    duration = observed.get("hook_duration_ms") if isinstance(observed, dict) else None
+    duration_count = count_value(duration, "count")
+    duration_avg = count_value(duration, "avg_ms")
+    duration_p95 = count_value(duration, "p95_ms")
+    partial = state == "partial" or any(
+        item is None for item in (verified_build, follow_up, unresolved, repeated, suppressions, uncorrelatable)
+    )
+    if uncorrelatable is not None and uncorrelatable > 0:
+        partial = True
+
+    if state in {"missing", "empty"}:
+        headline = "No local event data in the selected window."
+        body = "The dashboard keeps this state explicit; it does not turn an absent or empty source into zero evidence."
+        next_action = "Trigger one protected action in the project, then regenerate the dashboard."
+    elif verified_build is not None and verified_build > 0:
+        headline = "A later build pass is recorded after VibeGuard stepped in."
+        body = f"{plural_count(verified_build, 'session')} contains a strictly later post-build-check pass after a guardrail signal. This is a time-ordered association, not proof VibeGuard caused the result."
+        next_action = "Keep observing the next intervention-to-pass sequence in this project."
+    elif follow_up is not None and follow_up > 0:
+        headline = "A follow-up pass is visible after VibeGuard stepped in."
+        body = f"The event stream shows a later ordinary pass in {plural_count(follow_up, 'session')}, but no later build-pass association is recorded here."
+        next_action = "Run or observe a post-build check after the next follow-up."
+    elif unresolved is not None and unresolved > 0:
+        headline = f"A guardrail signal still needs follow-up in {plural_count(unresolved, 'session')}."
+        body = "These sessions have no later ordinary pass recorded in the selected event window."
+        next_action = "Inspect the unresolved sessions before drawing a conclusion."
+    elif partial:
+        headline = "Partial / unresolved local evidence."
+        body = "Some guardrail signals or fields cannot support a complete sequence in this window."
+        next_action = "Inspect the local event stream and observe the next intervention-to-pass sequence."
+    else:
+        headline = "No supported intervention-to-follow-up sequence is recorded yet."
+        body = "The selected event stream is present, but it does not contain a supported first-win story in this window."
+        next_action = "Use VibeGuard in the project and observe the next protected action."
+
+    if state not in {"missing", "empty"} and partial:
+        body += " Evidence is partial:"
+        if uncorrelatable is not None and uncorrelatable > 0:
+            body += f" {plural_count(uncorrelatable, 'guardrail signal')} could not be correlated by session and timestamp."
+        else:
+            body += " one or more required fields were unavailable."
+
+    if duration_count is not None and duration_count > 0 and duration_avg is not None:
+        overhead = f"{duration_avg} ms"
+        overhead_note = f"Average observed hook duration across {plural_count(duration_count, 'event')}"
+        if duration_p95 is not None:
+            overhead_note += f"; p95 {duration_p95} ms."
+        else:
+            overhead_note += "."
+    elif state in {"missing", "empty"}:
+        overhead = "No data"
+        overhead_note = "No timing data in the selected source."
+    elif duration_count == 0:
+        overhead = "No timing data"
+        overhead_note = "The selected events did not include usable durations."
+    else:
+        overhead = "Unavailable"
+        overhead_note = "Hook duration was not available in the observe-value JSON."
+
+    estimated = value.get("estimated", {})
+    estimated_reason = estimated.get("reason") if isinstance(estimated, dict) else None
+    if not isinstance(estimated_reason, str) or not estimated_reason:
+        estimated_reason = "The local event stream does not provide causal, incident, savings, or compliance evidence."
+    friction_note = "These are observed friction signals, not outcome claims."
+    if attention_events is not None and attention_sessions is not None:
+        friction_note = f"Observed {plural_count(attention_events, 'attention event')} across {plural_count(attention_sessions, 'session')}; these signals do not establish impact."
+
+    return {
+        "state": state,
+        "state_label": "Partial / unresolved local evidence" if partial else ("Observed local evidence" if state == "observed" else "No local event data"),
+        "headline": headline,
+        "body": body,
+        "next_action": next_action,
+        "verified_build": count_text(verified_build, state),
+        "verified_note": metric_note(verified_build, state, "The selected source has no usable events.", "No later build-pass association is recorded in this window.", "Strictly later post-build-check pass association(s) after a guardrail signal."),
+        "follow_up": count_text(follow_up, state),
+        "follow_note": metric_note(follow_up, state, "The selected source has no usable events.", "No later ordinary pass is recorded in this window.", "Later ordinary pass(es) observed after a guardrail signal."),
+        "unresolved": count_text(unresolved, state),
+        "unresolved_note": metric_note(unresolved, state, "The selected source has no usable events.", "No unresolved guardrail-signal session is recorded in this window.", "Guardrail-signal session(s) without a later ordinary pass."),
+        "overhead": overhead,
+        "overhead_note": overhead_note,
+        "repeated": count_text(repeated, state),
+        "suppressions": count_text(suppressions, state),
+        "uncorrelatable": count_text(uncorrelatable, state),
+        "friction_note": friction_note,
+        "estimated_reason": estimated_reason,
+        "limitations": diagnostic_list(value.get("limitations")),
+        "raw": raw,
+    }
+
+
+def main():
+    template_path = Path(os.environ["DASHBOARD_TEMPLATE_PATH"])
+    output_path = Path(os.environ["DASHBOARD_OUTPUT_PATH"])
+    template = template_path.read_text(encoding="utf-8")
+    evidence = render_evidence()
+    replacements = {
+        "REPO_DIR": escape(os.environ.get("DASHBOARD_REPO_DIR", "")),
+        "GENERATED_AT": escape(os.environ.get("DASHBOARD_GENERATED_AT", "")),
+        "SCOPE": escape(os.environ.get("DASHBOARD_SCOPE", "project")),
+        "PERIOD": escape(os.environ.get("DASHBOARD_PERIOD", "last 7 days")),
+        "DATA_STATE": escape(evidence["state"]),
+        "STATE_LABEL": escape(evidence["state_label"]),
+        "STORY_HEADLINE": escape(evidence["headline"]),
+        "STORY_BODY": escape(evidence["body"]),
+        "NEXT_ACTION": escape(evidence["next_action"]),
+        "VERIFIED_BUILD": escape(evidence["verified_build"]),
+        "VERIFIED_NOTE": escape(evidence["verified_note"]),
+        "FOLLOW_UP": escape(evidence["follow_up"]),
+        "FOLLOW_NOTE": escape(evidence["follow_note"]),
+        "UNRESOLVED": escape(evidence["unresolved"]),
+        "UNRESOLVED_NOTE": escape(evidence["unresolved_note"]),
+        "OVERHEAD": escape(evidence["overhead"]),
+        "OVERHEAD_NOTE": escape(evidence["overhead_note"]),
+        "REPEATED": escape(evidence["repeated"]),
+        "SUPPRESSIONS": escape(evidence["suppressions"]),
+        "UNCORRELATABLE": escape(evidence["uncorrelatable"]),
+        "FRICTION_NOTE": escape(evidence["friction_note"]),
+        "ESTIMATED_REASON": escape(evidence["estimated_reason"]),
+        "LIMITATIONS": evidence["limitations"],
+        "STATUS_OUT": escape(os.environ.get("DASHBOARD_STATUS_OUT", "")),
+        "STATS_OUT": escape(os.environ.get("DASHBOARD_STATS_OUT", "")),
+        "HEALTH_OUT": escape(os.environ.get("DASHBOARD_HEALTH_OUT", "")),
+        "VALUE_OUT": escape(evidence["raw"]),
+        "STATUS_COMMAND": escape(os.environ.get("DASHBOARD_STATUS_COMMAND", "")),
+        "STATS_COMMAND": escape(os.environ.get("DASHBOARD_STATS_COMMAND", "")),
+        "HEALTH_COMMAND": escape(os.environ.get("DASHBOARD_HEALTH_COMMAND", "")),
+        "VALUE_COMMAND": escape(os.environ.get("DASHBOARD_VALUE_COMMAND", "")),
+    }
+    for key, value in replacements.items():
+        template = template.replace("{{" + key + "}}", value)
+    if "{{" in template:
+        raise RuntimeError("dashboard template contains an unresolved placeholder")
+    output_path.write_text(template, encoding="utf-8")
+
+
+try:
+    main()
+except (OSError, RuntimeError, UnicodeError) as error:
+    sys.stderr.write(f"ERROR: could not generate dashboard: {error}\n")
+    raise SystemExit(1)
+PY
+  then
+    if ! chmod 600 "${output_path}"; then
+      printf 'ERROR: could not set private permissions on dashboard: %s\n' "${output_path}" >&2
+      return 1
+    fi
+    printf '%s\n' "${output_path}"
+  else
+    printf 'ERROR: dashboard template generation failed\n' >&2
+    return 1
+  fi
+
   if [[ "${open_after}" -eq 1 ]]; then
     open_path "${output_path}"
   fi

--- a/plugins/vibeguard/scripts/vibeguard-plugin.sh
+++ b/plugins/vibeguard/scripts/vibeguard-plugin.sh
@@ -40,6 +40,144 @@ strip_ansi() {
   perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g'
 }
 
+render_dashboard_template() {
+  local template_path="$1"
+  local output_path="$2"
+  shift 2
+
+  if [[ ! -r "${template_path}" ]]; then
+    printf 'ERROR: dashboard template is not readable: %s\n' "${template_path}" >&2
+    return 1
+  fi
+  if (( $# % 2 != 0 )); then
+    printf 'ERROR: dashboard template replacements must be key/value pairs\n' >&2
+    return 1
+  fi
+
+  local key value key_list=""
+  local -a replacement_env=()
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    value="$2"
+    shift 2
+    key_list="${key_list}${key_list:+ }${key}"
+    replacement_env+=("DASHBOARD_REPLACE_${key}=${value}")
+  done
+
+  local temp_output
+  if ! temp_output="$(mktemp "${output_path}.tmp.XXXXXX")"; then
+    printf 'ERROR: could not create temporary dashboard beside: %s\n' "${output_path}" >&2
+    return 1
+  fi
+  if ! env "${replacement_env[@]}" awk -v key_list="${key_list}" '
+    BEGIN {
+      key_count = split(key_list, keys, " ")
+      failed = 0
+    }
+    {
+      source = $0
+      rendered = ""
+      while (length(source) > 0) {
+        unknown_at = index(source, "{{")
+        best_at = 0
+        best_key = ""
+        best_token = ""
+        for (index_key = 1; index_key <= key_count; index_key++) {
+          token = "{{" keys[index_key] "}}"
+          token_at = index(source, token)
+          if (token_at > 0 && (best_at == 0 || token_at < best_at)) {
+            best_at = token_at
+            best_key = keys[index_key]
+            best_token = token
+          }
+        }
+        if (unknown_at > 0 && (best_at == 0 || unknown_at < best_at)) {
+          failed = 1
+          next
+        }
+        if (best_at == 0) {
+          rendered = rendered source
+          source = ""
+        } else {
+          rendered = rendered substr(source, 1, best_at - 1) ENVIRON["DASHBOARD_REPLACE_" best_key]
+          source = substr(source, best_at + length(best_token))
+        }
+      }
+      if (!failed) {
+        print rendered
+      }
+    }
+    END {
+      if (failed) {
+        print "ERROR: dashboard template contains an unknown placeholder" > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "${template_path}" > "${temp_output}"; then
+    rm -f "${temp_output}"
+    printf 'ERROR: could not write dashboard: %s\n' "${output_path}" >&2
+    return 1
+  fi
+  if ! mv -f "${temp_output}" "${output_path}"; then
+    rm -f "${temp_output}"
+    printf 'ERROR: could not install generated dashboard: %s\n' "${output_path}" >&2
+    return 1
+  fi
+}
+
+dashboard_json_field() {
+  local runtime="$1"
+  local payload="$2"
+  local field="$3"
+  printf '%s\n' "${payload}" | "${runtime}" json-field --strict "${field}" 2>/dev/null
+}
+
+dashboard_count_value() {
+  local value
+  value="$(dashboard_json_field "$1" "$2" "$3")" || return 1
+  [[ "${value}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "${value}"
+}
+
+dashboard_count_text() {
+  local value="$1"
+  local state="$2"
+  if [[ "${state}" == "missing" || "${state}" == "empty" ]]; then
+    printf 'No data\n'
+  elif [[ -z "${value}" ]]; then
+    printf 'Unavailable\n'
+  else
+    printf '%s\n' "${value}"
+  fi
+}
+
+dashboard_plural_count() {
+  local value="$1"
+  local noun="$2"
+  if [[ "${value}" == "1" ]]; then
+    printf '1 %s\n' "${noun}"
+  else
+    printf '%s %ss\n' "${value}" "${noun}"
+  fi
+}
+
+dashboard_metric_note() {
+  local value="$1"
+  local state="$2"
+  local missing_text="$3"
+  local zero_text="$4"
+  local observed_text="$5"
+  if [[ "${state}" == "missing" || "${state}" == "empty" ]]; then
+    printf '%s\n' "${missing_text}"
+  elif [[ -z "${value}" ]]; then
+    printf 'This value was not available in the observe-value JSON.\n'
+  elif [[ "${value}" == "0" ]]; then
+    printf '%s\n' "${zero_text}"
+  else
+    printf '%s\n' "${observed_text}"
+  fi
+}
+
 capture_command() {
   local output status
   status=0
@@ -340,312 +478,230 @@ USAGE
   stats_clean="$(printf '%s\n' "${stats_out}" | strip_ansi)"
   health_clean="$(printf '%s\n' "${health_out}" | strip_ansi)"
   value_clean="$(printf '%s\n' "${value_out}" | strip_ansi)"
-  status_cmd="bash ${repo_dir}/setup.sh --codex-status"
+  status_cmd="$(printf 'bash %q --codex-status' "${repo_dir}/setup.sh")"
   stats_cmd="$({ printf 'bash %q' "${repo_dir}/scripts/stats.sh"; printf ' %q' "${stats_args[@]}"; printf '\n'; } )"
   health_cmd="$({ printf 'bash %q' "${repo_dir}/scripts/hook-health.sh"; printf ' %q' "${health_args[@]}"; printf '\n'; } )"
-  if [[ -n "${value_runtime}" ]]; then
-    value_cmd="$({ printf '%q' "${value_runtime}"; printf ' %q' "${value_args[@]}"; printf '\n'; } )"
+  value_cmd="$({ printf '%q' "${value_runtime:-vibeguard-runtime}"; printf ' %q' "${value_args[@]}"; printf '\n'; } )"
+
+  local state="unavailable"
+  local state_label="Evidence unavailable"
+  local headline body next_action
+  local verified_build="" follow_up="" unresolved="" repeated="" suppressions="" uncorrelatable=""
+  local attention_events="" attention_sessions="" duration_count="" duration_avg="" duration_p95=""
+  local overhead="Unavailable" overhead_note="No JSON evidence was available."
+  local friction_note="Friction cannot be assessed until the JSON evidence command succeeds."
+  local estimated_reason limitations_html
+  local partial=0 parse_status=0
+
+  limitations_html='<p class="muted">No additional limitations were provided.</p>'
+  if [[ "${value_status}" -ne 0 ]]; then
+    if [[ "${value_resolution_status}" -eq 0 ]]; then
+      headline="Evidence command failed; no headline evidence was rendered."
+      body="The selected runtime was available, but observe value --json did not complete successfully."
+      next_action="Check the escaped command output below, then update or build the VibeGuard runtime if needed."
+      estimated_reason="The evidence command did not produce usable output."
+    else
+      headline="First-win evidence is unavailable."
+      body="The selected runtime could not provide observe value --json, so no headline evidence is shown."
+      next_action="Update or build the VibeGuard runtime, then regenerate this dashboard."
+      estimated_reason="The selected runtime does not support observe-value evidence."
+    fi
   else
-    value_cmd="vibeguard-runtime observe value --json --limit all --days ${days}"
+    state="$(dashboard_json_field "${value_runtime}" "${value_clean}" value.data_state)" || parse_status=$?
+    if [[ "${parse_status}" -ne 0 ]]; then
+      state="unavailable"
+      headline="Evidence output could not be parsed; no headline evidence was rendered."
+      body="The runtime returned output, but it was not the expected observe-value JSON envelope."
+      next_action="Update or build the VibeGuard runtime, then regenerate this dashboard."
+      overhead_note="The JSON output could not be parsed."
+      friction_note="Friction cannot be assessed until the JSON evidence output is valid."
+      estimated_reason="The observe-value JSON could not be parsed."
+    else
+      case "${state}" in
+        missing|empty|observed) ;;
+        *) state="partial" ;;
+      esac
+
+      verified_build="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.verified.sessions_with_later_build_pass)" || verified_build=""
+      follow_up="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.sessions_with_later_follow_up_pass)" || follow_up=""
+      unresolved="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.sessions_without_later_follow_up_pass)" || unresolved=""
+      repeated="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.sessions_with_repeated_attention)" || repeated=""
+      suppressions="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.suppression_events)" || suppressions=""
+      uncorrelatable="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.uncorrelatable_attention_events)" || uncorrelatable=""
+      attention_events="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.attention_events)" || attention_events=""
+      attention_sessions="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.sessions_with_attention)" || attention_sessions=""
+      duration_count="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.hook_duration_ms.count)" || duration_count=""
+      duration_avg="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.hook_duration_ms.avg_ms)" || duration_avg=""
+      duration_p95="$(dashboard_count_value "${value_runtime}" "${value_clean}" value.observed.hook_duration_ms.p95_ms)" || duration_p95=""
+
+      if [[ "${state}" == "partial" || -z "${verified_build}" || -z "${follow_up}" || -z "${unresolved}" || -z "${repeated}" || -z "${suppressions}" || -z "${uncorrelatable}" ]]; then
+        partial=1
+      fi
+      if [[ -n "${uncorrelatable}" && "${uncorrelatable}" -gt 0 ]]; then
+        partial=1
+      fi
+
+      if [[ "${state}" == "missing" ]]; then
+        headline="The selected local event source is missing."
+        body="The configured source could not be found, so this dashboard cannot treat the window as empty or report zero evidence."
+        next_action="Check the selected log path and VibeGuard setup, then regenerate the dashboard."
+      elif [[ "${state}" == "empty" ]]; then
+        headline="No local event data in the selected window."
+        body="The selected source exists but has no usable events in this window; the dashboard does not turn that absence into zero evidence."
+        next_action="Trigger one protected action in the project, then regenerate the dashboard."
+      elif [[ -n "${verified_build}" && "${verified_build}" -gt 0 ]]; then
+        headline="A later build pass is recorded after VibeGuard stepped in."
+        body="$(dashboard_plural_count "${verified_build}" session) contains a strictly later post-build-check pass after a guardrail signal. This is a time-ordered association, not proof VibeGuard caused the result."
+        next_action="Keep observing the next intervention-to-pass sequence in this project."
+      elif [[ -n "${follow_up}" && "${follow_up}" -gt 0 ]]; then
+        headline="A follow-up pass is visible after VibeGuard stepped in."
+        body="The event stream shows a later ordinary pass in $(dashboard_plural_count "${follow_up}" session), but no later build-pass association is recorded here."
+        next_action="Run or observe a post-build check after the next follow-up."
+      elif [[ -n "${unresolved}" && "${unresolved}" -gt 0 ]]; then
+        headline="A guardrail signal still needs follow-up in $(dashboard_plural_count "${unresolved}" session)."
+        body="These sessions have no later ordinary pass recorded in the selected event window."
+        next_action="Inspect the unresolved sessions before drawing a conclusion."
+      elif [[ "${partial}" -eq 1 ]]; then
+        headline="Partial / unresolved local evidence."
+        body="Some guardrail signals or fields cannot support a complete sequence in this window."
+        next_action="Inspect the local event stream and observe the next intervention-to-pass sequence."
+      else
+        headline="No supported intervention-to-follow-up sequence is recorded yet."
+        body="The selected event stream is present, but it does not contain a supported first-win story in this window."
+        next_action="Use VibeGuard in the project and observe the next protected action."
+      fi
+
+      if [[ "${state}" != "missing" && "${state}" != "empty" && "${partial}" -eq 1 ]]; then
+        if [[ -n "${uncorrelatable}" && "${uncorrelatable}" -gt 0 ]]; then
+          body="${body} Evidence is partial: $(dashboard_plural_count "${uncorrelatable}" "guardrail signal") could not be correlated by session and timestamp."
+        else
+          body="${body} Evidence is partial: one or more required fields were unavailable."
+        fi
+      fi
+
+      if [[ -n "${duration_count}" && "${duration_count}" -gt 0 && -n "${duration_avg}" ]]; then
+        overhead="${duration_avg} ms"
+        overhead_note="Average observed hook duration across $(dashboard_plural_count "${duration_count}" event)"
+        if [[ -n "${duration_p95}" ]]; then
+          overhead_note="${overhead_note}; p95 ${duration_p95} ms."
+        else
+          overhead_note="${overhead_note}."
+        fi
+      elif [[ "${state}" == "missing" || "${state}" == "empty" ]]; then
+        overhead="No data"
+        overhead_note="No timing data in the selected source."
+      elif [[ "${duration_count}" == "0" ]]; then
+        overhead="No timing data"
+        overhead_note="The selected events did not include usable durations."
+      else
+        overhead="Unavailable"
+        overhead_note="Hook duration was not available in the observe-value JSON."
+      fi
+
+      estimated_reason="$(dashboard_json_field "${value_runtime}" "${value_clean}" value.estimated.reason)" || estimated_reason=""
+      if [[ -z "${estimated_reason}" ]]; then
+        estimated_reason="The local event stream does not provide causal, incident, savings, or compliance evidence."
+      fi
+      if [[ -n "${attention_events}" && -n "${attention_sessions}" ]]; then
+        friction_note="Observed $(dashboard_plural_count "${attention_events}" "attention event") across $(dashboard_plural_count "${attention_sessions}" session); these signals do not establish impact."
+      else
+        friction_note="These are observed friction signals, not outcome claims."
+      fi
+
+      local limitation limitations_raw index=0 limitation_items=""
+      limitations_raw="$(dashboard_json_field "${value_runtime}" "${value_clean}" value.limitations)" || limitations_raw=""
+      while limitation="$(dashboard_json_field "${value_runtime}" "${value_clean}" "value.limitations.${index}")"; do
+        if [[ -n "${limitation}" ]]; then
+          limitation_items="${limitation_items}<li>$(printf '%s' "${limitation}" | html_escape)</li>"
+        fi
+        index=$((index + 1))
+      done
+      if [[ -n "${limitation_items}" ]]; then
+        limitations_html="<ul class=\"limit-list\">${limitation_items}</ul>"
+      elif [[ -n "${limitations_raw}" && "${limitations_raw}" != "[]" ]]; then
+        limitations_html='<p class="muted">Limitations were reported but could not be rendered; inspect the raw observe-value output below.</p>'
+      fi
+
+      if [[ "${partial}" -eq 1 ]]; then
+        state_label="Partial / unresolved local evidence"
+      elif [[ "${state}" == "observed" ]]; then
+        state_label="Observed local evidence"
+      elif [[ "${state}" == "missing" ]]; then
+        state_label="Event source missing"
+      else
+        state_label="No local event data"
+      fi
+    fi
   fi
 
-  if \
-    DASHBOARD_TEMPLATE_PATH="${PLUGIN_DIR}/assets/dashboard-template.html" \
-    DASHBOARD_OUTPUT_PATH="${output_path}" \
-    DASHBOARD_REPO_DIR="${repo_dir}" \
-    DASHBOARD_GENERATED_AT="${generated_at}" \
-    DASHBOARD_SCOPE="${scope:-project}" \
-    DASHBOARD_PERIOD="${period_label}" \
-    DASHBOARD_STATUS_OUT="${status_clean}" \
-    DASHBOARD_STATS_OUT="${stats_clean}" \
-    DASHBOARD_HEALTH_OUT="${health_clean}" \
-    DASHBOARD_VALUE_OUT="${value_clean}" \
-    DASHBOARD_VALUE_STATUS="${value_status}" \
-    DASHBOARD_VALUE_RESOLUTION_STATUS="${value_resolution_status}" \
-    DASHBOARD_STATUS_COMMAND="${status_cmd}" \
-    DASHBOARD_STATS_COMMAND="${stats_cmd}" \
-    DASHBOARD_HEALTH_COMMAND="${health_cmd}" \
-    DASHBOARD_VALUE_COMMAND="${value_cmd}" \
-    python3 - <<'PY'
-import html
-import json
-import os
-import sys
-from pathlib import Path
-
-
-def escape(value):
-    return html.escape(str(value), quote=True)
-
-
-def count_value(section, key):
-    if not isinstance(section, dict):
-        return None
-    value = section.get(key)
-    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-        return value
-    return None
-
-
-def count_text(value, state):
-    if state in {"missing", "empty"}:
-        return "No data"
-    if value is None:
-        return "Unavailable"
-    return str(value)
-
-
-def plural_count(value, noun):
-    return f"{value} {noun}" if value == 1 else f"{value} {noun}s"
-
-
-def diagnostic_list(items):
-    if not isinstance(items, list):
-        return '<p class="muted">No additional limitations were provided.</p>'
-    values = [escape(item) for item in items if isinstance(item, str) and item]
-    if not values:
-        return '<p class="muted">No additional limitations were provided.</p>'
-    return '<ul class="limit-list">' + ''.join(f"<li>{item}</li>" for item in values) + '</ul>'
-
-
-def metric_note(value, state, missing_text, zero_text, observed_text):
-    if state in {"missing", "empty"}:
-        return missing_text
-    if value is None:
-        return "This value was not available in the observe-value JSON."
-    if value == 0:
-        return zero_text
-    return observed_text
-
-
-def render_evidence():
-    raw = os.environ.get("DASHBOARD_VALUE_OUT", "")
-    try:
-        command_status = int(os.environ.get("DASHBOARD_VALUE_STATUS", "2"))
-    except ValueError:
-        command_status = 2
-    try:
-        resolution_status = int(os.environ.get("DASHBOARD_VALUE_RESOLUTION_STATUS", command_status))
-    except ValueError:
-        resolution_status = command_status
-
-    if command_status != 0:
-        return {
-            "state": "unavailable",
-            "state_label": "Evidence unavailable",
-            "headline": "Evidence command failed; no headline evidence was rendered." if resolution_status == 0 else "First-win evidence is unavailable.",
-            "body": "The selected runtime was available, but observe value --json did not complete successfully." if resolution_status == 0 else "The selected runtime could not provide observe value --json, so no headline evidence is shown.",
-            "next_action": "Check the escaped command output below, then update or build the VibeGuard runtime if needed." if resolution_status == 0 else "Update or build the VibeGuard runtime, then regenerate this dashboard.",
-            "verified_build": "Unavailable",
-            "verified_note": "No JSON evidence was available.",
-            "follow_up": "Unavailable",
-            "follow_note": "No JSON evidence was available.",
-            "unresolved": "Unavailable",
-            "unresolved_note": "No JSON evidence was available.",
-            "overhead": "Unavailable",
-            "overhead_note": "No JSON evidence was available.",
-            "repeated": "Unavailable",
-            "suppressions": "Unavailable",
-            "uncorrelatable": "Unavailable",
-            "friction_note": "Friction cannot be assessed until the JSON evidence command succeeds.",
-            "estimated_reason": "The evidence command did not produce usable output." if resolution_status == 0 else "The selected runtime does not support observe-value evidence.",
-            "limitations": diagnostic_list([]),
-            "raw": raw,
-        }
-
-    try:
-        payload = json.loads(raw)
-        value = payload["value"]
-        if not isinstance(payload, dict) or not isinstance(value, dict):
-            raise ValueError("observe value JSON does not contain an object value")
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
-        return {
-            "state": "unavailable",
-            "state_label": "Evidence unavailable",
-            "headline": "Evidence output could not be parsed; no headline evidence was rendered.",
-            "body": "The runtime returned output, but it was not the expected observe-value JSON envelope.",
-            "next_action": "Update or build the VibeGuard runtime, then regenerate this dashboard.",
-            "verified_build": "Unavailable",
-            "verified_note": "The JSON output could not be parsed.",
-            "follow_up": "Unavailable",
-            "follow_note": "The JSON output could not be parsed.",
-            "unresolved": "Unavailable",
-            "unresolved_note": "The JSON output could not be parsed.",
-            "overhead": "Unavailable",
-            "overhead_note": "The JSON output could not be parsed.",
-            "repeated": "Unavailable",
-            "suppressions": "Unavailable",
-            "uncorrelatable": "Unavailable",
-            "friction_note": "Friction cannot be assessed until the JSON evidence output is valid.",
-            "estimated_reason": f"The observe-value JSON could not be parsed ({error}).",
-            "limitations": diagnostic_list([]),
-            "raw": raw,
-        }
-
-    data_state = value.get("data_state")
-    state = data_state if isinstance(data_state, str) and data_state in {"missing", "empty", "observed"} else "partial"
-    verified = value.get("verified", {})
-    observed = value.get("observed", {})
-    verified_build = count_value(verified, "sessions_with_later_build_pass")
-    follow_up = count_value(observed, "sessions_with_later_follow_up_pass")
-    unresolved = count_value(observed, "sessions_without_later_follow_up_pass")
-    repeated = count_value(observed, "sessions_with_repeated_attention")
-    suppressions = count_value(observed, "suppression_events")
-    uncorrelatable = count_value(observed, "uncorrelatable_attention_events")
-    attention_events = count_value(observed, "attention_events")
-    attention_sessions = count_value(observed, "sessions_with_attention")
-    duration = observed.get("hook_duration_ms") if isinstance(observed, dict) else None
-    duration_count = count_value(duration, "count")
-    duration_avg = count_value(duration, "avg_ms")
-    duration_p95 = count_value(duration, "p95_ms")
-    partial = state == "partial" or any(
-        item is None for item in (verified_build, follow_up, unresolved, repeated, suppressions, uncorrelatable)
-    )
-    if uncorrelatable is not None and uncorrelatable > 0:
-        partial = True
-
-    if state in {"missing", "empty"}:
-        headline = "No local event data in the selected window."
-        body = "The dashboard keeps this state explicit; it does not turn an absent or empty source into zero evidence."
-        next_action = "Trigger one protected action in the project, then regenerate the dashboard."
-    elif verified_build is not None and verified_build > 0:
-        headline = "A later build pass is recorded after VibeGuard stepped in."
-        body = f"{plural_count(verified_build, 'session')} contains a strictly later post-build-check pass after a guardrail signal. This is a time-ordered association, not proof VibeGuard caused the result."
-        next_action = "Keep observing the next intervention-to-pass sequence in this project."
-    elif follow_up is not None and follow_up > 0:
-        headline = "A follow-up pass is visible after VibeGuard stepped in."
-        body = f"The event stream shows a later ordinary pass in {plural_count(follow_up, 'session')}, but no later build-pass association is recorded here."
-        next_action = "Run or observe a post-build check after the next follow-up."
-    elif unresolved is not None and unresolved > 0:
-        headline = f"A guardrail signal still needs follow-up in {plural_count(unresolved, 'session')}."
-        body = "These sessions have no later ordinary pass recorded in the selected event window."
-        next_action = "Inspect the unresolved sessions before drawing a conclusion."
-    elif partial:
-        headline = "Partial / unresolved local evidence."
-        body = "Some guardrail signals or fields cannot support a complete sequence in this window."
-        next_action = "Inspect the local event stream and observe the next intervention-to-pass sequence."
-    else:
-        headline = "No supported intervention-to-follow-up sequence is recorded yet."
-        body = "The selected event stream is present, but it does not contain a supported first-win story in this window."
-        next_action = "Use VibeGuard in the project and observe the next protected action."
-
-    if state not in {"missing", "empty"} and partial:
-        body += " Evidence is partial:"
-        if uncorrelatable is not None and uncorrelatable > 0:
-            body += f" {plural_count(uncorrelatable, 'guardrail signal')} could not be correlated by session and timestamp."
-        else:
-            body += " one or more required fields were unavailable."
-
-    if duration_count is not None and duration_count > 0 and duration_avg is not None:
-        overhead = f"{duration_avg} ms"
-        overhead_note = f"Average observed hook duration across {plural_count(duration_count, 'event')}"
-        if duration_p95 is not None:
-            overhead_note += f"; p95 {duration_p95} ms."
-        else:
-            overhead_note += "."
-    elif state in {"missing", "empty"}:
-        overhead = "No data"
-        overhead_note = "No timing data in the selected source."
-    elif duration_count == 0:
-        overhead = "No timing data"
-        overhead_note = "The selected events did not include usable durations."
-    else:
-        overhead = "Unavailable"
-        overhead_note = "Hook duration was not available in the observe-value JSON."
-
-    estimated = value.get("estimated", {})
-    estimated_reason = estimated.get("reason") if isinstance(estimated, dict) else None
-    if not isinstance(estimated_reason, str) or not estimated_reason:
-        estimated_reason = "The local event stream does not provide causal, incident, savings, or compliance evidence."
-    friction_note = "These are observed friction signals, not outcome claims."
-    if attention_events is not None and attention_sessions is not None:
-        friction_note = f"Observed {plural_count(attention_events, 'attention event')} across {plural_count(attention_sessions, 'session')}; these signals do not establish impact."
-
-    return {
-        "state": state,
-        "state_label": "Partial / unresolved local evidence" if partial else ("Observed local evidence" if state == "observed" else "No local event data"),
-        "headline": headline,
-        "body": body,
-        "next_action": next_action,
-        "verified_build": count_text(verified_build, state),
-        "verified_note": metric_note(verified_build, state, "The selected source has no usable events.", "No later build-pass association is recorded in this window.", "Strictly later post-build-check pass association(s) after a guardrail signal."),
-        "follow_up": count_text(follow_up, state),
-        "follow_note": metric_note(follow_up, state, "The selected source has no usable events.", "No later ordinary pass is recorded in this window.", "Later ordinary pass(es) observed after a guardrail signal."),
-        "unresolved": count_text(unresolved, state),
-        "unresolved_note": metric_note(unresolved, state, "The selected source has no usable events.", "No unresolved guardrail-signal session is recorded in this window.", "Guardrail-signal session(s) without a later ordinary pass."),
-        "overhead": overhead,
-        "overhead_note": overhead_note,
-        "repeated": count_text(repeated, state),
-        "suppressions": count_text(suppressions, state),
-        "uncorrelatable": count_text(uncorrelatable, state),
-        "friction_note": friction_note,
-        "estimated_reason": estimated_reason,
-        "limitations": diagnostic_list(value.get("limitations")),
-        "raw": raw,
-    }
-
-
-def main():
-    template_path = Path(os.environ["DASHBOARD_TEMPLATE_PATH"])
-    output_path = Path(os.environ["DASHBOARD_OUTPUT_PATH"])
-    template = template_path.read_text(encoding="utf-8")
-    evidence = render_evidence()
-    replacements = {
-        "REPO_DIR": escape(os.environ.get("DASHBOARD_REPO_DIR", "")),
-        "GENERATED_AT": escape(os.environ.get("DASHBOARD_GENERATED_AT", "")),
-        "SCOPE": escape(os.environ.get("DASHBOARD_SCOPE", "project")),
-        "PERIOD": escape(os.environ.get("DASHBOARD_PERIOD", "last 7 days")),
-        "DATA_STATE": escape(evidence["state"]),
-        "STATE_LABEL": escape(evidence["state_label"]),
-        "STORY_HEADLINE": escape(evidence["headline"]),
-        "STORY_BODY": escape(evidence["body"]),
-        "NEXT_ACTION": escape(evidence["next_action"]),
-        "VERIFIED_BUILD": escape(evidence["verified_build"]),
-        "VERIFIED_NOTE": escape(evidence["verified_note"]),
-        "FOLLOW_UP": escape(evidence["follow_up"]),
-        "FOLLOW_NOTE": escape(evidence["follow_note"]),
-        "UNRESOLVED": escape(evidence["unresolved"]),
-        "UNRESOLVED_NOTE": escape(evidence["unresolved_note"]),
-        "OVERHEAD": escape(evidence["overhead"]),
-        "OVERHEAD_NOTE": escape(evidence["overhead_note"]),
-        "REPEATED": escape(evidence["repeated"]),
-        "SUPPRESSIONS": escape(evidence["suppressions"]),
-        "UNCORRELATABLE": escape(evidence["uncorrelatable"]),
-        "FRICTION_NOTE": escape(evidence["friction_note"]),
-        "ESTIMATED_REASON": escape(evidence["estimated_reason"]),
-        "LIMITATIONS": evidence["limitations"],
-        "STATUS_OUT": escape(os.environ.get("DASHBOARD_STATUS_OUT", "")),
-        "STATS_OUT": escape(os.environ.get("DASHBOARD_STATS_OUT", "")),
-        "HEALTH_OUT": escape(os.environ.get("DASHBOARD_HEALTH_OUT", "")),
-        "VALUE_OUT": escape(evidence["raw"]),
-        "STATUS_COMMAND": escape(os.environ.get("DASHBOARD_STATUS_COMMAND", "")),
-        "STATS_COMMAND": escape(os.environ.get("DASHBOARD_STATS_COMMAND", "")),
-        "HEALTH_COMMAND": escape(os.environ.get("DASHBOARD_HEALTH_COMMAND", "")),
-        "VALUE_COMMAND": escape(os.environ.get("DASHBOARD_VALUE_COMMAND", "")),
-    }
-    for key, value in replacements.items():
-        template = template.replace("{{" + key + "}}", value)
-    if "{{" in template:
-        raise RuntimeError("dashboard template contains an unresolved placeholder")
-    output_path.write_text(template, encoding="utf-8")
-
-
-try:
-    main()
-except (OSError, RuntimeError, UnicodeError) as error:
-    sys.stderr.write(f"ERROR: could not generate dashboard: {error}\n")
-    raise SystemExit(1)
-PY
-  then
-    if ! chmod 600 "${output_path}"; then
-      printf 'ERROR: could not set private permissions on dashboard: %s\n' "${output_path}" >&2
-      return 1
-    fi
-    printf '%s\n' "${output_path}"
+  local unavailable_note="No JSON evidence was available."
+  if [[ "${parse_status}" -ne 0 ]]; then
+    unavailable_note="The JSON output could not be parsed."
+  fi
+  local verified_text follow_up_text unresolved_text repeated_text suppressions_text uncorrelatable_text
+  local verified_note follow_up_note unresolved_note
+  if [[ "${state}" == "unavailable" ]]; then
+    verified_text="Unavailable"
+    follow_up_text="Unavailable"
+    unresolved_text="Unavailable"
+    repeated_text="Unavailable"
+    suppressions_text="Unavailable"
+    uncorrelatable_text="Unavailable"
+    verified_note="${unavailable_note}"
+    follow_up_note="${unavailable_note}"
+    unresolved_note="${unavailable_note}"
   else
+    verified_text="$(dashboard_count_text "${verified_build}" "${state}")"
+    follow_up_text="$(dashboard_count_text "${follow_up}" "${state}")"
+    unresolved_text="$(dashboard_count_text "${unresolved}" "${state}")"
+    repeated_text="$(dashboard_count_text "${repeated}" "${state}")"
+    suppressions_text="$(dashboard_count_text "${suppressions}" "${state}")"
+    uncorrelatable_text="$(dashboard_count_text "${uncorrelatable}" "${state}")"
+    verified_note="$(dashboard_metric_note "${verified_build}" "${state}" "The selected source has no usable events." "No later build-pass association is recorded in this window." "Strictly later post-build-check pass association(s) after a guardrail signal.")"
+    follow_up_note="$(dashboard_metric_note "${follow_up}" "${state}" "The selected source has no usable events." "No later ordinary pass is recorded in this window." "Later ordinary pass(es) observed after a guardrail signal.")"
+    unresolved_note="$(dashboard_metric_note "${unresolved}" "${state}" "The selected source has no usable events." "No unresolved guardrail-signal session is recorded in this window." "Guardrail-signal session(s) without a later ordinary pass.")"
+  fi
+
+  if ! render_dashboard_template "${PLUGIN_DIR}/assets/dashboard-template.html" "${output_path}" \
+    REPO_DIR "$(printf '%s' "${repo_dir}" | html_escape)" \
+    GENERATED_AT "$(printf '%s' "${generated_at}" | html_escape)" \
+    SCOPE "$(printf '%s' "${scope:-project}" | html_escape)" \
+    PERIOD "$(printf '%s' "${period_label}" | html_escape)" \
+    DATA_STATE "$(printf '%s' "${state}" | html_escape)" \
+    STATE_LABEL "$(printf '%s' "${state_label}" | html_escape)" \
+    STORY_HEADLINE "$(printf '%s' "${headline}" | html_escape)" \
+    STORY_BODY "$(printf '%s' "${body}" | html_escape)" \
+    NEXT_ACTION "$(printf '%s' "${next_action}" | html_escape)" \
+    VERIFIED_BUILD "$(printf '%s' "${verified_text}" | html_escape)" \
+    VERIFIED_NOTE "$(printf '%s' "${verified_note}" | html_escape)" \
+    FOLLOW_UP "$(printf '%s' "${follow_up_text}" | html_escape)" \
+    FOLLOW_NOTE "$(printf '%s' "${follow_up_note}" | html_escape)" \
+    UNRESOLVED "$(printf '%s' "${unresolved_text}" | html_escape)" \
+    UNRESOLVED_NOTE "$(printf '%s' "${unresolved_note}" | html_escape)" \
+    OVERHEAD "$(printf '%s' "${overhead}" | html_escape)" \
+    OVERHEAD_NOTE "$(printf '%s' "${overhead_note}" | html_escape)" \
+    REPEATED "$(printf '%s' "${repeated_text}" | html_escape)" \
+    SUPPRESSIONS "$(printf '%s' "${suppressions_text}" | html_escape)" \
+    UNCORRELATABLE "$(printf '%s' "${uncorrelatable_text}" | html_escape)" \
+    FRICTION_NOTE "$(printf '%s' "${friction_note}" | html_escape)" \
+    ESTIMATED_REASON "$(printf '%s' "${estimated_reason}" | html_escape)" \
+    LIMITATIONS "${limitations_html}" \
+    STATUS_OUT "$(printf '%s' "${status_clean}" | html_escape)" \
+    STATS_OUT "$(printf '%s' "${stats_clean}" | html_escape)" \
+    HEALTH_OUT "$(printf '%s' "${health_clean}" | html_escape)" \
+    VALUE_OUT "$(printf '%s' "${value_clean}" | html_escape)" \
+    STATUS_COMMAND "$(printf '%s' "${status_cmd}" | html_escape)" \
+    STATS_COMMAND "$(printf '%s' "${stats_cmd}" | html_escape)" \
+    HEALTH_COMMAND "$(printf '%s' "${health_cmd}" | html_escape)" \
+    VALUE_COMMAND "$(printf '%s' "${value_cmd}" | html_escape)"; then
     printf 'ERROR: dashboard template generation failed\n' >&2
     return 1
   fi
+  if ! chmod 600 "${output_path}"; then
+    printf 'ERROR: could not set private permissions on dashboard: %s\n' "${output_path}" >&2
+    return 1
+  fi
+  printf '%s\n' "${output_path}"
 
   if [[ "${open_after}" -eq 1 ]]; then
     open_path "${output_path}"

--- a/plugins/vibeguard/skills/vibeguard-observe/SKILL.md
+++ b/plugins/vibeguard/skills/vibeguard-observe/SKILL.md
@@ -26,7 +26,7 @@ JSONL logs before discussing external telemetry.
 ## Checklist
 
 - [ ] Resolve the source checkout with `plugins/vibeguard/scripts/vibeguard-plugin.sh repo-dir`.
-- [ ] Use `dashboard` for a local HTML overview.
+- [ ] Use `dashboard` for a local HTML first-win overview.
 - [ ] Use `health` for recent hook health.
 - [ ] Use `stats` for project/global trigger summaries.
 - [ ] Use `doctor` or `codex-status` for install/capability diagnosis.
@@ -53,3 +53,28 @@ When running from a plugin cache:
 VIBEGUARD_REPO_DIR=/path/to/vibeguard \
   bash scripts/vibeguard-plugin.sh dashboard --no-open
 ```
+
+## Dashboard evidence boundary
+
+The dashboard's headline cards come only from the selected runtime's
+`observe value --json` output. They do not parse or infer evidence from human
+`stats` or `health` output. The first screen separates:
+
+- verified later `post-build-check` pass associations in the same session;
+- observed ordinary follow-up, unresolved attention sessions, and hook
+  overhead;
+- observed friction such as repeated attention, suppressions, and
+  uncorrelatable events.
+
+The dashboard is a standalone local HTML file with no network assets,
+telemetry, upload, account, or server. Installation state and raw diagnostics
+are secondary and live in escaped collapsible details. Missing, empty,
+partial/unresolved, malformed, failed, and unsupported evidence states remain
+explicit. The dashboard does not claim causality, incidents prevented,
+token/time/money savings, or compliance. The built-in 5-positive/5-negative
+benchmark is a small reproducible corpus, not evidence of impact on the
+user's project.
+
+If the selected runtime lacks `observe value`, update or build the runtime and
+regenerate the dashboard. The dashboard flags remain available, and
+`--project` is still rejected together with `--scope global`.

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -72,6 +72,9 @@ vg_runtime_supports() {
     observe_health)
       vg_runtime_supports_observe_health "${candidate}"
       ;;
+    observe_value)
+      vg_runtime_supports_observe_value "${candidate}"
+      ;;
     observe_export_prometheus)
       vg_runtime_supports_observe_export_prometheus "${candidate}"
       ;;
@@ -89,6 +92,11 @@ vg_runtime_supports_observe() {
 vg_runtime_supports_observe_health() {
   local candidate="$1"
   "${candidate}" observe health --hours all --limit all --log-file /dev/null >/dev/null 2>&1
+}
+
+vg_runtime_supports_observe_value() {
+  local candidate="$1"
+  "${candidate}" observe value --json --days all --limit all --log-file /dev/null >/dev/null 2>&1
 }
 
 vg_runtime_supports_observe_export_prometheus() {

--- a/site/index.html
+++ b/site/index.html
@@ -16,6 +16,7 @@
   </a>
   <div class="links">
     <a href="#how">how it works</a>
+    <a href="#journey">first win</a>
     <a href="#rules">rules</a>
     <a href="#intercept">intercept</a>
     <a href="#install">install</a>
@@ -39,11 +40,27 @@
       <a class="btn ghost" href="#how">how it works →</a>
     </div>
 
-    <div class="stat-strip" aria-label="Product stats">
-      <div class="stat"><div class="num">127</div><div class="lbl">native rules</div></div>
-      <div class="stat"><div class="num">7</div><div class="lbl">constraint layers</div></div>
-      <div class="stat"><div class="num">12</div><div class="lbl">Codex hook entries</div></div>
-      <div class="stat"><div class="num">2</div><div class="lbl">agents supported</div></div>
+    <div class="journey-strip" aria-label="First-win journey">
+      <article class="journey-step">
+        <span class="step-no">01 / problem</span>
+        <h3>Problem surfaces</h3>
+        <p>An agent proposes a risky or unverified action inside your project.</p>
+      </article>
+      <article class="journey-step">
+        <span class="step-no">02 / intervention</span>
+        <h3>Intervention</h3>
+        <p>A native hook blocks, warns, or returns a concrete correction at the action boundary.</p>
+      </article>
+      <article class="journey-step">
+        <span class="step-no">03 / follow-up</span>
+        <h3>Correction / follow-up</h3>
+        <p>The local event stream records whether a later ordinary pass appears in the same session.</p>
+      </article>
+      <article class="journey-step">
+        <span class="step-no">04 / verification</span>
+        <h3>Verification</h3>
+        <p>A later build pass is a time-ordered association to inspect, not a causal impact claim.</p>
+      </article>
     </div>
   </div>
 </section>
@@ -74,6 +91,34 @@
         </ul>
       </div>
     </div>
+  </div>
+</section>
+
+<section class="band sunk" id="journey">
+  <div class="inner">
+    <div class="section-eyebrow">What the local evidence can tell you</div>
+    <h2 class="section-h2">Know the sequence. Keep the <span class="accent">boundary</span>.</h2>
+    <div class="knowledge-grid">
+      <article class="knowledge-card">
+        <div class="knowledge-label">verified</div>
+        <h3>Verified sequence</h3>
+        <p>A strictly later <code>post-build-check</code> pass in the same session can verify event order after a guardrail signal. It does not prove cause.</p>
+      </article>
+      <article class="knowledge-card">
+        <div class="knowledge-label">observed</div>
+        <h3>Observed signals and friction</h3>
+        <p>The local stream can show follow-up passes, unresolved sessions, repeated guardrail signals, suppressions, events that cannot be correlated, and hook overhead.</p>
+      </article>
+      <article class="knowledge-card unavailable-knowledge">
+        <div class="knowledge-label">unavailable</div>
+        <h3>Unavailable outcome claims</h3>
+        <p>The event stream cannot establish causality, incidents prevented, token, time, or money savings, or compliance.</p>
+      </article>
+    </div>
+    <aside class="benchmark-boundary">
+      <div class="section-eyebrow">benchmark boundary / 5 + 5</div>
+      <p>The built-in 5-positive/5-negative benchmark is a small reproducible corpus, not evidence of impact on your project.</p>
+    </aside>
   </div>
 </section>
 
@@ -116,6 +161,15 @@
         <tr><td class="key">Observability</td><td>Metrics, logs, and health checks for every interception. You see what was blocked and why.</td></tr>
       </tbody>
     </table>
+    <div class="system-facts" aria-label="Implementation facts, not project impact metrics">
+      <div class="fact-note">implementation facts / not project impact metrics</div>
+      <div class="stat-strip">
+        <div class="stat"><div class="num">127</div><div class="lbl">native rules</div></div>
+        <div class="stat"><div class="num">7</div><div class="lbl">constraint layers</div></div>
+        <div class="stat"><div class="num">12</div><div class="lbl">Codex hook entries</div></div>
+        <div class="stat"><div class="num">2</div><div class="lbl">agents supported</div></div>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -80,6 +80,35 @@ a:hover { text-decoration:underline; text-decoration-thickness:1px; }
 .stat .lbl { font-family:var(--font-mono); font-size:11px; letter-spacing:0.14em;
   text-transform:uppercase; color:var(--color-fg-inv-2); margin-top:8px; }
 
+/* ============ FIRST-WIN JOURNEY ============ */
+.journey-strip { display:grid; grid-template-columns:repeat(4,1fr); gap:0;
+  margin-top:72px; border-top:1px solid var(--color-ink-rim);
+  border-bottom:1px solid var(--color-ink-rim); }
+.journey-step { min-height:168px; padding:20px 22px; border-right:1px solid var(--color-ink-rim); }
+.journey-step:last-child { border-right:none; }
+.step-no, .knowledge-label, .fact-note { font-family:var(--font-mono); font-size:11px;
+  letter-spacing:0.14em; text-transform:uppercase; color:var(--ansi-cyan); }
+.journey-step h3 { font-family:var(--font-display); font-size:23px; font-weight:500;
+  letter-spacing:-0.02em; line-height:1.1; color:var(--color-fg-inv); margin:18px 0 8px; }
+.journey-step p { color:var(--color-fg-inv-2); font-size:13px; line-height:1.55; margin:0; }
+.knowledge-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--border); }
+.knowledge-card { min-height:230px; padding:24px 22px; background:var(--bg-raised); }
+.knowledge-card:nth-child(2) { background:var(--color-paper-2); }
+.knowledge-card.unavailable-knowledge { background:var(--color-ink); color:var(--color-fg-inv); }
+.knowledge-card h3 { font-family:var(--font-display); font-size:24px; font-weight:500;
+  letter-spacing:-0.025em; line-height:1.1; margin:30px 0 12px; }
+.knowledge-card p { color:var(--fg-muted); font-size:14px; line-height:1.6; margin:0; }
+.knowledge-card.unavailable-knowledge p { color:var(--color-fg-inv-2); }
+.knowledge-card:nth-child(2) .knowledge-label { color:var(--ansi-cyan-strong); }
+.benchmark-boundary { margin-top:28px; padding:24px 26px; border:1px solid var(--ansi-cyan-strong);
+  background:var(--color-ink); color:var(--color-fg-inv); box-shadow:var(--shadow-glow); }
+.benchmark-boundary .section-eyebrow { margin-bottom:10px; }
+.benchmark-boundary p { max-width:68ch; font-family:var(--font-display); font-size:20px;
+  line-height:1.35; margin:0; }
+.system-facts { margin-top:48px; }
+.system-facts .fact-note { color:var(--fg-subtle); margin-bottom:12px; }
+.system-facts .stat-strip { margin-top:0; }
+
 /* ============ SECTION BASE ============ */
 section.band { padding:100px 40px; }
 .inner { max-width:1100px; margin:0 auto; }
@@ -172,7 +201,21 @@ section.band { padding:100px 40px; }
   .hero { padding:80px 24px 100px; }
   section.band { padding:72px 24px; }
   .pitch-grid, .rule-grid, .compare { grid-template-columns:1fr; }
+  .journey-strip { grid-template-columns:repeat(2,1fr); }
+  .knowledge-grid { grid-template-columns:1fr; }
+  .journey-step:nth-child(2) { border-right:none; }
+  .journey-step:nth-child(-n+2) { border-bottom:1px solid var(--color-ink-rim); }
   .stat-strip { grid-template-columns:repeat(2,1fr); }
   .stat { border-right:none; border-bottom:1px solid var(--color-ink-rim); }
   .install { padding:80px 24px; }
+}
+
+@media (max-width:560px) {
+  .nav { align-items:flex-start; gap:14px; }
+  .nav .links { display:flex; flex-wrap:wrap; justify-content:flex-end; gap:4px 12px; }
+  .nav .links a { margin-left:0; }
+  .journey-strip { grid-template-columns:1fr; }
+  .journey-step, .journey-step:nth-child(2) { border-right:none; border-bottom:1px solid var(--color-ink-rim); }
+  .journey-step:last-child { border-bottom:none; }
+  .knowledge-card { min-height:0; }
 }

--- a/tests/test_codex_plugin_manifest.sh
+++ b/tests/test_codex_plugin_manifest.sh
@@ -41,6 +41,7 @@ make_dashboard_fixture() {
     "${fixture}/scripts/lib" \
     "${fixture}/vibeguard-runtime"
   touch "${fixture}/vibeguard-runtime/Cargo.toml"
+  touch "${fixture}/events.jsonl"
   cp "${REPO_DIR}/scripts/lib/runtime.sh" "${fixture}/scripts/lib/runtime.sh"
 
   cat > "${fixture}/setup.sh" <<'SH'
@@ -221,6 +222,18 @@ dashboard_empty_and_unresolved_states_test() {
   dashboard_require_contains 'data-state="empty"' "${output_path}" || return 1
   dashboard_require_contains 'No local event data in the selected window.' "${output_path}" || return 1
   dashboard_require_absent 'data-evidence="verified-build-pass">0<' "${output_path}" || return 1
+
+  DASHBOARD_TEST_MODE=observed \
+    DASHBOARD_TEST_VALUE_JSON="${empty_json}" \
+    VIBEGUARD_RUNTIME="${fixture}/vibeguard-test-runtime" \
+    VIBEGUARD_REPO_DIR="${fixture}" \
+    bash "${PLUGIN_SCRIPT}" dashboard \
+      --no-open \
+      --output "${output_path}" \
+      --log-file "${fixture}/missing-events.jsonl" >/dev/null
+  dashboard_require_contains 'The selected local event source is missing.' "${output_path}" || return 1
+  dashboard_require_contains 'Check the selected log path and VibeGuard setup' "${output_path}" || return 1
+  dashboard_require_absent 'Update or build the VibeGuard runtime' "${output_path}" || return 1
 
   run_dashboard_fixture unresolved "${unresolved_json}" "${fixture}" "${output_path}"
   dashboard_require_contains 'Partial / unresolved local evidence' "${output_path}" || return 1

--- a/tests/test_codex_plugin_manifest.sh
+++ b/tests/test_codex_plugin_manifest.sh
@@ -9,6 +9,8 @@ PLUGIN_SCRIPT="${PLUGIN_DIR}/scripts/vibeguard-plugin.sh"
 PLUGIN_JSON="${PLUGIN_DIR}/.codex-plugin/plugin.json"
 MARKETPLACE_JSON="${REPO_DIR}/.agents/plugins/marketplace.json"
 SKILL_VALIDATOR="${REPO_DIR}/scripts/ci/validate-skill-format.py"
+DASHBOARD_TEST_JSON_PYTHON_BIN="$(command -v python3)"
+export DASHBOARD_TEST_JSON_PYTHON_BIN
 
 PASS=0
 FAIL=0
@@ -84,6 +86,42 @@ if [[ "${1:-}" == "observe" && "${2:-}" == "value" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "json-field" ]]; then
+  shift
+  strict=0
+  if [[ "${1:-}" == "--strict" ]]; then
+    strict=1
+    shift
+  fi
+  field="${1:-}"
+  payload="$(cat)"
+  DASHBOARD_TEST_JSON_PAYLOAD="${payload}" \
+    "${DASHBOARD_TEST_JSON_PYTHON_BIN}" - "${strict}" "${field}" <<'PY'
+import json
+import os
+import sys
+
+strict = sys.argv[1] == "1"
+value = json.loads(os.environ["DASHBOARD_TEST_JSON_PAYLOAD"])
+try:
+    for part in sys.argv[2].split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+except (KeyError, IndexError, TypeError, ValueError):
+    if strict:
+        raise SystemExit(1)
+    value = None
+if value is None:
+    if strict:
+        raise SystemExit(1)
+    print("")
+elif isinstance(value, str):
+    print(value)
+else:
+    print(json.dumps(value, separators=(",", ":")))
+PY
+  exit $?
+fi
+
 printf 'unexpected runtime command:' >&2
 printf ' %q' "$@" >&2
 printf '%s\n' '' >&2
@@ -101,6 +139,7 @@ run_dashboard_fixture() {
   local value_json="$2"
   local fixture="$3"
   local output_path="$4"
+  shift 4
 
   DASHBOARD_TEST_MODE="${mode}" \
     DASHBOARD_TEST_VALUE_JSON="${value_json}" \
@@ -109,19 +148,20 @@ run_dashboard_fixture() {
     bash "${PLUGIN_SCRIPT}" dashboard \
       --no-open \
       --output "${output_path}" \
-      --log-file "${fixture}/events.jsonl" >/dev/null
+      --log-file "${fixture}/events.jsonl" \
+      "$@" >/dev/null
 }
 
 dashboard_require_contains() {
   local expected="$1"
   local file="$2"
-  grep -qF "${expected}" "${file}"
+  grep -qF -- "${expected}" "${file}"
 }
 
 dashboard_require_absent() {
   local forbidden="$1"
   local file="$2"
-  ! grep -qF "${forbidden}" "${file}"
+  ! grep -qF -- "${forbidden}" "${file}"
 }
 
 dashboard_json_evidence_test() {
@@ -129,7 +169,7 @@ dashboard_json_evidence_test() {
   tmp_dir="$(mktemp -d)"
   fixture="${tmp_dir}/repo"
   output_path="${tmp_dir}/dashboard.html"
-  value_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":17},"observed":{"attention_events":23,"sessions_with_attention":9,"sessions_with_later_follow_up_pass":13,"sessions_without_later_follow_up_pass":4,"sessions_with_repeated_attention":6,"uncorrelatable_attention_events":3,"suppression_events":5,"hook_duration_ms":{"count":8,"total_ms":1440,"avg_ms":180,"p95_ms":400}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["Association only."]}}'
+  value_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":17},"observed":{"attention_events":23,"sessions_with_attention":9,"sessions_with_later_follow_up_pass":13,"sessions_without_later_follow_up_pass":4,"sessions_with_repeated_attention":6,"uncorrelatable_attention_events":3,"suppression_events":5,"hook_duration_ms":{"count":8,"total_ms":1440,"avg_ms":180,"p95_ms":400}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["Association only.","Literal {{name}} token."]}}'
   make_dashboard_fixture "${fixture}"
   run_dashboard_fixture observed "${value_json}" "${fixture}" "${output_path}"
   dashboard_require_contains 'data-evidence="verified-build-pass">17<' "${output_path}" || return 1
@@ -140,6 +180,7 @@ dashboard_json_evidence_test() {
   dashboard_require_contains 'data-friction="suppressions">5<' "${output_path}" || return 1
   dashboard_require_contains 'data-friction="uncorrelatable">3<' "${output_path}" || return 1
   dashboard_require_contains '&lt;em&gt;diagnostic&lt;/em&gt;' "${output_path}" || return 1
+  dashboard_require_contains 'Literal {{name}} token.' "${output_path}" || return 1
   dashboard_require_absent 'data-evidence="verified-build-pass">901<' "${output_path}" || return 1
   dashboard_require_absent 'data-evidence="observed-follow-up">902<' "${output_path}" || return 1
   rm -rf "${tmp_dir}"
@@ -161,13 +202,20 @@ dashboard_verified_plus_partial_story_test() {
 }
 
 dashboard_empty_and_unresolved_states_test() {
-  local tmp_dir fixture output_path empty_json unresolved_json
+  local tmp_dir fixture output_path missing_json empty_json unresolved_json
   tmp_dir="$(mktemp -d)"
   fixture="${tmp_dir}/repo"
   output_path="${tmp_dir}/dashboard.html"
+  missing_json='{"command":"value","value":{"data_state":"missing","verified":{"sessions_with_later_build_pass":0},"observed":{"attention_events":0,"sessions_with_attention":0,"sessions_with_later_follow_up_pass":0,"sessions_without_later_follow_up_pass":0,"sessions_with_repeated_attention":0,"uncorrelatable_attention_events":0,"suppression_events":0,"hook_duration_ms":{"count":0,"total_ms":0,"avg_ms":0,"p95_ms":null}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["Event log not found."]}}'
   empty_json='{"command":"value","value":{"data_state":"empty","verified":{"sessions_with_later_build_pass":0},"observed":{"attention_events":0,"sessions_with_attention":0,"sessions_with_later_follow_up_pass":0,"sessions_without_later_follow_up_pass":0,"sessions_with_repeated_attention":0,"uncorrelatable_attention_events":0,"suppression_events":0,"hook_duration_ms":{"count":0,"total_ms":0,"avg_ms":0,"p95_ms":null}},"estimated":{"available":false,"reason":"No causal data."},"limitations":[]}}'
   unresolved_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":0},"observed":{"attention_events":7,"sessions_with_attention":5,"sessions_with_later_follow_up_pass":2,"sessions_without_later_follow_up_pass":3,"sessions_with_repeated_attention":3,"uncorrelatable_attention_events":4,"suppression_events":1,"hook_duration_ms":{"count":2,"total_ms":90,"avg_ms":45,"p95_ms":60}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["Partial timestamps."]}}'
   make_dashboard_fixture "${fixture}"
+
+  run_dashboard_fixture missing "${missing_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains 'data-state="missing"' "${output_path}" || return 1
+  dashboard_require_contains 'The selected local event source is missing.' "${output_path}" || return 1
+  dashboard_require_contains 'Check the selected log path and VibeGuard setup' "${output_path}" || return 1
+  dashboard_require_absent 'Trigger one protected action in the project' "${output_path}" || return 1
 
   run_dashboard_fixture empty "${empty_json}" "${fixture}" "${output_path}"
   dashboard_require_contains 'data-state="empty"' "${output_path}" || return 1
@@ -198,17 +246,40 @@ dashboard_failure_and_unavailable_states_test() {
   dashboard_require_contains 'Evidence output could not be parsed; no headline evidence was rendered.' "${output_path}" || return 1
   dashboard_require_contains '&lt;broken&gt;' "${output_path}" || return 1
 
-  run_dashboard_fixture unavailable '' "${fixture}" "${output_path}"
+  run_dashboard_fixture unavailable '' "${fixture}" "${output_path}" --scope project --project "${fixture}"
   dashboard_require_contains 'First-win evidence is unavailable' "${output_path}" || return 1
   dashboard_require_contains 'Update or build the VibeGuard runtime' "${output_path}" || return 1
   dashboard_require_absent 'data-evidence="verified-build-pass">0<' "${output_path}" || return 1
+  dashboard_require_contains '--log-file' "${output_path}" || return 1
+  dashboard_require_contains '--scope project' "${output_path}" || return 1
+  dashboard_require_contains '--project' "${output_path}" || return 1
+  rm -rf "${tmp_dir}"
+}
+
+dashboard_python_free_generation_test() {
+  local tmp_dir fixture output_path poison_bin value_json
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  poison_bin="${tmp_dir}/bin"
+  value_json='{"command":"value","value":{"data_state":"empty"}}'
+  make_dashboard_fixture "${fixture}"
+  mkdir -p "${poison_bin}"
+  cat > "${poison_bin}/python3" <<'SH'
+#!/usr/bin/env bash
+exit 97
+SH
+  chmod +x "${poison_bin}/python3"
+
+  PATH="${poison_bin}:${PATH}" run_dashboard_fixture empty "${value_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains '<!doctype html>' "${output_path}" || return 1
   rm -rf "${tmp_dir}"
 }
 
 dashboard_static_contract_test() {
   local tmp_dir fixture output_path value_json
   tmp_dir="$(mktemp -d)"
-  fixture="${tmp_dir}/repo"
+  fixture="${tmp_dir}/repo with spaces"
   output_path="${tmp_dir}/dashboard.html"
   value_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":1},"observed":{"attention_events":1,"sessions_with_attention":1,"sessions_with_later_follow_up_pass":1,"sessions_without_later_follow_up_pass":0,"sessions_with_repeated_attention":0,"uncorrelatable_attention_events":0,"suppression_events":0,"hook_duration_ms":{"count":1,"total_ms":24,"avg_ms":24,"p95_ms":24}},"estimated":{"available":false,"reason":"No causal data."},"limitations":[]}}'
   make_dashboard_fixture "${fixture}"
@@ -216,8 +287,9 @@ dashboard_static_contract_test() {
   dashboard_require_contains '<main class="shell" aria-labelledby="dashboard-title"' "${output_path}" || return 1
   dashboard_require_contains '<h1 id="dashboard-title">See what happened after VibeGuard stepped in.</h1>' "${output_path}" || return 1
   dashboard_require_contains '<div class="metric-label">Later build pass after intervention</div>' "${output_path}" || return 1
-  dashboard_require_contains '<div class="metric-label">Guardrail signals without follow-up</div>' "${output_path}" || return 1
-  dashboard_require_absent '>Unresolved attention sessions<' "${output_path}" || return 1
+  dashboard_require_contains '<div class="metric-label">Sessions without later follow-up</div>' "${output_path}" || return 1
+  dashboard_require_absent '>Guardrail signals without follow-up<' "${output_path}" || return 1
+  dashboard_require_contains 'repo\ with\ spaces/setup.sh --codex-status' "${output_path}" || return 1
   dashboard_require_contains '<span>window</span><strong>last 7 days</strong>' "${output_path}" || return 1
   dashboard_require_contains '<details>' "${output_path}" || return 1
   dashboard_require_contains 'Local-only evidence' "${output_path}" || return 1
@@ -282,6 +354,7 @@ assert_cmd "dashboard headline cards use observe value JSON, not human output" d
 assert_cmd "verified story remains primary when other evidence is partial" dashboard_verified_plus_partial_story_test
 assert_cmd "dashboard makes empty and unresolved evidence explicit" dashboard_empty_and_unresolved_states_test
 assert_cmd "dashboard renders command, parse, and runtime capability failures visibly" dashboard_failure_and_unavailable_states_test
+assert_cmd "dashboard generation does not require Python" dashboard_python_free_generation_test
 assert_cmd "dashboard HTML is semantic, responsive, local-only, and standalone" dashboard_static_contract_test
 assert_cmd "dashboard renders all-history period and documents value-evidence selectors" dashboard_all_history_and_help_test
 assert_cmd "landing page has one journey and a separate evidence-boundary explanation" landing_page_evidence_journey_test

--- a/tests/test_codex_plugin_manifest.sh
+++ b/tests/test_codex_plugin_manifest.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_DIR="${REPO_DIR}/plugins/vibeguard"
+PLUGIN_SCRIPT="${PLUGIN_DIR}/scripts/vibeguard-plugin.sh"
 PLUGIN_JSON="${PLUGIN_DIR}/.codex-plugin/plugin.json"
 MARKETPLACE_JSON="${REPO_DIR}/.agents/plugins/marketplace.json"
 SKILL_VALIDATOR="${REPO_DIR}/scripts/ci/validate-skill-format.py"
@@ -29,6 +30,261 @@ assert_cmd() {
     FAIL=$((FAIL + 1))
   fi
 }
+
+make_dashboard_fixture() {
+  local fixture="$1"
+  mkdir -p \
+    "${fixture}/hooks" \
+    "${fixture}/skills" \
+    "${fixture}/scripts/lib" \
+    "${fixture}/vibeguard-runtime"
+  touch "${fixture}/vibeguard-runtime/Cargo.toml"
+  cp "${REPO_DIR}/scripts/lib/runtime.sh" "${fixture}/scripts/lib/runtime.sh"
+
+  cat > "${fixture}/setup.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'HUMAN STATUS: installed'
+SH
+  cat > "${fixture}/scripts/stats.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'HUMAN STATS: sessions_with_later_build_pass: 901 <em>diagnostic</em>'
+SH
+  cat > "${fixture}/scripts/hook-health.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'HUMAN HEALTH: sessions_with_later_follow_up_pass: 902'
+SH
+  cat > "${fixture}/vibeguard-test-runtime" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "observe" && "${2:-}" == "value" ]]; then
+  if [[ "${DASHBOARD_TEST_MODE:-}" == "unavailable" ]]; then
+    printf '%s\n' 'unknown command: observe value' >&2
+    exit 2
+  fi
+  if [[ "$*" == *"--days all"* ]]; then
+    printf '%s\n' '{"command":"value","value":{"data_state":"observed"}}'
+    exit 0
+  fi
+  case "${DASHBOARD_TEST_MODE:-}" in
+    command-failure)
+      printf '%s\n' '<script>alert("x")</script>' >&2
+      exit 23
+      ;;
+    malformed)
+      printf '%s\n' '{"value":<broken>}'
+      exit 0
+      ;;
+  esac
+  if [[ -n "${DASHBOARD_TEST_VALUE_JSON:-}" ]]; then
+    printf '%s\n' "${DASHBOARD_TEST_VALUE_JSON}"
+  else
+    printf '%s\n' '{"command":"value","value":{"data_state":"empty"}}'
+  fi
+  exit 0
+fi
+
+printf 'unexpected runtime command:' >&2
+printf ' %q' "$@" >&2
+printf '%s\n' '' >&2
+exit 2
+SH
+  chmod +x \
+    "${fixture}/setup.sh" \
+    "${fixture}/scripts/stats.sh" \
+    "${fixture}/scripts/hook-health.sh" \
+    "${fixture}/vibeguard-test-runtime"
+}
+
+run_dashboard_fixture() {
+  local mode="$1"
+  local value_json="$2"
+  local fixture="$3"
+  local output_path="$4"
+
+  DASHBOARD_TEST_MODE="${mode}" \
+    DASHBOARD_TEST_VALUE_JSON="${value_json}" \
+    VIBEGUARD_RUNTIME="${fixture}/vibeguard-test-runtime" \
+    VIBEGUARD_REPO_DIR="${fixture}" \
+    bash "${PLUGIN_SCRIPT}" dashboard \
+      --no-open \
+      --output "${output_path}" \
+      --log-file "${fixture}/events.jsonl" >/dev/null
+}
+
+dashboard_require_contains() {
+  local expected="$1"
+  local file="$2"
+  grep -qF "${expected}" "${file}"
+}
+
+dashboard_require_absent() {
+  local forbidden="$1"
+  local file="$2"
+  ! grep -qF "${forbidden}" "${file}"
+}
+
+dashboard_json_evidence_test() {
+  local tmp_dir fixture output_path value_json
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  value_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":17},"observed":{"attention_events":23,"sessions_with_attention":9,"sessions_with_later_follow_up_pass":13,"sessions_without_later_follow_up_pass":4,"sessions_with_repeated_attention":6,"uncorrelatable_attention_events":3,"suppression_events":5,"hook_duration_ms":{"count":8,"total_ms":1440,"avg_ms":180,"p95_ms":400}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["Association only."]}}'
+  make_dashboard_fixture "${fixture}"
+  run_dashboard_fixture observed "${value_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains 'data-evidence="verified-build-pass">17<' "${output_path}" || return 1
+  dashboard_require_contains 'data-evidence="observed-follow-up">13<' "${output_path}" || return 1
+  dashboard_require_contains 'data-evidence="unresolved-attention">4<' "${output_path}" || return 1
+  dashboard_require_contains 'data-evidence="hook-overhead">180 ms<' "${output_path}" || return 1
+  dashboard_require_contains 'data-friction="repeated-attention">6<' "${output_path}" || return 1
+  dashboard_require_contains 'data-friction="suppressions">5<' "${output_path}" || return 1
+  dashboard_require_contains 'data-friction="uncorrelatable">3<' "${output_path}" || return 1
+  dashboard_require_contains '&lt;em&gt;diagnostic&lt;/em&gt;' "${output_path}" || return 1
+  dashboard_require_absent 'data-evidence="verified-build-pass">901<' "${output_path}" || return 1
+  dashboard_require_absent 'data-evidence="observed-follow-up">902<' "${output_path}" || return 1
+  rm -rf "${tmp_dir}"
+}
+
+dashboard_verified_plus_partial_story_test() {
+  local tmp_dir fixture output_path value_json
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  value_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":1},"observed":{"attention_events":2,"sessions_with_attention":1,"sessions_with_later_follow_up_pass":1,"sessions_without_later_follow_up_pass":0,"sessions_with_repeated_attention":0,"uncorrelatable_attention_events":1,"suppression_events":0,"hook_duration_ms":{"count":1,"total_ms":24,"avg_ms":24,"p95_ms":24}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["One event could not be correlated."]}}'
+  make_dashboard_fixture "${fixture}"
+  run_dashboard_fixture observed "${value_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains 'A later build pass is recorded after VibeGuard stepped in.' "${output_path}" || return 1
+  dashboard_require_contains 'Partial / unresolved local evidence' "${output_path}" || return 1
+  dashboard_require_contains 'Evidence is partial: 1 guardrail signal could not be correlated by session and timestamp.' "${output_path}" || return 1
+  dashboard_require_contains 'data-friction="uncorrelatable">1<' "${output_path}" || return 1
+  rm -rf "${tmp_dir}"
+}
+
+dashboard_empty_and_unresolved_states_test() {
+  local tmp_dir fixture output_path empty_json unresolved_json
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  empty_json='{"command":"value","value":{"data_state":"empty","verified":{"sessions_with_later_build_pass":0},"observed":{"attention_events":0,"sessions_with_attention":0,"sessions_with_later_follow_up_pass":0,"sessions_without_later_follow_up_pass":0,"sessions_with_repeated_attention":0,"uncorrelatable_attention_events":0,"suppression_events":0,"hook_duration_ms":{"count":0,"total_ms":0,"avg_ms":0,"p95_ms":null}},"estimated":{"available":false,"reason":"No causal data."},"limitations":[]}}'
+  unresolved_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":0},"observed":{"attention_events":7,"sessions_with_attention":5,"sessions_with_later_follow_up_pass":2,"sessions_without_later_follow_up_pass":3,"sessions_with_repeated_attention":3,"uncorrelatable_attention_events":4,"suppression_events":1,"hook_duration_ms":{"count":2,"total_ms":90,"avg_ms":45,"p95_ms":60}},"estimated":{"available":false,"reason":"No causal data."},"limitations":["Partial timestamps."]}}'
+  make_dashboard_fixture "${fixture}"
+
+  run_dashboard_fixture empty "${empty_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains 'data-state="empty"' "${output_path}" || return 1
+  dashboard_require_contains 'No local event data in the selected window.' "${output_path}" || return 1
+  dashboard_require_absent 'data-evidence="verified-build-pass">0<' "${output_path}" || return 1
+
+  run_dashboard_fixture unresolved "${unresolved_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains 'Partial / unresolved local evidence' "${output_path}" || return 1
+  dashboard_require_contains 'Evidence is partial: 4 guardrail signals could not be correlated by session and timestamp.' "${output_path}" || return 1
+  dashboard_require_contains 'data-friction="repeated-attention">3<' "${output_path}" || return 1
+  dashboard_require_contains 'data-friction="uncorrelatable">4<' "${output_path}" || return 1
+  rm -rf "${tmp_dir}"
+}
+
+dashboard_failure_and_unavailable_states_test() {
+  local tmp_dir fixture output_path
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  make_dashboard_fixture "${fixture}"
+
+  run_dashboard_fixture command-failure '' "${fixture}" "${output_path}"
+  dashboard_require_contains 'Evidence command failed; no headline evidence was rendered.' "${output_path}" || return 1
+  dashboard_require_contains '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;' "${output_path}" || return 1
+  dashboard_require_absent '<script>alert("x")</script>' "${output_path}" || return 1
+
+  run_dashboard_fixture malformed '' "${fixture}" "${output_path}"
+  dashboard_require_contains 'Evidence output could not be parsed; no headline evidence was rendered.' "${output_path}" || return 1
+  dashboard_require_contains '&lt;broken&gt;' "${output_path}" || return 1
+
+  run_dashboard_fixture unavailable '' "${fixture}" "${output_path}"
+  dashboard_require_contains 'First-win evidence is unavailable' "${output_path}" || return 1
+  dashboard_require_contains 'Update or build the VibeGuard runtime' "${output_path}" || return 1
+  dashboard_require_absent 'data-evidence="verified-build-pass">0<' "${output_path}" || return 1
+  rm -rf "${tmp_dir}"
+}
+
+dashboard_static_contract_test() {
+  local tmp_dir fixture output_path value_json
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  value_json='{"command":"value","value":{"data_state":"observed","verified":{"sessions_with_later_build_pass":1},"observed":{"attention_events":1,"sessions_with_attention":1,"sessions_with_later_follow_up_pass":1,"sessions_without_later_follow_up_pass":0,"sessions_with_repeated_attention":0,"uncorrelatable_attention_events":0,"suppression_events":0,"hook_duration_ms":{"count":1,"total_ms":24,"avg_ms":24,"p95_ms":24}},"estimated":{"available":false,"reason":"No causal data."},"limitations":[]}}'
+  make_dashboard_fixture "${fixture}"
+  run_dashboard_fixture observed "${value_json}" "${fixture}" "${output_path}"
+  dashboard_require_contains '<main class="shell" aria-labelledby="dashboard-title"' "${output_path}" || return 1
+  dashboard_require_contains '<h1 id="dashboard-title">See what happened after VibeGuard stepped in.</h1>' "${output_path}" || return 1
+  dashboard_require_contains '<div class="metric-label">Later build pass after intervention</div>' "${output_path}" || return 1
+  dashboard_require_contains '<div class="metric-label">Guardrail signals without follow-up</div>' "${output_path}" || return 1
+  dashboard_require_absent '>Unresolved attention sessions<' "${output_path}" || return 1
+  dashboard_require_contains '<span>window</span><strong>last 7 days</strong>' "${output_path}" || return 1
+  dashboard_require_contains '<details>' "${output_path}" || return 1
+  dashboard_require_contains 'Local-only evidence' "${output_path}" || return 1
+  dashboard_require_contains 'The built-in 5-positive/5-negative benchmark is a small reproducible corpus, not evidence of impact on your project.' "${output_path}" || return 1
+  dashboard_require_contains 'prefers-reduced-motion' "${output_path}" || return 1
+  dashboard_require_contains '@media (max-width: 760px)' "${output_path}" || return 1
+  ! grep -q '<script' "${output_path}" || return 1
+  ! grep -Eq 'https?://|//[A-Za-z]' "${output_path}" || return 1
+  python3 - "${output_path}" <<'PY' || return 1
+import stat
+import sys
+from pathlib import Path
+
+mode = stat.S_IMODE(Path(sys.argv[1]).stat().st_mode)
+raise SystemExit(0 if mode == 0o600 else 1)
+PY
+  rm -rf "${tmp_dir}"
+}
+
+dashboard_all_history_and_help_test() {
+  local tmp_dir fixture output_path help_out
+  tmp_dir="$(mktemp -d)"
+  fixture="${tmp_dir}/repo"
+  output_path="${tmp_dir}/dashboard.html"
+  make_dashboard_fixture "${fixture}"
+  DASHBOARD_TEST_MODE=observed \
+    VIBEGUARD_RUNTIME="${fixture}/vibeguard-test-runtime" \
+    VIBEGUARD_REPO_DIR="${fixture}" \
+    bash "${PLUGIN_SCRIPT}" dashboard \
+      --no-open \
+      --days all \
+      --output "${output_path}" \
+      --log-file "${fixture}/events.jsonl" >/dev/null
+  dashboard_require_contains '<span>window</span><strong>all available history</strong>' "${output_path}" || return 1
+  dashboard_require_absent 'last all days' "${output_path}" || return 1
+
+  help_out="$(bash "${PLUGIN_SCRIPT}" dashboard --help)"
+  grep -qF 'Select value evidence, stats, and health scope' <<<"${help_out}" || return 1
+  grep -qF 'Select project for value evidence, stats, and health' <<<"${help_out}" || return 1
+  grep -qF 'Read value evidence, stats, and health from PATH' <<<"${help_out}" || return 1
+  rm -rf "${tmp_dir}"
+}
+
+landing_page_evidence_journey_test() {
+  local site_file="${REPO_DIR}/site/index.html"
+  [[ "$(grep -c 'class="journey-step"' "${site_file}")" -eq 4 ]] || return 1
+  ! grep -q 'class="journey-card"' "${site_file}" || return 1
+  grep -qF '<h3>Problem surfaces</h3>' "${site_file}" || return 1
+  grep -qF '<h3>Intervention</h3>' "${site_file}" || return 1
+  grep -qF '<h3>Correction / follow-up</h3>' "${site_file}" || return 1
+  grep -qF '<h3>Verification</h3>' "${site_file}" || return 1
+  grep -qF 'What the local evidence can tell you' "${site_file}" || return 1
+  grep -qF '<h3>Verified sequence</h3>' "${site_file}" || return 1
+  grep -qF '<h3>Observed signals and friction</h3>' "${site_file}" || return 1
+  grep -qF '<h3>Unavailable outcome claims</h3>' "${site_file}" || return 1
+  grep -qF 'The built-in 5-positive/5-negative benchmark is a small reproducible corpus, not evidence of impact on your project.' "${site_file}" || return 1
+  grep -qF 'git clone https://github.com/majiayu000/vibeguard.git ~/vibeguard && bash ~/vibeguard/setup.sh --yes' "${site_file}" || return 1
+  ! grep -qF '<h3>Attention lands</h3>' "${site_file}" || return 1
+}
+
+assert_cmd "dashboard headline cards use observe value JSON, not human output" dashboard_json_evidence_test
+assert_cmd "verified story remains primary when other evidence is partial" dashboard_verified_plus_partial_story_test
+assert_cmd "dashboard makes empty and unresolved evidence explicit" dashboard_empty_and_unresolved_states_test
+assert_cmd "dashboard renders command, parse, and runtime capability failures visibly" dashboard_failure_and_unavailable_states_test
+assert_cmd "dashboard HTML is semantic, responsive, local-only, and standalone" dashboard_static_contract_test
+assert_cmd "dashboard renders all-history period and documents value-evidence selectors" dashboard_all_history_and_help_test
+assert_cmd "landing page has one journey and a separate evidence-boundary explanation" landing_page_evidence_journey_test
 
 header "codex plugin files"
 assert_cmd "plugin manifest exists" test -f "${PLUGIN_JSON}"

--- a/tests/test_stats.sh
+++ b/tests/test_stats.sh
@@ -127,6 +127,16 @@ exit 2
 SH
 chmod +x "${export_observe_runtime}"
 
+value_observe_runtime="${TMP_DIR}/value-observe-runtime"
+cat > "${value_observe_runtime}" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == "observe value --json --days all --limit all --log-file /dev/null" ]]; then
+  exit 0
+fi
+exit 2
+SH
+chmod +x "${value_observe_runtime}"
+
 full_observe_runtime="${TMP_DIR}/full-observe-runtime"
 cat > "${full_observe_runtime}" <<'SH'
 #!/usr/bin/env bash
@@ -148,6 +158,20 @@ assert_cmd_fails "Summary probe rejects export-only runtimes" \
   vg_runtime_supports_observe "${export_observe_runtime}"
 assert_cmd "Export probe accepts export-only runtimes" \
   vg_runtime_supports_observe_export_prometheus "${export_observe_runtime}"
+assert_cmd "Value probe accepts runtimes with observe value support" \
+  vg_runtime_supports_observe_value "${value_observe_runtime}"
+
+resolver_value_repo="${TMP_DIR}/resolver-value-repo"
+resolver_value_home="${TMP_DIR}/resolver-value-home"
+mkdir -p "${resolver_value_repo}/vibeguard-runtime/target/debug" "${resolver_value_home}"
+cp "${value_observe_runtime}" "${resolver_value_repo}/vibeguard-runtime/target/debug/vibeguard-runtime"
+selected_value_runtime="$(
+  env -u VIBEGUARD_RUNTIME HOME="${resolver_value_home}" bash -c '
+    source "$1"
+    vg_resolve_runtime "$2" observe_value
+  ' bash "${REPO_DIR}/scripts/lib/runtime.sh" "${resolver_value_repo}"
+)"
+assert_contains "${selected_value_runtime}" "${resolver_value_repo}/vibeguard-runtime/target/debug/vibeguard-runtime" "Resolver selects observe-value capable runtime"
 
 resolver_repo="${TMP_DIR}/resolver-repo"
 resolver_home="${TMP_DIR}/resolver-home"

--- a/vibeguard-runtime/src/json_field.rs
+++ b/vibeguard-runtime/src/json_field.rs
@@ -26,7 +26,10 @@ fn read_stdin() -> io::Result<String> {
 fn get_nested<'a>(data: &'a Value, path: &str) -> Option<&'a Value> {
     let mut val = data;
     for key in path.split('.') {
-        val = val.get(key)?;
+        val = match val {
+            Value::Array(items) => items.get(key.parse::<usize>().ok()?)?,
+            _ => val.get(key)?,
+        };
     }
     Some(val)
 }
@@ -123,6 +126,18 @@ mod tests {
 
         assert!(get_nested(&data, "tool_input.file_path").is_none());
         assert!(get_nested(&data, "tool_input.command.value").is_none());
+    }
+
+    #[test]
+    fn get_nested_follows_numeric_array_indexes() {
+        let data = json!({"limitations": ["first", "second"]});
+
+        assert_eq!(
+            get_nested(&data, "limitations.1").and_then(Value::as_str),
+            Some("second")
+        );
+        assert!(get_nested(&data, "limitations.2").is_none());
+        assert!(get_nested(&data, "limitations.not-a-number").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Turns the local observability dashboard into an honest first-win experience. Headline cards now consume `observe value --json`, separate verified associations from observed signals and friction, keep missing/partial/failed evidence explicit, and preserve raw installation/health output as escaped secondary diagnostics.

Also rewrites the quickstart and landing-page journey around problem -> intervention -> follow-up -> verification, while clearly labeling the built-in 5+5 benchmark as a small reproducible corpus rather than project-impact evidence.

This is a stacked PR and depends on #787 (`feat/issue-784-bounded-value`). Review only the single commit after that branch.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New guard script

## Checklist

- [x] Tests pass (`cargo test` / `go test ./...` / `pytest`)
- [x] Guard scripts tested (if applicable)
- [x] Documentation updated
- [x] No hardcoded paths
- [x] Conventional commit message used (`feat:` / `fix:` / `chore:` etc.)

## Related issues

Closes #785

Depends on #787

## Screenshots / logs

- `bash tests/test_codex_plugin_manifest.sh` — PASS
- `bash tests/test_stats.sh` — 63/63 PASS
- `bash scripts/ci/validate-doc-paths.sh` — PASS (63 files)
- `bash scripts/ci/validate-doc-command-paths.sh` — PASS (118 command paths)
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bash scripts/local-contract-check.sh --quick` — PASS
- Playwright visual QA — PASS at 1440x1000 and 390x844 for both the generated dashboard and landing page

The generated dashboard is standalone and local-only: no client script, external resources, telemetry, upload, account, or server. The output file is written with mode 0600.
