### PR TITLE
feat(project-init): add read-only preview

### DIFF
--- a/docs/how/quickstart.md
+++ b/docs/how/quickstart.md
@@ -41,15 +41,19 @@ bash ~/vibeguard/scripts/doctors/codex-doctor.sh
 
 ```bash
 cd /path/to/project
+bash ~/vibeguard/scripts/project-init.sh --no-hooks "$PWD"  # inspect only
 bash ~/vibeguard/scripts/project-init.sh "$PWD"
 ```
 
-This prints a `Suggested project CLAUDE.md snippet` and installs the shared
-pre-commit/pre-push wrappers when they are available. Save the suggested
-snippet into the repository's `CLAUDE.md`, `AGENTS.md`, or equivalent project
-guidance file before relying on agent-visible instructions. Open a new Claude
-Code or Codex session after saving that guidance so the agent loads the updated
-instructions and hooks.
+The first command detects the project and prints a `Suggested agent guidance
+snippet` without writing Git hooks. The second repeats the report and installs
+the shared pre-commit/pre-push wrappers when they are available. Neither command
+modifies `AGENTS.md` or `CLAUDE.md`; review and save the snippet in the guidance
+file for the agent host you use. Open a new Claude Code or Codex session after
+saving that guidance so the agent loads the updated instructions and hooks.
+
+Run `bash ~/vibeguard/scripts/project-init.sh --help` for the complete command
+contract.
 
 `project-init.sh` only bootstraps repositories where it detects a known
 language marker such as `Cargo.toml`, `tsconfig.json`, `package.json`,

--- a/scripts/project-init.sh
+++ b/scripts/project-init.sh
@@ -400,7 +400,7 @@ echo
 
 echo "--- Next steps ---"
 echo "1. Save the reviewed guidance snippet in AGENTS.md or CLAUDE.md."
-echo "2. Verify this project: bash \"${VIBEGUARD_DIR}/setup.sh\" verify-project"
+echo "2. Verify this project: (cd \"${PROJECT_ROOT_ABS}\" && bash \"${VIBEGUARD_DIR}/setup.sh\" verify-project)"
 echo "3. Prove interception: bash \"${VIBEGUARD_DIR}/setup.sh\" demo safe-bash"
 echo
 

--- a/scripts/project-init.sh
+++ b/scripts/project-init.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# VibeGuard Project Init — Generate project-level guard configuration for the current warehouse
+# VibeGuard Project Init — Inspect a project and attach VibeGuard protection
 #
-# Detect language/framework → List activated guards/rules → Generate project-level CLAUDE.md fragment
+# Detect language/framework → List available guards/rules → Print agent guidance → Install Git hooks
 #
-# Usage: bash project-init.sh [project_root]
+# Usage: bash project-init.sh [--no-hooks] [project_root]
 set -euo pipefail
 
 # Resolve the script before entering the target repository. A relative $0 must
@@ -18,7 +18,62 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
 VIBEGUARD_DIR="${VIBEGUARD_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
