### PR TITLE
fix(project-init): attach git hooks independently

### DIFF
--- a/scripts/project-init.sh
+++ b/scripts/project-init.sh
@@ -380,6 +380,10 @@ record_project_hook_install() {
   fi
 }
 
+usable_hook_wrapper() {
+  [[ -f "$1" && -x "$1" ]]
+}
+
 project_hook_state() {
   local hook_path="$1" expected_target="$2" actual_target=""
   if [[ ! -x "${hook_path}" ]]; then
@@ -388,10 +392,12 @@ project_hook_state() {
     printf '%s\n' "unverified (existing hook is not VibeGuard-owned)"
   else
     actual_target="$(readlink "${hook_path}" 2>/dev/null || true)"
-    if [[ "${actual_target}" == "${expected_target}" ]]; then
-      printf '%s\n' "attached (already present)"
-    else
+    if [[ "${actual_target}" != "${expected_target}" ]]; then
       printf '%s\n' "unverified (existing hook is not VibeGuard-owned)"
+    elif ! usable_hook_wrapper "${expected_target}"; then
+      printf '%s\n' "inactive (wrapper is not an executable file)"
+    else
+      printf '%s\n' "attached (already present)"
     fi
   fi
 }
@@ -405,6 +411,34 @@ existing_hook_state() {
   fi
 }
 
+sync_project_hook() {
+  local hook_name="$1" wrapper="$2" hook_path="$3" state=""
+  if ! usable_hook_wrapper "${wrapper}"; then
+    echo " ~/.vibeguard/${hook_name} is missing, not a file, or not executable; run setup.sh first"
+    if [[ -e "${hook_path}" || -L "${hook_path}" ]]; then
+      state="$(project_hook_state "${hook_path}" "${wrapper}")"
+    else
+      state="unavailable (run setup.sh first)"
+    fi
+  elif [[ -e "${hook_path}" || -L "${hook_path}" ]]; then
+    if [[ "${hook_name}" == "pre-commit" ]]; then
+      echo ".git/hooks/pre-commit already exists, skip (manual override: ln -sf ${wrapper} ${hook_path})"
+    else
+      echo ".git/hooks/pre-push already exists, skip (manual overwrite: ln -sf ${wrapper} ${hook_path})"
+    fi
+    state="$(project_hook_state "${hook_path}" "${wrapper}")"
+  else
+    ln -sf "${wrapper}" "${hook_path}"
+    record_project_hook_install "${hook_name}" "${hook_path}"
+    echo "${hook_name} hook installed"
+    state="attached"
+  fi
+  case "${hook_name}" in
+    pre-commit) PRE_COMMIT_STATE="${state}" ;;
+    pre-push) PRE_PUSH_STATE="${state}" ;;
+  esac
+}
+
 PRE_COMMIT_STATE="not-attached"
 PRE_PUSH_STATE="not-attached"
 if [[ "${INSTALL_HOOKS}" -eq 0 ]]; then
@@ -416,39 +450,14 @@ if [[ "${INSTALL_HOOKS}" -eq 0 ]]; then
     PRE_COMMIT_STATE="$(existing_hook_state "$GIT_HOOKS_DIR/pre-commit" "$PRE_COMMIT_WRAPPER")"
     PRE_PUSH_STATE="$(existing_hook_state "$GIT_HOOKS_DIR/pre-push" "$PRE_PUSH_WRAPPER")"
   fi