-PROJECT_ROOT="${1:-$(pwd)}"
+usage() {
+  printf '%s\n' \
+    'Usage: project-init.sh [--no-hooks] [project_root]' \
+    '' \
+    'Detect the project stack, print agent guidance, and attach the shared' \
+    'VibeGuard pre-commit and pre-push hooks when they are installed.' \
+    '' \
+    'Options:' \
+    '  --no-hooks  Inspect and print guidance without modifying Git hooks.' \
+    '  -h, --help  Show this help.' \
+    '' \
+    'No AGENTS.md or CLAUDE.md file is modified.'
+}
+
+INSTALL_HOOKS=1
+PROJECT_ROOT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-hooks)
+      INSTALL_HOOKS=0
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      if [[ $# -gt 0 ]]; then
+        PROJECT_ROOT="$1"
+        shift
+      fi
+      if [[ $# -gt 0 ]]; then
+        echo "ERROR: project-init accepts at most one project_root" >&2
+        usage >&2
+        exit 2
+      fi
+      break
+      ;;
+    -*)
+      echo "ERROR: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "${PROJECT_ROOT}" ]]; then
+        echo "ERROR: project-init accepts at most one project_root" >&2
+        usage >&2
+        exit 2
+      fi
+      PROJECT_ROOT="$1"
+      ;;
+  esac
+  shift
+done
+
+PROJECT_ROOT="${PROJECT_ROOT:-$(pwd)}"
 cd "$PROJECT_ROOT" || { echo "ERROR: Unable to enter directory $PROJECT_ROOT"; exit 1; }
 PROJECT_ROOT_ABS="$(pwd -P)"
 
@@ -172,22 +227,26 @@ if [[ ${#LANGS[@]} -eq 0 ]]; then
 fi
 
 echo "Language detected: ${LANGS[*]}"
-[[ ${#FRAMEWORKS[@]} -gt 0 ]] && echo "Frame detected: ${FRAMEWORKS[*]}"
+[[ ${#FRAMEWORKS[@]} -gt 0 ]] && echo "Framework detected: ${FRAMEWORKS[*]}"
 echo
 
-# --- List active guards ---
-echo "--- activated guard ---"
+# --- List available static guards ---
+echo "--- Available static guards ---"
 GUARDS_DIR="$VIBEGUARD_DIR/guards"
-ACTIVE_GUARDS=()
+AVAILABLE_GUARDS=()
+
+append_available_guards() {
+  local guard_dir="$1" label="$2" guard_file
+  [[ -d "${guard_dir}" ]] || return 0
+  for guard_file in "${guard_dir}"/check_*.sh "${guard_dir}"/check_*.py; do
+    [[ -f "${guard_file}" ]] || continue
+    AVAILABLE_GUARDS+=("$(basename "${guard_file}")")
+    echo "[${label}] $(basename "${guard_file}")"
+  done
+}
 
 # Universal guard
-if [[ -d "$GUARDS_DIR/universal" ]]; then
-  for g in "$GUARDS_DIR/universal"/check_*.sh; do
-    [[ -f "$g" ]] || continue
-    ACTIVE_GUARDS+=("$(basename "$g")")
-    echo "[General] $(basename "$g")"
-  done
-fi
+append_available_guards "${GUARDS_DIR}/universal" universal
 
 # Language Guard
 for lang in "${LANGS[@]}"; do
@@ -196,20 +255,15 @@ for lang in "${LANGS[@]}"; do
     rust) LANG_DIR="$GUARDS_DIR/rust" ;;
     typescript|javascript) LANG_DIR="$GUARDS_DIR/typescript" ;;
     go) LANG_DIR="$GUARDS_DIR/go" ;;
+    python) LANG_DIR="$GUARDS_DIR/python" ;;
   esac
-  if [[ -n "$LANG_DIR" ]] && [[ -d "$LANG_DIR" ]]; then
-    for g in "$LANG_DIR"/check_*.sh; do
-      [[ -f "$g" ]] || continue
-      ACTIVE_GUARDS+=("$(basename "$g")")
-      echo "  [${lang}] $(basename "$g")"
-    done
-  fi
+  [[ -n "${LANG_DIR}" ]] && append_available_guards "${LANG_DIR}" "${lang}"
 done
-echo "A total of ${#ACTIVE_GUARDS[@]} guards activated"
+echo "${#AVAILABLE_GUARDS[@]} static guards available"
 echo
 
-# --- List activated native rules ---
-echo "---Activated native rules ---"
+# --- List installed Claude Code native rules ---
+echo "--- Installed Claude Code rules ---"
 RULES_DIR="$HOME/.claude/rules/vibeguard"
 RULE_COUNT=0
 
@@ -239,24 +293,27 @@ for lang in "${LANGS[@]}"; do
     done
   fi
 done
-echo "A total of ${RULE_COUNT} rules activated"
+echo "${RULE_COUNT} Claude Code rules found"
 echo
 
-# --- Check if project-level CLAUDE.md already exists ---
-if [[ -f "CLAUDE.md" ]]; then
-  echo "The project already has CLAUDE.md, skip generation."
-  echo "It is recommended to add the following content manually:"
-  echo
+# --- Report existing project guidance without modifying it ---
+GUIDANCE_FILES=()
+for guidance_file in AGENTS.md CLAUDE.md; do
+  [[ -f "${guidance_file}" ]] && GUIDANCE_FILES+=("${guidance_file}")
+done
+if [[ ${#GUIDANCE_FILES[@]} -gt 0 ]]; then
+  echo "Existing agent guidance: ${GUIDANCE_FILES[*]}"
 else
-  echo "The project does not have CLAUDE.md, you can choose to generate it."
-  echo
+  echo "No AGENTS.md or CLAUDE.md file found."
 fi
+echo "No guidance file was modified."
+echo
 
-# --- Output suggested CLAUDE.md fragment ---
-echo "--- Suggested project CLAUDE.md snippet ---"
+# --- Output suggested agent-guidance fragment ---
+echo "--- Suggested agent guidance snippet ---"
 echo
 echo '```markdown'
-echo "# project constraints"
+echo "# Project constraints"
 echo
 echo "## build command"
 if [[ ${#BUILD_CMDS[@]} -eq 0 ]]; then
@@ -285,16 +342,18 @@ if [[ "$ENTRY_POINTS" -gt 1 ]]; then
   echo
 fi
 
-echo "## VibeGuard guard"
-echo "${#ACTIVE_GUARDS[@]} guards + ${RULE_COUNT} rules activated"
+echo "## VibeGuard coverage"
+echo "${#AVAILABLE_GUARDS[@]} static guards available; ${RULE_COUNT} Claude Code rules found"
 echo '```'
+echo "Review and save this snippet in AGENTS.md or CLAUDE.md for the agent host you use."
 echo
 # --- Automatically install git hooks ---
 echo "--- Git Hooks ---"
 PRE_COMMIT_WRAPPER="${HOME}/.vibeguard/pre-commit"
 PRE_PUSH_WRAPPER="${HOME}/.vibeguard/pre-push"
 GIT_HOOKS_DIR=""
-if git -C "${PROJECT_ROOT_ABS}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [[ "${INSTALL_HOOKS}" -eq 1 ]] \
+  && git -C "${PROJECT_ROOT_ABS}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if ! GIT_HOOKS_DIR="$(git -C "${PROJECT_ROOT_ABS}" rev-parse --path-format=absolute --git-path hooks 2>/dev/null)" \
     || [[ -z "${GIT_HOOKS_DIR}" ]]; then
     echo "ERROR: unable to resolve Git hooks directory for ${PROJECT_ROOT_ABS}" >&2
@@ -310,7 +369,9 @@ record_project_hook_install() {
   fi
 }
 
-if [[ -n "${GIT_HOOKS_DIR}" ]] && [[ -f "$PRE_COMMIT_WRAPPER" ]]; then
+if [[ "${INSTALL_HOOKS}" -eq 0 ]]; then
+  echo "Git hook installation skipped (--no-hooks)"
+elif [[ -n "${GIT_HOOKS_DIR}" ]] && [[ -f "$PRE_COMMIT_WRAPPER" ]]; then
   mkdir -p "$GIT_HOOKS_DIR"
   if [[ -f "$GIT_HOOKS_DIR/pre-commit" ]]; then
     echo ".git/hooks/pre-commit already exists, skip (manual override: ln -sf $PRE_COMMIT_WRAPPER $GIT_HOOKS_DIR/pre-commit)"
@@ -335,6 +396,12 @@ elif [[ -z "${GIT_HOOKS_DIR}" ]]; then
 elif [[ ! -f "$PRE_COMMIT_WRAPPER" ]]; then
   echo " ~/.vibeguard/pre-commit does not exist, please run setup.sh first"
 fi
+echo
+
+echo "--- Next steps ---"
+echo "1. Save the reviewed guidance snippet in AGENTS.md or CLAUDE.md."
+echo "2. Verify this project: bash \"${VIBEGUARD_DIR}/setup.sh\" verify-project"
+echo "3. Prove interception: bash \"${VIBEGUARD_DIR}/setup.sh\" demo safe-bash"
 echo
 
 echo "=== Done ==="

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -99,7 +99,9 @@ version = "0.1.0"
 edition = "2021"
 TOML
 project_init_read_only_out="$(bash "${REPO_DIR}/scripts/project-init.sh" --no-hooks "${project_init_read_only_target}" 2>&1)"
+project_init_read_only_target_abs="$(cd "${project_init_read_only_target}" && pwd -P)"
 assert_contains "${project_init_read_only_out}" "Git hook installation skipped (--no-hooks)" "project-init read-only mode reports skipped writes"
+assert_contains "${project_init_read_only_out}" "(cd \"${project_init_read_only_target_abs}\" && bash \"${REPO_DIR}/setup.sh\" verify-project)" "project-init verification step targets the inspected project"
 assert_cmd "project-init read-only mode does not install pre-commit" test ! -e "${project_init_read_only_target}/.git/hooks/pre-commit"
 assert_cmd "project-init read-only mode does not install pre-push" test ! -e "${project_init_read_only_target}/.git/hooks/pre-push"
 

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -55,6 +55,10 @@ assert_profile_hook_restored_after_repair() {
 }
 
 header "setup --clean"
+project_init_help_out="$(bash "${REPO_DIR}/scripts/project-init.sh" --help 2>&1)"
+assert_contains "${project_init_help_out}" "Usage: project-init.sh [--no-hooks] [project_root]" "project-init help shows the command contract"
+assert_contains "${project_init_help_out}" "--no-hooks" "project-init help documents read-only inspection"
+
 printf 'user codex note\n' >> "${HOME}/.codex/AGENTS.md"
 mkdir -p "${HOME}/.vibeguard/projects/session-a"
 printf '{"write_mode":"warn"}\n' > "${HOME}/.vibeguard/config.json"
@@ -79,8 +83,33 @@ TOML
 project_init_out="$(bash "${REPO_DIR}/scripts/project-init.sh" "${project_init_target}" 2>&1)"
 assert_contains "${project_init_out}" "pre-commit hook installed" "project-init installs tracked pre-commit hook"
 assert_contains "${project_init_out}" "pre-push hook installed" "project-init installs tracked pre-push hook"
+assert_contains "${project_init_out}" "Available static guards" "project-init distinguishes available checks from active hooks"
+assert_contains "${project_init_out}" "Suggested agent guidance snippet" "project-init guidance is host-neutral"
+assert_contains "${project_init_out}" "AGENTS.md or CLAUDE.md" "project-init names both supported guidance files"
 assert_cmd "project-init pre-commit hook targets VibeGuard wrapper" bash -c "[[ \"\$(readlink '${project_init_target}/.git/hooks/pre-commit')\" == '${HOME}/.vibeguard/pre-commit' ]]"
 assert_cmd "install-state records project-init hooks" bash -c "grep -q '${project_init_target}/.git/hooks/pre-commit' '${HOME}/.vibeguard/install-state.json'"
+
+project_init_read_only_target="${TMP_HOME}/project-init-read-only-target"
+mkdir -p "${project_init_read_only_target}"
+git -C "${project_init_read_only_target}" init >/dev/null
+cat > "${project_init_read_only_target}/Cargo.toml" <<'TOML'
+[package]
+name = "project-init-read-only-target"
+version = "0.1.0"
+edition = "2021"
+TOML
+project_init_read_only_out="$(bash "${REPO_DIR}/scripts/project-init.sh" --no-hooks "${project_init_read_only_target}" 2>&1)"
+assert_contains "${project_init_read_only_out}" "Git hook installation skipped (--no-hooks)" "project-init read-only mode reports skipped writes"
+assert_cmd "project-init read-only mode does not install pre-commit" test ! -e "${project_init_read_only_target}/.git/hooks/pre-commit"
+assert_cmd "project-init read-only mode does not install pre-push" test ! -e "${project_init_read_only_target}/.git/hooks/pre-push"
+
+project_init_python_target="${TMP_HOME}/project-init-python-target"
+mkdir -p "${project_init_python_target}"
+printf '%s\n' '[project]' 'name = "project-init-python-target"' 'version = "0.1.0"' \
+  > "${project_init_python_target}/pyproject.toml"
+project_init_python_out="$(bash "${REPO_DIR}/scripts/project-init.sh" --no-hooks "${project_init_python_target}" 2>&1)"
+assert_contains "${project_init_python_out}" "[universal] check_dependency_layers.py" "project-init lists universal Python guards"
+assert_contains "${project_init_python_out}" "[python] check_duplicates.py" "project-init lists Python project guards"
 
 project_init_relative_target="${TMP_HOME}/project-init-relative-target"
 mkdir -p "${project_init_relative_target}"


### PR DESCRIPTION
Part of #791 — onboarding tranche of the user-friendly guardrail roadmap.

## Summary

- add a documented `--no-hooks` inspection mode and standard help and argument handling
- distinguish available guards from installed Claude Code rules and include Python guard discovery
- make generated guidance host-neutral, preserve `AGENTS.md` and `CLAUDE.md`, and print actionable next steps
- update the quickstart and profile-flow regression coverage

## Research rationale

This adopts preview-before-write and explicit next-step patterns used by Biome, pre-commit, Lefthook, and Semgrep, while keeping VibeGuard high-context guidance files human-reviewed.

## Verification

Fresh checks against head `a6c4cda9f5eb9aae9baf431bd398ba13fef98448`:

- `bash -n scripts/project-init.sh` — pass
- `bash scripts/ci/validate-doc-paths.sh` — pass
- `bash scripts/ci/validate-doc-command-paths.sh` — pass
- clean-clone profile run: all project-init/onboarding assertions passed; the broader shard reached 117/118 before one unrelated strict-status assertion reported a local transient
- isolated diagnostic rerun at that checkpoint: expected `DEGRADED` exit 1 with 0 FAIL, 0 BROKEN, and 0 MISSING
- GitHub CI: all current Ubuntu, macOS, Windows, setup-regression, self-application, and benchmark checks pass, including both profile shards