-elif [[ -n "${GIT_HOOKS_DIR}" ]] && [[ -x "$PRE_COMMIT_WRAPPER" ]]; then
-  mkdir -p "$GIT_HOOKS_DIR"
-  if [[ -e "$GIT_HOOKS_DIR/pre-commit" || -L "$GIT_HOOKS_DIR/pre-commit" ]]; then
-    echo ".git/hooks/pre-commit already exists, skip (manual override: ln -sf $PRE_COMMIT_WRAPPER $GIT_HOOKS_DIR/pre-commit)"
-    PRE_COMMIT_STATE="$(project_hook_state "$GIT_HOOKS_DIR/pre-commit" "$PRE_COMMIT_WRAPPER")"
-  else
-    ln -sf "$PRE_COMMIT_WRAPPER" "$GIT_HOOKS_DIR/pre-commit"
-    record_project_hook_install "pre-commit" "${GIT_HOOKS_DIR}/pre-commit"
-    echo "pre-commit hook installed"
-    PRE_COMMIT_STATE="attached"
-  fi
-  if [[ -x "$PRE_PUSH_WRAPPER" ]]; then
-    if [[ -e "$GIT_HOOKS_DIR/pre-push" || -L "$GIT_HOOKS_DIR/pre-push" ]]; then
-      echo ".git/hooks/pre-push already exists, skip (manual overwrite: ln -sf $PRE_PUSH_WRAPPER $GIT_HOOKS_DIR/pre-push)"
-      PRE_PUSH_STATE="$(project_hook_state "$GIT_HOOKS_DIR/pre-push" "$PRE_PUSH_WRAPPER")"
-    else
-      ln -sf "$PRE_PUSH_WRAPPER" "$GIT_HOOKS_DIR/pre-push"
-      record_project_hook_install "pre-push" "${GIT_HOOKS_DIR}/pre-push"
-      echo "pre-push hook installed"
-      PRE_PUSH_STATE="attached"
-    fi
-  else
-    echo " ~/.vibeguard/pre-push is missing or not executable; run setup.sh first"
-    PRE_PUSH_STATE="unavailable (run setup.sh first)"
-  fi
 elif [[ -z "${GIT_HOOKS_DIR}" ]]; then
   echo "Non-git repository, skip"
   PRE_COMMIT_STATE="unavailable (not a git repository)"
   PRE_PUSH_STATE="unavailable (not a git repository)"
-elif [[ ! -x "$PRE_COMMIT_WRAPPER" ]]; then
-  echo " ~/.vibeguard/pre-commit is missing or not executable; run setup.sh first"
-  PRE_COMMIT_STATE="unavailable (run setup.sh first)"
-  PRE_PUSH_STATE="unavailable (run setup.sh first)"
+else
+  mkdir -p "$GIT_HOOKS_DIR"
+  sync_project_hook "pre-commit" "$PRE_COMMIT_WRAPPER" "$GIT_HOOKS_DIR/pre-commit"
+  sync_project_hook "pre-push" "$PRE_PUSH_WRAPPER" "$GIT_HOOKS_DIR/pre-push"
 fi
 echo
 

--- a/tests/setup/profile_flow_tests.sh
+++ b/tests/setup/profile_flow_tests.sh
@@ -165,6 +165,76 @@ assert_cmd "project-init preserves foreign pre-commit hook" \
 assert_cmd "project-init preserves non-executable pre-push hook" \
   test ! -x "${project_init_existing_hooks_target}/.git/hooks/pre-push"
 
+project_init_push_only_target="${TMP_HOME}/project-init-push-only-target"
+mkdir -p "${project_init_push_only_target}"
+git -C "${project_init_push_only_target}" init >/dev/null
+mv "${HOME}/.vibeguard/pre-commit" "${HOME}/.vibeguard/pre-commit.hidden"
+project_init_push_only_out="$(
+  set +e
+  bash "${REPO_DIR}/scripts/project-init.sh" "${project_init_push_only_target}" 2>&1
+  status=$?
+  mv "${HOME}/.vibeguard/pre-commit.hidden" "${HOME}/.vibeguard/pre-commit"
+  exit "${status}"
+)"
+assert_contains "${project_init_push_only_out}" \
+  "Git pre-commit: unavailable (run setup.sh first)" \
+  "project-init reports missing pre-commit wrapper without blocking pre-push"
+assert_contains "${project_init_push_only_out}" "pre-push hook installed" \
+  "project-init still attaches pre-push when pre-commit wrapper is missing"
+assert_contains "${project_init_push_only_out}" "Git pre-push: attached" \
+  "project-init reports attached pre-push independently of pre-commit"
+assert_cmd "project-init does not invent a pre-commit hook without a wrapper" \
+  test ! -e "${project_init_push_only_target}/.git/hooks/pre-commit"
+assert_cmd "project-init attaches pre-push without a pre-commit wrapper" bash -c \
+  "[[ \"\$(readlink '${project_init_push_only_target}/.git/hooks/pre-push')\" == '${HOME}/.vibeguard/pre-push' ]]"
+
+project_init_push_present_target="${TMP_HOME}/project-init-push-present-target"
+mkdir -p "${project_init_push_present_target}/.git/hooks"
+git -C "${project_init_push_present_target}" init >/dev/null
+ln -sf "${HOME}/.vibeguard/pre-push" "${project_init_push_present_target}/.git/hooks/pre-push"
+mv "${HOME}/.vibeguard/pre-commit" "${HOME}/.vibeguard/pre-commit.hidden"
+project_init_push_present_out="$(
+  set +e
+  bash "${REPO_DIR}/scripts/project-init.sh" "${project_init_push_present_target}" 2>&1
+  status=$?
+  mv "${HOME}/.vibeguard/pre-commit.hidden" "${HOME}/.vibeguard/pre-commit"
+  exit "${status}"
+)"
+assert_contains "${project_init_push_present_out}" \
+  "Git pre-commit: unavailable (run setup.sh first)" \
+  "missing pre-commit wrapper does not rewrite live pre-push state"
+assert_contains "${project_init_push_present_out}" \
+  "Git pre-push: attached (already present)" \
+  "project-init keeps reporting an attached pre-push when pre-commit wrapper is missing"
+assert_not_contains "${project_init_push_present_out}" "pre-push hook installed" \
+  "project-init does not reinstall an already-attached pre-push hook"
+assert_cmd "project-init preserves an attached pre-push without a pre-commit wrapper" bash -c \
+  "[[ \"\$(readlink '${project_init_push_present_target}/.git/hooks/pre-push')\" == '${HOME}/.vibeguard/pre-push' ]]"
+
+project_init_dir_wrapper_target="${TMP_HOME}/project-init-dir-wrapper-target"
+mkdir -p "${project_init_dir_wrapper_target}"
+git -C "${project_init_dir_wrapper_target}" init >/dev/null
+mv "${HOME}/.vibeguard/pre-push" "${HOME}/.vibeguard/pre-push.hidden"
+mkdir "${HOME}/.vibeguard/pre-push"
+chmod 755 "${HOME}/.vibeguard/pre-push"
+project_init_dir_wrapper_out="$(
+  set +e
+  bash "${REPO_DIR}/scripts/project-init.sh" "${project_init_dir_wrapper_target}" 2>&1
+  status=$?
+  rmdir "${HOME}/.vibeguard/pre-push"
+  mv "${HOME}/.vibeguard/pre-push.hidden" "${HOME}/.vibeguard/pre-push"
+  exit "${status}"
+)"
+assert_contains "${project_init_dir_wrapper_out}" \
+  "Git pre-push: unavailable (run setup.sh first)" \
+  "project-init does not treat a wrapper directory as attachable pre-push protection"
+assert_not_contains "${project_init_dir_wrapper_out}" "pre-push hook installed" \
+  "project-init does not symlink a project hook to a wrapper directory"
+assert_contains "${project_init_dir_wrapper_out}" "pre-commit hook installed" \
+  "a corrupt pre-push wrapper does not block pre-commit attachment"
+assert_cmd "project-init does not install a pre-push hook to a directory wrapper" \
+  test ! -e "${project_init_dir_wrapper_target}/.git/hooks/pre-push"
+
 project_init_python_target="${TMP_HOME}/project-init-python-target"
 mkdir -p "${project_init_python_target}"
 printf '%s\n' '[project]' 'name = "project-init-python-target"' 'version = "0.1.0"' \


### PR DESCRIPTION
## Summary
- Install and report `pre-commit` and `pre-push` independently so a missing pre-commit wrapper no longer drops force-push protection.
- Treat wrappers as attachable only when they are executable regular files, so a directory at `~/.vibeguard/pre-push` cannot be reported as active protection.

## Test plan
- [x] `bash -n scripts/project-init.sh`
- [x] Isolated smokes: missing pre-commit wrapper, already-attached pre-push, directory pre-push wrapper
- [x] `VIBEGUARD_TEST_PREBUILT_RUNTIME=1 bash tests/test_setup.sh --shard profile` (161 pass / 0 fail)